### PR TITLE
Don't have to pass `-transcoder` anymore for cli

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -110,7 +110,7 @@ func main() {
 		return
 	}
 
- 	if *rinkeby {
+	if *rinkeby {
 		*bootID = "122019c1a1f0d9fa2296dccb972e7478c5163415cd55722dcf0123553f397c45df7e"
 		*bootAddr = "/ip4/18.217.129.34/tcp/15000"
 
@@ -200,8 +200,8 @@ func main() {
 			//Connect to specified websocket
 			gethUrl = *ethWsUrl
 		} else {
-				glog.Errorf("Cannot connect to production network yet.")
-				return
+			glog.Errorf("Cannot connect to production network yet.")
+			return
 		}
 
 		glog.Infof("Setting up client...")
@@ -387,6 +387,7 @@ func getLPKeys(datadir string) (crypto.PrivKey, crypto.PubKey, error) {
 }
 
 func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMonitor, ipfsPath string) error {
+	n.IsTranscoder = true
 	//Check if transcoder is active
 	active, err := n.Eth.IsActiveTranscoder()
 	if err != nil {

--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -38,10 +38,6 @@ func main() {
 			Value: 4,
 			Usage: "log level to emit to the screen",
 		},
-		cli.BoolFlag{
-			Name:  "transcoder",
-			Usage: "transcoder on off flag",
-		},
 	}
 	app.Action = func(c *cli.Context) error {
 		if c.Bool("version") {
@@ -54,13 +50,13 @@ func main() {
 
 		// Start the wizard and relinquish control
 		w := &wizard{
-			endpoint:   fmt.Sprintf("http://%v:%v/status", c.String("host"), c.String("http")),
-			rtmpPort:   c.String("rtmp"),
-			httpPort:   c.String("http"),
-			host:       c.String("host"),
-			transcoder: c.Bool("transcoder"),
-			in:         bufio.NewReader(os.Stdin),
+			endpoint: fmt.Sprintf("http://%v:%v/status", c.String("host"), c.String("http")),
+			rtmpPort: c.String("rtmp"),
+			httpPort: c.String("http"),
+			host:     c.String("host"),
+			in:       bufio.NewReader(os.Stdin),
 		}
+		w.transcoder = w.isTranscoder()
 		w.run()
 
 		return nil

--- a/cmd/livepeer_cli/wizard_transcoder.go
+++ b/cmd/livepeer_cli/wizard_transcoder.go
@@ -8,6 +8,11 @@ import (
 	lpcommon "github.com/livepeer/go-livepeer/common"
 )
 
+func (w *wizard) isTranscoder() bool {
+	isT := httpGet(fmt.Sprintf("http://%v:%v/IsTranscoder", w.host, w.httpPort))
+	return isT == "true"
+}
+
 func (w *wizard) promptTranscoderConfig() (float64, float64, *big.Int) {
 	var (
 		blockRewardCut  float64

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -68,6 +68,7 @@ type LivepeerNode struct {
 	Ipfs            ipfs.IpfsApi
 	WorkDir         string
 	PeerConns       []PeerConn
+	IsTranscoder    bool
 }
 
 //NewLivepeerNode creates a new Livepeer Node. Eth can be nil.

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -992,4 +992,8 @@ func (s *LivepeerServer) StartWebserver() {
 			}
 		}
 	})
+
+	http.HandleFunc("/IsTranscoder", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(fmt.Sprintf("%v", s.LivepeerNode.IsTranscoder)))
+	})
 }


### PR DESCRIPTION
CLI can determine whether the node is running as a transcoder by querying it first.