### PR TITLE
Replacement transactions and round initialization checks for automatic rewards

### DIFF
--- a/eth/accountmanager.go
+++ b/eth/accountmanager.go
@@ -117,14 +117,19 @@ func (am *AccountManager) CreateTransactOpts(gasLimit uint64, gasPrice *big.Int)
 				return nil, errors.New("not authorized to sign this account")
 			}
 
-			signature, err := am.keyStore.SignHash(am.Account, signer.Hash(tx).Bytes())
-			if err != nil {
-				return nil, err
-			}
-
-			return tx.WithSignature(signer, signature)
+			return am.SignTx(signer, tx)
 		},
 	}, nil
+}
+
+// Sign a transaction. Account must be unlocked
+func (am *AccountManager) SignTx(signer types.Signer, tx *types.Transaction) (*types.Transaction, error) {
+	signature, err := am.keyStore.SignHash(am.Account, signer.Hash(tx).Bytes())
+	if err != nil {
+		return nil, err
+	}
+
+	return tx.WithSignature(signer, signature)
 }
 
 // Sign byte array message. Account must be unlocked

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -153,7 +153,10 @@ func (c *StubClient) VerificationCodeHash() (string, error)            { return 
 
 func (c *StubClient) ContractAddresses() map[string]common.Address { return nil }
 func (c *StubClient) CheckTx(tx *types.Transaction) error          { return nil }
-func (e *StubClient) Sign(msg []byte) ([]byte, error)              { return nil, nil }
-func (c *StubClient) LatestBlockNum() (*big.Int, error)            { return big.NewInt(0), nil }
-func (c *StubClient) GetGasInfo() (uint64, *big.Int)               { return 0, nil }
-func (c *StubClient) SetGasInfo(uint64, *big.Int) error            { return nil }
+func (c *StubClient) ReplaceTransaction(tx *types.Transaction, method string, gasPrice *big.Int) (*types.Transaction, error) {
+	return nil, nil
+}
+func (c *StubClient) Sign(msg []byte) ([]byte, error)   { return nil, nil }
+func (c *StubClient) LatestBlockNum() (*big.Int, error) { return big.NewInt(0), nil }
+func (c *StubClient) GetGasInfo() (uint64, *big.Int)    { return 0, nil }
+func (c *StubClient) SetGasInfo(uint64, *big.Int) error { return nil }


### PR DESCRIPTION
- Check that the current round is initialized before trying to call reward
- If the reward service previously submitted a reward transactions that has not confirmed, instead of submitting a new transaction every polling interval, replace the original transaction by using the same nonce and bumping the gas price