### PR TITLE
On-chain job-claim-verify-distributefees

### DIFF
--- a/core/claimmanager.go
+++ b/core/claimmanager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/eth"
+	ethTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/livepeer/go-livepeer/types"
 )
 
@@ -24,161 +25,190 @@ type ClaimManager struct {
 	profiles []types.VideoProfile
 	pLookup  map[types.VideoProfile]int
 
-	seqNos      [][]int64
-	claimHashes [][]common.Hash
-	dataHashes  [][]common.Hash
-	tDataHashes [][]common.Hash
-	bSigs       [][][]byte
+	seqNos        [][]int64
+	receiptHashes [][]common.Hash
+	dataHashes    [][]string
+	tDataHashes   [][]string
+	bSigs         [][][]byte
 }
 
 //NewClaimManager creates a new claim manager.
 func NewClaimManager(sid string, jid *big.Int, p []types.VideoProfile, c eth.LivepeerEthClient) *ClaimManager {
 	seqNos := make([][]int64, len(p), len(p))
-	tcHashes := make([][]common.Hash, len(p), len(p))
-	dHashes := make([][]common.Hash, len(p), len(p))
-	tHashes := make([][]common.Hash, len(p), len(p))
+	rHashes := make([][]common.Hash, len(p), len(p))
+	dHashes := make([][]string, len(p), len(p))
+	tHashes := make([][]string, len(p), len(p))
 	sigs := make([][][]byte, len(p), len(p))
 	pLookup := make(map[types.VideoProfile]int)
 
 	for i := 0; i < len(p); i++ {
 		sNo := make([]int64, 0)
 		seqNos[i] = sNo
-		tch := make([]common.Hash, 0)
-		tcHashes[i] = tch
-		dh := make([]common.Hash, 0)
+		rh := make([]common.Hash, 0)
+		rHashes[i] = rh
+		dh := make([]string, 0)
 		dHashes[i] = dh
-		th := make([]common.Hash, 0)
+		th := make([]string, 0)
 		tHashes[i] = th
 		s := make([][]byte, 0)
 		sigs[i] = s
 		pLookup[p[i]] = i
 	}
 
-	return &ClaimManager{client: c, strmID: sid, jobID: jid, seqNos: seqNos, claimHashes: tcHashes, dataHashes: dHashes, tDataHashes: tHashes, bSigs: sigs, profiles: p, pLookup: pLookup}
+	return &ClaimManager{client: c, strmID: sid, jobID: jid, seqNos: seqNos, receiptHashes: rHashes, dataHashes: dHashes, tDataHashes: tHashes, bSigs: sigs, profiles: p, pLookup: pLookup}
 }
 
 //AddClaim adds a claim for a given video segment.
-// func (c *ClaimManager) AddClaim(seqNo int64, dataHash common.Hash, tDataHash common.Hash, bSig []byte, profile types.VideoProfile) {
-// 	claim := &ethTypes.TranscodeClaim{
-// 		StreamID:              c.strmID,
-// 		SegmentSequenceNumber: big.NewInt(seqNo),
-// 		DataHash:              dataHash,
-// 		TranscodedDataHash:    tDataHash,
-// 		BroadcasterSig:        bSig,
-// 	}
+func (c *ClaimManager) AddReceipt(seqNo int64, dataHash string, tDataHash string, bSig []byte, profile types.VideoProfile) {
+	receipt := &ethTypes.TranscodeReceipt{
+		StreamID:              c.strmID,
+		SegmentSequenceNumber: big.NewInt(seqNo),
+		DataHash:              dataHash,
+		TranscodedDataHash:    tDataHash,
+		BroadcasterSig:        bSig,
+	}
 
-// 	pi, ok := c.pLookup[profile]
-// 	if !ok {
-// 		glog.Errorf("Cannot find profile: %v", profile)
-// 		return
-// 	}
+	pi, ok := c.pLookup[profile]
+	if !ok {
+		glog.Errorf("Cannot find profile: %v", profile)
+		return
+	}
 
-// 	if len(c.seqNos[pi]) != 0 && c.seqNos[pi][len(c.seqNos[pi])-1] >= seqNo {
-// 		glog.Errorf("Cannot insert out of order.  Trying to insert %v into %v", c.seqNos[pi], seqNo)
-// 	}
+	if len(c.seqNos[pi]) != 0 && c.seqNos[pi][len(c.seqNos[pi])-1] >= seqNo {
+		glog.Errorf("Cannot insert out of order.  Trying to insert %v into %v", c.seqNos[pi], seqNo)
+	}
 
-// 	c.seqNos[pi] = append(c.seqNos[pi], seqNo)
-// 	c.claimHashes[pi] = append(c.claimHashes[pi], claim.Hash())
-// 	c.dataHashes[pi] = append(c.dataHashes[pi], dataHash)
-// 	c.tDataHashes[pi] = append(c.tDataHashes[pi], tDataHash)
-// 	c.bSigs[pi] = append(c.bSigs[pi], bSig)
-// }
+	c.seqNos[pi] = append(c.seqNos[pi], seqNo)
+	c.receiptHashes[pi] = append(c.receiptHashes[pi], receipt.Hash())
+	c.dataHashes[pi] = append(c.dataHashes[pi], dataHash)
+	c.tDataHashes[pi] = append(c.tDataHashes[pi], tDataHash)
+	c.bSigs[pi] = append(c.bSigs[pi], bSig)
+}
 
 //Claim creates the onchain claim for all the claims added through AddClaim
 func (c *ClaimManager) Claim(p types.VideoProfile) error {
-	// pi, ok := c.pLookup[p]
-	// if !ok {
-	// 	glog.Errorf("Cannot find video profile: %v", p)
-	// 	return ErrClaim
-	// }
+	pi, ok := c.pLookup[p]
+	if !ok {
+		glog.Errorf("Cannot find video profile: %v", p)
+		return ErrClaim
+	}
 
-	// c.claimAndVerify(c.jobID, c.seqNos[pi], c.dataHashes[pi], c.claimHashes[pi], c.tDataHashes[pi], c.bSigs[pi])
+	claimVerifyDistribute(c.client, c.jobID, c.seqNos[pi], c.dataHashes[pi], c.receiptHashes[pi], c.tDataHashes[pi], c.bSigs[pi])
 	return nil
 }
 
 //TODO: Can't just check for empty - need to check for seq No...
