### PR TITLE
Manifest Fix

### DIFF
--- a/net/interface.go
+++ b/net/interface.go
@@ -22,7 +22,7 @@ type VideoNetwork interface {
 	Connect(nodeID string, nodeAddr []string) error
 	SetupProtocol() error
 	SendTranscodeResponse(nodeID string, manifestID string, transcodeResult map[string]string) error
-	ReceivedTranscodeResponse(manifestID string, gotResult func(transcodeResult map[string]string))
+	ReceivedTranscodeResponse(strmID string, gotResult func(transcodeResult map[string]string))
 	GetNodeStatus(nodeID string) (chan *NodeStatus, error)
 	String() string
 }

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -247,6 +247,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 			glog.Errorf("Error broadasting manifest to network: %v", err)
 		}
 
+		//Set up the transcode response callback
 		s.LivepeerNode.VideoNetwork.ReceivedTranscodeResponse(string(hlsStrmID), func(result map[string]string) {
 			//Parse through the results
 			for strmID, tProfile := range result {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -242,9 +242,27 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		manifest := m3u8.NewMasterPlaylist()
 		vParams := lpmscore.VideoProfileToVariantParams(lpmscore.VideoProfileLookup[vProfile.Name])
 		manifest.Append(fmt.Sprintf("%v.m3u8", hlsStrmID), pl, vParams)
+
 		if err := s.LivepeerNode.VideoNetwork.UpdateMasterPlaylist(string(mid), manifest); err != nil {
 			glog.Errorf("Error broadasting manifest to network: %v", err)
 		}
+
+		s.LivepeerNode.VideoNetwork.ReceivedTranscodeResponse(string(hlsStrmID), func(result map[string]string) {
+			//Parse through the results
+			for strmID, tProfile := range result {
+				vParams := lpmscore.VideoProfileToVariantParams(lpmscore.VideoProfileLookup[tProfile])
+				pl, _ := m3u8.NewMediaPlaylist(stream.DefaultHLSStreamWin, stream.DefaultHLSStreamCap)
+				variant := &m3u8.Variant{URI: fmt.Sprintf("%v.m3u8", strmID), Chunklist: pl, VariantParams: vParams}
+				manifest.Append(variant.URI, variant.Chunklist, variant.VariantParams)
+			}
+
+			//Update the master playlist on the network
+			if err = s.LivepeerNode.VideoNetwork.UpdateMasterPlaylist(string(mid), manifest); err != nil {
+				glog.Errorf("Error updating master playlist on network: %v", err)
+				return
+			}
+		})
+
 		glog.Infof("\n\nManifestID: %v\n\n", mid)
 		glog.V(common.SHORT).Infof("\n\nhlsStrmID: %v\n\n", hlsStrmID)
 


### PR DESCRIPTION
After creating a broadcast job, we are not installing the callback to handle transcode result from the transcoder.

We were using BroadcastManifestToNetwork for this, but in the recent refactor stopped using it.  So I removed it for now.  

In general, we shouldn't use basic_hls_manifest and basic_hls_videostream unless we have to.

Closes https://github.com/livepeer/go-livepeer/issues/258