### PR TITLE
Hotfix

### DIFF
--- a/vendor/github.com/livepeer/lpms/README.md
+++ b/vendor/github.com/livepeer/lpms/README.md
@@ -39,10 +39,7 @@ Do the following steps to view a live stream video:
 
 For ffmpeg on osx, run: `ffmpeg -f avfoundation -framerate 30 -pixel_format uyvy422 -i "0:0" -vcodec libx264 -tune zerolatency -b 900k -x264-params keyint=60:min-keyint=60 -f flv rtmp://localhost:1935/stream/test`
 
-For OBS, fill in the information like this:
-
-![OBS Screenshot](https://s3.amazonaws.com/livepeer/obs_screenshot.png)
-
+For OBS, fill in Settings->Stream->URL to be rtmp://localhost:1935
 
 3. If you have successfully uploaded the stream, you should see something like this in the LPMS output
 ```

--- a/vendor/github.com/livepeer/lpms/circle.yml
+++ b/vendor/github.com/livepeer/lpms/circle.yml
@@ -8,11 +8,11 @@ dependencies:
     - "$HOME/.go_workspace/"
     # - "$HOME/ffmpeg-static"
   override:
-    - go get -d github.com/livepeer/lpms/cmd/example
-    - cd $HOME/.go_workspace/src/github.com/livepeer/go-livepeer/ && git pull
+    - mkdir -p "$HOME/.go_workspace/src/github.com/livepeer" && cd "$HOME/.go_workspace/src/github.com/livepeer" && rm -rf go-livepeer && git clone https://github.com/livepeer/go-livepeer
+    - go get github.com/livepeer/lpms/cmd/example
     - cd $HOME/.go_workspace/src/github.com/livepeer/lpms/ && git fetch && git checkout $CIRCLE_BRANCH && git pull
     - npm install -g ffmpeg-static
 
 test:
   override:
-    - bash test.sh
+    - cd "$HOME/.go_workspace/src/github.com/livepeer/lpms" && bash test.sh

--- a/vendor/github.com/livepeer/lpms/cmd/rtmp_segment_packer/main.go
+++ b/vendor/github.com/livepeer/lpms/cmd/rtmp_segment_packer/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"strings"
 
 	"time"
@@ -250,7 +252,11 @@ func main() {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
-	lpms := core.New("1935", "8000", "", "")
+	dir, err := os.Getwd()
+	if err != nil {
+		glog.Infof("Error getting work directory: %v", err)
+	}
+	lpms := core.New("1935", "8000", "", "", fmt.Sprintf("%v/.tmp", dir))
 
 	lpms.HandleRTMPPublish(
 		//makeStreamID

--- a/vendor/github.com/livepeer/lpms/vidlistener/listener.go
+++ b/vendor/github.com/livepeer/lpms/vidlistener/listener.go
@@ -52,7 +52,6 @@ func (self *VidListener) HandleRTMPPublish(
 
 		select {
 		case <-eof:
-			glog.Infof("RTMP publish got eof...")
 			endStream(conn.URL, s)
 			cancel()
 		}


### PR DESCRIPTION
Our fix yesterday introduced a bug - https://github.com/livepeer/go-livepeer/compare/et/lpms-hotfix?expand=1#diff-841eeb1cdc334ad7aeb6e27481f0c69eL65

We changed to an async ReadRTMPFromStream, but still had `defer dst.Close`.  This caused the video to immediately upon exiting the function.  I added a test to check for this.

This change also broke some other tests (external.go is no longer used, so I just fixed the code to the point where the tests will pass).

Also, some code cleanup.