### PR TITLE
CLI claim action and job service fixes

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -188,7 +188,7 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm eth.
 						glog.Errorf("Error claiming work: %v", err)
 					}
 				} else {
-					glog.Infof("Not segments to claim")
+					glog.Infof("No segments to claim")
 				}
 			}
 			return

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -178,12 +178,17 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm eth.
 			if cm != nil && config.PerformOnchainClaim {
 				glog.V(common.SHORT).Infof("Stream finished. Claiming work.")
 
-				if cm.CanClaim() {
+				canClaim, err := cm.CanClaim()
+				if err != nil {
+					glog.Error(err)
+				}
+
+				if canClaim {
 					if err := cm.ClaimVerifyAndDistributeFees(); err != nil {
 						glog.Errorf("Error claiming work: %v", err)
 					}
 				} else {
-					glog.Infof("No segments to claim")
+					glog.Infof("Not segments to claim")
 				}
 			}
 			return
@@ -198,7 +203,12 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm eth.
 			if !sufficient {
 				glog.V(common.SHORT).Infof("Broadcaster does not have enough funds. Claiming work.")
 
-				if cm.CanClaim() {
+				canClaim, err := cm.CanClaim()
+				if err != nil {
+					glog.Error(err)
+				}
+
+				if canClaim {
 					if err := cm.ClaimVerifyAndDistributeFees(); err != nil {
 						glog.Errorf("Error claiming work: %v", err)
 					}

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -22,7 +22,7 @@ func (cm *StubClaimManager) AddReceipt(seqNo int64, data []byte, tDataHash []byt
 func (cm *StubClaimManager) SufficientBroadcasterDeposit() (bool, error) { return true, nil }
 func (cm *StubClaimManager) ClaimVerifyAndDistributeFees() error         { return nil }
 func (cm *StubClaimManager) DidFirstClaim() bool                         { return false }
-func (cm *StubClaimManager) CanClaim() bool                              { return true }
+func (cm *StubClaimManager) CanClaim() (bool, error)                     { return true, nil }
 
 type StubTranscoder struct {
 	Profiles      []lpmscore.VideoProfile

--- a/eth/claimmanager.go
+++ b/eth/claimmanager.go
@@ -126,7 +126,7 @@ func (c *BasicClaimManager) CanClaim() (bool, error) {
 		return false, err
 	}
 
-	if job.TranscoderAddress == c.client.Account().Address || currentBlk.Number().Cmp(new(big.Int).Add(job.CreationBlock, BlocksUntilFirstClaimDeadline)) == -1 {
+	if job.TranscoderAddress == c.client.Account().Address || currentBlk.Number().Cmp(new(big.Int).Add(job.CreationBlock, BlocksUntilFirstClaimDeadline)) != 1 {
 		return true, nil
 	} else {
 		return false, nil

--- a/eth/claimmanager.go
+++ b/eth/claimmanager.go
@@ -25,7 +25,7 @@ type ClaimManager interface {
 	AddReceipt(seqNo int64, data []byte, tDataHash []byte, bSig []byte, profile lpmscore.VideoProfile) error
 	SufficientBroadcasterDeposit() (bool, error)
 	ClaimVerifyAndDistributeFees() error
-	CanClaim() bool
+	CanClaim() (bool, error)
 	DidFirstClaim() bool
 }
 
@@ -103,8 +103,34 @@ func NewBasicClaimManager(sid string, jid *big.Int, broadcaster common.Address, 
 	}
 }
 
-func (c *BasicClaimManager) CanClaim() bool {
-	return len(c.unclaimedSegs) > 0
+func (c *BasicClaimManager) CanClaim() (bool, error) {
+	// A transcoder can claim if:
+	// - There are unclaimed segments
+	// - If the on-chain job explicitly stores the transcoder's address OR the transcoder was assigned but did not make the first claim and it is within the first 230 blocks of the job's creation block
+	if len(c.unclaimedSegs) == 0 {
+		return false, nil
+	}
+
+	job, err := c.client.GetJob(c.jobID)
+	if err != nil {
+		return false, err
+	}
+
+	backend, err := c.client.Backend()
+	if err != nil {
+		return false, err
+	}
+
+	currentBlk, err := backend.BlockByNumber(context.Background(), nil)
+	if err != nil {
+		return false, err
+	}
+
+	if job.TranscoderAddress == c.client.Account().Address || currentBlk.Number().Cmp(new(big.Int).Add(job.CreationBlock, BlocksUntilFirstClaimDeadline)) == -1 {
+		return true, nil
+	} else {
+		return false, nil
+	}
 }
 
 func (c *BasicClaimManager) DidFirstClaim() bool {

--- a/eth/helpers.go
+++ b/eth/helpers.go
@@ -11,6 +11,10 @@ import (
 	"github.com/golang/glog"
 )
 
+var (
+	BlocksUntilFirstClaimDeadline = big.NewInt(230)
+)
+
 func FormatUnits(baseAmount *big.Int, name string) string {
 	amount := FromBaseUnit(baseAmount)
 

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -68,8 +68,8 @@ func (e *StubClient) Bond(amount *big.Int, toAddr common.Address) (*types.Transa
 func (e *StubClient) Unbond() (*types.Transaction, error)        { return nil, nil }
 func (e *StubClient) WithdrawStake() (*types.Transaction, error) { return nil, nil }
 func (e *StubClient) WithdrawFees() (*types.Transaction, error)  { return nil, nil }
-func (e *StubClient) ClaimTokenPoolsShares(endRound *big.Int) (*types.Transaction, error) {
-	return nil, nil
+func (e *StubClient) ClaimTokenPoolsShares(endRound *big.Int) error {
+	return nil
 }
 func (e *StubClient) GetTranscoder(addr common.Address) (*lpTypes.Transcoder, error) { return nil, nil }
 func (e *StubClient) GetDelegator(addr common.Address) (*lpTypes.Delegator, error)   { return nil, nil }

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -435,13 +435,7 @@ func (s *LivepeerServer) StartWebserver() {
 				return
 			}
 
-			tx, err := s.LivepeerNode.Eth.ClaimTokenPoolsShares(endRound)
-			if err != nil {
-				glog.Error(err)
-				return
-			}
-
-			err = s.LivepeerNode.Eth.CheckTx(tx)
+			err = s.LivepeerNode.Eth.ClaimTokenPoolsShares(endRound)
 			if err != nil {
 				glog.Error(err)
 				return


### PR DESCRIPTION
- Updates the CLI claim rewards/fees action to submit multiple transactions for chunks of rounds instead of trying to loop through all the rounds since the last claim round
- Update the constant `BlocksUntilFirstClaimDeadline` to 230 (previously 200). This number is arbitrary and is a little bit less than the absolute max 256 to give a little flexibility for network congestion
- Update the constant `RoundsPerTokenSharesClaim` to 50 (previously 20). The client will now loop through 50 rounds per claimTokenPoolsShares transaction
- In `jobservice.go` stop watching to perform the first claim if it has been `BlocksUntilFirstClaimDeadline` since the job creation block and there are no claimable segments

Closes #275 and #274 