### PR TITLE
Check for nonce too low error when replacing transactions

### DIFF
--- a/eth/eventservices/rewardservice.go
+++ b/eth/eventservices/rewardservice.go
@@ -107,7 +107,7 @@ func (s *RewardService) tryReward() error {
 			// Replace pending tx by bumping gas price
 			tx, err = s.client.ReplaceTransaction(s.pendingTx, "reward", nil)
 			if err != nil {
-				if err == eth.ErrReplacingMinedTx {
+				if err == eth.ErrReplacingMinedTx || err.Error() == "nonce too low" {
 					// Pending tx confirmed so we should not try to replace next time
 					s.pendingTx = nil
 				}


### PR DESCRIPTION
Fixes #471 

The `core` package in go-ethereum exports an `ErrNonceTooLow` error, but I ran into a bunch of compilation errors related variable re-declarations, so I used an error string comparison instead of using the exported error.