### PR TITLE
ClaimManager builder API

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"sort"
 	"time"
 
 	"github.com/ericxtang/m3u8"
@@ -126,12 +125,7 @@ func (n *LivepeerNode) CreateTranscodeJob(strmID StreamID, profiles []ffmpeg.Vid
 		return ErrNotFound
 	}
 
-	//Sort profiles first
-	sort.Sort(ffmpeg.ByName(profiles))
-	transOpts := []byte{}
-	for _, prof := range profiles {
-		transOpts = append(transOpts, crypto.Keccak256([]byte(prof.Name))[0:4]...)
-	}
+	transOpts := common.ProfilesToTranscodeOpts(profiles)
 
 	//Call eth client to create the job
 	blknum, err := n.Eth.LatestBlockNum()

--- a/eth/claimmanager.go
+++ b/eth/claimmanager.go
@@ -63,7 +63,8 @@ type BasicClaimManager struct {
 }
 
 //NewBasicClaimManager creates a new claim manager.
-func NewBasicClaimManager(sid string, jid *big.Int, broadcaster ethcommon.Address, pricePerSegment *big.Int, p []ffmpeg.VideoProfile, c LivepeerEthClient, ipfs ipfs.IpfsApi) *BasicClaimManager {
+func NewBasicClaimManager(job *ethTypes.Job, c LivepeerEthClient, ipfs ipfs.IpfsApi) *BasicClaimManager {
+	p := job.Profiles
 	seqNos := make([][]int64, len(p), len(p))
 	rHashes := make([][]ethcommon.Hash, len(p), len(p))
 	sd := make([][][]byte, len(p), len(p))
@@ -92,17 +93,17 @@ func NewBasicClaimManager(sid string, jid *big.Int, broadcaster ethcommon.Addres
 	return &BasicClaimManager{
 		client:          c,
 		ipfs:            ipfs,
-		strmID:          sid,
-		jobID:           jid,
+		strmID:          job.StreamId,
+		jobID:           job.JobId,
 		cost:            big.NewInt(0),
-		totalSegCost:    new(big.Int).Mul(pricePerSegment, big.NewInt(int64(len(p)))),
-		broadcasterAddr: broadcaster,
-		pricePerSegment: pricePerSegment,
+		totalSegCost:    new(big.Int).Mul(job.MaxPricePerSegment, big.NewInt(int64(len(p)))),
+		broadcasterAddr: job.BroadcasterAddress,
+		pricePerSegment: job.MaxPricePerSegment,
 		profiles:        p,
 		pLookup:         pLookup,
 		segClaimMap:     make(map[int64]*claimData),
 		unclaimedSegs:   make(map[int64]bool),
-		claims:          0,
+		claims:          job.TotalClaims.Int64(),
 	}
 }
 

--- a/eth/client.go
+++ b/eth/client.go
@@ -647,12 +647,17 @@ func (c *client) GetJob(jobID *big.Int) (*lpTypes.Job, error) {
 		return nil, err
 	}
 
+	profiles, err := common.TxDataToVideoProfile(jInfo.TranscodingOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	return &lpTypes.Job{
 		JobId:              jobID,
 		StreamId:           jInfo.StreamId,
+		Profiles:           profiles,
 		MaxPricePerSegment: jInfo.MaxPricePerSegment,
 		BroadcasterAddress: jInfo.BroadcasterAddress,
-		TranscodingOptions: jInfo.TranscodingOptions,
 		TranscoderAddress:  jInfo.TranscoderAddress,
 		CreationRound:      jInfo.CreationRound,
 		CreationBlock:      jInfo.CreationBlock,

--- a/eth/client.go
+++ b/eth/client.go
@@ -658,6 +658,7 @@ func (c *client) GetJob(jobID *big.Int) (*lpTypes.Job, error) {
 		CreationBlock:      jInfo.CreationBlock,
 		EndBlock:           jInfo.EndBlock,
 		Escrow:             jInfo.Escrow,
+		TotalClaims:        jInfo.TotalClaims,
 		Status:             status,
 	}, nil
 }

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -118,7 +118,7 @@ func (s *JobService) doTranscode(job *lpTypes.Job) (bool, error) {
 	glog.Infof("Transcoder got job %v - strmID: %v, tData: %v, config: %v", job.JobId, job.StreamId, job.Profiles, config)
 
 	//Do The Transcoding
-	cm := eth.NewBasicClaimManager(job.StreamId, job.JobId, job.BroadcasterAddress, job.MaxPricePerSegment, job.Profiles, s.node.Eth, s.node.Ipfs)
+	cm := eth.NewBasicClaimManager(job, s.node.Eth, s.node.Ipfs)
 	tr := transcoder.NewFFMpegSegmentTranscoder(job.Profiles, s.node.WorkDir)
 	strmIDs, err := s.node.TranscodeAndBroadcast(config, cm, tr)
 	if err != nil {

--- a/eth/types/contracts.go
+++ b/eth/types/contracts.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	ffmpeg "github.com/livepeer/lpms/ffmpeg"
 )
 
 var (
@@ -78,7 +79,7 @@ type TokenPools struct {
 type Job struct {
 	JobId              *big.Int
 	StreamId           string
-	TranscodingOptions string
+	Profiles           []ffmpeg.VideoProfile
 	MaxPricePerSegment *big.Int
 	BroadcasterAddress common.Address
 	TranscoderAddress  common.Address

--- a/eth/types/contracts.go
+++ b/eth/types/contracts.go
@@ -86,6 +86,7 @@ type Job struct {
 	CreationBlock      *big.Int
 	EndBlock           *big.Int
 	Escrow             *big.Int
+	TotalClaims        *big.Int
 	Status             string
 }
 


### PR DESCRIPTION
This is mostly to make the API simpler for state recovery.

Store TotalClaims in Job struct https://github.com/livepeer/go-livepeer/commit/d596b81787774e9745d635ba2bd32be7bc6836a6 : **required** for state recovery in order to fetch the correct claim from the blockchain after the claim tx completes. Maybe there's a smarter way to do that rather than incrementing an internal counter (`BasicClaimManager.claims`), but this method works for now [1].

Deserialized profiles in Job struct https://github.com/livepeer/go-livepeer/commit/9358fbec4df2af81d4b4fa562ba9bdfa8442b3ca : not required, but it is good to validate as early as possible, and removes a parameter from the claimmanager API.

Simplify builder API: https://github.com/livepeer/go-livepeer/commit/1162d6fa8ac59d1e6932a58e8f319a153ff9963a : Without this, the BasicClaimManager builder would have 9 parameters once job recovery is merged. Since we need a valid job anyway before creating the claimmanager, we can pass in the job as an arg and take the number of required parameters down to 4 (3 here, plus one more later for the DB handle).

[1] Incrementing a counter isn't enough anymore. https://github.com/livepeer/go-livepeer/pull/358#issuecomment-385144955