### PR TITLE
Interim changes for Networking v2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,7 @@ dependencies:
     - git clone http://github.com/livepeer/go-livepeer.git
     - go get github.com/golang/glog
     - go get github.com/ericxtang/m3u8
+    - go get -u google.golang.org/grpc
     - npm install -g ffmpeg-static@2.0.0
 
 test:

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/livepeer/go-livepeer/eth"
+	lpTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/livepeer/go-livepeer/net"
 	ffmpeg "github.com/livepeer/lpms/ffmpeg"
 )
@@ -98,4 +99,50 @@ func TestTranscodeAndBroadcast(t *testing.T) {
 	ids, err = n.TranscodeAndBroadcast(config, &StubClaimManager{}, tr)
 
 	//TODO: Should have done the claiming
+}
+
+func TestNodeClaimManager(t *testing.T) {
+	nid := NodeID("12201c23641663bf06187a8c154a6c97266d138cb8379c1bc0828122dcc51c83698d")
+	stubnet := &StubVideoNetwork{subscribers: make(map[string]*StubSubscriber)}
+	n, err := NewLivepeerNode(nil, stubnet, nid, ".", nil)
+
+	job := &lpTypes.Job{
+		JobId:              big.NewInt(15),
+		MaxPricePerSegment: big.NewInt(1),
+		Profiles:           []ffmpeg.VideoProfile{},
+		TotalClaims:        big.NewInt(0),
+	}
+
+	// test claimmanager existence via manual insertion
+	n.ClaimManagers[15] = &StubClaimManager{}
+	cm, err := n.GetClaimManager(job)
+	if err != nil || cm == nil {
+		t.Error("Did not retrieve claimmanager ", cm, err)
+		return
+	}
+
+	job.JobId = big.NewInt(10)
+
+	// test with a nil eth client
+	cm, err = n.GetClaimManager(job)
+	if err != nil || cm != nil {
+		t.Error("Claimmanager unexpected result %v %v", cm, err)
+		return
+	}
+
+	// test with a nonexisting job
+	stubClient := eth.StubClient{}
+	n.Eth = &stubClient
+	cm, err = n.GetClaimManager(nil)
+	if err == nil || err.Error() != "Nil job" {
+		t.Error("Expected nil job ", err)
+		return
+	}
+
+	// test creating a new claimmanager
+	cm, err = n.GetClaimManager(job)
+	if err != nil || cm == nil {
+		t.Error("Expected claimmanager from job ", cm, err)
+		return
+	}
 }

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -139,7 +139,11 @@ func (s *JobService) doTranscode(job *lpTypes.Job) (bool, error) {
 	glog.Infof("Transcoder got job %v - strmID: %v, tData: %v, config: %v", job.JobId, job.StreamId, job.Profiles, config)
 
 	//Do The Transcoding
-	cm := eth.NewBasicClaimManager(job, s.node.Eth, s.node.Ipfs, s.node.Database)
+	cm, err := s.node.GetClaimManager(job)
+	if err != nil {
+		glog.Error("Could not get claim manager: ", err)
+		return false, err
+	}
 	tr := transcoder.NewFFMpegSegmentTranscoder(job.Profiles, s.node.WorkDir)
 	strmIDs, err := s.node.TranscodeAndBroadcast(config, cm, tr)
 	if err != nil {

--- a/eth/types/segment.go
+++ b/eth/types/segment.go
@@ -16,3 +16,11 @@ type Segment struct {
 func (s *Segment) Hash() common.Hash {
 	return crypto.Keccak256Hash([]byte(s.StreamID), common.LeftPadBytes(s.SegmentSequenceNumber.Bytes(), 32), s.DataHash.Bytes())
 }
+
+func (s *Segment) Flatten() []byte {
+	buf := make([]byte, len(s.StreamID)+32+len(s.DataHash.Bytes()))
+	i := copy(buf[0:], []byte(s.StreamID))
+	i += copy(buf[i:], common.LeftPadBytes(s.SegmentSequenceNumber.Bytes(), 32))
+	i += copy(buf[i:], s.DataHash.Bytes())
+	return buf
+}

--- a/eth/types/segment_test.go
+++ b/eth/types/segment_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 func TestSegmentHash(t *testing.T) {
@@ -13,7 +13,7 @@ func TestSegmentHash(t *testing.T) {
 		segmentNumber = big.NewInt(0)
 		d0            = "QmR9BnJQisvevpCoSVWWKyownN58nydb2zQt9Z2VtnTnKe"
 
-		sHash = common.BytesToHash(common.FromHex("7fa493826bf6dc8fdd3e65ad6170193ec1a92cee5d78311953b3d0da928d7871"))
+		sHash = ethcommon.BytesToHash(ethcommon.FromHex("7fa493826bf6dc8fdd3e65ad6170193ec1a92cee5d78311953b3d0da928d7871"))
 	)
 
 	segment := &Segment{
@@ -24,5 +24,19 @@ func TestSegmentHash(t *testing.T) {
 
 	if segment.Hash() != sHash {
 		t.Fatalf("Invalid segment hash")
+	}
+}
+
+func TestSegmentFlatten(t *testing.T) {
+	// ensure that the flatten + manual hash results are identical to the
+	// segment hash results
+
+	s := Segment{
+		StreamID: "abcdef",
+		SegmentSequenceNumber: big.NewInt(1234),
+		DataHash: ethcommon.RightPadBytes([]byte("browns"), 32)
+	}
+	if !bytes.Equal(ethcommon.Keccak256(s.Flatten()), s.Hash().Bytes()) {
+		t.Error("Flattened segment + hash did not match segment hash function")
 	}
 }

--- a/vendor/github.com/ipfs/go-ipfs/repo/fsrepo/datastores.go
+++ b/vendor/github.com/ipfs/go-ipfs/repo/fsrepo/datastores.go
@@ -4,14 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 
 	repo "github.com/ipfs/go-ipfs/repo"
 
-	badgerds "gx/ipfs/QmPAiAmc3qhTFwzWnKpxr6WCXGZ5mqpaQ2YEwSTnwyduHo/go-ds-badger"
-	humanize "gx/ipfs/QmPSBJL4momYnE7DcUyk2DVhD6rH488ZmHBGLbxNdhU44K/go-humanize"
 	flatfs "gx/ipfs/QmPiYdqnkkiPEffrWq2M3Phb3NT8r49kqUXMev2hkkM7uV/go-ds-flatfs"
 	levelds "gx/ipfs/QmVVhwMHaGHPgZY6pi8hbWGLSgMcZUSdEhJBChjxhBMCoy/go-ds-leveldb"
 	ds "gx/ipfs/QmXRKBQA4wXP7xWbFiZsR1GP4HV6wMDQ1aWFxZZ4uBcPX9/go-datastore"
@@ -58,13 +55,12 @@ var datastores map[string]ConfigFromMap
 
 func init() {
 	datastores = map[string]ConfigFromMap{
-		"mount":    MountDatastoreConfig,
-		"flatfs":   FlatfsDatastoreConfig,
-		"levelds":  LeveldsDatastoreConfig,
-		"badgerds": BadgerdsDatastoreConfig,
-		"mem":      MemDatastoreConfig,
-		"log":      LogDatastoreConfig,
-		"measure":  MeasureDatastoreConfig,
+		"mount":   MountDatastoreConfig,
+		"flatfs":  FlatfsDatastoreConfig,
+		"levelds": LeveldsDatastoreConfig,
+		"mem":     MemDatastoreConfig,
+		"log":     LogDatastoreConfig,
+		"measure": MeasureDatastoreConfig,
 	}
 }
 
@@ -336,77 +332,4 @@ func (c measureDatastoreConfig) Create(path string) (repo.Datastore, error) {
 		return nil, err
 	}
 	return measure.New(c.prefix, child), nil
-}
-
-type badgerdsDatastoreConfig struct {
-	path       string
-	syncWrites bool
-
-	vlogFileSize int64
-}
-
-// BadgerdsDatastoreConfig returns a configuration stub for a badger datastore
-// from the given parameters
-func BadgerdsDatastoreConfig(params map[string]interface{}) (DatastoreConfig, error) {
-	var c badgerdsDatastoreConfig
-	var ok bool
-
-	c.path, ok = params["path"].(string)
-	if !ok {
-		return nil, fmt.Errorf("'path' field is missing or not string")
-	}
-
-	sw, ok := params["syncWrites"]
-	if !ok {
-		c.syncWrites = true
-	} else {
-		if swb, ok := sw.(bool); ok {
-			c.syncWrites = swb
-		} else {
-			return nil, fmt.Errorf("'syncWrites' field was not a boolean")
-		}
-	}
-
-	vls, ok := params["vlogFileSize"]
-	if !ok {
-		// default to 1GiB
-		c.vlogFileSize = badgerds.DefaultOptions.ValueLogFileSize
-	} else {
-		if vlogSize, ok := vls.(string); ok {
-			s, err := humanize.ParseBytes(vlogSize)
-			if err != nil {
-				return nil, err
-			}
-			c.vlogFileSize = int64(s)
-		} else {
-			return nil, fmt.Errorf("'vlogFileSize' field was not a string")
-		}
-	}
-
-	return &c, nil
-}
-
-func (c *badgerdsDatastoreConfig) DiskSpec() DiskSpec {
-	return map[string]interface{}{
-		"type": "badgerds",
-		"path": c.path,
-	}
-}
-
-func (c *badgerdsDatastoreConfig) Create(path string) (repo.Datastore, error) {
-	p := c.path
-	if !filepath.IsAbs(p) {
-		p = filepath.Join(path, p)
-	}
-
-	err := os.MkdirAll(p, 0755)
-	if err != nil {
-		return nil, err
-	}
-
-	defopts := badgerds.DefaultOptions
-	defopts.SyncWrites = c.syncWrites
-	defopts.ValueLogFileSize = c.vlogFileSize
-
-	return badgerds.NewDatastore(p, &defopts)
 }


### PR DESCRIPTION
* **circle: Add grpc.**

* **vendor: Fix IPFS with grpc.**
Update go-ipfs to livepeer/go-ipfs@e6c0cc0.

As described in https://github.com/ipfs/go-ipfs/issues/5034 . Our out-of-tree fix lives at https://github.com/livepeer/go-ipfs/tree/livepeer

* **node: Track claimmanagers in memory.**
Needed for the networking system, but also fixes https://github.com/livepeer/go-livepeer/issues/376 as a side effect.

* **Client code for ServiceRegistry.**
* **Check for valid service URI input from user**
We probably need to upgrade the protocol first before merging this.

* **eth: Add flatten helper.**
This helps make the networking `Sign` API a bit safer and less surprising: rather than making a keccak256 hash an unenforced input precondition (as in the existing `eth.Sign` function), we take any arbitrary string as a message, then hash+sign from there. In order to allow the broadcaster to sign segments, we add a `flatten` helper to collapse the `Segment` struct for signing. For example:

https://github.com/livepeer/go-livepeer/blob/f1dc2ecfd57b17d5be8c58126cacc65497e212fb/server/rpc.go#L85-L90

https://github.com/livepeer/go-livepeer/blob/e8d2df63e6a358c7b1660b3b44e13b6dafdbe61e/server/rpc.go#L218-L223

(note that the `Sign` API signature may be tweaked a bit yet in order to minimize copying on type-conversion, but the `flatten` function will probably stay as-is)