### PR TITLE
Check if round is initialized before creating a job.

### DIFF
--- a/vendor/github.com/livepeer/lpms/ffmpeg/lpms_ffmpeg.c
+++ b/vendor/github.com/livepeer/lpms/ffmpeg/lpms_ffmpeg.c
@@ -257,7 +257,7 @@ static int open_output(struct output_ctx *octx, struct input_ctx *ictx)
   }
 
   if (!(fmt->flags & AVFMT_NOFILE)) {
-    avio_open(&octx->oc->pb, octx->fname, AVIO_FLAG_WRITE);
+    ret = avio_open(&octx->oc->pb, octx->fname, AVIO_FLAG_WRITE);
     if (ret < 0) em_err("Error opening output file\n");
   }
 

--- a/vendor/github.com/livepeer/lpms/transcoder/ffmpeg_segment_transcoder_test.go
+++ b/vendor/github.com/livepeer/lpms/transcoder/ffmpeg_segment_transcoder_test.go
@@ -187,5 +187,10 @@ func TestInvalidFile(t *testing.T) {
 		t.Error(err)
 	}
 
-	// XXX test bad output file names / directories
+	// test bad output file names / directories
+	tr = NewFFMpegSegmentTranscoder(configs, "/asdf/qwerty!")
+	_, err = tr.Transcode("test.ts")
+	if err == nil || err.Error() != "No such file or directory" {
+		t.Error(err)
+	}
 }

--- a/vendor/github.com/livepeer/lpms/vidlistener/listener.go
+++ b/vendor/github.com/livepeer/lpms/vidlistener/listener.go
@@ -46,6 +46,8 @@ func (self *VidListener) HandleRTMPPublish(
 		err = gotStream(conn.URL, s)
 		if err != nil {
 			glog.Errorf("Error RTMP gotStream handler: %v", err)
+			endStream(conn.URL, s)
+			conn.Close()
 			cancel()
 			return
 		}


### PR DESCRIPTION
New jobs won't be picked up by a transcoder while a round is
uninitialized.

Addresses https://github.com/livepeer/go-livepeer/issues/379

* Should we also stop the incoming RTMP stream? This would give immediate feedback to the broadcaster that their job isn't going through, and software like OBS will retry the stream periodically.
  * On closer inspection of the code in LPMS, it appears that the incoming stream probably *should* already be cancelled if an error is returned from the RTMP stream handler, but that's not the current behavior. Possibly a separate issue within LPMS.
* One implication is you can't create a stream, even for testing purposes, until a transcoder has initialized a round, which may be inconvenient during local testing.