### PR TITLE
Disconnect broadcaster in case of a segmentation error.

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -254,6 +254,9 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 				if err := s.LivepeerNode.BroadcastFinishMsg(hlsStrmID.String()); err != nil {
 					glog.Errorf("Error broadcaseting finish message: %v", err)
 				}
+				// Stop the incoming RTMP connection.
+				// TODO retry segmentation if err != SegmenterTimeout; may be recoverable
+				rtmpStrm.Close()
 			}
 		}(broadcaster, rtmpStrm)
 

--- a/vendor/github.com/livepeer/lpms/ffmpeg/ffmpeg_test.go
+++ b/vendor/github.com/livepeer/lpms/ffmpeg/ffmpeg_test.go
@@ -50,4 +50,9 @@ func TestLength(t *testing.T) {
 		t.Error("Did not get an error on nb packets check where one was expected")
 	}
 
+	// check invalid file
+	err = CheckMediaLen("nonexistent", ts, nb_packets)
+	if err == nil || err.Error() != "No such file or directory" {
+		t.Error("Did not get the expected error: ", err)
+	}
 }

--- a/vendor/github.com/livepeer/lpms/ffmpeg/lpms_ffmpeg.c
+++ b/vendor/github.com/livepeer/lpms/ffmpeg/lpms_ffmpeg.c
@@ -766,7 +766,7 @@ int lpms_length(char *inp, int ts_max, int packet_max)
     AVRational limit_tb   = {1, 1000}; // MilliSeconds
     int64_t pts_max       = ts_max;
     struct input_metrics im[LPMS_MAX_INPUT_STREAMS];
-    AVPacket pkt;
+    AVPacket pkt          = {0};
 
     ret = avformat_open_input(&ic, inp, NULL, NULL);
     if (ret < 0) len_err("len: Unable to open input\n");

--- a/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
+++ b/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
@@ -72,6 +72,7 @@ func (s *TestStream) ReadHLSFromStream(ctx context.Context, buffer stream.HLSMux
 func (s *TestStream) ReadHLSSegment() (stream.HLSSegment, error)                          { return stream.HLSSegment{}, nil }
 func (s *TestStream) Width() int                                                          { return 0 }
 func (s *TestStream) Height() int                                                         { return 0 }
+func (s *TestStream) Close()                                                              {}
 
 func RunRTMPToHLS(vs *FFMpegVideoSegmenter, ctx context.Context) error {
 	// hack cuz listener might not be ready

--- a/vendor/github.com/livepeer/lpms/stream/interface.go
+++ b/vendor/github.com/livepeer/lpms/stream/interface.go
@@ -46,6 +46,7 @@ type RTMPVideoStream interface {
 	VideoStream
 	ReadRTMPFromStream(ctx context.Context, dst av.MuxCloser) (eof chan struct{}, err error)
 	WriteRTMPToStream(ctx context.Context, src av.DemuxCloser) (eof chan struct{}, err error)
+	Close()
 	Height() int
 	Width() int
 }


### PR DESCRIPTION
This resolves the immediate issue of broadcast nodes hanging after OBS does not cleanly disconnect. The segmenter already has a built-in timeout which is typically triggered by idle RTMP ingest connections, so use that as a signal to kill the ingest connection.