### PR TITLE
Check signature on segments from broadcaster as transcoder

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -96,7 +96,7 @@ func main() {
 	testnet := flag.Bool("testnet", false, "Set to true to connect to testnet")
 	rinkeby := flag.Bool("rinkeby", false, "Set to true to connect to rinkeby")
 	controllerAddr := flag.String("controllerAddr", "", "Protocol smart contract address")
-	gasLimit := flag.Int("gasLimit", 4000000, "Gas limit for ETH transactions")
+	gasLimit := flag.Int("gasLimit", 0, "Gas limit for ETH transactions")
 	gasPrice := flag.Int("gasPrice", 4000000000, "Gas price for ETH transactions")
 	monitor := flag.Bool("monitor", false, "Set to true to send performance metrics")
 	monhost := flag.String("monitorhost", "http://viz.livepeer.org:8081/metrics", "host name for the metrics data collector")

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -235,7 +235,7 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm eth.
 
 		//If running in on-chain mode, check that segment was signed by broadcaster ETH address
 		segHash := (&ethTypes.Segment{StreamID: config.StrmID, SegmentSequenceNumber: big.NewInt(int64(seqNo)), DataHash: crypto.Keccak256Hash(ss.Seg.Data)}).Hash()
-		if cm == nil || eth.VerifySig(cm.BroadcasterAddr(), segHash.Bytes(), ss.Sig) {
+		if cm == nil || (cm.BroadcasterAddr() == common.Address{}) || eth.VerifySig(cm.BroadcasterAddr(), segHash.Bytes(), ss.Sig) {
 			glog.V(common.DEBUG).Infof("Verified segment received from stream broadcaster")
 
 			n.transcodeAndBroadcastSeg(&ss.Seg, ss.Sig, cm, t, resultStrmIDs, broadcasters, config)

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -235,7 +235,7 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm eth.
 
 		//If running in on-chain mode, check that segment was signed by broadcaster ETH address
 		segHash := (&ethTypes.Segment{StreamID: config.StrmID, SegmentSequenceNumber: big.NewInt(int64(seqNo)), DataHash: crypto.Keccak256Hash(ss.Seg.Data)}).Hash()
-		if cm == nil || (cm.BroadcasterAddr() == common.Address{}) || eth.VerifySig(cm.BroadcasterAddr(), segHash.Bytes(), ss.Sig) {
+		if cm == nil || (cm.BroadcasterAddr() == ethcommon.Address{}) || eth.VerifySig(cm.BroadcasterAddr(), segHash.Bytes(), ss.Sig) {
 			glog.V(common.DEBUG).Infof("Verified segment received from stream broadcaster")
 
 			n.transcodeAndBroadcastSeg(&ss.Seg, ss.Sig, cm, t, resultStrmIDs, broadcasters, config)

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/net"
 	ffmpeg "github.com/livepeer/lpms/ffmpeg"
@@ -17,6 +18,7 @@ type StubClaimManager struct {
 	distributeFeesCalled bool
 }
 
+func (cm *StubClaimManager) BroadcasterAddr() common.Address { return common.Address{} }
 func (cm *StubClaimManager) AddReceipt(seqNo int64, data []byte, tDataHash []byte, bSig []byte, profile ffmpeg.VideoProfile) error {
 	return nil
 }

--- a/eth/claimmanager.go
+++ b/eth/claimmanager.go
@@ -27,6 +27,7 @@ type ClaimManager interface {
 	ClaimVerifyAndDistributeFees() error
 	CanClaim() (bool, error)
 	DidFirstClaim() bool
+	BroadcasterAddr() common.Address
 }
 
 type claimData struct {
@@ -101,6 +102,10 @@ func NewBasicClaimManager(sid string, jid *big.Int, broadcaster common.Address, 
 		unclaimedSegs:   make(map[int64]bool),
 		claims:          0,
 	}
+}
+
+func (c *BasicClaimManager) BroadcasterAddr() common.Address {
+	return c.broadcasterAddr
 }
 
 func (c *BasicClaimManager) CanClaim() (bool, error) {

--- a/eth/helpers.go
+++ b/eth/helpers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/golang/glog"
 )
@@ -14,6 +15,18 @@ import (
 var (
 	BlocksUntilFirstClaimDeadline = big.NewInt(230)
 )
+
+func VerifySig(addr common.Address, msg, sig []byte) bool {
+	personalMsg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", 32, msg)
+	personalHash := crypto.Keccak256([]byte(personalMsg))
+
+	pubkey, err := crypto.SigToPub(personalHash, sig)
+	if err != nil {
+		return false
+	}
+
+	return crypto.PubkeyToAddress(*pubkey) == addr
+}
 
 func FormatUnits(baseAmount *big.Int, name string) string {
 	amount := FromBaseUnit(baseAmount)


### PR DESCRIPTION
Closes #36 

This PR just adds broadcaster signature verifications by a transcoder when it receives video segments from the broadcaster. I think the player could do broadcaster signature verifications on behalf of stream viewers since it should have access to all the necessary information.