-// func (c *ClaimManager) claimAndVerify(jid *big.Int, seqNos []int64, dHashes []common.Hash, tcHashes []common.Hash, thashes []common.Hash, sigs [][]byte) {
-// 	claimLen := len(seqNos)
-// 	if len(dHashes) != claimLen || len(tcHashes) != claimLen || len(thashes) != claimLen || len(sigs) != claimLen {
-// 		glog.Errorf("Claim data length doesn't match")
-// 		return
-// 	}
-
-// 	ranges := make([][2]int64, 0)
-// 	start := seqNos[0]
-// 	for i := int64(0); i < int64(len(seqNos)); i++ {
-// 		if i+1 == int64(len(seqNos)) || seqNos[i+1] != seqNos[i]+1 {
-// 			ranges = append(ranges, [2]int64{start, seqNos[i]})
-// 			if i+1 != int64(len(seqNos)) {
-// 				start = seqNos[i+1]
-// 			}
-// 			continue
-// 		}
-// 	}
-
-// 	// glog.Infof("seq: %v, ranges: %v", seqNos, ranges)
-
-// 	startIdx := int64(0)
-// 	for _, r := range ranges {
-// 		endIdx := startIdx + r[1] - r[0]
-// 		root, proofs, err := ethTypes.NewMerkleTree(tcHashes[startIdx : endIdx+1])
-// 		if err != nil {
-// 			glog.Errorf("Error: %v - creating merkle root for: %v", err, tcHashes[startIdx:endIdx+1])
-// 			//TODO: If this happens, should we cancel the job?
-// 		}
-
-// 		tx, err := c.client.ClaimWork(jid, big.NewInt(r[0]), big.NewInt(r[1]), root.Hash)
-// 		if err != nil {
-// 			glog.Errorf("Error claiming work: %v", err)
-// 		} else {
-// 			verify(jid, dHashes[startIdx:endIdx+1], thashes[startIdx:endIdx+1], sigs[startIdx:endIdx+1], proofs, r[0], r[1], c.client, tx.Hash())
-// 		}
-
-// 		startIdx = endIdx + 1
-// 	}
-// }
-
-// func verify(jid *big.Int, dataHashes []common.Hash, tHashes []common.Hash, sigs [][]byte, proofs []*ethTypes.MerkleProof, start, end int64, c eth.LivepeerEthClient, txHash common.Hash) {
-// 	num := end - start + 1
-// 	if len(dataHashes) != int(num) || len(tHashes) != int(num) || len(sigs) != int(num) || len(proofs) != int(num) {
-// 		glog.Errorf("Wrong input data length in verify: dHashes(%v), tHashes(%v), sigs(%v), proofs(%v)", len(dataHashes), len(tHashes), len(sigs), len(proofs))
-// 	}
-// 	//Wait until tx is mined
-// 	_, err := eth.WaitForMinedTx(c.Backend(), EthRpcTimeout, EthMinedTxTimeout, txHash)
-// 	if err != nil {
-// 		glog.Errorf("Error waiting for tx mine in verify: %v", err)
-// 	}
-
-// 	//Get block info
-// 	bNum, bHash := getBlockInfo(c)
-
-// 	for i := 0; i < len(dataHashes); i++ {
-// 		//Figure out which seg needs to be verified
-// 		if shouldVerifySegment(start+int64(i), start, end, int64(bNum), bHash, VerifyRate) {
-// 			//Call verify
-// 			_, err := c.Verify(jid, big.NewInt(start+int64(i)), dataHashes[i], tHashes[i], sigs[i], proofs[i].Bytes())
-// 			if err != nil {
-// 				glog.Errorf("Error submitting verify transaction: %v", err)
-// 			}
-// 		}
-// 	}
-// }
-
-func getBlockInfo(c eth.LivepeerEthClient) (uint64, common.Hash) {
-	if c.Backend() == nil {
-		return 0, common.StringToHash("abc")
-	} else {
-		sp, err := c.Backend().SyncProgress(context.Background())
-		if err != nil || sp == nil {
-			glog.Errorf("Error getting block: %v", err)
-			return 0, common.Hash{}
-		}
-		blk, err := c.Backend().BlockByNumber(context.Background(), big.NewInt(int64(sp.CurrentBlock)))
-		if err != nil {
-			glog.Errorf("Error getting block: %v", err)
-		}
-		return blk.NumberU64(), blk.Hash()
+func claimVerifyDistribute(client eth.LivepeerEthClient, jid *big.Int, seqNos []int64, dHashes []string, rHashes []common.Hash, tHashes []string, sigs [][]byte) {
+	claimLen := len(seqNos)
+	if len(dHashes) != claimLen || len(rHashes) != claimLen || len(tHashes) != claimLen || len(sigs) != claimLen {
+		glog.Errorf("Claim data length doesn't match")
+		return
 	}
+
+	ranges := make([][2]int64, 0)
+	start := seqNos[0]
+	for i := int64(0); i < int64(len(seqNos)); i++ {
+		if i+1 == int64(len(seqNos)) || seqNos[i+1] != seqNos[i]+1 {
+			ranges = append(ranges, [2]int64{start, seqNos[i]})
+			if i+1 != int64(len(seqNos)) {
+				start = seqNos[i+1]
+			}
+		}
+	}
+
+	startIdx := int64(0)
+	for idx, r := range ranges {
+		endIdx := startIdx + r[1] - r[0]
+
+		go func() {
+			root, proofs, err := ethTypes.NewMerkleTree(rHashes[startIdx : endIdx+1])
+			if err != nil {
+				glog.Errorf("Error: %v - creating merkle root for: %v", err, rHashes[startIdx:endIdx+1])
+				//TODO: If this happens, should we cancel the job?
+			}
+
+			resCh, errCh := client.ClaimWork(jid, [2]*big.Int{big.NewInt(r[0]), big.NewInt(r[1])}, root.Hash)
+			select {
+			case <-resCh:
+				verify(client, jid, big.NewInt(int64(idx)), dHashes[startIdx:endIdx+1], tHashes[startIdx:endIdx+1], sigs[startIdx:endIdx+1], proofs, r[0], r[1])
+			case err := <-errCh:
+				glog.Errorf("Error claiming work: %v", err)
+			}
+		}()
+
+		startIdx = endIdx + 1
+	}
+}
+
+func verify(client eth.LivepeerEthClient, jid *big.Int, cid *big.Int, dataHashes []string, tHashes []string, sigs [][]byte, proofs []*ethTypes.MerkleProof, start, end int64) {
+	num := end - start + 1
+	if len(dataHashes) != int(num) || len(tHashes) != int(num) || len(sigs) != int(num) || len(proofs) != int(num) {
+		glog.Errorf("Wrong input data length in verify: dHashes(%v), tHashes(%v), sigs(%v), proofs(%v)", len(dataHashes), len(tHashes), len(sigs), len(proofs))
+	}
+
+	verifyRate, err := client.VerificationRate()
+	if err != nil {
+		return
+	}
+
+	claim, err := client.GetClaim(jid, cid)
+	if err != nil {
+		return
+	}
+
+	bNum, bHash, err := getBlockInfo(client, claim.ClaimBlock)
+	if err != nil {
+		return
+	}
+
+	for i := 0; i < len(dataHashes); i++ {
+		go func() {
+			//Figure out which seg needs to be verified
+			if shouldVerifySegment(start+int64(i), start, end, int64(bNum), bHash, int64(verifyRate)) {
+				//Call verify
+				resCh, errCh := client.Verify(jid, cid, big.NewInt(start+int64(i)), dataHashes[i], tHashes[i], sigs[i], proofs[i].Bytes())
+				select {
+				case <-resCh:
+					distributeFees(client, jid, cid)
+				case err := <-errCh:
+					glog.Errorf("Error submitting verify transaction: %v", err)
+				}
+			}
+		}()
+	}
+}
+
+func distributeFees(client eth.LivepeerEthClient, jid *big.Int, cid *big.Int) {
+	verificationPeriod, err := client.VerificationPeriod()
+	if err != nil {
+		return
+	}
+
+	slashingPeriod, err := client.SlashingPeriod()
+	if err != nil {
+		return
+	}
+
+	eth.Wait(client.Backend(), client.RpcTimeout(), new(big.Int).Add(verificationPeriod, slashingPeriod))
+
+	resCh, errCh := client.DistributeFees(jid, cid)
+	select {
+	case <-resCh:
+		glog.Infof("Distributed fess")
+	case err := <-errCh:
+		glog.Infof("Error distributing fees: %v", err)
+	}
+}
+
+func getBlockInfo(client eth.LivepeerEthClient, blockNum *big.Int) (uint64, common.Hash, error) {
+	ctx, _ := context.WithTimeout(context.Background(), client.RpcTimeout())
+
+	block, err := client.Backend().BlockByNumber(ctx, blockNum)
+	if err != nil {
+		return 0, common.Hash{}, err
+	}
+
+	return block.NumberU64(), block.Hash(), nil
 }
 
 func shouldVerifySegment(seqNum int64, start int64, end int64, blkNum int64, blkHash common.Hash, verifyRate int64) bool {
@@ -200,7 +230,7 @@ func shouldVerifySegment(seqNum int64, start int64, end int64, blkNum int64, blk
 	if i != 0 {
 		glog.Errorf("Error converting bytes in shouldVerifySegment.  num: %v, i: %v.  blkNumB:%x, blkHash:%x, seqNumB:%x", num, i, blkNumB, blkHash.Bytes(), seqNumB)
 	}
-	if num%uint64(VerifyRate) == 0 {
+	if num%uint64(verifyRate) == 0 {
 		return true
 	} else {
 		return false

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -139,7 +139,23 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm *Cla
 	glog.Infof("Subscriber: %v", sub)
 	sub.Subscribe(context.Background(), func(seqNo uint64, data []byte, eof bool) {
 		if eof {
-			glog.Infof("Stream finished.  Claiming work.")
+			glog.Infof("Stream finished. Claiming work.")
+
+			for _, p := range config.Profiles {
+				cm.Claim(p)
+			}
+
+			return
+		}
+
+		sufficient, err := cm.SufficientBroadcasterDeposit()
+		if err != nil {
+			glog.Errorf("Error checking broadcaster funds: %v", err)
+		}
+
+		if !sufficient {
+			glog.Infof("Broadcaster does not have enough funds. Claiming work.")
+
 			for _, p := range config.Profiles {
 				cm.Claim(p)
 			}

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -248,7 +248,6 @@ func (n *LivepeerNode) BroadcastToNetwork(strm stream.HLSVideoStream) error {
 
 		//Encode segment into []byte, broadcast it
 		if ssb, err := SignedSegmentToBytes(SignedSegment{Seg: *seg, Sig: sig}); err == nil {
-			// if ssb, err := SignedSegmentToBytes(SignedSegment{Seg: *seg, Sig: nil}); err == nil {
 			if err = b.Broadcast(counter, ssb); err != nil {
 				glog.Errorf("Error broadcasting segment to network: %v", err)
 			}

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -4,15 +4,20 @@ Core contains the main functionality of the Livepeer node.
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/ericxtang/m3u8"
 
+	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/eth"
+	ethTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/types"
 	"github.com/livepeer/lpms/stream"
@@ -74,38 +79,30 @@ func (n *LivepeerNode) Start(bootID, bootAddr string) error {
 }
 
 //CreateTranscodeJob creates the on-chain transcode job.
-// func (n *LivepeerNode) CreateTranscodeJob(strmID StreamID, profiles []types.VideoProfile, price uint64) error {
-// 	if n.Eth == nil {
-// 		glog.Errorf("Cannot create transcode job, no eth client found")
-// 		return ErrNotFound
-// 	}
+func (n *LivepeerNode) CreateTranscodeJob(strmID StreamID, profiles []types.VideoProfile, price uint64) error {
+	if n.Eth == nil {
+		glog.Errorf("Cannot create transcode job, no eth client found")
+		return ErrNotFound
+	}
 
-// 	//Verify the stream exists(assume it's a local stream)
-// 	if hlsStream := n.StreamDB.GetHLSStream(strmID); hlsStream == nil {
-// 		glog.Errorf("Cannot find stream %v for creating transcode job", strmID)
-// 		return ErrNotFound
-// 	}
+	//Verify the stream exists(assume it's a local stream)
+	if hlsStream := n.StreamDB.GetHLSStream(strmID); hlsStream == nil {
+		glog.Errorf("Cannot find stream %v for creating transcode job", strmID)
+		return ErrNotFound
+	}
 
-// 	//Call eth client to create the job
-// 	tOpt := [32]byte{}
-// 	p := big.NewInt(int64(price))
-// 	count := 0
-// 	for _, p := range profiles {
-// 		count += copy(tOpt[count:], p.Name)
-// 		if count > 32 {
-// 			glog.Errorf("Too many profiles.  Names can best at most 32 bytes")
-// 			return fmt.Errorf("Transcode Job Error")
-// 		}
-// 	}
-// 	tx, err := n.Eth.Job(strmID.String(), tOpt, p)
-// 	if err != nil || tx == nil {
-// 		glog.Errorf("Error creating transcode job: %v", err)
-// 		return err
-// 	}
+	//Call eth client to create the job
+	p := big.NewInt(int64(price))
 
-// 	glog.Infof("Created transcode job: %v", tx)
-// 	return nil
-// }
+	var tOpt bytes.Buffer
+	for _, p := range profiles {
+		tOpt.WriteString(p.Name)
+	}
+
+	n.Eth.Job(strmID.String(), tOpt.String(), p)
+
+	return nil
+}
 
 //TranscodeAndBroadcast transcodes one stream into multiple streams (specified by TranscodeConfig), broadcasts the streams, and returns a list of streamIDs.
 func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm *ClaimManager) ([]StreamID, error) {
@@ -178,7 +175,7 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm *Cla
 
 			//Don't do the onchain stuff unless specified
 			if config.PerformOnchainClaim {
-				// cm.AddClaim(int64(seqNo), common.BytesToHash(ss.Seg.Data), common.BytesToHash(tData[i]), ss.Sig, config.Profiles[i])
+				cm.AddReceipt(int64(seqNo), common.BytesToHash(ss.Seg.Data).Hex(), common.BytesToHash(tData[i]).Hex(), ss.Sig, config.Profiles[i])
 			}
 
 		}
@@ -225,19 +222,19 @@ func (n *LivepeerNode) BroadcastToNetwork(strm stream.HLSVideoStream) error {
 	counter := uint64(0)
 	strm.SetSubscriber(func(strm stream.HLSVideoStream, strmID string, seg *stream.HLSSegment) {
 		//Get segment signature
-		// segHash := (&ethTypes.Segment{StreamID: strm.GetStreamID(), SegmentSequenceNumber: big.NewInt(int64(counter)), DataHash: common.BytesToHash(seg.Data)}).Hash()
-		// var sig []byte
-		// if c, ok := n.Eth.(*eth.Client); ok {
-		// 	sig, err = eth.SignSegmentHash(c, n.EthPassword, segHash.Bytes())
-		// 	if err != nil {
-		// 		glog.Errorf("Error signing segment %v-%v: %v", strm.GetStreamID(), counter, err)
-		// 		return
-		// 	}
-		// }
+		segHash := (&ethTypes.Segment{StreamID: strm.GetStreamID(), SegmentSequenceNumber: big.NewInt(int64(counter)), DataHash: common.BytesToHash(seg.Data).Hex()}).Hash()
+		var sig []byte
+		if c, ok := n.Eth.(*eth.Client); ok {
+			sig, err = c.SignSegmentHash(n.EthPassword, segHash.Bytes())
+			if err != nil {
+				glog.Errorf("Error signing segment %v-%v: %v", strm.GetStreamID(), counter, err)
+				return
+			}
+		}
 
 		//Encode segment into []byte, broadcast it
-		// if ssb, err := SignedSegmentToBytes(SignedSegment{Seg: *seg, Sig: sig}); err == nil {
-		if ssb, err := SignedSegmentToBytes(SignedSegment{Seg: *seg, Sig: nil}); err == nil {
+		if ssb, err := SignedSegmentToBytes(SignedSegment{Seg: *seg, Sig: sig}); err == nil {
+			// if ssb, err := SignedSegmentToBytes(SignedSegment{Seg: *seg, Sig: nil}); err == nil {
 			if err = b.Broadcast(counter, ssb); err != nil {
 				glog.Errorf("Error broadcasting segment to network: %v", err)
 			}

--- a/core/rewardmanager.go
+++ b/core/rewardmanager.go
@@ -2,60 +2,63 @@ package core
 
 import (
 	"context"
+	"math/big"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/eth"
 )
 
 //RewardManager manages the transcoder's reward-calling cycle.
 type RewardManager struct {
-	checkFreq time.Duration
-	eth       eth.LivepeerEthClient
+	checkFreq       time.Duration
+	lastRewardRound *big.Int
+	client          eth.LivepeerEthClient
 }
 
 //NewRewardManager creates a new reward manager with a given checkFrequency.
-func NewRewardManager(checkFreq time.Duration, eth eth.LivepeerEthClient) *RewardManager {
-	return &RewardManager{checkFreq: checkFreq, eth: eth}
+func NewRewardManager(checkFreq time.Duration, client eth.LivepeerEthClient) *RewardManager {
+	return &RewardManager{checkFreq: checkFreq, client: client}
 }
 
 //Start repeatedly calls reward.
 func (r *RewardManager) Start(ctx context.Context) {
+	lastRewardRound, err := r.client.LastRewardRound()
+	if err != nil {
+		glog.Errorf("Error getting last reward round: %v", err)
+	}
+
+	r.lastRewardRound = lastRewardRound
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(r.checkFreq):
-			// r.callReward()
+			r.callReward()
 		}
 	}
 }
 
-// func (r *RewardManager) callReward() {
-// 	if err := eth.CheckRoundAndInit(r.eth, EthRpcTimeout, EthMinedTxTimeout); err != nil {
-// 		glog.Errorf("%v", err)
-// 		return
-// 	}
+func (r *RewardManager) callReward() {
+	currentRound, _, _, err := r.client.RoundInfo()
+	if err != nil {
+		glog.Errorf("Error getting round info: %v", err)
+		return
+	}
 
-// 	valid, err := r.eth.ValidRewardTimeWindow()
-// 	if err != nil {
-// 		glog.Errorf("Error getting reward time window info: %v", err)
-// 		return
-// 	}
+	if r.lastRewardRound.Cmp(currentRound) == -1 {
+		if err := eth.CheckRoundAndInit(r.client); err != nil {
+			glog.Errorf("%v", err)
+			return
+		}
 
-// 	if valid {
-// 		glog.Infof("It's our window. Calling reward()")
-// 		tx, err := r.eth.Reward()
-// 		if err != nil || tx == nil {
-// 			glog.Errorf("Error calling reward: %v", err)
-// 			return
-// 		}
-// 		r, err := eth.WaitForMinedTx(r.eth.Backend(), EthRpcTimeout, EthMinedTxTimeout, tx.Hash())
-// 		if err != nil {
-// 			glog.Errorf("Error waiting for mined tx: %v", err)
-// 		}
-// 		if tx.Gas().Cmp(r.GasUsed) == 0 {
-// 			glog.Errorf("Call Reward Failed")
-// 			return
-// 		}
-// 	}
-// }
+		resCh, errCh := r.client.Reward()
+		select {
+		case <-resCh:
+			r.lastRewardRound = currentRound
+		case err := <-errCh:
+			glog.Errorf("Error calling reward: %v", err)
+		}
+	}
+}

--- a/eth/client.go
+++ b/eth/client.go
@@ -53,6 +53,7 @@ type LivepeerEthClient interface {
 	Transcoder(blockRewardCut uint8, feeShare uint8, pricePerSegment *big.Int) (<-chan types.Receipt, <-chan error)
 	Bond(amount *big.Int, toAddr common.Address) (<-chan types.Receipt, <-chan error)
 	Reward() (<-chan types.Receipt, <-chan error)
+	Deposit(amount *big.Int) (<-chan types.Receipt, <-chan error)
 	Job(streamId string, transcodingOptions string, maxPricePerSegment *big.Int) (<-chan types.Receipt, <-chan error)
 	ClaimWork(jobId *big.Int, segmentRange [2]*big.Int, claimRoot [32]byte) (<-chan types.Receipt, <-chan error)
 	Verify(jobId *big.Int, claimId *big.Int, segmentNumber *big.Int, dataHash string, transcodedDataHash string, broadcasterSig []byte, proof []byte) (<-chan types.Receipt, <-chan error)
@@ -543,6 +544,13 @@ func (c *Client) GetJob(jobID *big.Int) (*Job, error) {
 
 func (c *Client) GetClaim(jobID *big.Int, claimID *big.Int) (*Claim, error) {
 	segmentRange, claimRoot, claimBlock, endVerificationBlock, endSlashingBlock, transcoderTotalStake, status, err := c.jobsManagerSession.GetClaimDetails(jobID, claimID)
+	glog.Infof("Segment range: %v", segmentRange)
+	glog.Infof("Claim root: %v", claimRoot)
+	glog.Infof("Claim block: %v", claimBlock)
+	glog.Infof("EV block: %v", endVerificationBlock)
+	glog.Infof("ES block: %v", endSlashingBlock)
+	glog.Infof("Ttotalstake: %v", transcoderTotalStake)
+	glog.Infof("Status: %v", status)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/client.go
+++ b/eth/client.go
@@ -54,6 +54,7 @@ type LivepeerEthClient interface {
 	Bond(amount *big.Int, toAddr common.Address) (<-chan types.Receipt, <-chan error)
 	Reward() (<-chan types.Receipt, <-chan error)
 	Deposit(amount *big.Int) (<-chan types.Receipt, <-chan error)
+	WithdrawDeposit() (<-chan types.Receipt, <-chan error)
 	Job(streamId string, transcodingOptions string, maxPricePerSegment *big.Int) (<-chan types.Receipt, <-chan error)
 	ClaimWork(jobId *big.Int, segmentRange [2]*big.Int, claimRoot [32]byte) (<-chan types.Receipt, <-chan error)
 	Verify(jobId *big.Int, claimId *big.Int, segmentNumber *big.Int, dataHash string, transcodedDataHash string, broadcasterSig []byte, proof []byte) (<-chan types.Receipt, <-chan error)
@@ -249,6 +250,9 @@ func NewTransactOptsForAccount(account accounts.Account, passphrase string, keyS
 		return nil, err
 	}
 
+	// Set to 4 GWei
+	// transactOpts.GasPrice = big.NewInt(4000000000)
+
 	return transactOpts, err
 }
 
@@ -304,6 +308,17 @@ func (c *Client) Deposit(amount *big.Int) (<-chan types.Receipt, <-chan error) {
 			return nil, err
 		} else {
 			glog.Infof("[%v] Submitted tx %v. Deposit %v LPTU", c.account.Address.Hex(), tx.Hash().Hex(), amount)
+			return tx, nil
+		}
+	})
+}
+
+func (c *Client) WithdrawDeposit() (<-chan types.Receipt, <-chan error) {
+	return c.WaitForReceipt(func() (*types.Transaction, error) {
+		if tx, err := c.jobsManagerSession.Withdraw(); err != nil {
+			return nil, err
+		} else {
+			glog.Infof("[%v] Submitted tx %v. Withdraw deposit", c.account.Address.Hex(), tx.Hash().Hex())
 			return tx, nil
 		}
 	})
@@ -542,15 +557,9 @@ func (c *Client) GetJob(jobID *big.Int) (*Job, error) {
 	}, nil
 }
 
+//TODO: Go binding has an issue returning [32]byte...
 func (c *Client) GetClaim(jobID *big.Int, claimID *big.Int) (*Claim, error) {
 	segmentRange, claimRoot, claimBlock, endVerificationBlock, endSlashingBlock, transcoderTotalStake, status, err := c.jobsManagerSession.GetClaimDetails(jobID, claimID)
-	glog.Infof("Segment range: %v", segmentRange)
-	glog.Infof("Claim root: %v", claimRoot)
-	glog.Infof("Claim block: %v", claimBlock)
-	glog.Infof("EV block: %v", endVerificationBlock)
-	glog.Infof("ES block: %v", endSlashingBlock)
-	glog.Infof("Ttotalstake: %v", transcoderTotalStake)
-	glog.Infof("Status: %v", status)
 	if err != nil {
 		return nil, err
 	}
@@ -617,6 +626,13 @@ func (c *Client) WaitForReceipt(txFunc func() (*types.Transaction, error)) (<-ch
 		defer close(outRes)
 		defer close(outErr)
 
+		// startBalance, err := c.backend.BalanceAt(context.Background(), c.account.Address, nil)
+		// if err != nil {
+		// 	glog.Errorf("Error getting balance: %v", err)
+		// }
+
+		// startBalanceETH := new(big.Float).Quo(new(big.Float).SetInt(startBalance), big.NewFloat(1000000000000000000))
+
 		tx, err := txFunc()
 		if err != nil {
 			outErr <- err
@@ -629,6 +645,22 @@ func (c *Client) WaitForReceipt(txFunc func() (*types.Transaction, error)) (<-ch
 		} else {
 			outRes <- *receipt
 		}
+
+		// glog.Infof("Gas used for tx %v: %v", receipt.TxHash.Hex(), receipt.GasUsed)
+		// gasCost := new(big.Int).Mul(receipt.GasUsed, big.NewInt(4000000000))
+		// glog.Infof("Gas cost (4 GWei gas price) for tx %v: %v", receipt.TxHash.Hex(), gasCost)
+		// glog.Infof("Gas cost ETH for tx %v: %v", receipt.TxHash.Hex(), new(big.Float).Quo(new(big.Float).SetInt(gasCost), big.NewFloat(1000000000000000000)))
+		// glog.Infof("ETH balance before tx %v: %v", receipt.TxHash.Hex(), startBalanceETH)
+
+		// endBalance, err := c.backend.BalanceAt(context.Background(), c.account.Address, nil)
+		// if err != nil {
+		// 	glog.Errorf("Error getting balance: %v", err)
+		// }
+
+		// endBalanceETH := new(big.Float).Quo(new(big.Float).SetInt(endBalance), big.NewFloat(1000000000000000000))
+
+		// glog.Infof("ETH balance after tx %v: %v", receipt.TxHash.Hex(), endBalanceETH)
+		// glog.Infof("Balance diff (ETH) after tx %v: %v", receipt.TxHash.Hex(), new(big.Float).Sub(startBalanceETH, endBalanceETH))
 
 		return
 	}()

--- a/eth/client.go
+++ b/eth/client.go
@@ -67,6 +67,7 @@ type LivepeerEthClient interface {
 	VerificationRate() (uint64, error)
 	VerificationPeriod() (*big.Int, error)
 	SlashingPeriod() (*big.Int, error)
+	LastRewardRound() (*big.Int, error)
 }
 
 type Client struct {

--- a/eth/client.go
+++ b/eth/client.go
@@ -68,6 +68,8 @@ type LivepeerEthClient interface {
 	VerificationPeriod() (*big.Int, error)
 	SlashingPeriod() (*big.Int, error)
 	LastRewardRound() (*big.Int, error)
+	IsRegisteredTranscoder() (bool, error)
+	TranscoderBond() (*big.Int, error)
 }
 
 type Client struct {
@@ -456,6 +458,16 @@ func (c *Client) CurrentRoundInitialized() (bool, error) {
 	}
 
 	return initialized, nil
+}
+
+func (c *Client) IsRegisteredTranscoder() (bool, error) {
+	status, err := c.bondingManagerSession.TranscoderStatus(c.account.Address)
+	if err != nil {
+		return false, err
+	}
+
+	// TODO: Use enum here for transcoder status?
+	return status == 1, nil
 }
 
 func (c *Client) IsActiveTranscoder() (bool, error) {

--- a/eth/client_test.go
+++ b/eth/client_test.go
@@ -266,6 +266,8 @@ func TestReward(t *testing.T) {
 	var (
 		err error
 
+		gasPrice = big.NewInt(4000000000)
+
 		blockRewardCut  uint8 = 10
 		feeShare        uint8 = 5
 		pricePerSegment       = big.NewInt(10)
@@ -299,22 +301,22 @@ func TestReward(t *testing.T) {
 
 	// SETUP CLIENTS
 
-	transcoderClient, err := NewClient(accounts[0], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	transcoderClient, err := NewClient(accounts[0], defaultPassword, datadir, backend, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	delegatorClient0, err := NewClient(accounts[1], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	delegatorClient0, err := NewClient(accounts[1], defaultPassword, datadir, backend, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	delegatorClient1, err := NewClient(accounts[2], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	delegatorClient1, err := NewClient(accounts[2], defaultPassword, datadir, backend, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	delegatorClient2, err := NewClient(accounts[3], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	delegatorClient2, err := NewClient(accounts[3], defaultPassword, datadir, backend, gasPrice, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 	if err != nil {
 		t.Fatalf("Failedd to create client: %v", err)
 	}
@@ -388,6 +390,8 @@ func TestJobClaimVerify(t *testing.T) {
 	var (
 		err error
 
+		gasPrice = big.NewInt(4000000000)
+
 		receiptCh <-chan types.Receipt
 		errCh     <-chan error
 
@@ -425,17 +429,17 @@ func TestJobClaimVerify(t *testing.T) {
 
 	// SETUP CLIENTS
 
-	transcoderClient, err := NewClient(accounts[0], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	transcoderClient, err := NewClient(accounts[0], defaultPassword, datadir, backend, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 	if err != nil {
 		t.Fatalf("Failed to create transcoder client: %v", err)
 	}
 
-	delegatorClient, _ := NewClient(accounts[1], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	delegatorClient, _ := NewClient(accounts[1], defaultPassword, datadir, backend, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 	if err != nil {
 		t.Fatalf("Failed to create delegator client: %v", err)
 	}
 
-	broadcasterClient, _ := NewClient(accounts[2], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	broadcasterClient, _ := NewClient(accounts[2], defaultPassword, datadir, backend, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 	if err != nil {
 		t.Fatalf("Failed to create broadcaster client: %v", err)
 	}
@@ -621,6 +625,8 @@ func TestJobClaimVerify(t *testing.T) {
 
 func TestDeployContract(t *testing.T) {
 	var (
+		gasPrice = big.NewInt(4000000000)
+
 		receiptCh <-chan types.Receipt
 		errCh     <-chan error
 	)
@@ -645,7 +651,7 @@ func TestDeployContract(t *testing.T) {
 	distributeTokens(transactOpts, backend, rpcTimeout, minedTxTimeout, tokenAddr, big.NewInt(1000000), accounts)
 	initProtocol(transactOpts, backend, rpcTimeout, minedTxTimeout, protocolAddr, tokenAddr, bondingManagerAddr, jobsManagerAddr, roundsManagerAddr)
 
-	client0, err := NewClient(accounts[0], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	client0, err := NewClient(accounts[0], defaultPassword, datadir, backend, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 
 	b0, _ := client0.TokenBalance()
 	glog.Infof("Token balance for %v: %v", accounts[0].Address.Hex(), b0)
@@ -653,7 +659,7 @@ func TestDeployContract(t *testing.T) {
 	receiptCh, errCh = client0.Transfer(accounts[1].Address, big.NewInt(1000))
 	checkTxReceipt(t, receiptCh, errCh)
 
-	client1, err := NewClient(accounts[1], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	client1, err := NewClient(accounts[1], defaultPassword, datadir, backend, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 	b1, _ := client1.TokenBalance()
 	glog.Infof("Token balance for %v: %v", accounts[1].Address.Hex(), b1)
 	b0, _ = client0.TokenBalance()
@@ -664,6 +670,7 @@ func TestTranscoderLoop(t *testing.T) {
 	var (
 		err error
 
+		gasPrice  = big.NewInt(4000000000)
 		receiptCh <-chan types.Receipt
 		errCh     <-chan error
 
@@ -696,12 +703,12 @@ func TestTranscoderLoop(t *testing.T) {
 	distributeTokens(transactOpts, backend, rpcTimeout, minedTxTimeout, tokenAddr, big.NewInt(1000000), accounts)
 	initProtocol(transactOpts, backend, rpcTimeout, minedTxTimeout, protocolAddr, tokenAddr, bondingManagerAddr, jobsManagerAddr, roundsManagerAddr)
 
-	transcoderClient, err := NewClient(accounts[0], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	transcoderClient, err := NewClient(accounts[0], defaultPassword, datadir, backend, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	broadcasterClient, err := NewClient(accounts[1], defaultPassword, datadir, backend, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
+	broadcasterClient, err := NewClient(accounts[1], defaultPassword, datadir, backend, gasPrice, protocolAddr, tokenAddr, rpcTimeout, eventTimeout)
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}

--- a/eth/init.sh
+++ b/eth/init.sh
@@ -1,3 +1,3 @@
 $GOPATH/bin/geth --datadir ~/.lpTest init genesis.json
 cp $GOPATH/src/github.com/livepeer/go-livepeer/eth/keys/* ~/.lpTest/keystore
-$GOPATH/bin/geth --datadir ~/.lpTest --networkid 777 --nodiscover --maxpeers 0 --rpc --mine --minerthreads 1 --etherbase "0x0161e041aad467a890839d5b08b138c1e6373072"
+$GOPATH/bin/geth --datadir ~/.lpTest --networkid 777 --nodiscover --maxpeers 0 --rpc --mine --minerthreads 1 --gasprice 4000000000 --etherbase "0x0161e041aad467a890839d5b08b138c1e6373072"

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -91,11 +91,26 @@ func (e *StubClient) Verify(jobId *big.Int, claimId *big.Int, segmentNumber *big
 	e.VerifyCounter++
 	return nil, nil
 }
+func (e *StubClient) DistributeFees(jobId *big.Int, claimId *big.Int) (<-chan types.Receipt, <-chan error) {
+	return nil, nil
+}
 func (e *StubClient) Transfer(toAddr common.Address, amount *big.Int) (<-chan types.Receipt, <-chan error) {
 	return nil, nil
 }
 func (e *StubClient) TokenBalance() (*big.Int, error) { return big.NewInt(100000), nil }
 func (e *StubClient) WaitUntilNextRound() error       { return nil }
 func (e *StubClient) GetJob(jobID *big.Int) (*Job, error) {
+	return nil, nil
+}
+func (e *StubClient) GetClaim(jobID *big.Int) (*Claim, error) {
+	return nil, nil
+}
+func (e *StubClient) VerificationRate() (uint64, error) {
+	return 0, nil
+}
+func (e *StubClient) VerificationPeriod() (*big.Int, error) {
+	return nil, nil
+}
+func (e *StubClient) SlashingPeriod() (*big.Int, error) {
 	return nil, nil
 }

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -114,3 +114,6 @@ func (e *StubClient) VerificationPeriod() (*big.Int, error) {
 func (e *StubClient) SlashingPeriod() (*big.Int, error) {
 	return nil, nil
 }
+func (e *StubClient) LastRewardRound() (*big.Int, error) {
+	return nil, nil
+}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -170,13 +170,9 @@ func gotRTMPStreamHandler(s *LivepeerServer, deposit int, maxPricePerSegment int
 			err := s.RTMPSegmenter.SegmentRTMPToHLS(context.Background(), rtmpStrm, hlsStrm, SegOptions) //TODO: do we need to cancel this thread when the stream finishes?
 			if err != nil {
 				glog.Infof("Error in segmenter: %v, broadcasting finish message", err)
-				// err = hlsStrm.AddHLSSegment(hlsStrmID.String(), &stream.HLSSegment{Name: fmt.Sprintf("%v_eof", hlsStrmID), EOF: true})
 				if err := s.LivepeerNode.BroadcastFinishMsg(hlsStrmID.String()); err != nil {
 					glog.Errorf("Error broadcaseting finish message: %v", err)
 				}
-				// if err != nil {
-				// 	glog.Errorf("Error adding segmenter finish: %v", err)
-				// }
 			}
 		}()
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -216,8 +216,6 @@ func endRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		s.LivepeerNode.StreamDB.DeleteStream(core.StreamID(rtmpStrm.GetStreamID()))
 		//Remove HLS stream associated with the RTMP stream
 		s.LivepeerNode.StreamDB.DeleteStream(core.StreamID(s.broadcastRtmpToHLSMap[rtmpStrm.GetStreamID()]))
-		// Withdraw deposit if there is anything left
-		s.LivepeerNode.Eth.WithdrawDeposit()
 
 		return nil
 	}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -235,6 +235,9 @@ func endRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		s.LivepeerNode.StreamDB.DeleteStream(core.StreamID(rtmpStrm.GetStreamID()))
 		//Remove HLS stream associated with the RTMP stream
 		s.LivepeerNode.StreamDB.DeleteStream(core.StreamID(s.broadcastRtmpToHLSMap[rtmpStrm.GetStreamID()]))
+		// Withdraw deposit if there is anything left
+		s.LivepeerNode.Eth.WithdrawDeposit()
+
 		return nil
 	}
 }


### PR DESCRIPTION
Refactored the `claimmanager.go` and `rewardmanager.go` to work with the new client architecture. The LP node can now act as an on-chain transcoder. When a node is started in transcoder mode for the first time, the node will register the user ETH account as a transcoder and prompt the user for an amount to bond to itself. Afterwords, the user will become an active transcoder the following round. The transcoding node listens for NewJob events that include it as an elected transcoder. When a broadcaster ends a stream, the transcoder will claim segments on-chain, verify the necessary segments and call distribute fees. The broadcaster will try to withdraw its deposit.