### PR TITLE
Miscellaneous fixes.

### DIFF
--- a/common/db.go
+++ b/common/db.go
@@ -406,7 +406,7 @@ func (db *DB) InsertReceipt(jobID *big.Int, seqNo int64,
 	}
 	glog.V(DEBUG).Infof("db: Inserting receipt for job %v - %v", jobID.String(), seqNo)
 	time2str := func(t time.Time) string {
-		return t.UTC().Format("2006-01-02 15:04:05")
+		return t.UTC().Format("2006-01-02 15:04:05.000")
 	}
 	_, err := db.insertRec.Exec(jobID.Int64(), seqNo, bcastFile,
 		ethcommon.ToHex(bcastHash), ethcommon.ToHex(bcastSig),

--- a/common/db.go
+++ b/common/db.go
@@ -38,7 +38,7 @@ type DBJob struct {
 	price       int64
 	profiles    []ffmpeg.VideoProfile
 	broadcaster ethcommon.Address
-	transcoder  ethcommon.Address
+	Transcoder  ethcommon.Address
 	startBlock  int64
 	endBlock    int64
 	stopReason  string
@@ -118,7 +118,7 @@ func NewDBJob(id *big.Int, streamID string,
 	startBlock *big.Int, endBlock *big.Int) *DBJob {
 	return &DBJob{
 		ID: id.Int64(), streamID: streamID, profiles: profiles,
-		price: segmentPrice.Int64(), broadcaster: broadcaster, transcoder: transcoder,
+		price: segmentPrice.Int64(), broadcaster: broadcaster, Transcoder: transcoder,
 		startBlock: startBlock.Int64(), endBlock: endBlock.Int64(),
 	}
 }
@@ -327,7 +327,7 @@ func (db *DB) InsertJob(job *DBJob) error {
 	options := ethcommon.ToHex(ProfilesToTranscodeOpts(job.profiles))
 	glog.V(DEBUG).Info("db: Inserting job ", job.ID)
 	_, err := db.insertJob.Exec(job.ID, job.streamID, job.price, options,
-		job.broadcaster.String(), job.transcoder.String(),
+		job.broadcaster.String(), job.Transcoder.String(),
 		job.startBlock, job.endBlock)
 	if err != nil {
 		glog.Error("db: Unable to insert job ", err)
@@ -360,7 +360,7 @@ func (db *DB) ActiveJobs(since *big.Int) ([]*DBJob, error) {
 		if err != nil {
 			glog.Error("Unable to convert transcode options into ffmpeg profile ", err)
 		}
-		job.transcoder = ethcommon.HexToAddress(transcoder)
+		job.Transcoder = ethcommon.HexToAddress(transcoder)
 		job.broadcaster = ethcommon.HexToAddress(broadcaster)
 		job.profiles = profiles
 		jobs = append(jobs, &job)

--- a/common/db.go
+++ b/common/db.go
@@ -324,7 +324,7 @@ func (db *DB) InsertJob(job *DBJob) error {
 	if db == nil {
 		return nil
 	}
-	options := ethcommon.ToHex(ProfilesToTranscodeOpts(job.profiles))
+	options := ethcommon.ToHex(ProfilesToTranscodeOpts(job.profiles))[2:]
 	glog.V(DEBUG).Info("db: Inserting job ", job.ID)
 	_, err := db.insertJob.Exec(job.ID, job.streamID, job.price, options,
 		job.broadcaster.String(), job.Transcoder.String(),
@@ -356,7 +356,7 @@ func (db *DB) ActiveJobs(since *big.Int) ([]*DBJob, error) {
 			glog.Error("db: Unable to fetch job ", err)
 			continue
 		}
-		profiles, err := TxDataToVideoProfile(string(ethcommon.FromHex(options)))
+		profiles, err := TxDataToVideoProfile(options)
 		if err != nil {
 			glog.Error("Unable to convert transcode options into ffmpeg profile ", err)
 		}

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -113,10 +113,26 @@ func TestDBVersion(t *testing.T) {
 
 func NewStubJob() *DBJob {
 	return &DBJob{
-		ID: 0, streamID: "1", price: 0, profiles: []ffmpeg.VideoProfile{},
-		broadcaster: ethcommon.Address{}, Transcoder: ethcommon.Address{},
+		ID: 0, streamID: "1", price: 0,
+		profiles: []ffmpeg.VideoProfile{
+			ffmpeg.P720p60fps16x9,
+			ffmpeg.P360p30fps4x3,
+			ffmpeg.P144p30fps16x9,
+		}, broadcaster: ethcommon.Address{}, Transcoder: ethcommon.Address{},
 		startBlock: 1, endBlock: 2,
 	}
+}
+
+func profilesMatch(j1 []ffmpeg.VideoProfile, j2 []ffmpeg.VideoProfile) bool {
+	if len(j1) != len(j2) {
+		return false
+	}
+	for i, v := range j1 {
+		if j2[i] != v {
+			return false
+		}
+	}
+	return true
 }
 
 func TestDBJobs(t *testing.T) {
@@ -140,6 +156,9 @@ func TestDBJobs(t *testing.T) {
 	if err != nil || len(jobs) != 1 || jobs[0].ID != 2 {
 		t.Error("Unexpected error in active jobs ", err, len(jobs))
 		return
+	}
+	if !profilesMatch(jobs[0].profiles, j.profiles) {
+		t.Error("Mismatched profiles in query")
 	}
 	// check stop reason filter
 	dbh.SetStopReason(big.NewInt(j.ID), "insufficient lolz")

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -114,7 +114,7 @@ func TestDBVersion(t *testing.T) {
 func NewStubJob() *DBJob {
 	return &DBJob{
 		ID: 0, streamID: "1", price: 0, profiles: []ffmpeg.VideoProfile{},
-		broadcaster: ethcommon.Address{}, transcoder: ethcommon.Address{},
+		broadcaster: ethcommon.Address{}, Transcoder: ethcommon.Address{},
 		startBlock: 1, endBlock: 2,
 	}
 }

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -52,6 +52,10 @@ func (s *JobService) Start(ctx context.Context) error {
 		var job *lpTypes.Job
 		getJob := func() error {
 			j, err := s.node.Eth.GetJob(jid)
+			if err != nil || j == nil {
+				glog.Errorf("Unable to get job %v, try again. Error: %v", jid, err)
+				return err
+			}
 			if j.StreamId == "" {
 				glog.Errorf("Got empty job for id:%v. Should try again.", jid.Int64())
 				return errors.New("ErrGetJob")

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -165,6 +165,11 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 			}
 		}
 
+		// We can only have one concurrent stream for now
+		if len(s.rtmpStreams) > 0 {
+			return ErrAlreadyExists
+		}
+
 		//Check if stream ID already exists
 		if _, ok := s.rtmpStreams[core.StreamID(rtmpStrm.GetStreamID())]; ok {
 			return ErrAlreadyExists

--- a/vendor/github.com/livepeer/lpms/ffmpeg/ffmpeg.go
+++ b/vendor/github.com/livepeer/lpms/ffmpeg/ffmpeg.go
@@ -18,16 +18,18 @@ import "C"
 
 var ErrTranscoderRes = errors.New("TranscoderInvalidResolution")
 
-func RTMPToHLS(localRTMPUrl string, outM3U8 string, tmpl string, seglen_secs string) error {
+func RTMPToHLS(localRTMPUrl string, outM3U8 string, tmpl string, seglen_secs string, seg_start int) error {
 	inp := C.CString(localRTMPUrl)
 	outp := C.CString(outM3U8)
 	ts_tmpl := C.CString(tmpl)
 	seglen := C.CString(seglen_secs)
-	ret := int(C.lpms_rtmp2hls(inp, outp, ts_tmpl, seglen))
+	segstart := C.CString(fmt.Sprintf("%v", seg_start))
+	ret := int(C.lpms_rtmp2hls(inp, outp, ts_tmpl, seglen, segstart))
 	C.free(unsafe.Pointer(inp))
 	C.free(unsafe.Pointer(outp))
 	C.free(unsafe.Pointer(ts_tmpl))
 	C.free(unsafe.Pointer(seglen))
+	C.free(unsafe.Pointer(segstart))
 	if 0 != ret {
 		glog.Infof("RTMP2HLS Transmux Return : %v\n", Strerror(ret))
 		return ErrorMap[ret]

--- a/vendor/github.com/livepeer/lpms/ffmpeg/lpms_ffmpeg.c
+++ b/vendor/github.com/livepeer/lpms/ffmpeg/lpms_ffmpeg.c
@@ -50,7 +50,7 @@ void lpms_deinit()
 // Segmenter
 //
 
-int lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char* seg_time)
+int lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char* seg_time, char *seg_start)
 {
 #define r2h_err(str) {\
   if (!ret) ret = 1; \
@@ -98,6 +98,7 @@ int lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char* seg_time)
 
   av_dict_set(&md, "hls_time", seg_time, 0);
   av_dict_set(&md, "hls_segment_filename", ts_tmpl, 0);
+  av_dict_set(&md, "start_number", seg_start, 0);
   ret = avformat_write_header(oc, &md);
   if (ret < 0) r2h_err("Error writing header\n");
 

--- a/vendor/github.com/livepeer/lpms/ffmpeg/lpms_ffmpeg.h
+++ b/vendor/github.com/livepeer/lpms/ffmpeg/lpms_ffmpeg.h
@@ -8,6 +8,6 @@ typedef struct {
 
 void lpms_init();
 void lpms_deinit();
-int  lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char *seg_time);
+int  lpms_rtmp2hls(char *listen, char *outf, char *ts_tmpl, char *seg_time, char *seg_start);
 int  lpms_transcode(char *inp, output_params *params, int nb_outputs);
 int  lpms_length(char *inp, int ts_max, int packet_max);


### PR DESCRIPTION
https://github.com/livepeer/go-livepeer/commit/a79d7f9167612d0301a4932b0ac409af6b5a04b1 : Needed to support delayed broadcasting.

https://github.com/livepeer/go-livepeer/commit/b257b329b2aa71b26489cbb0b0b656091191ba5f : First checkbox of https://github.com/livepeer/go-livepeer/issues/316#issuecomment-386110923

https://github.com/livepeer/go-livepeer/commit/a7bc096da6afead60052e90f62a9ad0752bfb4ff : Minor change to how we track transcoded timestamps in the DB. Seconds are not granular enough.

https://github.com/livepeer/go-livepeer/commit/f89837dde95ee384dfde24129b878269b7ea291b : This is technically a breaking change since it changes how profiles are stored in the DB. We could avoid breaking old clients by trimming `0x` at select time rather than insert time, but I think the impact of this change should be minimal -- the profile field is not used anywhere right now, and we don't have that many jobs on the network.

https://github.com/livepeer/go-livepeer/commit/9dbae48ff002c6a8944615b431c6709829ad7a02 : Fixes https://github.com/livepeer/go-livepeer/issues/422#issuecomment-387633706 . Wasn't able to reproduce the crash under non-artificial conditions, but at least two people have reported it.

https://github.com/livepeer/go-livepeer/commit/0448dede03189ad555602ec19fbd92fcf998e9d1 : Pending https://github.com/livepeer/lpms/pull/77