### PR TITLE
Add events for StreamCreated, StreamStarted, and StreamEnded

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -167,12 +167,6 @@ func main() {
 		glog.Errorf("Error getting keys: %v", err)
 		return
 	}
-
-	//Create Livepeer Node
-	if *monitor {
-		glog.Info("Monitor is set to 'true' by default.  If you want to disable it, use -monitor=false when starting Livepeer.")
-		lpmon.Endpoint = *monhost
-	}
 	notifiee := bnet.NewBasicNotifiee(lpmon.Instance())
 	var maddrs []ma.Multiaddr
 	if *bindIPs != "" {
@@ -346,6 +340,13 @@ func main() {
 
 			defer n.StopEthServices()
 		}
+	}
+
+	//Create Livepeer Node
+	if *monitor {
+		glog.Info("Monitor is set to 'true' by default.  If you want to disable it, use -monitor=false when starting Livepeer.")
+		lpmon.Endpoint = *monhost
+		n.MonitorMetrics = true
 	}
 
 	// Set up logging

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -76,6 +76,7 @@ type LivepeerNode struct {
 	WorkDir         string
 	NodeType        NodeType
 	Database        *common.DB
+	MonitorMetrics  bool
 }
 
 //NewLivepeerNode creates a new Livepeer Node. Eth can be nil.

--- a/monitor/events.go
+++ b/monitor/events.go
@@ -1,0 +1,87 @@
+package monitor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/golang/glog"
+)
+
+type Event struct {
+	Name       string            `json:"event"`
+	Properties map[string]string `json:"properties"`
+}
+
+var EventsURL = "http://metrics.livepeer.org/events"
+
+func LogStreamCreatedEvent(manifestID string, nonce uint64) {
+	e := &Event{
+		Name: "StreamCreated",
+		Properties: map[string]string{
+			"manifestID": manifestID,
+			"nonce":      fmt.Sprintf("%v", nonce),
+		},
+	}
+
+	sendPost(e)
+}
+
+func LogStreamStartedEvent(manifestID string, nonce uint64) {
+	e := &Event{
+		Name: "StreamStarted",
+		Properties: map[string]string{
+			"manifestID": manifestID,
+			"nonce":      fmt.Sprintf("%v", nonce),
+		},
+	}
+
+	sendPost(e)
+}
+
+func LogStreamEndedEvent(manifestID string, nonce uint64) {
+	e := &Event{
+		Name: "StreamEnded",
+		Properties: map[string]string{
+			"manifestID": manifestID,
+			"nonce":      fmt.Sprintf("%v", nonce),
+		},
+	}
+
+	sendPost(e)
+}
+
+func LogStreamCreateFailed(manifestID string, nonce uint64, reason string) {
+	glog.Infof("Logging StreamCreateFailed...")
+	e := &Event{
+		Name: "StreamCreateFailed",
+		Properties: map[string]string{
+			"manifestID": manifestID,
+			"reason":     reason,
+			"nonce":      fmt.Sprintf("%v", nonce),
+		},
+	}
+
+	sendPost(e)
+}
+
+func sendPost(e *Event) {
+	jsonStr, err := json.Marshal(e)
+	if err != nil {
+		glog.Errorf("Error sending event to logger.")
+		return
+	}
+	req, err := http.NewRequest("POST", EventsURL, bytes.NewBuffer(jsonStr))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		glog.Errorf("Error sending event to logger.")
+		return
+	}
+}

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -196,6 +196,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 		t.Errorf("Expecting publish error because stream already exists, but got: %v", err)
 	}
 	delete(s.rtmpStreams, "strmID")
+	delete(s.VideoNonce, "strmID")
 
 	//Try to handle test RTMP data.
 	b := &StubBroadcaster{Data: make(map[uint64][]byte)}


### PR DESCRIPTION
This is being sent to the event tracking daemon run at `http://metrics.livepeer.org`