### PR TITLE
fix nil pointer bug

### DIFF
--- a/server/webserver.go
+++ b/server/webserver.go
@@ -696,7 +696,7 @@ func (s *LivepeerServer) StartWebserver() {
 	})
 
 	http.HandleFunc("/transcoderEventSubscriptions", func(w http.ResponseWriter, r *http.Request) {
-		if s.LivepeerNode.Eth != nil {
+		if s.LivepeerNode.Eth != nil && s.LivepeerNode.EthEventMonitor != nil {
 			activeEventSubMap := s.LivepeerNode.EthEventMonitor.EventSubscriptions()
 
 			data, err := json.Marshal(activeEventSubMap)


### PR DESCRIPTION
Got this bug:

```

2018/04/07 20:49:10 http: panic serving [::1]:59712: runtime error: invalid memory address or nil pointer dereference
goroutine 785 [running]:
net/http.(*conn).serve.func1(0xc42068b180)
	/usr/local/go/src/net/http/server.go:1697 +0xd0
panic(0x5063740, 0x5bc7470)
	/usr/local/go/src/runtime/panic.go:491 +0x283
github.com/livepeer/go-livepeer/server.(*LivepeerServer).StartWebserver.func28(0x5af1b00, 0xc420833420, 0xc420101f00)
	/Users/ericxtang/Code/Livepeer/lpdev-data/go/src/github.com/livepeer/go-livepeer/server/webserver.go:700 +0x44
net/http.HandlerFunc.ServeHTTP(0xc420657250, 0x5af1b00, 0xc420833420, 0xc420101f00)
	/usr/local/go/src/net/http/server.go:1918 +0x44
net/http.(*ServeMux).ServeHTTP(0x5bf22a0, 0x5af1b00, 0xc420833420, 0xc420101f00)
	/usr/local/go/src/net/http/server.go:2254 +0x130
net/http.serverHandler.ServeHTTP(0xc420084dd0, 0x5af1b00, 0xc420833420, 0xc420101f00)
	/usr/local/go/src/net/http/server.go:2619 +0xb4
net/http.(*conn).serve(0xc42068b180, 0x5af2b80, 0xc420a4cb00)
	/usr/local/go/src/net/http/server.go:1801 +0x71d
```