### PR TITLE
Transcoder fix

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -50,7 +50,7 @@ type LivepeerNode struct {
 	Eth          eth.LivepeerEthClient
 	EthAccount   string
 	EthPassword  string
-	workDir      string
+	WorkDir      string
 }
 
 //NewLivepeerNode creates a new Livepeer Node. Eth can be nil.
@@ -60,7 +60,7 @@ func NewLivepeerNode(e eth.LivepeerEthClient, vn net.VideoNetwork, nodeId NodeID
 		return nil, ErrLivepeerNode
 	}
 
-	return &LivepeerNode{StreamDB: NewStreamDB(vn.GetNodeID()), VideoNetwork: vn, Identity: nodeId, Addrs: addrs, Eth: e, workDir: wd}, nil
+	return &LivepeerNode{StreamDB: NewStreamDB(vn.GetNodeID()), VideoNetwork: vn, Identity: nodeId, Addrs: addrs, Eth: e, WorkDir: wd}, nil
 }
 
 //Start sets up the Livepeer protocol and connects the node to the network
@@ -108,7 +108,7 @@ func (n *LivepeerNode) CreateTranscodeJob(strmID StreamID, profiles []types.Vide
 }
 
 //TranscodeAndBroadcast transcodes one stream into multiple streams (specified by TranscodeConfig), broadcasts the streams, and returns a list of streamIDs.
-func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm *ClaimManager) ([]StreamID, error) {
+func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm ClaimManager, t transcoder.Transcoder) ([]StreamID, error) {
 	//Get TranscodeProfiles from VideoProfiles, create the broadcasters
 	tProfiles := make([]lptr.TranscodeProfile, len(config.Profiles), len(config.Profiles))
 	broadcasters := make(map[StreamID]net.Broadcaster)
@@ -129,9 +129,6 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm *Cla
 		}
 		broadcasters[strmID] = b
 	}
-
-	//Create the transcoder
-	t := transcoder.NewFFMpegSegmentTranscoder(tProfiles, "", n.workDir)
 
 	//Subscribe to broadcast video, do the transcoding, broadcast the transcoded video, do the on-chain claim / verify
 	sub, err := n.VideoNetwork.GetSubscriber(config.StrmID)
