### PR TITLE
Move Logic Into basicnet

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -151,13 +151,13 @@ func main() {
 	for _, addr := range node.PeerHost.Addrs() {
 		addrs = append(addrs, addr.String())
 	}
-	nw, err := bnet.NewBasicVideoNetwork(node)
+	nw, err := bnet.NewBasicVideoNetwork(node, *datadir)
 	if err != nil {
 		glog.Errorf("Cannot create network node: %v", err)
 		return
 	}
 
-	n, err := core.NewLivepeerNode(nil, nw, core.NodeID(nw.GetNodeID()), addrs, fmt.Sprintf("%v/.tmp", *datadir))
+	n, err := core.NewLivepeerNode(nil, nw, core.NodeID(nw.GetNodeID()), addrs, *datadir)
 	if err != nil {
 		glog.Errorf("Error creating livepeer node: %v", err)
 	}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -26,7 +26,7 @@ import (
 
 type StubConnInfo struct {
 	NodeID   string
-	NodeAddr string
+	NodeAddr []string
 }
 type StubVideoNetwork struct {
 	T            *testing.T
@@ -57,7 +57,7 @@ func (n *StubVideoNetwork) GetBroadcaster(strmID string) (net.Broadcaster, error
 func (n *StubVideoNetwork) GetSubscriber(strmID string) (net.Subscriber, error) {
 	return &StubSubscriber{T: n.T}, nil
 }
-func (n *StubVideoNetwork) Connect(nodeID, nodeAddr string) error {
+func (n *StubVideoNetwork) Connect(nodeID string, nodeAddr []string) error {
 	if n.connectInfo == nil {
 		n.connectInfo = make([]StubConnInfo, 0)
 	}
@@ -328,7 +328,7 @@ func TestNotifyBroadcaster(t *testing.T) {
 		glog.Errorf("Error creating a new node: %v", err)
 		return
 	}
-	nw, err := bnet.NewBasicVideoNetwork(node)
+	nw, err := bnet.NewBasicVideoNetwork(node, "")
 	if err != nil {
 		glog.Errorf("Cannot create network node: %v", err)
 		return

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -1,17 +1,13 @@
 package core
 
 import (
-	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/ericxtang/m3u8"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/golang/glog"
 
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/net"
@@ -198,45 +194,4 @@ func TestClaimVerifyDistributeFee(t *testing.T) {
 	if cm.distributeFeesCalled == false {
 		t.Errorf("Expect distributeFees to be called")
 	}
-}
-
-func TestLoadConnectionFile(t *testing.T) {
-	wd, err := os.Getwd()
-	if err != nil {
-		t.Errorf("Error getting wd: %v", err)
-	}
-	if err := ioutil.WriteFile(fmt.Sprintf("%v/conn", wd), []byte(fmt.Sprintf("%v|%v\n%v|%v\n", "nid1", "addr1", "nid2", "addr2")), 0644); err != nil {
-		t.Errorf("Error writing conn file: %v", err)
-	}
-	nid := NodeID("12201c23641663bf06187a8c154a6c97266d138cb8379c1bc0828122dcc51c83698d")
-	n, err := NewLivepeerNode(&eth.StubClient{}, &StubVideoNetwork{}, nid, []string{""}, wd)
-	if err != nil {
-		t.Errorf("Error creating node: %v", err)
-	}
-
-	ConnFileWriteFreq = 100 * time.Millisecond
-	ctx, cancel := context.WithCancel(context.Background())
-	if err := n.Start(ctx, "bootid", "bootaddr"); err != nil {
-		t.Errorf("Error starting node: %v", err)
-	}
-
-	if len(n.PeerConns) != 3 {
-		glog.Errorf("Expecting 3 peer connections, got: %v", n.PeerConns)
-	}
-
-	// Synchronization is a problem for consistency here, let's skip the file writing test for now
-	// time.Sleep(time.Second)
-	// f, _ := ioutil.ReadFile(fmt.Sprintf("%v/conn", wd))
-	// lines := make([]string, 0)
-	// for _, l := range strings.Split(string(f), "\n") {
-	// 	if l != "" {
-	// 		lines = append(lines, l)
-	// 	}
-	// }
-	// if len(lines) != 3 {
-	// 	t.Errorf("Expecting 3 peer connections in conn file, got %v", lines)
-	// }
-
-	cancel()
-	os.Remove(fmt.Sprintf("%v/conn", wd))
 }

--- a/net/interface.go
+++ b/net/interface.go
@@ -15,7 +15,7 @@ type VideoNetwork interface {
 	UpdateMasterPlaylist(manifestID string, mpl *m3u8.MasterPlaylist) error
 	GetBroadcaster(strmID string) (Broadcaster, error)
 	GetSubscriber(strmID string) (Subscriber, error)
-	Connect(nodeID, nodeAddr string) error
+	Connect(nodeID string, nodeAddr []string) error
 	SetupProtocol() error
 	SendTranscodeResponse(nodeID string, manifestID string, transcodeResult map[string]string) error
 	ReceivedTranscodeResponse(manifestID string, gotResult func(transcodeResult map[string]string))

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -67,7 +67,7 @@ type LivepeerServer struct {
 }
 
 func NewLivepeerServer(rtmpPort string, httpPort string, ffmpegPath string, lpNode *core.LivepeerNode) *LivepeerServer {
-	server := lpmscore.New(rtmpPort, httpPort, ffmpegPath, "", lpNode.WorkDir)
+	server := lpmscore.New(rtmpPort, httpPort, ffmpegPath, "", fmt.Sprintf("%v/.tmp", lpNode.WorkDir))
 	return &LivepeerServer{RTMPSegmenter: server, LPMS: server, HttpPort: httpPort, RtmpPort: rtmpPort, FfmpegPath: ffmpegPath, LivepeerNode: lpNode, broadcastRtmpToHLSMap: make(map[string]string), broadcastRtmpToManifestMap: make(map[string]string)}
 }
 

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -31,7 +31,7 @@ func setupServer() *LivepeerServer {
 			glog.Errorf("Error creating a new node: %v", err)
 			return nil
 		}
-		nw, err := bnet.NewBasicVideoNetwork(node)
+		nw, err := bnet.NewBasicVideoNetwork(node, "")
 		if err != nil {
 			glog.Errorf("Cannot create network node: %v", err)
 			return nil
@@ -68,8 +68,8 @@ func (n *StubNetwork) GetSubscriber(strmID string) (net.Subscriber, error) {
 	return n.S, nil
 }
 
-func (n *StubNetwork) Connect(nodeID, nodeAddr string) error { return nil }
-func (n *StubNetwork) SetupProtocol() error                  { return nil }
+func (n *StubNetwork) Connect(nodeID string, nodeAddr []string) error { return nil }
+func (n *StubNetwork) SetupProtocol() error                           { return nil }
 func (b *StubNetwork) SendTranscodeResponse(nodeID string, strmID string, transcodeResult map[string]string) error {
 	return nil
 }

--- a/vendor/github.com/livepeer/go-livepeer-basicnet/peerCache.go
+++ b/vendor/github.com/livepeer/go-livepeer-basicnet/peerCache.go
@@ -1,0 +1,71 @@
+package basicnet
+
+import (
+	"context"
+	"fmt"
+	peerstore "gx/ipfs/QmPgDWmTmuzvP7QE5zwo1TmjbJme9pmZHNujB2453jkCTr/go-libp2p-peerstore"
+	peer "gx/ipfs/QmXYjuNuxVzXKJCfWasQk1RqkhVLDM9jtUKhqc2WPQmFSB/go-libp2p-peer"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+type PeerCache struct {
+	Peerstore peerstore.Peerstore
+	Filename  string
+}
+
+func NewPeerCache(peerStore peerstore.Peerstore, filename string) *PeerCache {
+	return &PeerCache{Peerstore: peerStore, Filename: filename}
+}
+
+//LoadPeers Load peer info from a file and try to connect to them
+func (pc *PeerCache) LoadPeers(nw *BasicVideoNetwork) {
+	bytes, err := ioutil.ReadFile(pc.Filename)
+	if err == nil {
+		for _, line := range strings.Split(string(bytes), "\n") {
+			larr := strings.Split(line, "|")
+			if len(larr) == 2 {
+				addrs := strings.Split(larr[1], ",")
+				if err := nw.Connect(larr[0], addrs); err != nil {
+					glog.Errorf("Cannot connect to node: %v", err)
+				}
+			}
+		}
+	}
+}
+
+//Record Periodically write peers to a file
+func (pc *PeerCache) Record(ctx context.Context) {
+	ticker := time.NewTicker(ConnFileWriteFreq)
+	for {
+		select {
+		case <-ticker.C:
+			peers := pc.Peerstore.Peers()
+			if len(peers) == 0 {
+				continue
+			}
+
+			str := ""
+			for _, p := range peers {
+				pInfo := pc.Peerstore.PeerInfo(p)
+				if len(pInfo.Addrs) > 0 {
+					addrsStr := make([]string, 0)
+					for _, addr := range pInfo.Addrs {
+						addrsStr = append(addrsStr, addr.String())
+					}
+					str = fmt.Sprintf("%v\n%v|%v", str, peer.IDHexEncode(pInfo.ID), strings.Join(addrsStr, ","))
+				}
+			}
+			if len(str) > 0 {
+				if err := ioutil.WriteFile(pc.Filename, []byte(str), 0644); err != nil {
+					glog.Errorf("Error writing connection to file system")
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}


### PR DESCRIPTION
This PR uses the `peerStore` in libp2p to remember peers, and periodically write them to disk.  It addresses the problem of automatically re-establishing connections when restarting a node.

This closes #221