### PR TITLE
Memory Fix

### DIFF
--- a/vendor/github.com/livepeer/lpms/cmd/example/main.go
+++ b/vendor/github.com/livepeer/lpms/cmd/example/main.go
@@ -79,12 +79,6 @@ func main() {
 
 			//Segment the video into HLS (If we need multiple outlets for the HLS stream, we'd need to create a buffer.  But here we only have one outlet for the transcoder)
 			hlsStrm = stream.NewBasicHLSVideoStream(randString(10), 3)
-			// tSubscriber, err := transcodeSubscriber(hlsStrm)
-			// if err != nil {
-			// 	glog.Errorf("Error transcoding: %v", err)
-			// }
-			// hlsStrm.SetSubscriber(tSubscriber)
-			// glog.Infof("After set subscriber")
 
 			opt := segmenter.SegmenterOptions{SegLength: 8 * time.Second}
 			var ctx context.Context

--- a/vendor/github.com/livepeer/lpms/cmd/example/main.go
+++ b/vendor/github.com/livepeer/lpms/cmd/example/main.go
@@ -57,7 +57,7 @@ func main() {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
-	lpms := core.New("1935", "8000", "", "")
+	lpms := core.New("1935", "8000", "", "", "~/lpmsdata")
 
 	//Streams needed for transcoding:
 	var rtmpStrm stream.RTMPVideoStream
@@ -79,13 +79,13 @@ func main() {
 
 			//Segment the video into HLS (If we need multiple outlets for the HLS stream, we'd need to create a buffer.  But here we only have one outlet for the transcoder)
 			hlsStrm = stream.NewBasicHLSVideoStream(randString(10), 3)
-			var subscriber func(*stream.HLSSegment, bool)
-			subscriber, err = transcode(hlsStrm)
-			if err != nil {
-				glog.Errorf("Error transcoding: %v", err)
-			}
-			hlsStrm.SetSubscriber(subscriber)
-			glog.Infof("After set subscriber")
+			// tSubscriber, err := transcodeSubscriber(hlsStrm)
+			// if err != nil {
+			// 	glog.Errorf("Error transcoding: %v", err)
+			// }
+			// hlsStrm.SetSubscriber(tSubscriber)
+			// glog.Infof("After set subscriber")
+
 			opt := segmenter.SegmenterOptions{SegLength: 8 * time.Second}
 			var ctx context.Context
 			ctx, cancelSeg = context.WithCancel(context.Background())
@@ -171,13 +171,14 @@ func main() {
 	lpms.Start(context.Background())
 }
 
-func transcode(hlsStream stream.HLSVideoStream) (func(*stream.HLSSegment, bool), error) {
+func transcodeSubscriber(hlsStream stream.HLSVideoStream) (func(*stream.HLSSegment, bool), error) {
 	//Create Transcoder
-	profiles := []transcoder.TranscodeProfile{
-		transcoder.P144p30fps16x9,
-		transcoder.P240p30fps16x9,
-		transcoder.P576p30fps16x9,
+	profiles := []core.VideoProfile{
+		core.P144p30fps16x9,
+		core.P240p30fps16x9,
+		core.P576p30fps16x9,
 	}
+
 	t := transcoder.NewFFMpegSegmentTranscoder(profiles, "", "./tmp")
 
 	//Create variants in the stream

--- a/vendor/github.com/livepeer/lpms/core/lpms.go
+++ b/vendor/github.com/livepeer/lpms/core/lpms.go
@@ -104,12 +104,14 @@ func (l *LPMS) SegmentRTMPToHLS(ctx context.Context, rs stream.RTMPVideoStream, 
 	segCtx, segCancel := context.WithCancel(context.Background())
 	go func() {
 		c <- func() error {
+			var seg *segmenter.VideoSegment
+			var err error
 			for {
 				if hs == nil {
 					glog.Errorf("HLS Stream is nil")
 					return segmenter.ErrSegmenter
 				}
-				seg, err := s.PollSegment(segCtx)
+				seg, err = s.PollSegment(segCtx)
 				if err != nil {
 					return err
 				}

--- a/vendor/github.com/livepeer/lpms/segmenter/video_segmenter.go
+++ b/vendor/github.com/livepeer/lpms/segmenter/video_segmenter.go
@@ -94,7 +94,7 @@ func (s *FFMpegVideoSegmenter) RTMPToHLS(ctx context.Context, opt SegmenterOptio
 
 	var cmd *exec.Cmd
 
-	cmd = exec.Command(path.Join(s.ffmpegPath, "ffmpeg"), "-i", s.LocalRtmpUrl, "-vcodec", "copy", "-acodec", "copy", "-bsf:v", "h264_mp4toannexb", "-f", "segment", "-segment_time", "4", "-muxdelay", "0", "-segment_list", plfn, tsfn)
+	cmd = exec.Command(path.Join(s.ffmpegPath, "ffmpeg"), "-i", s.LocalRtmpUrl, "-vcodec", "copy", "-acodec", "copy", "-bsf:v", "h264_mp4toannexb", "-f", "segment", "-segment_time", fmt.Sprintf("%v", opt.SegLength.Seconds()), "-muxdelay", "0", "-segment_list", plfn, tsfn)
 
 	err = cmd.Start()
 	if err != nil {
@@ -252,11 +252,12 @@ func (s *FFMpegVideoSegmenter) pollPlaylist(ctx context.Context, fn string, slee
 }
 
 func (s *FFMpegVideoSegmenter) pollSegment(ctx context.Context, curFn string, nextFn string, sleepTime time.Duration) (f []byte, err error) {
+	var content []byte
 	for {
 		//Because FFMpeg keeps appending to the current segment until it's full before moving onto the next segment, we monitor the existance of
 		//the next file as a signal for the completion of the current segment.
 		if _, err := os.Stat(nextFn); err == nil {
-			content, err := ioutil.ReadFile(curFn)
+			content, err = ioutil.ReadFile(curFn)
 			if err != nil {
 				return nil, err
 			}

--- a/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
+++ b/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
@@ -90,7 +90,8 @@ func TestSegmenter(t *testing.T) {
 	}()
 
 	se := make(chan error, 1)
-	opt := SegmenterOptions{}
+	segLength := time.Second * 4
+	opt := SegmenterOptions{SegLength: segLength}
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
@@ -141,9 +142,9 @@ func TestSegmenter(t *testing.T) {
 			t.Errorf("Expecting HLS segment, got %v", seg.Format)
 		}
 
-		timeDiff := seg.Length - time.Second*time.Duration(SegmentTime)
+		timeDiff := seg.Length - segLength
 		if timeDiff > time.Millisecond*500 || timeDiff < -time.Millisecond*500 {
-			t.Errorf("Expecting 2 sec segments, got %v", seg.Length)
+			t.Errorf("Expecting %v sec segments, got %v.  Diff: %v", segLength, seg.Length, timeDiff)
 		}
 
 		fn := "test_" + strconv.Itoa(i) + ".ts"

--- a/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
+++ b/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
@@ -54,7 +54,9 @@ func (s *TestStream) ReadRTMPFromStream(ctx context.Context, dst av.MuxCloser) e
 		dst.WritePacket(pkt)
 	}
 }
-func (s *TestStream) WriteRTMPToStream(ctx context.Context, src av.DemuxCloser) error     { return nil }
+func (s *TestStream) WriteRTMPToStream(ctx context.Context, src av.DemuxCloser) (chan struct{}, error) {
+	return nil, nil
+}
 func (s *TestStream) WriteHLSPlaylistToStream(pl m3u8.MediaPlaylist) error                { return nil }
 func (s *TestStream) WriteHLSSegmentToStream(seg stream.HLSSegment) error                 { return nil }
 func (s *TestStream) ReadHLSFromStream(ctx context.Context, buffer stream.HLSMuxer) error { return nil }
@@ -139,7 +141,7 @@ func TestSegmenter(t *testing.T) {
 			t.Errorf("Expecting HLS segment, got %v", seg.Format)
 		}
 
-		timeDiff := seg.Length - time.Second*8
+		timeDiff := seg.Length - time.Second*time.Duration(SegmentTime)
 		if timeDiff > time.Millisecond*500 || timeDiff < -time.Millisecond*500 {
 			t.Errorf("Expecting 2 sec segments, got %v", seg.Length)
 		}

--- a/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
+++ b/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
@@ -30,29 +30,33 @@ func (s TestStream) String() string                       { return "" }
 func (s *TestStream) GetStreamFormat() stream.VideoFormat { return stream.RTMP }
 func (s *TestStream) GetStreamID() string                 { return "test" }
 func (s *TestStream) Len() int64                          { return 0 }
-func (s *TestStream) ReadRTMPFromStream(ctx context.Context, dst av.MuxCloser) error {
+func (s *TestStream) ReadRTMPFromStream(ctx context.Context, dst av.MuxCloser) (chan struct{}, error) {
 	format.RegisterAll()
 	wd, _ := os.Getwd()
 	file, err := avutil.Open(wd + "/test.flv")
 	if err != nil {
 		fmt.Println("Error opening file: ", err)
-		return err
+		return nil, err
 	}
 	header, err := file.Streams()
 	if err != nil {
 		glog.Errorf("Error reading headers: %v", err)
-		return err
+		return nil, err
 	}
 
 	dst.WriteHeader(header)
-	for {
-		pkt, err := file.ReadPacket()
-		if err == io.EOF {
-			dst.WriteTrailer()
-			return err
+	eof := make(chan struct{})
+	go func(eof chan struct{}) {
+		for {
+			pkt, err := file.ReadPacket()
+			if err == io.EOF {
+				dst.WriteTrailer()
+				eof <- struct{}{}
+			}
+			dst.WritePacket(pkt)
 		}
-		dst.WritePacket(pkt)
-	}
+	}(eof)
+	return eof, nil
 }
 func (s *TestStream) WriteRTMPToStream(ctx context.Context, src av.DemuxCloser) (chan struct{}, error) {
 	return nil, nil

--- a/vendor/github.com/livepeer/lpms/stream/basic_rtmp_videostream.go
+++ b/vendor/github.com/livepeer/lpms/stream/basic_rtmp_videostream.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"reflect"
-	"runtime/debug"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -13,16 +12,43 @@ import (
 )
 
 type BasicRTMPVideoStream struct {
-	streamID    string
-	buffer      *streamBuffer
-	RTMPTimeout time.Duration
-	header      []av.CodecData
+	streamID     string
+	ch           chan *av.Packet
+	src          av.DemuxCloser
+	listeners    []av.MuxCloser
+	listnersLock *sync.Mutex
+	header       []av.CodecData
+	exitWorker   chan struct{}
+	EOF          chan struct{}
+	RTMPTimeout  time.Duration
 }
 
 //NewBasicRTMPVideoStream creates a new BasicRTMPVideoStream.  The default RTMPTimeout is set to 10 milliseconds because we assume all RTMP streams are local.
 func NewBasicRTMPVideoStream(id string) *BasicRTMPVideoStream {
-	// return &BasicRTMPVideoStream{buffer: newStreamBuffer(), streamID: id, RTMPTimeout: 10 * time.Millisecond}
-	return &BasicRTMPVideoStream{buffer: newStreamBuffer(), streamID: id}
+	ch := make(chan *av.Packet)
+	eof := make(chan struct{})
+	listeners := make([]av.MuxCloser, 0)
+	lLock := &sync.Mutex{}
+
+	s := &BasicRTMPVideoStream{streamID: id, listeners: listeners, listnersLock: lLock, ch: ch, EOF: eof}
+	//Automatically start a worker that reads packets.  There is no buffering of the video packets.
+	go func(strm *BasicRTMPVideoStream) {
+		for {
+			select {
+			case pkt := <-strm.ch:
+				for i, l := range strm.listeners {
+					if err := l.WritePacket(*pkt); err != nil {
+						lLock.Lock()
+						strm.listeners = append(strm.listeners[:i], strm.listeners[i+1:]...)
+						lLock.Unlock()
+					}
+				}
+			case <-strm.EOF:
+				return
+			}
+		}
+	}(s)
+	return s
 }
 
 func (s *BasicRTMPVideoStream) GetStreamID() string {
@@ -37,97 +63,57 @@ func (s *BasicRTMPVideoStream) GetStreamFormat() VideoFormat {
 func (s *BasicRTMPVideoStream) ReadRTMPFromStream(ctx context.Context, dst av.MuxCloser) error {
 	defer dst.Close()
 
-	//TODO: Make sure to listen to ctx.Done()
-	for {
-		item, err := s.buffer.poll(ctx, s.RTMPTimeout)
-		if err != nil {
+	if err := dst.WriteHeader(s.header); err != nil {
+		return err
+	}
+
+	s.listnersLock.Lock()
+	s.listeners = append(s.listeners, dst)
+	s.listnersLock.Unlock()
+
+	select {
+	case <-s.EOF:
+		if err := dst.WriteTrailer(); err != nil {
 			return err
 		}
-
-		switch item.(type) {
-		case []av.CodecData:
-			headers := item.([]av.CodecData)
-			err = dst.WriteHeader(headers)
-			if err != nil {
-				glog.Errorf("Error writing RTMP header from Stream %v to mux", s.streamID)
-				return err
-			}
-		case av.Packet:
-			packet := item.(av.Packet)
-			err = dst.WritePacket(packet)
-			if err != nil {
-				glog.Errorf("Error writing RTMP packet from Stream %v to mux: %v", s.streamID, err)
-				return err
-			}
-		case RTMPEOF:
-			err := dst.WriteTrailer()
-			if err != nil {
-				glog.Errorf("Error writing RTMP trailer from Stream %v", s.streamID)
-				return err
-			}
-			return io.EOF
-		default:
-			glog.Errorf("Cannot recognize buffer iteam type: ", reflect.TypeOf(item))
-			debug.PrintStack()
-			return ErrBufferItemType
-		}
+	case <-ctx.Done():
+		return ctx.Err()
 	}
+
+	return nil
 }
 
 //WriteRTMPToStream writes a video stream from src into the stream.
-func (s *BasicRTMPVideoStream) WriteRTMPToStream(ctx context.Context, src av.DemuxCloser) error {
-	defer src.Close()
+func (s *BasicRTMPVideoStream) WriteRTMPToStream(ctx context.Context, src av.DemuxCloser) (eof chan struct{}, err error) {
+	// defer src.Close()
 
 	//Set header in case we want to use it.
 	h, err := src.Streams()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	s.header = h
 
-	c := make(chan error, 1)
-	go func() {
-		c <- func() error {
-			header, err := src.Streams()
-			if err != nil {
-				return err
+	go func(eof chan struct{}, ch chan *av.Packet) {
+		for {
+			packet, err := src.ReadPacket()
+			if err == io.EOF {
+				glog.Infof("EOF...")
+				close(eof)
+				src.Close()
+				return
+			} else if err != nil {
+				glog.Errorf("Error reading packet from RTMP: %v", err)
+				close(eof)
+				src.Close()
+				return
 			}
-			err = s.buffer.push(header)
-			if err != nil {
-				return err
-			}
 
-			// var lastKeyframe av.Packet
-			for {
-				packet, err := src.ReadPacket()
-				if err == io.EOF {
-					s.buffer.push(RTMPEOF{})
-					return err
-				} else if err != nil {
-					return err
-				} else if len(packet.Data) == 0 { //TODO: Investigate if it's possible for packet to be nil (what happens when RTMP stopped publishing because of a dropped connection? Is it possible to have err and packet both nil?)
-					return ErrDroppedRTMPStream
-				}
+			ch <- &packet
+		}
+	}(s.EOF, s.ch)
 
-				if packet.IsKeyFrame {
-					// lastKeyframe = packet
-				}
-
-				err = s.buffer.push(packet)
-				if err == ErrBufferFull {
-					//TODO: Delete all packets until last keyframe, insert headers in front - trying to get rid of streaming artifacts.
-				}
-			}
-		}()
-	}()
-
-	select {
-	case <-ctx.Done():
-		glog.V(2).Infof("Finished writing RTMP to Stream %v", s.streamID)
-		return ctx.Err()
-	case err := <-c:
-		return err
-	}
+	return s.EOF, nil
 }
 
 func (s BasicRTMPVideoStream) String() string {

--- a/vendor/github.com/livepeer/lpms/stream/basic_rtmp_videostream.go
+++ b/vendor/github.com/livepeer/lpms/stream/basic_rtmp_videostream.go
@@ -85,8 +85,6 @@ func (s *BasicRTMPVideoStream) ReadRTMPFromStream(ctx context.Context, dst av.Mu
 
 //WriteRTMPToStream writes a video stream from src into the stream.
 func (s *BasicRTMPVideoStream) WriteRTMPToStream(ctx context.Context, src av.DemuxCloser) (eof chan struct{}, err error) {
-	// defer src.Close()
-
 	//Set header in case we want to use it.
 	h, err := src.Streams()
 	if err != nil {

--- a/vendor/github.com/livepeer/lpms/stream/basic_rtmp_videostream_test.go
+++ b/vendor/github.com/livepeer/lpms/stream/basic_rtmp_videostream_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/nareix/joy4/av"
 	"github.com/nareix/joy4/codec/h264parser"
 )
@@ -50,19 +51,9 @@ func (d NoEOFDemuxer) ReadPacket() (av.Packet, error) {
 
 func TestWriteBasicRTMPErrors(t *testing.T) {
 	stream := NewBasicRTMPVideoStream("test")
-	err := stream.WriteRTMPToStream(context.Background(), BadStreamsDemuxer{})
+	_, err := stream.WriteRTMPToStream(context.Background(), BadStreamsDemuxer{})
 	if err != ErrStreams {
 		t.Error("Expecting Streams Error, but got: ", err)
-	}
-
-	err = stream.WriteRTMPToStream(context.Background(), BadPacketsDemuxer{})
-	if err != ErrPacketRead {
-		t.Error("Expecting Packet Read Error, but got: ", err)
-	}
-
-	err = stream.WriteRTMPToStream(context.Background(), NoEOFDemuxer{c: &Counter{Count: 0}})
-	if err != ErrDroppedRTMPStream {
-		t.Error("Expecting RTMP Dropped Error, but got: ", err)
 	}
 }
 
@@ -71,47 +62,41 @@ type PacketsDemuxer struct {
 	c *Counter
 }
 
-func (d PacketsDemuxer) Close() error { return nil }
-func (d PacketsDemuxer) Streams() ([]av.CodecData, error) {
+func (d *PacketsDemuxer) Close() error { return nil }
+func (d *PacketsDemuxer) Streams() ([]av.CodecData, error) {
 	return []av.CodecData{h264parser.CodecData{}}, nil
 }
-func (d PacketsDemuxer) ReadPacket() (av.Packet, error) {
+func (d *PacketsDemuxer) ReadPacket() (av.Packet, error) {
 	if d.c.Count == 10 {
-		return av.Packet{Data: []byte{0, 0}}, io.EOF
+		return av.Packet{}, io.EOF
 	}
 
+	// glog.Infof("Reading %v", d.c.Count)
+	p := av.Packet{Data: []byte{0, 0}, Idx: int8(d.c.Count)}
 	d.c.Count = d.c.Count + 1
-	return av.Packet{Data: []byte{0, 0}}, nil
+	return p, nil
 }
 
 func TestWriteBasicRTMP(t *testing.T) {
-	// stream := Stream{Buffer: NewStreamBuffer(), StreamID: "test"}
+	glog.Infof("\n\nTestWriteBasicRTMP\n\n")
 	stream := NewBasicRTMPVideoStream("test")
-	err := stream.WriteRTMPToStream(context.Background(), PacketsDemuxer{c: &Counter{Count: 0}})
-
-	if err != io.EOF {
-		t.Error("Expecting EOF, but got: ", err)
+	//Add a listener
+	l := &PacketsMuxer{}
+	stream.listeners = append(stream.listeners, l)
+	eof, err := stream.WriteRTMPToStream(context.Background(), &PacketsDemuxer{c: &Counter{Count: 0}})
+	if err != nil {
+		t.Error("Expecting nil, but got: ", err)
 	}
 
-	if stream.buffer.len() != 12 { //10 packets, 1 header, 1 trailer
-		t.Error("Expecting buffer length to be 12, but got: ", stream.buffer.len())
+	// Wait for eof
+	select {
+	case <-eof:
 	}
 
-	start := time.Now()
-	for time.Since(start) < time.Second {
-		if len(stream.header) == 0 {
-			time.Sleep(time.Millisecond * 100)
-			continue
-		}
-		break
+	time.Sleep(time.Millisecond * 100) //Sleep to make sure the last segment comes through
+	if len(l.packets) != 10 {
+		t.Errorf("Expecting packets length to be 10, but got: %v", l.packets)
 	}
-	if len(stream.header) == 0 {
-		t.Errorf("Expecting header to be set")
-	}
-
-	// fmt.Println(stream.buffer.q.Get(12))
-
-	//TODO: Test what happens when the buffer is full (should evict everything before the last keyframe)
 }
 
 var ErrBadHeader = errors.New("BadHeader")
@@ -119,58 +104,108 @@ var ErrBadPacket = errors.New("BadPacket")
 
 type BadHeaderMuxer struct{}
 
-func (d BadHeaderMuxer) Close() error                     { return nil }
-func (d BadHeaderMuxer) WriteHeader([]av.CodecData) error { return ErrBadHeader }
-func (d BadHeaderMuxer) WriteTrailer() error              { return nil }
-func (d BadHeaderMuxer) WritePacket(av.Packet) error      { return nil }
+func (d *BadHeaderMuxer) Close() error                     { return nil }
+func (d *BadHeaderMuxer) WriteHeader([]av.CodecData) error { return ErrBadHeader }
+func (d *BadHeaderMuxer) WriteTrailer() error              { return nil }
+func (d *BadHeaderMuxer) WritePacket(av.Packet) error      { return nil }
 
 type BadPacketMuxer struct{}
 
-func (d BadPacketMuxer) Close() error                     { return nil }
-func (d BadPacketMuxer) WriteHeader([]av.CodecData) error { return nil }
-func (d BadPacketMuxer) WriteTrailer() error              { return nil }
-func (d BadPacketMuxer) WritePacket(av.Packet) error      { return ErrBadPacket }
+func (d *BadPacketMuxer) Close() error                     { return nil }
+func (d *BadPacketMuxer) WriteHeader([]av.CodecData) error { return nil }
+func (d *BadPacketMuxer) WriteTrailer() error              { return nil }
+func (d *BadPacketMuxer) WritePacket(av.Packet) error      { return ErrBadPacket }
 
 func TestReadBasicRTMPError(t *testing.T) {
+	glog.Infof("\nTestReadBasicRTMPError\n\n")
 	stream := NewBasicRTMPVideoStream("test")
-	err := stream.WriteRTMPToStream(context.Background(), PacketsDemuxer{c: &Counter{Count: 0}})
-	if err != io.EOF {
-		t.Error("Error setting up the test - while inserting packet.")
+	done := make(chan struct{})
+	go func() {
+		if err := stream.ReadRTMPFromStream(context.Background(), &BadHeaderMuxer{}); err != ErrBadHeader {
+			t.Error("Expecting bad header error, but got ", err)
+		}
+		close(done)
+	}()
+	eof, err := stream.WriteRTMPToStream(context.Background(), &PacketsDemuxer{c: &Counter{Count: 0}})
+	if err != nil {
+		t.Error("Error writing RTMP to stream")
 	}
-	err = stream.ReadRTMPFromStream(context.Background(), BadHeaderMuxer{})
-
-	if err != ErrBadHeader {
-		t.Error("Expecting bad header error, but got ", err)
+	select {
+	case <-eof:
+	}
+	select {
+	case <-done:
 	}
 
-	err = stream.ReadRTMPFromStream(context.Background(), BadPacketMuxer{})
-	if err != ErrBadPacket {
-		t.Error("Expecting bad packet error, but got ", err)
+	stream = NewBasicRTMPVideoStream("test")
+	done = make(chan struct{})
+	go func() {
+		if err := stream.ReadRTMPFromStream(context.Background(), &BadPacketMuxer{}); err != nil {
+			t.Errorf("Expecting nil, but got %v", err)
+		}
+		start := time.Now()
+		for time.Since(start) < time.Second*2 && len(stream.listeners) > 0 {
+			time.Sleep(time.Millisecond * 100)
+		}
+		if len(stream.listeners) > 0 {
+			t.Errorf("Expecting listener to be removed, but got: %v", stream.listeners)
+		}
+		close(done)
+	}()
+	eof, err = stream.WriteRTMPToStream(context.Background(), &PacketsDemuxer{c: &Counter{Count: 0}})
+	if err != nil {
+		t.Error("Error writing RTMP to stream")
+	}
+	select {
+	case <-eof:
+	}
+	select {
+	case <-done:
 	}
 }
 
 //Test ReadRTMP
-type PacketsMuxer struct{}
+type PacketsMuxer struct {
+	packets []av.Packet
+	header  []av.CodecData
+	trailer bool
+}
 
-func (d PacketsMuxer) Close() error                     { return nil }
-func (d PacketsMuxer) WriteHeader([]av.CodecData) error { return nil }
-func (d PacketsMuxer) WriteTrailer() error              { return nil }
-func (d PacketsMuxer) WritePacket(av.Packet) error      { return nil }
+func (d *PacketsMuxer) Close() error { return nil }
+func (d *PacketsMuxer) WriteHeader(h []av.CodecData) error {
+	d.header = h
+	return nil
+}
+func (d *PacketsMuxer) WriteTrailer() error {
+	d.trailer = true
+	return nil
+}
+func (d *PacketsMuxer) WritePacket(pkt av.Packet) error {
+	if d.packets == nil {
+		d.packets = make([]av.Packet, 0)
+	}
+	d.packets = append(d.packets, pkt)
+	return nil
+}
 
 func TestReadBasicRTMP(t *testing.T) {
 	stream := NewBasicRTMPVideoStream("test")
-	err := stream.WriteRTMPToStream(context.Background(), PacketsDemuxer{c: &Counter{Count: 0}})
-	if err != io.EOF {
+	_, err := stream.WriteRTMPToStream(context.Background(), &PacketsDemuxer{c: &Counter{Count: 0}})
+	if err != nil {
 		t.Error("Error setting up the test - while inserting packet.")
 	}
-	readErr := stream.ReadRTMPFromStream(context.Background(), PacketsMuxer{})
 
-	if readErr != io.EOF {
-		t.Error("Expecting buffer to be empty, but got ", err)
+	r := &PacketsMuxer{}
+	readErr := stream.ReadRTMPFromStream(context.Background(), r)
+	if readErr != nil {
+		t.Errorf("Expecting no error, but got %v", err)
 	}
 
-	if stream.buffer.len() != 0 {
-		t.Error("Expecting buffer length to be 0, but got ", stream.buffer.len())
+	if len(r.header) != 1 {
+		t.Errorf("Expecting header to be set, got %v", r.header)
 	}
 
+	if r.trailer != true {
+		t.Errorf("Expecting trailer to be set, got %v", r.trailer)
+	}
 }

--- a/vendor/github.com/livepeer/lpms/stream/interface.go
+++ b/vendor/github.com/livepeer/lpms/stream/interface.go
@@ -44,7 +44,7 @@ type HLSVideoStream interface {
 
 type RTMPVideoStream interface {
 	VideoStream
-	ReadRTMPFromStream(ctx context.Context, dst av.MuxCloser) error
+	ReadRTMPFromStream(ctx context.Context, dst av.MuxCloser) (eof chan struct{}, err error)
 	WriteRTMPToStream(ctx context.Context, src av.DemuxCloser) (eof chan struct{}, err error)
 	Height() int
 	Width() int

--- a/vendor/github.com/livepeer/lpms/stream/interface.go
+++ b/vendor/github.com/livepeer/lpms/stream/interface.go
@@ -45,7 +45,7 @@ type HLSVideoStream interface {
 type RTMPVideoStream interface {
 	VideoStream
 	ReadRTMPFromStream(ctx context.Context, dst av.MuxCloser) error
-	WriteRTMPToStream(ctx context.Context, src av.DemuxCloser) error
+	WriteRTMPToStream(ctx context.Context, src av.DemuxCloser) (eof chan struct{}, err error)
 	Height() int
 	Width() int
 }

--- a/vendor/github.com/livepeer/lpms/test.sh
+++ b/vendor/github.com/livepeer/lpms/test.sh
@@ -1,30 +1,36 @@
 #Test script to run all the tests for continuous integration
 
+echo 'Testing core'
 cd core
 go test -logtostderr=true
 t1=$?
 cd ..
 
+echo 'Testing vidplayer'
 cd vidplayer
 go test -logtostderr=true
 t2=$?
 cd ..
 
+echo 'Testing vidlistener'
 cd vidlistener
 go test -logtostderr=true
 t3=$?
 cd ..
 
+echo 'Testing Stream'
 cd stream
 go test -logtostderr=true
 t4=$?
 cd ..
 
+echo 'Testing Transcoder'
 cd transcoder
 go test -logtostderr=true
 t5=$?
 cd ..
 
+echo 'Testing Segmener'
 cd segmenter
 go test -logtostderr=true
 t6=$?

--- a/vendor/github.com/livepeer/lpms/transcoder/external_test.go
+++ b/vendor/github.com/livepeer/lpms/transcoder/external_test.go
@@ -55,8 +55,8 @@ func TestStartUpload(t *testing.T) {
 	ctx := context.Background()
 
 	err := tr.StartUpload(ctx, mux, stream)
-	if err != nil {
-		t.Error("Expecting no error, but got:", err)
+	if err != io.EOF {
+		t.Error("Expecting io.EOF, but got:", err)
 	}
 
 	if mux.NumWrites != 12 {

--- a/vendor/github.com/livepeer/lpms/transcoder/external_test.go
+++ b/vendor/github.com/livepeer/lpms/transcoder/external_test.go
@@ -55,8 +55,8 @@ func TestStartUpload(t *testing.T) {
 	ctx := context.Background()
 
 	err := tr.StartUpload(ctx, mux, stream)
-	if err != io.EOF {
-		t.Error("Should have gotten EOF, but got:", err)
+	if err != nil {
+		t.Error("Expecting no error, but got:", err)
 	}
 
 	if mux.NumWrites != 12 {

--- a/vendor/github.com/livepeer/lpms/vidplayer/player.go
+++ b/vendor/github.com/livepeer/lpms/vidplayer/player.go
@@ -61,10 +61,14 @@ func (s *VidPlayer) rtmpServerHandlePlay() func(conn *joy4rtmp.Conn) {
 			return
 		}
 
-		if err = src.ReadRTMPFromStream(context.Background(), conn); err != nil {
+		eof, err := src.ReadRTMPFromStream(context.Background(), conn)
+		if err != nil {
 			if err != io.EOF {
 				glog.Errorf("Error copying RTMP stream: %v", err)
 			}
+		}
+		select {
+		case <-eof:
 			return
 		}
 	}


### PR DESCRIPTION
This fix removes the buffer for RTMP and HLS video streams.  Instead, we'll use channels for RTMP, and add a simple cache / eviction policy for HLS.

There are also some minor changes, commented in-line.

Closes https://github.com/livepeer/go-livepeer/issues/227, https://github.com/livepeer/go-livepeer/issues/181