### PR TITLE
Add return statement to prevent error message in CLI

### DIFF
--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -176,6 +176,7 @@ func (w *wizard) doCLIOpt(choice string, transcoder bool) {
 		switch choice {
 		case "14":
 			w.callReward()
+			return
 		case "15":
 			w.activateTranscoder()
 			return


### PR DESCRIPTION
The inclusion of the return statement prevents the CLI from printing an error message when the user manually invokes reward.