### PR TITLE
Early changes to support state recovery

### DIFF
--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -19,7 +19,7 @@ type StubClaimManager struct {
 }
 
 func (cm *StubClaimManager) BroadcasterAddr() common.Address { return common.Address{} }
-func (cm *StubClaimManager) AddReceipt(seqNo int64, data []byte, tDataHash []byte, bSig []byte, profile ffmpeg.VideoProfile) error {
+func (cm *StubClaimManager) AddReceipt(seqNo int64, data []byte, bSig []byte, tData map[ffmpeg.VideoProfile][]byte) error {
 	return nil
 }
 func (cm *StubClaimManager) SufficientBroadcasterDeposit() (bool, error) { return true, nil }

--- a/eth/claimmanager.go
+++ b/eth/claimmanager.go
@@ -121,17 +121,12 @@ func (c *BasicClaimManager) CanClaim() (bool, error) {
 		return false, err
 	}
 
-	backend, err := c.client.Backend()
+	blknum, err := c.client.LatestBlockNum()
 	if err != nil {
 		return false, err
 	}
 
-	currentBlk, err := backend.BlockByNumber(context.Background(), nil)
-	if err != nil {
-		return false, err
-	}
-
-	if job.TranscoderAddress == c.client.Account().Address || currentBlk.Number().Cmp(new(big.Int).Add(job.CreationBlock, BlocksUntilFirstClaimDeadline)) != 1 {
+	if job.TranscoderAddress == c.client.Account().Address || blknum.Cmp(new(big.Int).Add(job.CreationBlock, BlocksUntilFirstClaimDeadline)) != 1 {
 		return true, nil
 	} else {
 		return false, nil

--- a/eth/claimmanager_test.go
+++ b/eth/claimmanager_test.go
@@ -79,6 +79,10 @@ func TestAddReceipt(t *testing.T) {
 	if err := cm.AddReceipt(0, []byte("data"), []byte("sig"), td); err != nil {
 		t.Error("Unexpected error ", err)
 	}
+	// Should get an error due to an already existing receipt
+	if err := cm.AddReceipt(0, []byte("data"), []byte("sig"), td); err == nil {
+		t.Error("Did not get an error where one was expected")
+	}
 
 	if string(cm.segClaimMap[0].segData) != "data" {
 		t.Errorf("Expecting %v, got %v", "data", string(cm.segClaimMap[0].segData))

--- a/eth/claimmanager_test.go
+++ b/eth/claimmanager_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 
-	"github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang/glog"
 	ethTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/livepeer/go-livepeer/ipfs"
@@ -17,9 +17,9 @@ import (
 func TestShouldVerify(t *testing.T) {
 	client := &StubClient{}
 	ps := []ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P360p30fps4x3, ffmpeg.P720p30fps4x3}
-	cm := NewBasicClaimManager("strmID", big.NewInt(5), common.Address{}, big.NewInt(1), ps, client, &ipfs.StubIpfsApi{})
+	cm := NewBasicClaimManager("strmID", big.NewInt(5), ethcommon.Address{}, big.NewInt(1), ps, client, &ipfs.StubIpfsApi{})
 
-	blkHash := common.Hash([32]byte{0, 2, 4, 42, 2, 3, 4, 4, 4, 2, 21, 1, 1, 24, 134, 0, 02, 43})
+	blkHash := ethcommon.Hash([32]byte{0, 2, 4, 42, 2, 3, 4, 4, 4, 2, 21, 1, 1, 24, 134, 0, 02, 43})
 	//Just make sure the results are different
 	same := true
 	var result bool
@@ -38,7 +38,7 @@ func TestShouldVerify(t *testing.T) {
 
 func TestProfileOrder(t *testing.T) {
 	ps := []ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P360p30fps4x3, ffmpeg.P720p30fps4x3}
-	cm := NewBasicClaimManager("strmID", big.NewInt(5), common.Address{}, big.NewInt(1), ps, &StubClient{}, &ipfs.StubIpfsApi{})
+	cm := NewBasicClaimManager("strmID", big.NewInt(5), ethcommon.Address{}, big.NewInt(1), ps, &StubClient{}, &ipfs.StubIpfsApi{})
 
 	if cm.profiles[0] != ffmpeg.P720p30fps4x3 || cm.profiles[1] != ffmpeg.P360p30fps4x3 || cm.profiles[2] != ffmpeg.P240p30fps16x9 {
 		t.Errorf("wrong ordering: %v", cm.profiles)
@@ -47,7 +47,7 @@ func TestProfileOrder(t *testing.T) {
 
 func TestAddReceipt(t *testing.T) {
 	ps := []ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P360p30fps4x3, ffmpeg.P720p30fps4x3}
-	cm := NewBasicClaimManager("strmID", big.NewInt(5), common.Address{}, big.NewInt(1), ps, &StubClient{}, &ipfs.StubIpfsApi{})
+	cm := NewBasicClaimManager("strmID", big.NewInt(5), ethcommon.Address{}, big.NewInt(1), ps, &StubClient{}, &ipfs.StubIpfsApi{})
 
 	//Should get error for adding to a non-existing profile
 	if err := cm.AddReceipt(0, []byte("data"), []byte("tdatahash"), []byte("sig"), ffmpeg.P144p30fps16x9); err == nil {
@@ -79,7 +79,7 @@ func TestAddReceipt(t *testing.T) {
 func setupRanges(t *testing.T) *BasicClaimManager {
 	ethClient := &StubClient{ClaimStart: make([]*big.Int, 0), ClaimEnd: make([]*big.Int, 0), ClaimJid: make([]*big.Int, 0), ClaimRoot: make(map[[32]byte]bool)}
 	ps := []ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P360p30fps4x3, ffmpeg.P720p30fps4x3}
-	cm := NewBasicClaimManager("strmID", big.NewInt(5), common.Address{}, big.NewInt(1), ps, ethClient, &ipfs.StubIpfsApi{})
+	cm := NewBasicClaimManager("strmID", big.NewInt(5), ethcommon.Address{}, big.NewInt(1), ps, ethClient, &ipfs.StubIpfsApi{})
 
 	for _, segRange := range [][2]int64{[2]int64{0, 0}, [2]int64{3, 13}, [2]int64{15, 18}, [2]int64{21, 25}, [2]int64{27, 27}, [2]int64{29, 29}} {
 		for i := segRange[0]; i <= segRange[1]; i++ {
@@ -123,10 +123,10 @@ func TestRanges(t *testing.T) {
 func TestClaimVerifyAndDistributeFees(t *testing.T) {
 	ethClient := &StubClient{ClaimStart: make([]*big.Int, 0), ClaimEnd: make([]*big.Int, 0), ClaimJid: make([]*big.Int, 0), ClaimRoot: make(map[[32]byte]bool)}
 	ps := []ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P360p30fps4x3, ffmpeg.P720p30fps4x3}
-	cm := NewBasicClaimManager("strmID", big.NewInt(5), common.Address{}, big.NewInt(1), ps, ethClient, &ipfs.StubIpfsApi{})
+	cm := NewBasicClaimManager("strmID", big.NewInt(5), ethcommon.Address{}, big.NewInt(1), ps, ethClient, &ipfs.StubIpfsApi{})
 
 	//Add some receipts(0-9)
-	receiptHashes1 := make([]common.Hash, 10)
+	receiptHashes1 := make([]ethcommon.Hash, 10)
 	for i := 0; i < 10; i++ {
 		segTDataHashes := make([][]byte, len(ps))
 		data := []byte(fmt.Sprintf("data%v", i))
@@ -149,7 +149,7 @@ func TestClaimVerifyAndDistributeFees(t *testing.T) {
 	}
 
 	//Add some receipts(15-24)
-	receiptHashes2 := make([]common.Hash, 10)
+	receiptHashes2 := make([]ethcommon.Hash, 10)
 	for i := 15; i < 25; i++ {
 		segTDataHashes := make([][]byte, len(ps))
 		data := []byte(fmt.Sprintf("data%v", i))
@@ -198,15 +198,15 @@ func TestClaimVerifyAndDistributeFees(t *testing.T) {
 // func TestVerify(t *testing.T) {
 // 	ethClient := &StubClient{VeriRate: 10}
 // 	ps := []ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P360p30fps4x3, ffmpeg.P720p30fps4x3}
-// 	cm := NewBasicClaimManager("strmID", big.NewInt(5), common.Address{}, big.NewInt(1), ps, ethClient, &ipfs.StubIpfsApi{})
+// 	cm := NewBasicClaimManager("strmID", big.NewInt(5), ethcommon.Address{}, big.NewInt(1), ps, ethClient, &ipfs.StubIpfsApi{})
 // 	start := int64(0)
 // 	end := int64(100)
 // 	blkNum := int64(100)
 // 	seqNum := int64(10)
 // 	//Find a blkHash that will trigger verification
-// 	var blkHash common.Hash
+// 	var blkHash ethcommon.Hash
 // 	for i := 0; i < 100; i++ {
-// 		blkHash = common.HexToHash(fmt.Sprintf("0xDEADBEEF%v", i))
+// 		blkHash = ethcommon.HexToHash(fmt.Sprintf("0xDEADBEEF%v", i))
 // 		if cm.shouldVerifySegment(seqNum, start, end, blkNum, blkHash, 10) {
 // 			break
 // 		}
@@ -220,7 +220,7 @@ func TestClaimVerifyAndDistributeFees(t *testing.T) {
 // 	seg.claimStart = start
 // 	seg.claimEnd = end
 // 	seg.claimBlkNum = big.NewInt(blkNum)
-// 	ethClient.BlockHashToReturn = common.Hash{}
+// 	ethClient.BlockHashToReturn = ethcommon.Hash{}
 
 // 	if err := cm.Verify(); err != nil {
 // 		t.Errorf("Error: %v", err)

--- a/eth/eventmonitor.go
+++ b/eth/eventmonitor.go
@@ -240,7 +240,7 @@ func (em *eventMonitor) watchLogs(subName string, eventCb logCallback, errCb fun
 				return
 			}
 		case err := <-em.eventSubMap[subName].sub.Err():
-			glog.Errorf("Error with log subscription: %v", err)
+			glog.Errorf("Error with log subscription for %v: %v", subName, err)
 
 			errCb()
 		}
@@ -269,7 +269,7 @@ func (em *eventMonitor) watchBlocks(subName string, sub ethereum.Subscription, h
 				return
 			}
 		case err := <-em.eventSubMap[subName].sub.Err():
-			glog.Errorf("Error with header subscription: %v", err)
+			glog.Errorf("Error with header subscription for %v: %v", subName, err)
 
 			errCb()
 		}

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -149,3 +149,4 @@ func (c *StubClient) VerificationCodeHash() (string, error)            { return 
 func (c *StubClient) ContractAddresses() map[string]common.Address { return nil }
 func (c *StubClient) CheckTx(tx *types.Transaction) error          { return nil }
 func (e *StubClient) Sign(msg []byte) ([]byte, error)              { return nil, nil }
+func (c *StubClient) LatestBlockNum() (*big.Int, error)            { return big.NewInt(0), nil }

--- a/vendor/github.com/livepeer/lpms/circle.yml
+++ b/vendor/github.com/livepeer/lpms/circle.yml
@@ -16,7 +16,7 @@ dependencies:
     # - "$HOME/ffmpeg-static"
   override:
     - mkdir -p "$HOME/.go_workspace/src/github.com/livepeer" && cd "$HOME/.go_workspace/src/github.com/livepeer" && rm -rf go-livepeer && git clone https://github.com/livepeer/go-livepeer
-    - cd $HOME/.go_workspace/src/github.com/livepeer && rm -rf lpms && go get github.com/livepeer/lpms/cmd/example && cd lpms && git fetch && git checkout $CIRCLE_BRANCH && git pull
+    - cd $HOME/.go_workspace/src/github.com/livepeer && rm -rf lpms && go get -d github.com/livepeer/lpms/cmd/example && cd lpms && git fetch && git checkout $CIRCLE_BRANCH && git pull && go build cmd/example/*.go
     - npm install -g ffmpeg-static
 
 test:

--- a/vendor/github.com/livepeer/lpms/cmd/example/main.go
+++ b/vendor/github.com/livepeer/lpms/cmd/example/main.go
@@ -193,7 +193,7 @@ func transcode(hlsStream stream.HLSVideoStream) (func(*stream.HLSSegment, bool),
 		ffmpeg.P576p30fps16x9,
 	}
 	workDir := "./tmp"
-	t := transcoder.NewFFMpegSegmentTranscoder(profiles, "", workDir)
+	t := transcoder.NewFFMpegSegmentTranscoder(profiles, workDir)
 
 	//Create variants in the stream
 	strmIDs := make([]string, len(profiles), len(profiles))

--- a/vendor/github.com/livepeer/lpms/ffmpeg/ffmpeg.go
+++ b/vendor/github.com/livepeer/lpms/ffmpeg/ffmpeg.go
@@ -40,6 +40,7 @@ func Transcode(input string, workDir string, ps []VideoProfile) error {
 	params := make([]C.output_params, len(ps))
 	for i, param := range ps {
 		oname := C.CString(path.Join(workDir, fmt.Sprintf("out%v%v", i, filepath.Base(input))))
+		defer C.free(unsafe.Pointer(oname))
 		res := strings.Split(param.Resolution, "x")
 		if len(res) < 2 {
 			return ErrTranscoderRes

--- a/vendor/github.com/livepeer/lpms/ffmpeg/lpms_ffmpeg.c
+++ b/vendor/github.com/livepeer/lpms/ffmpeg/lpms_ffmpeg.c
@@ -634,7 +634,7 @@ int lpms_transcode(char *inp, output_params *params, int nb_outputs)
   struct input_ctx ictx;
   AVPacket ipkt;
   struct output_ctx outputs[MAX_OUTPUT_SIZE];
-  AVFrame *dframe;
+  AVFrame *dframe = NULL;
 
   memset(&ictx, 0, sizeof ictx);
   memset(outputs, 0, sizeof outputs);


### PR DESCRIPTION
Submitting now to ease review of https://github.com/livepeer/go-livepeer/pull/358, and to minimize potential merge headaches later on as the codebase continues to evolve.

Mostly consists of some helpers, the `AddReceipt` refactor, and a minor change to make `doTranscode` stand on its own, plus fixes to make tests pass.

Each commit should make sense on its own, but bundling them in the same PR for expediency.

Note that the DB changes are not in here yet, since dropping them in is fairly non-invasive at this point.