### PR TITLE
add some useful endpoints

### DIFF
--- a/core/streamdb.go
+++ b/core/streamdb.go
@@ -129,6 +129,16 @@ func (s *StreamDB) DeleteStream(strmID StreamID) {
 	// glog.Infof("streams len after delete: %v", len(s.streams))
 }
 
+func (s *StreamDB) GetStreamIDs(format stream.VideoFormat) []StreamID {
+	result := make([]StreamID, 0)
+	for id, strm := range s.streams {
+		if strm.GetStreamFormat() == format {
+			result = append(result, id)
+		}
+	}
+	return result
+}
+
 func (s StreamDB) String() string {
 	streams := ""
 	for vid, s := range s.streams {

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -82,6 +82,10 @@ func (m *Monitor) LogBuffer(strmID string) {
 	m.Node.AddBufferEvent(strmID)
 }
 
+func (m *Monitor) GetPeerCount() int {
+	return len(m.Node.Conns)
+}
+
 func (m *Monitor) StartWorker(ctx context.Context) {
 	ticker := time.NewTicker(PostFreq)
 	go func() {


### PR DESCRIPTION
This is mostly to support the desktop app.

Adding `/peersCount` and `/streamIDs`.  Note, I don't think we need to show RTMP streamIDs since they are never used except for segmenting to HLS.