@@ -224,6 +221,16 @@ func (n *LivepeerNode) BroadcastFinishMsg(strmID string) error {
 //BroadcastToNetwork is called when a new broadcast stream is available.  It lets the network decide how
 //to deal with the stream.
 func (n *LivepeerNode) BroadcastToNetwork(strm stream.HLSVideoStream) error {
+	//Update the playlist to the network
+	mpl, err := strm.GetMasterPlaylist()
+	if err != nil {
+		glog.Errorf("Error getting master playlist: %v", err)
+	}
+	if err = n.VideoNetwork.UpdateMasterPlaylist(strm.GetStreamID(), mpl); err != nil {
+		glog.Errorf("Error updating master playlist: %v", err)
+	}
+
+	//Get the broadcaster from the network
 	b, err := n.VideoNetwork.GetBroadcaster(strm.GetStreamID())
 	if err != nil {
 		glog.Errorf("Error getting broadcaster from network: %v", err)

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -1,0 +1,125 @@
+package core
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/net"
+	"github.com/livepeer/go-livepeer/types"
+	"github.com/livepeer/lpms/stream"
+)
+
+type StubClaimManager struct{}
+
+func (cm *StubClaimManager) AddReceipt(seqNo int64, dataHash string, tDataHash string, bSig []byte, profile types.VideoProfile) {
+}
+func (cm *StubClaimManager) SufficientBroadcasterDeposit() (bool, error) { return true, nil }
+func (cm *StubClaimManager) Claim(p types.VideoProfile) error            { return nil }
+
+type StubTranscoder struct {
+	Profiles  []types.VideoProfile
+	InputData [][]byte
+}
+
+func (t *StubTranscoder) Transcode(d []byte) ([][]byte, error) {
+	if d == nil {
+		return nil, ErrTranscode
+	}
+
+	t.InputData = append(t.InputData, d)
+
+	result := make([][]byte, 0)
+	for _, p := range t.Profiles {
+		result = append(result, []byte(fmt.Sprintf("Transcoded_%v", p.Name)))
+	}
+	return result, nil
+}
+
+func TestTranscodeAndBroadcast(t *testing.T) {
+	nid := NodeID("12201c23641663bf06187a8c154a6c97266d138cb8379c1bc0828122dcc51c83698d")
+	strmID := "strmID"
+	jid := big.NewInt(0)
+	p := []types.VideoProfile{types.P720p60fps16x9, types.P144p30fps16x9}
+	config := net.TranscodeConfig{StrmID: strmID, Profiles: p, PerformOnchainClaim: false, JobID: jid}
+
+	n, err := NewLivepeerNode(&eth.StubClient{}, &StubVideoNetwork{}, nid, []string{""}, "")
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+
+	tr := &StubTranscoder{InputData: make([][]byte, 0), Profiles: p}
+	ids, err := n.TranscodeAndBroadcast(config, &StubClaimManager{}, tr)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+
+	if len(ids) != 2 {
+		t.Errorf("Expecting 2 profiles, got %v", ids)
+	}
+
+	start := time.Now()
+	for time.Since(start) < time.Second {
+		if len(tr.InputData) == 0 {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	//Should have transcoded the segments into 2 different profiles (right now StubSubscriber emits 1 segment)
+	if len(tr.InputData) != 1 {
+		t.Errorf("Expecting 1 segment to be transcoded, got %v", tr.InputData)
+	}
+
+	//Should have broadcasted the transcoded segments into new streams
+	if len(n.VideoNetwork.(*StubVideoNetwork).mplMap) != 2 {
+		t.Errorf("Expecting 2 playlists to be created, but got %v", n.VideoNetwork.(*StubVideoNetwork).mplMap)
+	}
+	if len(n.VideoNetwork.(*StubVideoNetwork).broadcasters) != 2 {
+		t.Errorf("Expecting 2 broadcasters to be created, but got %v", n.VideoNetwork.(*StubVideoNetwork).broadcasters)
+	}
+
+	//TODO: Should have done the claiming
+}
+
+func TestBroadcastToNetwork(t *testing.T) {
+	nid := NodeID("12201c23641663bf06187a8c154a6c97266d138cb8379c1bc0828122dcc51c83698d")
+	n, err := NewLivepeerNode(&eth.StubClient{}, &StubVideoNetwork{}, nid, []string{""}, "")
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	strmID, err := MakeStreamID(nid, RandomVideoID(), "")
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	testStrm, err := n.StreamDB.AddNewHLSStream(strmID)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+
+	//Set up the broadcasting
+	if err := n.BroadcastToNetwork(testStrm); err != nil {
+		t.Errorf("Error: %v", err)
+	}
+
+	//Insert a segment into the stream
+	seg := &stream.HLSSegment{SeqNo: 0, Name: fmt.Sprintf("%v_00.ts", strmID), Data: []byte("hello"), Duration: 1}
+	if err := testStrm.AddHLSSegment(strmID.String(), seg); err != nil {
+		t.Errorf("Error: %v", err)
+	}
+
+	//We should have created a playlist and inserted into the network broadcaster
+	_, ok := n.VideoNetwork.(*StubVideoNetwork).mplMap[strmID.String()]
+	if !ok {
+		t.Errorf("Should have created a playlist")
+	}
+
+	b, ok := n.VideoNetwork.(*StubVideoNetwork).broadcasters[strmID.String()]
+	if !ok {
+		t.Errorf("Shoudl have created a broadcaster")
+	}
+
+	if string(b.Data) != string(seg.Data) {
+		t.Errorf("Expecting %v, got %v", seg.Data, b.Data)
+	}
+}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -181,14 +181,6 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		//Kick off go routine to broadcast the hls stream.
 		go func() {
 			// glog.Infof("Kicking off broadcaster")
-			mpl, err := hlsStrm.GetMasterPlaylist()
-			if err != nil {
-				glog.Errorf("Error getting master playlist: %v", err)
-			}
-			if err = s.LivepeerNode.VideoNetwork.UpdateMasterPlaylist(hlsStrm.GetStreamID(), mpl); err != nil {
-				glog.Errorf("Error updating master playlist: %v", err)
-			}
-
 			err = s.LivepeerNode.BroadcastToNetwork(hlsStrm)
 			if err == core.ErrEOF {
 				glog.Info("Broadcast Ended.")

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/livepeer/lpms/transcoder"
+
 	"github.com/livepeer/lpms/stream"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -30,7 +32,9 @@ func (s *LivepeerServer) StartWebserver() {
 		}
 
 		ps := []types.VideoProfile{types.P240p30fps16x9, types.P360p30fps16x9}
-		ids, err := s.LivepeerNode.TranscodeAndBroadcast(net.TranscodeConfig{StrmID: strmID, Profiles: ps}, nil)
+		tps := []transcoder.TranscodeProfile{transcoder.P240p30fps16x9, transcoder.P360p30fps16x9}
+		tr := transcoder.NewFFMpegSegmentTranscoder(tps, "", s.LivepeerNode.WorkDir)
+		ids, err := s.LivepeerNode.TranscodeAndBroadcast(net.TranscodeConfig{StrmID: strmID, Profiles: ps}, nil, tr)
 		if err != nil {
 			glog.Errorf("Error transcoding: %v", err)
 			http.Error(w, "Error transcoding.", 500)

--- a/vendor/github.com/livepeer/lpms/circle.yml
+++ b/vendor/github.com/livepeer/lpms/circle.yml
@@ -9,6 +9,7 @@ dependencies:
     # - "$HOME/ffmpeg-static"
   override:
     - go get github.com/livepeer/lpms/cmd/example
+    - cd $HOME/.go_workspace/src/github.com/livepeer/lpms/ && git pull
     - npm install -g ffmpeg-static
 
 test:

--- a/vendor/github.com/livepeer/lpms/transcoder/interface.go
+++ b/vendor/github.com/livepeer/lpms/transcoder/interface.go
@@ -1,0 +1,5 @@
+package transcoder
+
+type Transcoder interface {
+	Transcode(d []byte) ([][]byte, error)
+}


### PR DESCRIPTION
This is 1 of 2 fixes for our current transcoder problem (streams not being available).  After transcoding, transcoder creates a broadcaster but never creates a master playlist.  This make the video stream un-detectable by other peers.

The fix is to move the playlist creation logic from mediaserver.go into livepeernode.go.  I also added some tests for livepeernode.go.