### PR TITLE
Smarter bonding token approval and earnings claim process + display node ETH address

### DIFF
--- a/eth/accountmanager.go
+++ b/eth/accountmanager.go
@@ -55,7 +55,7 @@ func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string) (*Acco
 		}
 	}
 
-	glog.V(common.SHORT).Infof("Using ETH account: %v", acct.Address.Hex())
+	glog.Infof("Using ETH account: %v", acct.Address.Hex())
 
 	return &AccountManager{
 		Account:  acct,
@@ -73,7 +73,7 @@ func (am *AccountManager) Unlock(passphrase string) error {
 		if passphrase != "" {
 			return err
 		}
-		glog.Infof("Passphrase required to unlock ETH account")
+		glog.Infof("Passphrase required to unlock ETH account %v", am.Account.Address.Hex())
 
 		passphrase, err = getPassphrase(false)
 		err = am.keyStore.Unlock(am.Account, passphrase)
@@ -84,7 +84,7 @@ func (am *AccountManager) Unlock(passphrase string) error {
 
 	am.unlocked = true
 
-	glog.V(common.SHORT).Infof("ETH account %v unlocked", am.Account.Address.Hex())
+	glog.Infof("ETH account %v unlocked", am.Account.Address.Hex())
 
 	return nil
 }

--- a/eth/accountmanager.go
+++ b/eth/accountmanager.go
@@ -84,7 +84,7 @@ func (am *AccountManager) Unlock(passphrase string) error {
 
 	am.unlocked = true
 
-	glog.Infof("ETH account %v unlocked", am.Account.Address.Hex())
+	glog.Infof("Unlocked ETH account: %v", am.Account.Address.Hex())
 
 	return nil
 }


### PR DESCRIPTION
Fixes #405 - check approved allowance for BondingManager contract before bonding thus avoiding an additional `ERC20#approve()` transaction unless the existing allowance is insufficient

Fixes #438 - show node's ETH address by default

Modified `autoClaimEarnings()` in `eth/client.go` to accept an `allRounds` boolean flag. If the flag is set to false, then when this function is called, the earnings claim process will be executed, but if there are fewer than [maxEarningsClaimsRounds](https://github.com/livepeer/protocol/blob/master/contracts/bonding/BondingManager.sol#L30) remaining rounds an additional `BondingManager#claimEarnings()` transaction will not be submitted because a subsequent bonding related transaction (i.e. `BondingManager#bond()` or `BondingManager#unbond()`) will automatically claim earnings for the remaining rounds. If the flag is set to true, the additional `BondingManager#claimEarnings()` transaction will be submitted in the described scenario. This change is to make sure that if an account has many rounds to claim earnings for, it does not end up submitting an additional unnecessary transaction if it is going to be submitting a bonding related transaction afterwords.