### PR TITLE
Fix Error Code 

### DIFF
--- a/core/videocache.go
+++ b/core/videocache.go
@@ -148,6 +148,7 @@ func (c *BasicVideoCache) GetHLSMediaPlaylist(streamID StreamID) *m3u8.MediaPlay
 				c.segCache[streamID] = cache
 				cache.Insert(&ss.Seg)
 				plChan <- cache.GetMediaPlaylist()
+				return
 			}
 
 			//Add data to cache

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -25,7 +25,6 @@ import (
 	"github.com/livepeer/lpms/vidplayer"
 )
 
-var ErrNotFound = errors.New("ErrNotFound")
 var ErrAlreadyExists = errors.New("StreamAlreadyExists")
 var ErrRTMPPublish = errors.New("ErrRTMPPublish")
 var ErrBroadcast = errors.New("ErrBroadcast")
@@ -308,13 +307,13 @@ func getHLSMasterPlaylistHandler(s *LivepeerServer) func(url *url.URL) (*m3u8.Ma
 	return func(url *url.URL) (*m3u8.MasterPlaylist, error) {
 		manifestID, err := parseManifestID(url.Path)
 		if err != nil {
-			return nil, vidplayer.ErrNotMasterPlaylistID
+			return nil, vidplayer.ErrNotFound
 		}
 
 		//Just load it from the cache (it's already hooked up to the network)
 		manifest := s.LivepeerNode.VideoCache.GetHLSMasterPlaylist(core.ManifestID(manifestID))
 		if manifest == nil {
-			return nil, ErrNotFound
+			return nil, vidplayer.ErrNotFound
 		}
 		return manifest, nil
 	}
@@ -331,7 +330,7 @@ func getHLSMediaPlaylistHandler(s *LivepeerServer) func(url *url.URL) (*m3u8.Med
 		//Get the hls playlist, update the timeout timer
 		pl := s.LivepeerNode.VideoCache.GetHLSMediaPlaylist(strmID)
 		if pl == nil {
-			return nil, ErrNotFound
+			return nil, vidplayer.ErrNotFound
 		}
 		s.hlsSubTimer[strmID] = time.Now()
 		return pl, nil
@@ -347,12 +346,12 @@ func getHLSSegmentHandler(s *LivepeerServer) func(url *url.URL) ([]byte, error) 
 
 		segName := parseSegName(url.Path)
 		if segName == "" {
-			return nil, ErrNotFound
+			return nil, vidplayer.ErrNotFound
 		}
 
 		seg := s.LivepeerNode.VideoCache.GetHLSSegment(strmID, segName)
 		if seg == nil {
-			return nil, ErrNotFound
+			return nil, vidplayer.ErrNotFound
 		} else {
 			return seg.Data, nil
 		}
@@ -373,7 +372,7 @@ func getRTMPStreamHandler(s *LivepeerServer) func(url *url.URL) (stream.RTMPVide
 		strm, ok := s.rtmpStreams[core.StreamID(strmID)]
 		if !ok {
 			glog.Errorf("Cannot find RTMP stream")
-			return nil, ErrNotFound
+			return nil, vidplayer.ErrNotFound
 		}
 
 		//Could use a subscriber, but not going to here because the RTMP stream doesn't need to be available for consumption by multiple views.  It's only for the segmenter.
@@ -413,7 +412,7 @@ func parseManifestID(reqPath string) (core.ManifestID, error) {
 	if mid.IsValid() {
 		return mid, nil
 	} else {
-		return "", ErrNotFound
+		return "", vidplayer.ErrNotFound
 	}
 }
 
@@ -428,7 +427,7 @@ func parseStreamID(reqPath string) (core.StreamID, error) {
 	if sid.IsValid() {
 		return sid, nil
 	} else {
-		return "", ErrNotFound
+		return "", vidplayer.ErrNotFound
 	}
 }
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -331,8 +331,9 @@ func getHLSMediaPlaylistHandler(s *LivepeerServer) func(url *url.URL) (*m3u8.Med
 		pl := s.LivepeerNode.VideoCache.GetHLSMediaPlaylist(strmID)
 		if pl == nil {
 			return nil, vidplayer.ErrNotFound
+		} else {
+			s.hlsSubTimer[strmID] = time.Now()
 		}
-		s.hlsSubTimer[strmID] = time.Now()
 		return pl, nil
 	}
 }

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/lpms/segmenter"
 	"github.com/livepeer/lpms/stream"
+	"github.com/livepeer/lpms/vidplayer"
 )
 
 var S *LivepeerServer
@@ -80,7 +81,7 @@ func (b *StubNetwork) GetMasterPlaylist(nodeID string, strmID string) (chan *m3u
 	mplc := make(chan *m3u8.MasterPlaylist)
 	mpl, ok := b.MPL[strmID]
 	if !ok {
-		return nil, ErrNotFound
+		return nil, vidplayer.ErrNotFound
 	}
 
 	go func() {

--- a/vendor/github.com/livepeer/go-livepeer-basicnet/basic_network.go
+++ b/vendor/github.com/livepeer/go-livepeer-basicnet/basic_network.go
@@ -212,7 +212,7 @@ func (n *BasicVideoNetwork) connectPeerInfo(info peerstore.PeerInfo) error {
 	}
 }
 
-//SendTranscodeResponse tsends the transcode result to the broadcast node.
+//SendTranscodeResponse sends the transcode result to the broadcast node.
 func (n *BasicVideoNetwork) SendTranscodeResponse(broadcaster string, strmID string, transcodedVideos map[string]string) error {
 	//Don't do anything if the node is the transcoder and the broadcaster at the same time.
 	if n.GetNodeID() == broadcaster {
@@ -301,6 +301,13 @@ func (n *BasicVideoNetwork) GetMasterPlaylist(p string, manifestID string) (chan
 		}(returnC, mpl)
 
 		return returnC, nil
+	}
+	nid, err := extractNodeID(manifestID)
+	if err != nil {
+		return nil, ErrGetMasterPlaylist
+	}
+	if n.GetNodeID() == peer.IDHexEncode(nid) {
+		return nil, ErrGetMasterPlaylist
 	}
 	return n.getMasterPlaylistWithRelay(manifestID)
 }

--- a/vendor/github.com/livepeer/lpms/vidplayer/player.go
+++ b/vendor/github.com/livepeer/lpms/vidplayer/player.go
@@ -107,15 +107,15 @@ func handleLive(w http.ResponseWriter, r *http.Request,
 		//Could be a master playlist, or a media playlist
 		var masterPl *m3u8.MasterPlaylist
 		var mediaPl *m3u8.MediaPlaylist
-		masterPl, err := getMasterPlaylist(r.URL) //Return ErrNoMasterPlaylistID to by past the error case
+		masterPl, err := getMasterPlaylist(r.URL) //Return ErrNotFound to indicate passing to mediaPlayList
 		if err != nil {
-			glog.Errorf("Error getting HLS master playlist: %v", err)
 			if err == ErrNotFound {
-				http.Error(w, "ErrNotFound", 404)
+				//Do nothing here, because the call could be for mediaPlaylist
 			} else {
-				http.Error(w, "Error getting master playlist", 404)
+				glog.Errorf("Error getting HLS master playlist: %v", err)
+				http.Error(w, "Error getting master playlist", 500)
+				return
 			}
-			return
 		}
 		if masterPl != nil && len(masterPl.Variants) > 0 {
 			w.Header().Set("Connection", "keep-alive")


### PR DESCRIPTION
Currently we are returning 500 when we can't find a playlist, and the CDN’s default behavior is to keep serving the old asset if it gets a 500 from the origin.

This PR fixes the error codes.  

It also fixes a minor bug when we insert the very first segment into the videoCache twice.

And it contains a small enhancement where we save a trip to the network when we know the stream request is for a local stream.