### PR TITLE
Synchronize nonces used for different contract bindings

### DIFF
--- a/eth/claimmanager.go
+++ b/eth/claimmanager.go
@@ -366,7 +366,7 @@ func (c *BasicClaimManager) distributeFees(claimID *big.Int) error {
 		return err
 	}
 
-	glog.Infof("Distributed fees for claim %v", claimID)
+	glog.Infof("Distributed fees for job %v claim %v", c.jobID, claimID)
 
 	return nil
 }

--- a/vendor/github.com/ethereum/go-ethereum/accounts/abi/bind/base.go
+++ b/vendor/github.com/ethereum/go-ethereum/accounts/abi/bind/base.go
@@ -35,7 +35,7 @@ type SignerFn func(types.Signer, common.Address, *types.Transaction) (*types.Tra
 
 // NonceFetcherFn is a function callback that returns a pointer to the nonce to be used
 // by a transaction if a nonce is not explicitly provided
-type NonceFetcherFn func() (*big.Int, error)
+type NonceFetcherFn func() (uint64, error)
 
 // CallOpts is the collection of options to fine tune a contract call request.
 type CallOpts struct {
@@ -178,12 +178,10 @@ func (c *BoundContract) transact(opts *TransactOpts, contract *common.Address, i
 	}
 	var nonce uint64
 	if opts.Nonce == nil {
-		noncePtr, err := opts.NonceFetcher()
+		nonce, err = opts.NonceFetcher()
 		if err != nil {
 			return nil, err
 		}
-
-		nonce = noncePtr.Uint64()
 	} else {
 		nonce = opts.Nonce.Uint64()
 	}


### PR DESCRIPTION
Currently we do not manually set a nonce for the transact opts we use for each contract bindings when submitting transactions. By default, if we do not set a nonce, the `eth_getTransactionCount(.., "pending")` RPC method is used to ask the local node for the user's pending nonce. However, as described in #169 the current definition of pending state strictly refers to the pending block if the node is the miner or the latest canonical block if the node is not the miner. As a result, it is possible for the pending nonce retrieved from the local node to be inaccurate.

This PR attempts to synchronize the nonces used for different contract bindings and manually increments them to take into account pending transactions
- Added a `NonceFetcher` callback to the `TransactOpts` struct defined in `abigen` - we use this callback from the client to retrieve the next nonce
- Retrieving the next nonce is done by `getNonce` which uses a mutex to make sure different function calls do not try to read the same nonce at the same time. If `getNonce` is called for the first time, it asks the local node for the user's pending nonce and uses it. After the first time, `getNonce` increments the next nonce and then compares the next nonce with the pending nonce retrieved by the local node. If the pending nonce is greater than the next nonce, we use the pending nonce. Else, we use the next nonce.
- The same `NonceFetcher` callback is used by each contract binding