### PR TITLE
Et/transcode relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://circleci.com/gh/livepeer/go-livepeer.svg?style=shield&circle-token=e33534f6f4e2a6af19bb1596d7b72767a246cbab)](https://circleci.com/gh/livepeer/go-livepeer/tree/master)
+
+
 # go-livepeer
 [Livepeer](https://livepeer.org) is a live video streaming network protocol that is fully decentralized, highly scalable, crypto token incentivized, and results in a solution which is cheaper to an app developer or broadcaster than using traditional centralized live video solutions.  go-livepeer is a golang implementation of the protocol.
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/livepeer/lpms/transcoder"
+
 	crypto "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -465,8 +467,9 @@ func setupTranscoder(n *core.LivepeerNode, logsCh chan ethtypes.Log) error {
 				glog.Infof("Transcoder got job %v - strmID: %v, tData: %v, config: %v", jid, job.StreamId, job.TranscodingOptions, config)
 
 				//Do The Transcoding
-				cm := core.NewClaimManager(job.StreamId, jid, job.BroadcasterAddress, job.PricePerSegment, tProfiles, n.Eth)
-				strmIDs, err := n.TranscodeAndBroadcast(config, cm)
+				cm := core.NewBasicClaimManager(job.StreamId, jid, job.BroadcasterAddress, job.PricePerSegment, tProfiles, n.Eth)
+				tr := transcoder.NewFFMpegSegmentTranscoder([]transcoder.TranscodeProfile{transcoder.P360p30fps16x9, transcoder.P240p30fps16x9}, "", n.WorkDir)
+				strmIDs, err := n.TranscodeAndBroadcast(config, cm, tr)
 				if err != nil {
 					glog.Errorf("Transcode Error: %v", err)
 					continue

--- a/common/log.go
+++ b/common/log.go
@@ -1,0 +1,5 @@
+package common
+
+const SHORT = 4
+const DEBUG = 5
+const VERBOSE = 6

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -8,14 +8,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/big"
+	"path/filepath"
 	"time"
 
 	"github.com/ericxtang/m3u8"
-
-	"github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/eth"
 	ethTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/livepeer/go-livepeer/net"
@@ -132,19 +134,26 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm Clai
 		}
 	}
 
+	//If we found a local stream, transcode and broadcast local stream.  This is for testing only, so we'll always set cm to nil.
+	localStrm := n.StreamDB.GetHLSStream(StreamID(config.StrmID))
+	if localStrm != nil {
+		localStrm.SetSubscriber(func(origStrm stream.HLSVideoStream, strmID string, seg *stream.HLSSegment) {
+			n.transcodeAndBroadcastSeg(seg, nil, nil, t, resultStrmIDs, tranStrms, config)
+		})
+		return resultStrmIDs, nil
+	}
+
 	//Subscribe to broadcast video, do the transcoding, broadcast the transcoded video, do the on-chain claim / verify
 	sub, err := n.VideoNetwork.GetSubscriber(config.StrmID)
 	if err != nil {
 		glog.Errorf("Error getting subscriber for stream %v from network: %v", config.StrmID, err)
 	}
