### PR TITLE
Add the ability to configure gas price

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -85,7 +85,7 @@ func main() {
 	devenv := flag.Bool("devenv", false, "Set to true to enable devenv")
 	controllerAddr := flag.String("controllerAddr", "", "Protocol smart contract address")
 	gasLimit := flag.Int("gasLimit", 0, "Gas limit for ETH transactions")
-	gasPrice := flag.Int("gasPrice", 4000000000, "Gas price for ETH transactions")
+	gasPrice := flag.Int("gasPrice", 0, "Gas price for ETH transactions")
 	monitor := flag.Bool("monitor", false, "Set to true to send performance metrics")
 	monhost := flag.String("monitorhost", "http://viz.livepeer.org:8081/metrics", "host name for the metrics data collector")
 	ipfsPath := flag.String("ipfsPath", fmt.Sprintf("%v/.ipfs", usr.HomeDir), "IPFS path")

--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -102,6 +102,7 @@ func (w *wizard) initializeOptions() []wizardOpt {
 		{desc: "Invoke \"deposit\" (ETH)", invoke: w.deposit, notTranscoder: true},
 		{desc: "Invoke \"withdraw deposit\" (ETH)", invoke: w.withdraw, notTranscoder: true},
 		{desc: "Set broadcast config", invoke: w.setBroadcastConfig, notTranscoder: true},
+		{desc: "Set Eth gas price", invoke: w.setGasPrice},
 		{desc: "Get test LPT", invoke: w.requestTokens, rinkeby: true},
 		{desc: "Get test ETH", invoke: func() {
 			fmt.Print("For Rinkeby Eth, go to the Rinkeby faucet (https://faucet.rinkeby.io/).")

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -435,3 +435,13 @@ func (w *wizard) getDelegatorInfo() (lpTypes.Delegator, error) {
 
 	return dInfo, nil
 }
+
+func (w *wizard) getGasPrice() string {
+	g := httpGet(fmt.Sprintf("http://%v:%v/gasPrice", w.host, w.httpPort))
+	if g == "" {
+		g = "Unknown"
+	} else if g == "0" {
+		g = "automatic"
+	}
+	return g
+}

--- a/eth/client.go
+++ b/eth/client.go
@@ -367,6 +367,20 @@ func (c *client) Backend() (*ethclient.Client, error) {
 	}
 }
 
+// Rounds
+func (c *client) InitializeRound() (*types.Transaction, error) {
+	i, err := c.RoundsManagerSession.CurrentRoundInitialized()
+	if err != nil {
+		return nil, err
+	}
+	if i {
+		glog.V(common.SHORT).Infof("Round already initialized")
+		return nil, errors.New("ErrRoundInitialized")
+	} else {
+		return c.RoundsManagerSession.InitializeRound()
+	}
+}
+
 // Staking
 
 func (c *client) Transcoder(blockRewardCut, feeShare, pricePerSegment *big.Int) (*types.Transaction, error) {

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -155,3 +155,5 @@ func (c *StubClient) ContractAddresses() map[string]common.Address { return nil 
 func (c *StubClient) CheckTx(tx *types.Transaction) error          { return nil }
 func (e *StubClient) Sign(msg []byte) ([]byte, error)              { return nil, nil }
 func (c *StubClient) LatestBlockNum() (*big.Int, error)            { return big.NewInt(0), nil }
+func (c *StubClient) GetGasInfo() (uint64, *big.Int)               { return 0, nil }
+func (c *StubClient) SetGasInfo(uint64, *big.Int) error            { return nil }

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -1046,4 +1046,31 @@ func (s *LivepeerServer) StartWebserver() {
 		}
 		w.Write([]byte(fmt.Sprintf("%v", result)))
 	})
+
+	http.HandleFunc("/gasPrice", func(w http.ResponseWriter, r *http.Request) {
+		_, gprice := s.LivepeerNode.Eth.GetGasInfo()
+		w.Write([]byte(gprice.String()))
+	})
+
+	http.HandleFunc("/setGasPrice", func(w http.ResponseWriter, r *http.Request) {
+		amount := r.FormValue("amount")
+		if amount == "" {
+			glog.Errorf("Need to set amount")
+			return
+		}
+
+		gprice, err := lpcommon.ParseBigInt(amount)
+		if err != nil {
+			glog.Errorf("Parsing failed for price: %v", err)
+			return
+		}
+		if amount == "0" {
+			gprice = nil
+		}
+
+		glimit, _ := s.LivepeerNode.Eth.GetGasInfo()
+		if err := s.LivepeerNode.Eth.SetGasInfo(glimit, gprice); err != nil {
+			glog.Errorf("Error setting price info: %v", err)
+		}
+	})
 }

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -172,25 +172,28 @@ func (s *LivepeerServer) StartWebserver() {
 
 	http.HandleFunc("/initializeRound", func(w http.ResponseWriter, r *http.Request) {
 		if s.LivepeerNode.Eth != nil {
-			initialized, err := s.LivepeerNode.Eth.CurrentRoundInitialized()
+			tx, err := s.LivepeerNode.Eth.InitializeRound()
 			if err != nil {
 				glog.Error(err)
 				return
 			}
 
-			if !initialized {
-				tx, err := s.LivepeerNode.Eth.InitializeRound()
-				if err != nil {
-					glog.Error(err)
-					return
-				}
-
-				err = s.LivepeerNode.Eth.CheckTx(tx)
-				if err != nil {
-					glog.Error(err)
-					return
-				}
+			err = s.LivepeerNode.Eth.CheckTx(tx)
+			if err != nil {
+				glog.Error(err)
+				return
 			}
+		}
+	})
+
+	http.HandleFunc("/roundInitialized", func(w http.ResponseWriter, r *http.Request) {
+		if s.LivepeerNode.Eth != nil {
+			initialized, err := s.LivepeerNode.Eth.CurrentRoundInitialized()
+			if err != nil {
+				glog.Error(err)
+				return
+			}
+			w.Write([]byte(fmt.Sprintf("%v", initialized)))
 		}
 	})
 


### PR DESCRIPTION
Add CLI option to configure gas price.  Configure to `0` to use the gas oracle.

Also small fix to print out the right error message if `intializeRound` is selected but the round is already initialized.

Closes #420 