### PR TITLE
Don't block when connecting to the boot node.

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -180,10 +180,12 @@ func main() {
 		}
 		lpmon.Instance().SetBootNode()
 	} else {
-		if err := n.Start(context.Background(), *bootID, *bootAddr); err != nil {
-			glog.Errorf("Cannot connect to bootstrap node: %v", err)
-			return
-		}
+		go func() {
+			if err := n.Start(context.Background(), *bootID, *bootAddr); err != nil {
+				glog.Errorf("Cannot connect to bootstrap node: %v", err)
+				return
+			}
+		}()
 	}
 
 	var gethCmd *exec.Cmd


### PR DESCRIPTION
First attempt, not sure if it's enough to fix https://github.com/livepeer/go-livepeer/issues/266

We still need a story for error handling while connecting to the bootnode.

Even if this patch is enough for #266, I'm a little skeptical of introducing further async operations since it makes handling any dependency errors during startup harder, for example we don't want to start the LPMS listening components if we don't have an established Eth client.