### PR TITLE
Store receipts, submit claims for recovered receipts.

### DIFF
--- a/common/db.go
+++ b/common/db.go
@@ -78,6 +78,8 @@ var schema = `
 		stopReason STRING DEFAULT NULL,
 		stoppedAt STRING DEFAULT NULL
 	);
+	-- Index to avoid a full jobs table scan during recovery
+	CREATE INDEX IF NOT EXISTS idx_jobs_endblock_stopreason ON jobs(endBlock, stopReason);
 
 	CREATE TABLE IF NOT EXISTS claims (
 		id INTEGER,
@@ -106,6 +108,7 @@ var schema = `
 		FOREIGN KEY(jobID) REFERENCES jobs(id),
 		FOREIGN KEY(claimID, jobID) REFERENCES claims(id, jobID)
 	);
+	CREATE INDEX IF NOT EXISTS idx_receipts_claimid_errormsg ON receipts(claimID, errorMsg);
 `
 
 func NewDBJob(id *big.Int, streamID string,

--- a/common/db.go
+++ b/common/db.go
@@ -18,11 +18,16 @@ type DB struct {
 	dbh *sql.DB
 
 	// prepared statements
-	updateKV   *sql.Stmt
-	insertJob  *sql.Stmt
-	selectJobs *sql.Stmt
-	stopReason *sql.Stmt
-	insertRec  *sql.Stmt
+	updateKV          *sql.Stmt
+	insertJob         *sql.Stmt
+	selectJobs        *sql.Stmt
+	stopReason        *sql.Stmt
+	insertRec         *sql.Stmt
+	insertClaim       *sql.Stmt
+	countClaims       *sql.Stmt
+	setReceiptClaim   *sql.Stmt
+	setClaimStatus    *sql.Stmt
+	unclaimedReceipts *sql.Stmt
 }
 
 type DBJob struct {
@@ -64,8 +69,21 @@ var schema = `
 		stoppedAt STRING DEFAULT NULL
 	);
 
+	CREATE TABLE IF NOT EXISTS claims (
+		id INTEGER,
+		jobID INTEGER,
+		claimRoot STRING,
+		claimBlock INTEGER,
+		claimedAt STRING DEFAULT CURRENT_TIMESTAMP,
+		updatedAt STRING DEFAULT CURRENT_TIMESTAMP,
+		status STRING DEFAULT 'Created',
+		PRIMARY KEY(id, jobID),
+		FOREIGN KEY(jobID) REFERENCES jobs(id)
+	);
+
 	CREATE TABLE IF NOT EXISTS receipts (
 		jobID INTEGER NOT NULL,
+		claimID INTEGER,
 		seqNo INTEGER NOT NULL,
 		bcastFile STRING,
 		bcastHash STRING,
@@ -75,7 +93,8 @@ var schema = `
 		transcodeEndedAt STRING,
 		errorMsg STRING DEFAULT NULL,
 		PRIMARY KEY(jobID, seqNo),
-		FOREIGN KEY(jobID) REFERENCES jobs(id)
+		FOREIGN KEY(jobID) REFERENCES jobs(id),
+		FOREIGN KEY(claimID, jobID) REFERENCES claims(id, jobID)
 	);
 `
 
@@ -175,6 +194,37 @@ func InitDB(dbPath string) (*DB, error) {
 	}
 	d.insertRec = stmt
 
+	// Claim related prepared statements
+	stmt, err = db.Prepare("INSERT INTO claims(id, jobID, claimRoot) VALUES(?, ?, ?)")
+	if err != nil {
+		glog.Error("Unable to prepare insert claims ", err)
+		d.Close()
+		return nil, err
+	}
+	d.insertClaim = stmt
+	stmt, err = db.Prepare("SELECT count(*) FROM claims WHERE jobID=?")
+	if err != nil {
+		glog.Error("Unable to prepare claim count ", err)
+		d.Close()
+		return nil, err
+	}
+	d.countClaims = stmt
+	stmt, err = db.Prepare("UPDATE receipts SET claimID = ? WHERE jobID = ? AND seqNo BETWEEN ? AND ?")
+	if err != nil {
+		glog.Error("Unable to prepare setclaimid ", err)
+		d.Close()
+		return nil, err
+	}
+	d.setReceiptClaim = stmt
+
+	stmt, err = db.Prepare("UPDATE claims SET status=?, updatedAt=datetime() WHERE jobID=? AND id=?")
+	if err != nil {
+		glog.Error("Unable to prepare  setclaimstatus ", err)
+		d.Close()
+		return nil, err
+	}
+	d.setClaimStatus = stmt
+
 	glog.V(DEBUG).Info("Initialized DB node")
 	return &d, nil
 }
