### PR TITLE
Pick upcoming active transcoder to initialize new round

### DIFF
--- a/eth/client.go
+++ b/eth/client.go
@@ -78,6 +78,7 @@ type LivepeerEthClient interface {
 	BroadcasterDeposit(broadcaster common.Address) (*big.Int, error)
 
 	// Parameters
+	NumActiveTranscoders() (*big.Int, error)
 	RoundLength() (*big.Int, error)
 	UnbondingPeriod() (uint64, error)
 	VerificationRate() (uint64, error)

--- a/eth/eventservices/roundservice.go
+++ b/eth/eventservices/roundservice.go
@@ -3,14 +3,18 @@ package eventservices
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/eth"
 )
 
 var (
+	BlocksToWait = big.NewInt(5)
+
 	ErrRoundsServiceStarted = fmt.Errorf("rounds service already started")
 	ErrRoundsServiceStopped = fmt.Errorf("rounds service already stopped")
 )
@@ -36,7 +40,7 @@ func (s *RoundsService) Start(ctx context.Context) error {
 
 	headersCh := make(chan *types.Header)
 	sub, err := s.eventMonitor.SubscribeNewBlock(ctx, headersCh, func(h *types.Header) (bool, error) {
-		return s.tryInitializeRound()
+		return s.tryInitializeRound(h.Number, h.Hash())
 	})
 
 	if err != nil {
@@ -63,7 +67,7 @@ func (s *RoundsService) Stop() error {
 	return nil
 }
 
-func (s *RoundsService) tryInitializeRound() (bool, error) {
+func (s *RoundsService) tryInitializeRound(blkNum *big.Int, blkHash common.Hash) (bool, error) {
 	currentRound, err := s.client.CurrentRound()
 	if err != nil {
 		return false, err
@@ -75,18 +79,77 @@ func (s *RoundsService) tryInitializeRound() (bool, error) {
 	}
 
 	if lastInitializedRound.Cmp(currentRound) == -1 {
-		tx, err := s.client.InitializeRound()
+		shouldInitialize, err := s.shouldInitializeRound(blkNum, blkHash)
 		if err != nil {
 			return false, err
 		}
 
-		err = s.client.CheckTx(tx)
-		if err != nil {
-			return false, err
-		}
+		if shouldInitialize {
+			glog.Infof("New round - preparing to initialize round to join active set")
 
-		glog.Infof("Initialized round %v", currentRound)
+			tx, err := s.client.InitializeRound()
+			if err != nil {
+				return false, err
+			}
+
+			err = s.client.CheckTx(tx)
+			if err != nil {
+				return false, err
+			}
+
+			glog.Infof("Initialized round %v", currentRound)
+		}
 	}
 
 	return true, nil
+}
+
+func (s *RoundsService) shouldInitializeRound(blkNum *big.Int, blkHash common.Hash) (bool, error) {
+	// Check to initialize round only in multiples of BlocksToWait blocks
+	// to make sure a previous initializeRound call by someone else is processed
+	blkNumMod := new(big.Int).Mod(blkNum, BlocksToWait)
+	if blkNumMod.Cmp(big.NewInt(0)) != 0 {
+		return false, nil
+	}
+
+	transcoders, err := s.client.RegisteredTranscoders()
+	if err != nil {
+		return false, err
+	}
+
+	numActive, err := s.client.NumActiveTranscoders()
+	if err != nil {
+		return false, err
+	}
+
+	numTranscoders := big.NewInt(int64(len(transcoders)))
+
+	if numActive.Cmp(numTranscoders) == 1 {
+		// If # of registered transcoders < the size of the active set # of active = # of registered
+		numActive = numTranscoders
+	}
+
+	hashNum := new(big.Int).SetBytes(blkHash.Bytes())
+	result := new(big.Int).Mod(hashNum, numActive)
+
+	rank := -1
+	for i := 0; i < int(numActive.Int64()); i++ {
+		if transcoders[i].Address == s.client.Account().Address {
+			rank = i
+			break
+		}
+	}
+
+	if rank == -1 {
+		// Not in the upcoming active set
+		return false, nil
+	}
+
+	// If blockHash % numActive == my rank, it is my turn to initialize the round
+	// Else it is not my turn to initialize the round
+	if result.Cmp(big.NewInt(int64(rank))) == 0 {
+		return true, nil
+	} else {
+		return false, nil
+	}
 }

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -122,11 +122,12 @@ func (c *StubClient) GetClaim(jobID *big.Int, claimID *big.Int) (*lpTypes.Claim,
 
 // Parameters
 
-func (c *StubClient) RoundLength() (*big.Int, error)        { return big.NewInt(0), nil }
-func (c *StubClient) UnbondingPeriod() (uint64, error)      { return 0, nil }
-func (c *StubClient) VerificationRate() (uint64, error)     { return 0, nil }
-func (c *StubClient) VerificationPeriod() (*big.Int, error) { return big.NewInt(0), nil }
-func (c *StubClient) SlashingPeriod() (*big.Int, error)     { return big.NewInt(0), nil }
+func (c *StubClient) NumActiveTranscoders() (*big.Int, error) { return big.NewInt(0), nil }
+func (c *StubClient) RoundLength() (*big.Int, error)          { return big.NewInt(0), nil }
+func (c *StubClient) UnbondingPeriod() (uint64, error)        { return 0, nil }
+func (c *StubClient) VerificationRate() (uint64, error)       { return 0, nil }
+func (c *StubClient) VerificationPeriod() (*big.Int, error)   { return big.NewInt(0), nil }
+func (c *StubClient) SlashingPeriod() (*big.Int, error)       { return big.NewInt(0), nil }
 
 // Helpers
 


### PR DESCRIPTION
Implements a basic algorithm to pick which upcoming active transcoder to initialize a new round based on the description in #250 

The `BlocksToWait` constant is to ensure that initializeRound calls are processed by the time transcoder nodes check again if they should call initializeRound. In a more realistic scenario this can just be 1-2 blocks if the block time is ~15 seconds. However, in our test net since we have ~2 second blocks, we want to provide time for a transaction to be processed so that a transcoder does not think that initializeRound has not been called yet when a previous call is already pending, but it just has not been processed yet.