### PR TITLE
Store and recover jobs.

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -549,6 +549,13 @@ func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMoni
 		return err
 	}
 
+	// Restart jobs as necessary
+	err = js.RestartTranscoder()
+	if err != nil {
+		glog.Errorf("Unable to restart transcoder: %v", err)
+		// non-fatal, so continue
+	}
+
 	return nil
 }
 

--- a/common/db.go
+++ b/common/db.go
@@ -20,6 +20,7 @@ type DB struct {
 	updateKV   *sql.Stmt
 	insertJob  *sql.Stmt
 	selectJobs *sql.Stmt
+	stopReason *sql.Stmt
 }
 
 type DBJob struct {
@@ -31,6 +32,7 @@ type DBJob struct {
 	transcoder  ethcommon.Address
 	startBlock  int64
 	endBlock    int64
+	stopReason  string
 }
 
 var LivepeerDBVersion = 1
@@ -55,7 +57,9 @@ var schema = `
 		broadcaster STRING,
 		transcoder STRING,
 		startBlock INTEGER,
-		endBlock INTEGER
+		endBlock INTEGER,
+		stopReason STRING DEFAULT NULL,
+		stoppedAt STRING DEFAULT NULL
 	);
 `
 
@@ -129,13 +133,22 @@ func InitDB(dbPath string) (*DB, error) {
 	d.insertJob = stmt
 
 	// select all jobs since
-	stmt, err = db.Prepare("SELECT id, streamID, segmentPrice, transcodeOptions, broadcaster, transcoder, startBlock, endBlock FROM jobs WHERE endBlock > ?")
+	stmt, err = db.Prepare("SELECT id, streamID, segmentPrice, transcodeOptions, broadcaster, transcoder, startBlock, endBlock FROM jobs WHERE endBlock > ? AND stopReason IS NULL")
 	if err != nil {
 		glog.Error("Unable to prepare selectjob stmt ", err)
 		d.Close()
 		return nil, err
 	}
 	d.selectJobs = stmt
+
+	// set reason for stopping a job
+	stmt, err = db.Prepare("UPDATE jobs SET stopReason=?, stoppedAt=datetime() WHERE id=?")
+	if err != nil {
+		glog.Error("Unable to prepare stop reason statement ", err)
+		d.Close()
+		return nil, err
+	}
+	d.stopReason = stmt
 
 	glog.V(DEBUG).Info("Initialized DB node")
 	return &d, nil
@@ -151,6 +164,9 @@ func (db *DB) Close() {
 	}
 	if db.selectJobs != nil {
 		db.selectJobs.Close()
+	}
+	if db.stopReason != nil {
+		db.stopReason.Close()
 	}
 	if db.dbh != nil {
 		db.dbh.Close()
@@ -216,4 +232,17 @@ func (db *DB) ActiveJobs(since *big.Int) ([]*DBJob, error) {
 		jobs = append(jobs, &job)
 	}
 	return jobs, nil
+}
+
+func (db *DB) SetStopReason(id *big.Int, reason string) error {
+	if db == nil {
+		return nil
+	}
+	glog.V(DEBUG).Infof("db: Setting StopReason for job %v to %v", id, reason)
+	_, err := db.stopReason.Exec(reason, id.Int64())
+	if err != nil {
+		glog.Error("db: Error setting stop reason ", id, err)
+		return err
+	}
+	return nil
 }

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -140,4 +140,10 @@ func TestDBJobs(t *testing.T) {
 		t.Error("Unexpected error in active jobs ", err, len(jobs))
 		return
 	}
+	// check stop reason filter
+	dbh.SetStopReason(big.NewInt(j.ID), "insufficient lolz")
+	jobs, err = dbh.ActiveJobs(big.NewInt(0))
+	if err != nil || len(jobs) != 2 {
+		t.Error("Unexpected error in active jobs ", err, len(jobs))
+	}
 }

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -6,6 +6,8 @@ import (
 	"math/big"
 	"testing"
 
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/livepeer/lpms/ffmpeg"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -105,5 +107,37 @@ func TestDBVersion(t *testing.T) {
 	}
 	if dbh2 != nil {
 		dbh.Close()
+	}
+}
+
+func NewStubJob() *DBJob {
+	return &DBJob{
+		ID: 0, streamID: "1", price: 0, profiles: []ffmpeg.VideoProfile{},
+		broadcaster: ethcommon.Address{}, transcoder: ethcommon.Address{},
+		startBlock: 1, endBlock: 2,
+	}
+}
+
+func TestDBJobs(t *testing.T) {
+	dbh, dbraw, err := tempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	j := NewStubJob()
+	dbh.InsertJob(j)
+	j.ID = 1
+	dbh.InsertJob(j)
+	endBlock := j.endBlock
+	j.ID = 2
+	j.endBlock += 5
+	dbh.InsertJob(j)
+	jobs, err := dbh.ActiveJobs(big.NewInt(0))
+	if err != nil || len(jobs) != 3 {
+		t.Error("Unexpected error in active jobs ", err, len(jobs))
+		return
+	}
+	jobs, err = dbh.ActiveJobs(big.NewInt(endBlock))
+	if err != nil || len(jobs) != 1 || jobs[0].ID != 2 {
+		t.Error("Unexpected error in active jobs ", err, len(jobs))
+		return
 	}
 }

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -178,6 +178,7 @@ func (n *LivepeerNode) TranscodeAndBroadcast(config net.TranscodeConfig, cm eth.
 		glog.V(common.DEBUG).Infof("Starting to transcode segment %v", seqNo)
 		totalStart := time.Now()
 		if eof {
+			n.Database.SetStopReason(config.JobID, "Stream finished")
 			if cm != nil && config.PerformOnchainClaim {
 				glog.V(common.SHORT).Infof("Stream finished. Claiming work.")
 

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -187,6 +187,32 @@ func (s *JobService) doTranscode(job *lpTypes.Job) (bool, error) {
 	return true, nil
 }
 
+func (s *JobService) RestartTranscoder() error {
+	blknum, err := s.node.Eth.LatestBlockNum()
+	if err != nil {
+		return err
+	}
+	// fetch active jobs
+	jobs, err := s.node.Database.ActiveJobs(blknum)
+	if err != nil {
+		glog.Error("Could not fetch active jobs ", err)
+		return err
+	}
+	for _, j := range jobs {
+		job, err := s.node.Eth.GetJob(big.NewInt(j.ID)) // benchmark; may be faster to reconstruct locally?
+		if err != nil {
+			glog.Error("Unable to get job for ", j.ID, err)
+			continue
+		}
+		res, err := s.doTranscode(job)
+		if !res || err != nil {
+			glog.Error("Unable to restore transcoding of ", j.ID, err)
+			continue
+		}
+	}
+	return nil
+}
+
 func parseNewJobLog(log types.Log) (broadcasterAddr common.Address, jid *big.Int, streamID string, transOptions string) {
 	return common.BytesToAddress(log.Topics[1].Bytes()), new(big.Int).SetBytes(log.Data[0:32]), string(log.Data[192:338]), string(log.Data[338:])
 }

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/golang/glog"
+	lpcommon "github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/eth"
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
@@ -70,6 +71,12 @@ func (s *JobService) Start(ctx context.Context) error {
 		}
 
 		if assignedAddr == s.node.Eth.Account().Address {
+			dbjob := lpcommon.NewDBJob(
+				job.JobId, job.StreamId,
+				job.MaxPricePerSegment, job.Profiles,
+				job.BroadcasterAddress, s.node.Eth.Account().Address,
+				job.CreationBlock, job.EndBlock)
+			s.node.Database.InsertJob(dbjob)
 			return s.doTranscode(job)
 		} else {
 			return true, nil


### PR DESCRIPTION
Note that https://github.com/livepeer/go-livepeer/commit/0404d75b5d4ab043eb25d887c34d53dbb03063d7 follows the table defined in https://github.com/livepeer/go-livepeer/issues/359 . The condition for "Error processing transcoding options" no longer applies since https://github.com/livepeer/go-livepeer/commit/39def8b39680d73611675709bb63333d8ba5608e -- the job is now dropped before the DB entry is written.