### PR TITLE
claimmanager: Prevent segment replay attacks after recovery.

### DIFF
--- a/common/db_test.go
+++ b/common/db_test.go
@@ -204,6 +204,39 @@ func TestDBReceipts(t *testing.T) {
 		t.Error("Unexpected number of receipts for job")
 		return
 	}
+
+	// Receipt checking functions.
+
+	// Ensure that the receipt we just inserted exists
+	exists, err := dbh.ReceiptExists(big.NewInt(job.ID), 1)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if !exists {
+		t.Error("Expected segment to exist in DB")
+		return
+	}
+	// Ensure a nonexistent receipt does not exist: valid job, invalid seg
+	exists, err = dbh.ReceiptExists(big.NewInt(job.ID), 10)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if exists {
+		t.Error("Did not expect a segment to exist")
+		return
+	}
+	// Ensure a nonexistent receipt does not exist: invalid job, seg exists elsewhere
+	exists, err = dbh.ReceiptExists(big.NewInt(10), 1)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if exists {
+		t.Error("Did not expect a segment to exist")
+		return
+	}
 }
 
 func TestDBClaims(t *testing.T) {

--- a/eth/claimmanager.go
+++ b/eth/claimmanager.go
@@ -224,12 +224,15 @@ func (c *BasicClaimManager) AddReceipt(seqNo int64,
 		claimConcatTDatahash: tHash,
 	}
 
+	if err := c.db.InsertReceipt(c.jobID, seqNo, bDataFile, bHash, bSig, tHash, tStart, tEnd); err != nil {
+		return err
+	}
+
 	c.cost = new(big.Int).Add(c.cost, c.totalSegCost)
 	c.segClaimMap[seqNo] = cd
 	c.unclaimedSegs[seqNo] = true
 	// glog.Infof("Added %v. unclaimSegs: %v", seqNo, c.unclaimedSegs)
 
-	c.db.InsertReceipt(c.jobID, seqNo, bDataFile, bHash, bSig, tHash, tStart, tEnd)
 	return nil
 }
 


### PR DESCRIPTION
DB uniqueness constraints are used to tell us whether there's
an existing segment with the same number.

After thinking over https://github.com/livepeer/go-livepeer/issues/418 , I realized that we do indeed have a problem with replayed sequence numbers. This is due to recovered jobs not having a record of previous receipts.

This fixes that by actually checking the return code from the DB.