@@ -195,6 +245,15 @@ func (db *DB) Close() {
 	}
 	if db.insertRec != nil {
 		db.insertRec.Close()
+	}
+	if db.insertClaim != nil {
+		db.insertClaim.Close()
+	}
+	if db.setReceiptClaim != nil {
+		db.setReceiptClaim.Close()
+	}
+	if db.setClaimStatus != nil {
+		db.setClaimStatus.Close()
 	}
 	if db.dbh != nil {
 		db.dbh.Close()
@@ -291,6 +350,57 @@ func (db *DB) InsertReceipt(jobID *big.Int, seqNo int64,
 		time2str(tcodeStartedAt), time2str(tcodeEndedAt))
 	if err != nil {
 		glog.Error("db: Error inserting segment ", jobID, err)
+		return err
+	}
+	return nil
+}
+
+func (db *DB) InsertClaim(jobID *big.Int, segRange [2]int64,
+	root [32]byte) (*int64, error) {
+	glog.V(DEBUG).Infof("Inserting claim for job %v", jobID)
+	tx, err := db.dbh.Begin()
+	if err != nil {
+		glog.Error("Unable to begin tx ", err)
+		return nil, err
+	}
+	var claimID int64
+	insert := tx.Stmt(db.insertClaim)
+	count := tx.Stmt(db.countClaims)
+	update := tx.Stmt(db.setReceiptClaim)
+	row := count.QueryRow(jobID.Int64())
+	err = row.Scan(&claimID)
+	if err != nil {
+		glog.Error("Unable to count claims ", err)
+		tx.Rollback()
+		return nil, err
+	}
+	glog.V(DEBUG).Infof("Guessed claim ID to be %v for job %v", claimID, jobID)
+	_, err = insert.Exec(claimID, jobID.Int64(), ethcommon.ToHex(root[:]))
+	if err != nil {
+		glog.Error("Unable to insert claim ", err)
+		tx.Rollback()
+		return nil, err
+	}
+	_, err = update.Exec(claimID, jobID.Int64(), segRange[0], segRange[1])
+	if err != nil {
+		glog.Error("Unable to update segments with claims ", err)
+		tx.Rollback()
+		return nil, err
+	}
+	err = tx.Commit()
+	if err != nil {
+		glog.Error("Unable to commit tx ", err)
+		tx.Rollback()
+		return nil, err
+	}
+	return &claimID, nil
+}
+
+func (db *DB) SetClaimStatus(jobID *big.Int, id int64, status string) error {
+	glog.V(DEBUG).Infof("db: Setting ClaimStatus for job %v claim %v to %v", jobID, id, status)
+	_, err := db.setClaimStatus.Exec(status, jobID.Int64(), id)
+	if err != nil {
+		glog.Error("db: Error setting claim status ", id, err)
 		return err
 	}
 	return nil

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -267,6 +267,7 @@ func (n *LivepeerNode) transcodeAndBroadcastSeg(seg *stream.HLSSegment, sig []by
 		return // TODO return error?
 	}
 
+	transcodeStart := time.Now().UTC()
 	// Ensure length matches expectations. 4 second + 25% wiggle factor, 60fps
 	err := ffmpeg.CheckMediaLen(fname, 4*1.25*1000, 60*4*1.25)
 	if err != nil {
@@ -280,6 +281,7 @@ func (n *LivepeerNode) transcodeAndBroadcastSeg(seg *stream.HLSSegment, sig []by
 		glog.Errorf("Error transcoding seg: %v - %v", seg.Name, err)
 		return
 	}
+	transcodeEnd := time.Now().UTC()
 	tProfileData := make(map[ffmpeg.VideoProfile][]byte, 0)
 	glog.V(common.DEBUG).Infof("Transcoding of segment %v took %v", seg.SeqNo, time.Since(start))
 
@@ -307,7 +309,7 @@ func (n *LivepeerNode) transcodeAndBroadcastSeg(seg *stream.HLSSegment, sig []by
 	}
 	//Don't do the onchain stuff unless specified
 	if cm != nil && config.PerformOnchainClaim {
-		cm.AddReceipt(int64(seg.SeqNo), seg.Data, sig, tProfileData)
+		cm.AddReceipt(int64(seg.SeqNo), seg.Data, sig, tProfileData, transcodeStart, transcodeEnd)
 	}
 }
 

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -19,7 +19,7 @@ type StubClaimManager struct {
 }
 
 func (cm *StubClaimManager) BroadcasterAddr() common.Address { return common.Address{} }
-func (cm *StubClaimManager) AddReceipt(seqNo int64, data []byte, bSig []byte, tData map[ffmpeg.VideoProfile][]byte, tStart time.Time, tEnd time.Time) error {
+func (cm *StubClaimManager) AddReceipt(seqNo int64, fname string, data []byte, bSig []byte, tData map[ffmpeg.VideoProfile][]byte, tStart time.Time, tEnd time.Time) error {
 	return nil
 }
 func (cm *StubClaimManager) SufficientBroadcasterDeposit() (bool, error) { return true, nil }

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -19,7 +19,7 @@ type StubClaimManager struct {
 }
 
 func (cm *StubClaimManager) BroadcasterAddr() common.Address { return common.Address{} }
-func (cm *StubClaimManager) AddReceipt(seqNo int64, data []byte, bSig []byte, tData map[ffmpeg.VideoProfile][]byte) error {
+func (cm *StubClaimManager) AddReceipt(seqNo int64, data []byte, bSig []byte, tData map[ffmpeg.VideoProfile][]byte, tStart time.Time, tEnd time.Time) error {
 	return nil
 }
 func (cm *StubClaimManager) SufficientBroadcasterDeposit() (bool, error) { return true, nil }

--- a/eth/claimmanager_test.go
+++ b/eth/claimmanager_test.go
@@ -75,12 +75,12 @@ func TestAddReceipt(t *testing.T) {
 		ffmpeg.P360p30fps4x3:  []byte("tdatahash"),
 		ffmpeg.P240p30fps16x9: []byte("tdatahash"),
 	}
-	if err := cm.AddReceipt(0, []byte("data"), []byte("sig"), td, tStart, tEnd); err == nil {
+	if err := cm.AddReceipt(0, "", []byte("data"), []byte("sig"), td, tStart, tEnd); err == nil {
 		t.Error("Expecting an error for mismatched profile legnths.")
 	}
 	//Should get error for adding to a non-existing profile
 	td[ffmpeg.P144p30fps16x9] = []byte("tdatahash")
-	if err := cm.AddReceipt(0, []byte("data"), []byte("sig"), td, tStart, tEnd); err == nil {
+	if err := cm.AddReceipt(0, "", []byte("data"), []byte("sig"), td, tStart, tEnd); err == nil {
 		t.Error("Expecting an error for adding to a non-existing profile.")
 	}
 	// Should pass
@@ -89,11 +89,11 @@ func TestAddReceipt(t *testing.T) {
 		ffmpeg.P240p30fps16x9: []byte("tdatahash"),
 		ffmpeg.P720p30fps4x3:  []byte("tdatahash"),
 	}
-	if err := cm.AddReceipt(0, []byte("data"), []byte("sig"), td, tStart, tEnd); err != nil {
+	if err := cm.AddReceipt(0, "", []byte("data"), []byte("sig"), td, tStart, tEnd); err != nil {
 		t.Error("Unexpected error ", err)
 	}
 	// Should get an error due to an already existing receipt
-	if err := cm.AddReceipt(0, []byte("data"), []byte("sig"), td, tStart, tEnd); err == nil {
+	if err := cm.AddReceipt(0, "", []byte("data"), []byte("sig"), td, tStart, tEnd); err == nil {
 		t.Error("Did not get an error where one was expected")
 	}
 
@@ -131,7 +131,7 @@ func setupRanges(t *testing.T) *BasicClaimManager {
 			}
 			data := []byte(fmt.Sprintf("data%v", i))
 			sig := []byte(fmt.Sprintf("sig%v", i))
-			if err := cm.AddReceipt(int64(i), data, sig, td, tStart, tEnd); err != nil {
+			if err := cm.AddReceipt(int64(i), "", data, sig, td, tStart, tEnd); err != nil {
 				t.Errorf("Error: %v", err)
 			}
 			if i == 16 {
@@ -148,7 +148,7 @@ func setupRanges(t *testing.T) *BasicClaimManager {
 	td := map[ffmpeg.VideoProfile][]byte{
 		p: []byte(fmt.Sprintf("hash%v%v", p, i)),
 	}
-	if err := cm.AddReceipt(int64(i), data, sig, td, tStart, tEnd); err == nil {
+	if err := cm.AddReceipt(int64(i), "", data, sig, td, tStart, tEnd); err == nil {
 		t.Errorf("Did not get an error when expecting one")
 	}
 
@@ -181,7 +181,7 @@ func TestClaimVerifyAndDistributeFees(t *testing.T) {
 		for _, p := range ps {
 			td[p] = []byte(fmt.Sprintf("tHash%v%v", ffmpeg.P240p30fps16x9.Name, i)) // ???
 		}
-		if err := cm.AddReceipt(int64(i), data, sig, td, tStart, tEnd); err != nil {
+		if err := cm.AddReceipt(int64(i), "", data, sig, td, tStart, tEnd); err != nil {
 			t.Errorf("Error: %v", err)
 		}
 
@@ -204,7 +204,7 @@ func TestClaimVerifyAndDistributeFees(t *testing.T) {
 		for _, p := range ps {
 			td[p] = []byte(fmt.Sprintf("tHash%v%v", ffmpeg.P240p30fps16x9.Name, i)) // ???
 		}
-		if err := cm.AddReceipt(int64(i), data, sig, td, tStart, tEnd); err != nil {
+		if err := cm.AddReceipt(int64(i), "", data, sig, td, tStart, tEnd); err != nil {
 			t.Errorf("Error: %v", err)
 		}
 		receipt := &ethTypes.TranscodeReceipt{

--- a/eth/claimmanager_test.go
+++ b/eth/claimmanager_test.go
@@ -166,7 +166,7 @@ func TestRanges(t *testing.T) {
 }
 
 func TestClaimVerifyAndDistributeFees(t *testing.T) {
-	ethClient := &StubClient{ClaimStart: make([]*big.Int, 0), ClaimEnd: make([]*big.Int, 0), ClaimJid: make([]*big.Int, 0), ClaimRoot: make(map[[32]byte]bool)}
+	ethClient := &StubClient{ClaimStart: make([]*big.Int, 0), ClaimEnd: make([]*big.Int, 0), ClaimJid: make([]*big.Int, 0), ClaimRoot: make(map[[32]byte]bool), Claims: make(map[int]*ethTypes.Claim)}
 	ps := []ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P360p30fps4x3, ffmpeg.P720p30fps4x3}
 	cm := NewBasicClaimManager(newJob(), ethClient, &ipfs.StubIpfsApi{}, nil)
 	tStart := time.Now().UTC()

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -131,7 +131,7 @@ func (s *JobService) doTranscode(job *lpTypes.Job) (bool, error) {
 	glog.Infof("Transcoder got job %v - strmID: %v, tData: %v, config: %v", job.JobId, job.StreamId, job.Profiles, config)
 
 	//Do The Transcoding
-	cm := eth.NewBasicClaimManager(job, s.node.Eth, s.node.Ipfs)
+	cm := eth.NewBasicClaimManager(job, s.node.Eth, s.node.Ipfs, s.node.Database)
 	tr := transcoder.NewFFMpegSegmentTranscoder(job.Profiles, s.node.WorkDir)
 	strmIDs, err := s.node.TranscodeAndBroadcast(config, cm, tr)
 	if err != nil {

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -191,6 +191,9 @@ func (s *JobService) doTranscode(job *lpTypes.Job) (bool, error) {
 }
 
 func (s *JobService) RestartTranscoder() error {
+
+	eth.RecoverClaims(s.node.Eth, s.node.Ipfs, s.node.Database)
+
 	blknum, err := s.node.Eth.LatestBlockNum()
 	if err != nil {
 		return err

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -32,6 +32,7 @@ type StubClient struct {
 	JobsMap           map[string]*lpTypes.Job
 	BlockNum          *big.Int
 	BlockHashToReturn common.Hash
+	Claims            map[int]*lpTypes.Claim
 }
 
 func (e *StubClient) Setup(password string, gasLimit uint64, gasPrice *big.Int) error { return nil }
@@ -94,6 +95,10 @@ func (e *StubClient) ClaimWork(jobId *big.Int, segmentRange [2]*big.Int, claimRo
 	e.ClaimStart = append(e.ClaimStart, segmentRange[0])
 	e.ClaimEnd = append(e.ClaimEnd, segmentRange[1])
 	e.ClaimRoot[claimRoot] = true
+	e.Claims[e.ClaimCounter-1] = &lpTypes.Claim{
+		SegmentRange: segmentRange,
+		ClaimRoot:    claimRoot,
+	}
 	return nil, nil
 }
 func (e *StubClient) Verify(jobId *big.Int, claimId *big.Int, segmentNumber *big.Int, dataStorageHash string, dataHashes [2][32]byte, broadcasterSig []byte, proof []byte) (*types.Transaction, error) {
@@ -122,7 +127,7 @@ func (e *StubClient) GetJob(jobID *big.Int) (*lpTypes.Job, error) {
 	return nil, nil
 }
 func (c *StubClient) GetClaim(jobID *big.Int, claimID *big.Int) (*lpTypes.Claim, error) {
-	return nil, nil
+	return c.Claims[int(claimID.Int64())], nil
 }
 func (c *StubClient) NumJobs() (*big.Int, error) { return big.NewInt(0), nil }
 


### PR DESCRIPTION
Note that https://github.com/livepeer/go-livepeer/commit/2dbed04baaf9bf03142895175f46f7c5f9a4a6ca fixes https://github.com/livepeer/go-livepeer/issues/352 . If the claims process fails any time after submitting the tx, the segments will have to be cleaned up from disk manually (we don't yet attempt to fixup such claim transactions, either). See the note here: https://github.com/livepeer/go-livepeer/commit/2dbed04baaf9bf03142895175f46f7c5f9a4a6ca#diff-a776aba743c0cf86c5c34fc5236506eeR493