### PR TITLE
Fix dropped subscriptions due to ETH RPC client reconnects

### DIFF
--- a/vendor/github.com/ethereum/go-ethereum/accounts/abi/bind/util.go
+++ b/vendor/github.com/ethereum/go-ethereum/accounts/abi/bind/util.go
@@ -32,9 +32,12 @@ func WaitMined(ctx context.Context, b DeployBackend, tx *types.Transaction) (*ty
 	queryTicker := time.NewTicker(time.Second)
 	defer queryTicker.Stop()
 
+	localCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	logger := log.New("hash", tx.Hash())
 	for {
-		receipt, err := b.TransactionReceipt(ctx, tx.Hash())
+		receipt, err := b.TransactionReceipt(localCtx, tx.Hash())
 		if receipt != nil {
 			return receipt, nil
 		}


### PR DESCRIPTION
A recently observed issue on mainnet is that when a node waits for a transaction to be mined, if the transaction takes too long to be mined the node will get a `context deadline exceeded` error message and when the node later makes another RPC call oftentimes it will stop receiving subscription messages (i.e. new blocks, new jobs, etc.) from the ETH node that it is connected to. #455 is one such case.

This behavior is caused by a race condition created by the `WaitMined()` helper - the function accepts a context which is not only used to signal the end of the polling loop, but is also passed in to the `TransactionReceipt()` function (https://github.com/livepeer/go-livepeer/blob/master/vendor/github.com/ethereum/go-ethereum/accounts/abi/bind/util.go#L37) which will execute an RPC call to attempt to fetch the transaction receipt if it exists. Common usage of this helper would involve passing in a context with a timeout. But the context is also used by the RPC call within the polling loop which wouldn't normally be a problem except for the fact that if the deadline for the context used by the RPC call is exceeded then the RPC client will treat the timed out network write as a signal to establish a new connection on a subsequent RPC call (https://github.com/livepeer/go-livepeer/blob/master/vendor/github.com/ethereum/go-ethereum/rpc/client.go#L491). Furthermore, when the client tries to establish a new connection on a subsequent RPC call, the existing connection will be closed (https://github.com/livepeer/go-livepeer/blob/master/vendor/github.com/ethereum/go-ethereum/rpc/client.go#L577). Closing the existing connection will tell the ETH node to stop sending notifications for all subscriptions created using the connection (https://github.com/ethereum/go-ethereum/blob/master/eth/filters/api.go#L227).

I believe the race condition is triggered whenever the context deadline is exceeded when the network write for `TransactionReceipt()` has already been initiated - if the context deadline is exceeded before the network write for `TransactionReceipt()` is initiated I don't think the race condition is triggered.

This PR proposes a small change to mitigate the described issue by checking if a network write error is due to a timeout and if so the RPC client will not try to establish a new connection (and close the existing one) during a subsequent RPC call - instead it will continue to try to use the same existing connection. If the network write error is not due to a timeout (i.e. an EOF), it will try to establish a new connection during a subsequent RPC call.