### PR TITLE
Active event subscriptions and watching loops

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -451,6 +451,7 @@ func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMoni
 	}
 
 	n.Ipfs = ipfsApi
+	n.EthEventMonitor = em
 
 	// Create rounds service to initialize round if it has not already been initialized
 	rds := eventservices.NewRoundsService(em, n.Eth)

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -52,15 +52,16 @@ type PeerConn struct {
 
 //LivepeerNode handles videos going in and coming out of the Livepeer network.
 type LivepeerNode struct {
-	Identity     NodeID
-	Addrs        []string
-	VideoNetwork net.VideoNetwork
-	VideoCache   VideoCache
-	Eth          eth.LivepeerEthClient
-	EthServices  []eth.EventService
-	Ipfs         ipfs.IpfsApi
-	WorkDir      string
-	PeerConns    []PeerConn
+	Identity        NodeID
+	Addrs           []string
+	VideoNetwork    net.VideoNetwork
+	VideoCache      VideoCache
+	Eth             eth.LivepeerEthClient
+	EthEventMonitor eth.EventMonitor
+	EthServices     []eth.EventService
+	Ipfs            ipfs.IpfsApi
+	WorkDir         string
+	PeerConns       []PeerConn
 }
 
 //NewLivepeerNode creates a new Livepeer Node. Eth can be nil.

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -43,7 +43,7 @@ func (s *JobService) Start(ctx context.Context) error {
 	}
 
 	logsCh := make(chan types.Log)
-	sub, err := s.eventMonitor.SubscribeNewJob(ctx, logsCh, common.Address{}, func(l types.Log) (bool, error) {
+	sub, err := s.eventMonitor.SubscribeNewJob(ctx, "NewJob", logsCh, common.Address{}, func(l types.Log) (bool, error) {
 		_, jid, _, _ := parseNewJobLog(l)
 
 		job, err := s.node.Eth.GetJob(jid)
@@ -134,7 +134,7 @@ func (s *JobService) doTranscode(job *lpTypes.Job) (bool, error) {
 
 	firstClaimBlock := new(big.Int).Add(job.CreationBlock, eth.BlocksUntilFirstClaimDeadline)
 	headersCh := make(chan *types.Header)
-	s.eventMonitor.SubscribeNewBlock(context.Background(), headersCh, func(h *types.Header) (bool, error) {
+	s.eventMonitor.SubscribeNewBlock(context.Background(), "FirstClaim", headersCh, func(h *types.Header) (bool, error) {
 		if cm.DidFirstClaim() {
 			// If the first claim has already been made then exit
 			return false, nil

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -134,7 +134,7 @@ func (s *JobService) doTranscode(job *lpTypes.Job) (bool, error) {
 
 	firstClaimBlock := new(big.Int).Add(job.CreationBlock, eth.BlocksUntilFirstClaimDeadline)
 	headersCh := make(chan *types.Header)
-	s.eventMonitor.SubscribeNewBlock(context.Background(), "FirstClaim", headersCh, func(h *types.Header) (bool, error) {
+	s.eventMonitor.SubscribeNewBlock(context.Background(), fmt.Sprintf("FirstClaimForJob%v", job.JobId), headersCh, func(h *types.Header) (bool, error) {
 		if cm.DidFirstClaim() {
 			// If the first claim has already been made then exit
 			return false, nil

--- a/eth/eventservices/rewardservice.go
+++ b/eth/eventservices/rewardservice.go
@@ -36,7 +36,7 @@ func (s *RewardService) Start(ctx context.Context) error {
 	}
 
 	logsCh := make(chan types.Log)
-	sub, err := s.eventMonitor.SubscribeNewRound(ctx, logsCh, func(l types.Log) (bool, error) {
+	sub, err := s.eventMonitor.SubscribeNewRound(ctx, "RoundInitialized", logsCh, func(l types.Log) (bool, error) {
 		round := parseNewRoundLog(l)
 		return s.tryReward(round)
 	})

--- a/eth/eventservices/roundservice.go
+++ b/eth/eventservices/roundservice.go
@@ -68,17 +68,17 @@ func (s *RoundsService) Stop() error {
 }
 
 func (s *RoundsService) tryInitializeRound(blkNum *big.Int, blkHash common.Hash) (bool, error) {
-	currentRound, err := s.client.CurrentRound()
+	initialized, err := s.client.CurrentRoundInitialized()
 	if err != nil {
 		return true, err
 	}
 
-	lastInitializedRound, err := s.client.LastInitializedRound()
-	if err != nil {
-		return true, err
-	}
+	if !initialized {
+		currentRound, err := s.client.CurrentRound()
+		if err != nil {
+			return true, err
+		}
 
-	if lastInitializedRound.Cmp(currentRound) == -1 {
 		roundLength, err := s.client.RoundLength()
 		if err != nil {
 			return true, err
@@ -106,17 +106,12 @@ func (s *RoundsService) tryInitializeRound(blkNum *big.Int, blkHash common.Hash)
 				// initialized the round already or something else went wrong
 				// First check if someone manually initialized the round by
 				// checking if the current round is now initialized
-				currentRound, err = s.client.CurrentRound()
+				initialized, err = s.client.CurrentRoundInitialized()
 				if err != nil {
 					return true, err
 				}
 
-				lastInitializedRound, err = s.client.LastInitializedRound()
-				if err != nil {
-					return true, err
-				}
-
-				if lastInitializedRound.Cmp(currentRound) == -1 {
+				if !initialized {
 					// The current round is not initialized so
 					// no one manually initialized the round so
 					// something else went wrong - stop watching

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -620,6 +620,21 @@ func (s *LivepeerServer) StartWebserver() {
 		}
 	})
 
+	http.HandleFunc("/transcoderEventSubscriptions", func(w http.ResponseWriter, r *http.Request) {
+		if s.LivepeerNode.Eth != nil {
+			activeEventSubMap := s.LivepeerNode.EthEventMonitor.EventSubscriptions()
+
+			data, err := json.Marshal(activeEventSubMap)
+			if err != nil {
+				glog.Error(err)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(data)
+		}
+	})
+
 	http.HandleFunc("/protocolParameters", func(w http.ResponseWriter, r *http.Request) {
 		if s.LivepeerNode.Eth != nil {
 			lp := s.LivepeerNode.Eth


### PR DESCRIPTION
- The event watching loops now log errors, but continue to run unless a transaction in the callback function fails for an unknown reason. For the round initialization event watching loop, if the initializeRound transaction fails, we check if the current round is initialized which would likely mean that someone manually initialized the round. If that is the case, the event watching loop continues, if not, the event watching loop exits because initializeRound failed for an unknown reason (this is to prevent wasted transaction fees). Closes #296
- View active event watching subscriptions in the CLI if the node is set up as a transcoder