-	glog.Infof("Config strm ID: %v", config.StrmID)
-	glog.Infof("Subscriber: %v", sub)
 	sub.Subscribe(context.Background(), func(seqNo uint64, data []byte, eof bool) {
-		glog.Infof("Starting to transcode segment %v", seqNo)
+		glog.V(common.DEBUG).Infof("Starting to transcode segment %v", seqNo)
 		totalStart := time.Now()
 		if eof {
 			if cm != nil {
-				glog.Infof("Stream finished. Claiming work.")
+				glog.V(common.SHORT).Infof("Stream finished. Claiming work.")
 
 				for _, p := range config.Profiles {
 					cm.Claim(p)
@@ -161,7 +170,7 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm Clai
 			}
 
 			if !sufficient {
-				glog.Infof("Broadcaster does not have enough funds. Claiming work.")
+				glog.V(common.SHORT).Infof("Broadcaster does not have enough funds. Claiming work.")
 
 				for _, p := range config.Profiles {
 					cm.Claim(p)
@@ -177,39 +186,51 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm Clai
 		if err != nil {
 			glog.Errorf("Error decoding byte array into segment: %v", err)
 		}
-		glog.Infof("Decoding of segment took %v", time.Since(start))
-
-		//Do the transcoding
-		start = time.Now()
-		tData, err := t.Transcode(ss.Seg.Data)
-		if err != nil {
-			glog.Errorf("Error transcoding seg: %v - %v", ss.Seg.Name, err)
-		}
-		glog.Infof("Transcoding of segment %v took %v", ss.Seg.SeqNo, time.Since(start))
-
-		//Encode and broadcast the segment
-		start = time.Now()
-		for i, strmID := range resultStrmIDs {
-			//Insert the transcoded segments into the streams (streams are already broadcasted to the network)
-			newSeg := stream.HLSSegment{SeqNo: seqNo, Name: fmt.Sprintf("%v_%d.ts", strmID, seqNo), Data: tData[i], Duration: ss.Seg.Duration}
-			strm, ok := tranStrms[strmID]
-			if !ok {
-				glog.Errorf("Cannot find stream for %v", strmID)
-				continue
-			}
-			if err := strm.AddHLSSegment(strmID.String(), &newSeg); err != nil {
-				glog.Errorf("Error insert transcoded segment into video stream: %v", err)
-			}
-
-			//Don't do the onchain stuff unless specified
-			if cm != nil && config.PerformOnchainClaim {
-				cm.AddReceipt(int64(seqNo), common.BytesToHash(ss.Seg.Data).Hex(), common.BytesToHash(tData[i]).Hex(), ss.Sig, config.Profiles[i])
-			}
-		}
-		glog.Infof("Encoding and broadcasting of segment %v took %v", ss.Seg.SeqNo, time.Since(start))
-		glog.Infof("Finished transcoding segment %v, overall took %v\n\n\n", seqNo, time.Since(totalStart))
+		glog.V(common.DEBUG).Infof("Decoding of segment took %v", time.Since(start))
+		n.transcodeAndBroadcastSeg(&ss.Seg, ss.Sig, cm, t, resultStrmIDs, tranStrms, config)
+		glog.V(common.DEBUG).Infof("Encoding and broadcasting of segment %v took %v", ss.Seg.SeqNo, time.Since(start))
+		glog.V(common.SHORT).Infof("Finished transcoding segment %v, overall took %v\n\n\n", seqNo, time.Since(totalStart))
 	})
 	return resultStrmIDs, nil
+}
+
+func (n *LivepeerNode) transcodeAndBroadcastSeg(seg *stream.HLSSegment, sig []byte, cm ClaimManager, t transcoder.Transcoder, resultStrmIDs []StreamID, tranStrms map[StreamID]stream.HLSVideoStream, config net.TranscodeConfig) {
+	//Do the transcoding
+	start := time.Now()
+	tData, err := t.Transcode(seg.Data)
+	if err != nil {
+		glog.Errorf("Error transcoding seg: %v - %v", seg.Name, err)
+	}
+	glog.V(common.DEBUG).Infof("Transcoding of segment %v took %v", seg.SeqNo, time.Since(start))
+
+	//Encode and broadcast the segment
+	start = time.Now()
+	for i, resultStrmID := range resultStrmIDs {
+		// glog.Infof("Writing to %v", filepath.Join(n.WorkDir, "transegs", fmt.Sprintf("%v_%d.ts", strmID, seqNo)))
+		if err := ioutil.WriteFile(filepath.Join(n.WorkDir, "transegs", fmt.Sprintf("%v_%d.ts", resultStrmID, seg.SeqNo)), tData[i], 0600); err != nil {
+			glog.Errorf("Error writing transcoded seg: %v", err)
+		}
+
+		//Insert the transcoded segments into the streams (streams are already broadcasted to the network)
+		if tData[i] == nil {
+			glog.Errorf("Cannot find transcoded segment for %v", seg.SeqNo)
+			continue
+		}
+		newSeg := stream.HLSSegment{SeqNo: seg.SeqNo, Name: fmt.Sprintf("%v_%d.ts", resultStrmID, seg.SeqNo), Data: tData[i], Duration: seg.Duration}
+		transStrm, ok := tranStrms[resultStrmID]
+		if !ok {
+			glog.Errorf("Cannot find stream for %v", tranStrms)
+			continue
+		}
+		if err := transStrm.AddHLSSegment(resultStrmID.String(), &newSeg); err != nil {
+			glog.Errorf("Error insert transcoded segment into video stream: %v", err)
+		}
+
+		//Don't do the onchain stuff unless specified
+		if cm != nil && config.PerformOnchainClaim {
+			cm.AddReceipt(int64(seg.SeqNo), ethcommon.BytesToHash(seg.Data).Hex(), ethcommon.BytesToHash(tData[i]).Hex(), sig, config.Profiles[i])
+		}
+	}
 }
 
 func (n *LivepeerNode) BroadcastFinishMsg(strmID string) error {
@@ -246,7 +267,7 @@ func (n *LivepeerNode) BroadcastToNetwork(strm stream.HLSVideoStream) error {
 		//Parse through the results
 		for strmID, tProfile := range result {
 			vParams := transcoder.TranscodeProfileToVariantParams(transcoder.TranscodeProfileLookup[tProfile])
-			pl, _ := m3u8.NewMediaPlaylist(stream.DefaultMediaPlLen, stream.DefaultMediaPlLen)
+			pl, _ := m3u8.NewMediaPlaylist(HLSStreamWinSize, stream.DefaultMediaPlLen)
 			if err := strm.AddVariant(strmID, &m3u8.Variant{URI: fmt.Sprintf("%v.m3u8", strmID), Chunklist: pl, VariantParams: vParams}); err != nil {
 				glog.Errorf("Error adding variant: %v", err)
 			}
@@ -263,14 +284,14 @@ func (n *LivepeerNode) BroadcastToNetwork(strm stream.HLSVideoStream) error {
 			return
 		}
 
-		glog.Infof("Updated master playlist for %v", strm.GetStreamID())
+		glog.V(common.INFO).Infof("Updated master playlist for %v", strm.GetStreamID())
 	})
 
 	//Broadcast stream to network
 	counter := uint64(0)
 	strm.SetSubscriber(func(strm stream.HLSVideoStream, strmID string, seg *stream.HLSSegment) {
 		//Get segment signature
-		segHash := (&ethTypes.Segment{StreamID: strm.GetStreamID(), SegmentSequenceNumber: big.NewInt(int64(counter)), DataHash: common.BytesToHash(seg.Data).Hex()}).Hash()
+		segHash := (&ethTypes.Segment{StreamID: strm.GetStreamID(), SegmentSequenceNumber: big.NewInt(int64(counter)), DataHash: ethcommon.BytesToHash(seg.Data).Hex()}).Hash()
 		var sig []byte
 		if c, ok := n.Eth.(*eth.Client); ok {
 			sig, err = c.SignSegmentHash(n.EthPassword, segHash.Bytes())
@@ -298,7 +319,7 @@ func (n *LivepeerNode) BroadcastToNetwork(strm stream.HLSVideoStream) error {
 
 //SubscribeFromNetwork subscribes to a stream on the network.  Returns the stream as a reference.
 func (n *LivepeerNode) SubscribeFromNetwork(ctx context.Context, strmID StreamID, strm stream.HLSVideoStream) (net.Subscriber, error) {
-	glog.Infof("Subscriber from network...")
+	glog.V(common.DEBUG).Infof("Subscribe from network: %v", strmID)
 	sub, err := n.VideoNetwork.GetSubscriber(strmID.String())
 	if err != nil {
 		glog.Errorf("Error getting subscriber: %v", err)
@@ -309,8 +330,8 @@ func (n *LivepeerNode) SubscribeFromNetwork(ctx context.Context, strmID StreamID
 		//Two possibilities of ending the stream.
 		//1 - the subscriber quits
 		if eof {
-			glog.Infof("Got EOF, writing to buf")
-			strm.AddHLSSegment(strmID.String(), &stream.HLSSegment{Name: fmt.Sprintf("%v_eof", strmID), EOF: true})
+			glog.V(common.INFO).Infof("Got EOF, writing to buf")
+			strm.AddHLSSegment(strmID.String(), &stream.HLSSegment{Name: fmt.Sprintf("%v_eof", strmID), EOF: true, SeqNo: seqNo})
 			if err := sub.Unsubscribe(); err != nil {
 				glog.Errorf("Unsubscribe error: %v", err)
 				return
@@ -327,7 +348,7 @@ func (n *LivepeerNode) SubscribeFromNetwork(ctx context.Context, strmID StreamID
 		//Two possibilities of ending the stream.
 		//2 - receive a EOF segment
 		if ss.Seg.EOF {
-			glog.Infof("Got EOF, writing to buf")
+			glog.V(common.INFO).Infof("Got EOF, writing to buf")
 			// strm.AddHLSSegment(strmID.String(), &stream.HLSSegment{EOF: true})
 			strm.AddHLSSegment(strmID.String(), &ss.Seg)
 			if err := sub.Unsubscribe(); err != nil {

--- a/core/streamdb.go
+++ b/core/streamdb.go
@@ -16,6 +16,7 @@ import (
 var ErrNotFound = errors.New("NotFound")
 
 const HLSWaitTime = time.Second * 10
+const HLSStreamWinSize = uint(3)
 
 //StreamDB stores the video streams, the video buffers, and related information in memory. Note that HLS streams may have many streamIDs, each representing a
 //ABS rendition, so there may be multiple streamIDs that map to the same HLS stream in the streams map.
@@ -59,7 +60,7 @@ func (s *StreamDB) GetRTMPStream(id StreamID) stream.RTMPVideoStream {
 
 //AddNewHLSStream creates a new HLS video stream in the StreamDB
 func (s *StreamDB) AddNewHLSStream(strmID StreamID) (strm stream.HLSVideoStream, err error) {
-	strm = stream.NewBasicHLSVideoStream(strmID.String(), stream.DefaultSegWaitTime)
+	strm = stream.NewBasicHLSVideoStream(strmID.String(), stream.DefaultSegWaitTime, HLSStreamWinSize)
 	s.streams[strmID] = strm
 	lpmon.Instance().LogStream(strmID.String(), 0, 0)
 

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -20,7 +20,9 @@ const PostFreq = time.Second * 10
 func Instance() *Monitor {
 	if monitor == nil {
 		monitor = newMonitor()
-		monitor.StartWorker(context.Background())
+		if Endpoint != "" {
+			monitor.StartWorker(context.Background())
+		}
 	}
 
 	return monitor

--- a/vendor/github.com/livepeer/go-livepeer-basicnet/basic_broadcaster.go
+++ b/vendor/github.com/livepeer/go-livepeer-basicnet/basic_broadcaster.go
@@ -12,7 +12,7 @@ import (
 //BasicBroadcaster is unique for a specific video stream. It keeps track of a list of listeners and a queue of video chunks.  It won't start keeping track of things until there is at least 1 listener.
 type BasicBroadcaster struct {
 	Network      *BasicVideoNetwork
-	lastMsg      *StreamDataMsg
+	lastMsgs     []*StreamDataMsg
 	q            chan *StreamDataMsg
 	listeners    map[string]*BasicStream
 	StrmID       string
@@ -30,8 +30,10 @@ func (b *BasicBroadcaster) Broadcast(seqNo uint64, data []byte) error {
 		b.working = true
 	}
 
-	b.lastMsg = &StreamDataMsg{SeqNo: seqNo, Data: data}
-	b.q <- b.lastMsg
+	latest := &StreamDataMsg{SeqNo: seqNo, Data: data}
+	b.lastMsgs = append(b.lastMsgs, latest)
+	b.lastMsgs = b.lastMsgs[1:]
+	b.q <- latest
 	return nil
 }
 

--- a/vendor/github.com/livepeer/go-livepeer-basicnet/basic_subscriber.go
+++ b/vendor/github.com/livepeer/go-livepeer-basicnet/basic_subscriber.go
@@ -13,7 +13,7 @@ import (
 	"github.com/golang/glog"
 )
 
-var SubscriberDataInsertTimeout = time.Second * 5
+var SubscriberDataInsertTimeout = time.Second * 300
 var ErrSubscriber = errors.New("ErrSubscriber")
 
 //BasicSubscriber keeps track of
@@ -87,12 +87,14 @@ func (s *BasicSubscriber) startWorker(ctxW context.Context, p peer.ID, ws *Basic
 	//We expect DataStreamMsg to come back
 	go func() {
 		for {
-			//Get message from the broadcaster
+			//Get message from the msgChan (inserted from the network by StreamDataMsg)
 			//Call gotData(seqNo, data)
 			//Question: What happens if the handler gets stuck?
+			start := time.Now()
 			select {
 			case msg := <-s.msgChan:
 				gotData(msg.SeqNo, msg.Data, false)
+				glog.Infof("Subscriber worker inserted segment: %v - took %v", msg.SeqNo, time.Since(start))
 			case <-ctxW.Done():
 				s.networkStream = nil
 				s.working = false

--- a/vendor/github.com/livepeer/go-livepeer-basicnet/basic_subscriber.go
+++ b/vendor/github.com/livepeer/go-livepeer-basicnet/basic_subscriber.go
@@ -11,6 +11,7 @@ import (
 	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
 
 	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
 )
 
 var SubscriberDataInsertTimeout = time.Second * 300
@@ -93,8 +94,9 @@ func (s *BasicSubscriber) startWorker(ctxW context.Context, p peer.ID, ws *Basic
 			start := time.Now()
 			select {
 			case msg := <-s.msgChan:
+				networkWaitTime := time.Since(start)
 				gotData(msg.SeqNo, msg.Data, false)
-				glog.Infof("Subscriber worker inserted segment: %v - took %v", msg.SeqNo, time.Since(start))
+				glog.V(common.DEBUG).Infof("Subscriber worker inserted segment: %v - took %v in total, %v waiting for data", msg.SeqNo, time.Since(start), networkWaitTime)
 			case <-ctxW.Done():
 				s.networkStream = nil
 				s.working = false

--- a/vendor/github.com/livepeer/lpms/stream/basic_hls_videostream.go
+++ b/vendor/github.com/livepeer/lpms/stream/basic_hls_videostream.go
@@ -136,7 +136,7 @@ func (s *BasicHLSVideoStream) AddHLSSegment(strmID string, seg *HLSSegment) erro
 	if strmID == s.GetStreamID() {
 		s.strmLock.Lock()
 		defer s.strmLock.Unlock()
-		glog.Infof("Adding segment %v to stream: %v.  pl len: %v", seg.SeqNo, strmID, len(s.strmMediaPlCache.Segments))
+		// glog.Infof("Adding segment %v to stream: %v.  pl len: %v", seg.SeqNo, strmID, len(s.strmMediaPlCache.Segments))
 		if err := s.strmMediaPlCache.InsertSegment(seg.SeqNo, &m3u8.MediaSegment{SeqId: seg.SeqNo, Duration: seg.Duration, URI: seg.Name}); err != nil {
 			glog.Errorf("Error inserting segment %v: %v", seg.Name, err)
 			return ErrAddHLSSegment

--- a/vendor/github.com/livepeer/lpms/stream/basic_hls_videostream.go
+++ b/vendor/github.com/livepeer/lpms/stream/basic_hls_videostream.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
-	lpmon "github.com/livepeer/go-livepeer/monitor"
+	"github.com/livepeer/go-livepeer/common"
 )
 
 const DefaultMediaPlLen = uint(500)
+
+// const DefaultMediaWinLen = uint(5)
 const DefaultSegWaitTime = time.Second * 10
 const SegWaitInterval = time.Second
 
@@ -27,15 +29,16 @@ type BasicHLSVideoStream struct {
 	strmID              string
 	segWaitTime         time.Duration
 	subscriber          func(HLSVideoStream, string, *HLSSegment)
+	winSize             uint
 
 	//Keep track of the non-variant stream separately
 	strmMediaPlCache *m3u8.MediaPlaylist
 	strmLock         sync.Locker
 }
 
-func NewBasicHLSVideoStream(strmID string, segWaitTime time.Duration) *BasicHLSVideoStream {
+func NewBasicHLSVideoStream(strmID string, segWaitTime time.Duration, wSize uint) *BasicHLSVideoStream {
 	mpl := m3u8.NewMasterPlaylist()
-	pl, _ := m3u8.NewMediaPlaylist(DefaultMediaPlLen, DefaultMediaPlLen)
+	pl, _ := m3u8.NewMediaPlaylist(wSize, DefaultMediaPlLen)
 	strm := &BasicHLSVideoStream{
 		masterPlCache:       mpl,
 		variantMediaPlCache: make(map[string]*m3u8.MediaPlaylist),
@@ -44,7 +47,8 @@ func NewBasicHLSVideoStream(strmID string, segWaitTime time.Duration) *BasicHLSV
 		strmID:              strmID,
 		segWaitTime:         segWaitTime,
 		strmMediaPlCache:    pl,
-		strmLock:            &sync.Mutex{}}
+		strmLock:            &sync.Mutex{},
+		winSize:             wSize}
 
 	return strm
 }
@@ -68,6 +72,9 @@ func (s *BasicHLSVideoStream) GetMasterPlaylist() (*m3u8.MasterPlaylist, error) 
 //GetVariantPlaylist returns the media playlist represented by the streamID
 func (s *BasicHLSVideoStream) GetVariantPlaylist(strmID string) (*m3u8.MediaPlaylist, error) {
 	if strmID == s.GetStreamID() {
+		if s.strmMediaPlCache.Count() < s.winSize {
+			return nil, nil
+		}
 		return s.strmMediaPlCache, nil
 	}
 
@@ -76,26 +83,21 @@ func (s *BasicHLSVideoStream) GetVariantPlaylist(strmID string) (*m3u8.MediaPlay
 		return nil, ErrNotFound
 	}
 
+	// glog.Infof("Variant pl len: %v, %v", pl.Count(), pl)
+	if pl.Count() < s.winSize {
+		return nil, nil
+	}
+
 	return pl, nil
 }
 
 //GetHLSSegment gets the HLS segment.  It blocks until something is found, or timeout happens.
 func (s *BasicHLSVideoStream) GetHLSSegment(strmID string, segName string) (*HLSSegment, error) {
-	start := time.Now()
-	for {
-		if time.Since(start) > s.segWaitTime {
-			return nil, ErrNotFound
-		}
-
-		seg, ok := s.sqMap[sqMapKey(strmID, segName)]
-		if !ok {
-			lpmon.Instance().LogBuffer(strmID)
-			time.Sleep(SegWaitInterval)
-			continue
-		}
-
-		return seg, nil
+	seg, ok := s.sqMap[sqMapKey(strmID, segName)]
+	if !ok {
+		return nil, ErrNotFound
 	}
+	return seg, nil
 }
 
 //AddVariant adds a new variant playlist (and therefore, a new HLS video stream) to the master playlist.
@@ -132,14 +134,19 @@ func (s *BasicHLSVideoStream) AddVariant(strmID string, variant *m3u8.Variant) e
 
 //AddHLSSegment adds the hls segment to the right stream
 func (s *BasicHLSVideoStream) AddHLSSegment(strmID string, seg *HLSSegment) error {
-	// glog.Infof("Adding segment: %v", seg.Name)
+	if _, ok := s.sqMap[sqMapKey(strmID, seg.Name)]; ok {
+		return nil //Already have the seg.
+	}
+	glog.V(common.VERBOSE).Infof("Adding segment: %v", seg.Name)
 	if strmID == s.GetStreamID() {
 		s.strmLock.Lock()
 		defer s.strmLock.Unlock()
-		// glog.Infof("Adding segment %v to stream: %v.  pl len: %v", seg.SeqNo, strmID, len(s.strmMediaPlCache.Segments))
-		if err := s.strmMediaPlCache.InsertSegment(seg.SeqNo, &m3u8.MediaSegment{SeqId: seg.SeqNo, Duration: seg.Duration, URI: seg.Name}); err != nil {
-			glog.Errorf("Error inserting segment %v: %v", seg.Name, err)
+		if err := s.strmMediaPlCache.AppendSegment(&m3u8.MediaSegment{SeqId: seg.SeqNo, Duration: seg.Duration, URI: seg.Name}); err != nil {
+			glog.Errorf("Error appending segment %v: %v", seg.Name, err)
 			return ErrAddHLSSegment
+		}
+		if s.strmMediaPlCache.Count() > s.winSize {
+			s.strmMediaPlCache.Remove()
 		}
 		s.sqMap[sqMapKey(strmID, seg.Name)] = seg
 		if s.subscriber != nil {
@@ -156,11 +163,14 @@ func (s *BasicHLSVideoStream) AddHLSSegment(strmID string, seg *HLSSegment) erro
 	defer lock.Unlock()
 
 	//Add segment to media playlist
-	pl, err := s.GetVariantPlaylist(strmID)
-	if err != nil {
-		return err
+	pl, ok := s.variantMediaPlCache[strmID]
+	if !ok {
+		return ErrNotFound
 	}
-	pl.InsertSegment(seg.SeqNo, &m3u8.MediaSegment{SeqId: seg.SeqNo, Duration: seg.Duration, URI: seg.Name})
+	pl.AppendSegment(&m3u8.MediaSegment{SeqId: seg.SeqNo, Duration: seg.Duration, URI: seg.Name})
+	if pl.Count() > s.winSize {
+		pl.Remove()
+	}
 
 	//Add to buffer
 	s.sqMap[sqMapKey(strmID, seg.Name)] = seg

--- a/vendor/github.com/livepeer/lpms/stream/basic_hls_videostream.go
+++ b/vendor/github.com/livepeer/lpms/stream/basic_hls_videostream.go
@@ -136,6 +136,7 @@ func (s *BasicHLSVideoStream) AddHLSSegment(strmID string, seg *HLSSegment) erro
 	if strmID == s.GetStreamID() {
 		s.strmLock.Lock()
 		defer s.strmLock.Unlock()
+		glog.Infof("Adding segment %v to stream: %v.  pl len: %v", seg.SeqNo, strmID, len(s.strmMediaPlCache.Segments))
 		if err := s.strmMediaPlCache.InsertSegment(seg.SeqNo, &m3u8.MediaSegment{SeqId: seg.SeqNo, Duration: seg.Duration, URI: seg.Name}); err != nil {
 			glog.Errorf("Error inserting segment %v: %v", seg.Name, err)
 			return ErrAddHLSSegment

--- a/vendor/github.com/livepeer/lpms/transcoder/ffmpeg_segment_transcoder.go
+++ b/vendor/github.com/livepeer/lpms/transcoder/ffmpeg_segment_transcoder.go
@@ -45,7 +45,7 @@ func (t *FFMpegSegmentTranscoder) Transcode(d []byte) ([][]byte, error) {
 	//ffmpeg -i seg.ts -c:v libx264 -s 426:240 -r 30 -mpegts_copyts 1 -minrate 700k -maxrate 700k -bufsize 700k -threads 1 out3.ts
 	args := make([]string, 0, 0)
 	for i, p := range t.tProfiles {
-		args = append(args, []string{"-c:v", "libx264", "-s", p.Resolution, "-mpegts_copyts", "1", "-minrate", p.Bitrate, "-maxrate", p.Bitrate, "-bufsize", p.Bitrate, "-r", fmt.Sprintf("%d", p.Framerate), "-threads", "1", path.Join(t.workDir, fmt.Sprintf("out%v%v", i, inName))}...)
+		args = append(args, []string{"-c:v", "libx264", "-s", p.Resolution, "-minrate", p.Bitrate, "-maxrate", p.Bitrate, "-bufsize", p.Bitrate, "-r", fmt.Sprintf("%d", p.Framerate), "-threads", "1", "-copyts", path.Join(t.workDir, fmt.Sprintf("out%v%v", i, inName))}...)
 	}
 	cmd = exec.Command(path.Join(t.ffmpegPath, "ffmpeg"), append([]string{"-i", path.Join(t.workDir, inName)}, args...)...)
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
A few different bug fixes to improve transcoded video stability.

Some of the changes are captured in https://github.com/livepeer/go-livepeer-basicnet/pull/14 and https://github.com/livepeer/lpms/pull/41.

For this code base, we did a small code re-org for TranscodeAndBroadcast in livepeernode.go - but no functionality changes.  This was mostly for instrumentation of timing information.

We also changed the mediaserver wait pattern, so instead of relying on the hlsStrm to wait for segments, we do that explicitly.