### PR TITLE
install_ffmpeg: Slim down build.

### DIFF
--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -21,10 +21,23 @@ if [ ! -e "$HOME/x264/x264" ]; then
   make install-lib-static
 fi
 
-if [ ! -e "$HOME/ffmpeg/ffmpeg" ]; then
-  git clone https://git.ffmpeg.org/ffmpeg.git "$HOME/ffmpeg"
+if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
+  git clone https://git.ffmpeg.org/ffmpeg.git "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$HOME/ffmpeg"
-  ./configure --prefix="$HOME/compiled" --enable-gpl --enable-libx264 --disable-sdl2
+  ./configure --disable-programs --disable-doc --disable-sdl2 --disable-iconv \
+    --disable-muxers --disable-demuxers --disable-parsers --disable-protocols \
+    --disable-encoders --disable-decoders --disable-filters --disable-bsfs \
+    --disable-postproc --disable-lzma \
+    --enable-libx264 --enable-gpl \
+    --enable-protocol=rtmp,file \
+    --enable-muxer=mpegts,hls,segment --enable-demuxer=flv,mpegts \
+    --enable-bsf=h264_mp4toannexb,aac_adtstoasc,h264_metadata,h264_redundant_pps \
+    --enable-parser=aac,aac_latm,h264 \
+    --enable-filter=abuffer,buffer,abuffersink,buffersink,afifo,fifo,aformat \
+    --enable-filter=aresample,asetnsamples,fps,scale \
+    --enable-encoder=aac,libx264 \
+    --enable-decoder=aac,h264 \
+    --prefix="$HOME/compiled"
   make
   make install
 fi


### PR DESCRIPTION
Binary Size Comparison, macOS

 .|0.1.11 | 0.1.12 | this
--|------|-------|------
goclient | 40M | 102M | 54M
cli | 31M | 92M | 45M 

~50% reduction in size from 0.1.12. Also decreases build times significantly.

Compatible with the changes that are WIP in the LPMS transcoder.