### PR TITLE
Use polling instead of event subscriptions for reward service 

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -523,7 +523,7 @@ func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMoni
 	}
 
 	// Create reward service to claim/distribute inflationary rewards every round
-	rs := eventservices.NewRewardService(em, n.Eth)
+	rs := eventservices.NewRewardService(n.Eth)
 	n.EthServices = append(n.EthServices, rs)
 
 	// Create job service to listen for new jobs and transcode if assigned to the job


### PR DESCRIPTION
Switch to polling instead of event subscriptions for the reward service for interim stability purposes. The transcoder node will check if it should call reward every interval (currently set to 30 minutes).

Closes #421