### PR TITLE
Add support for partial unbonding in CLI and webserver

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -130,11 +130,7 @@ func main() {
 		}
 		if !*offchain {
 			if *ethUrl == "" {
-				if *transcoder {
-					*ethUrl = "wss://mainnet.infura.io/ws"
-				} else {
-					*ethUrl = "https://mainnet.infura.io/cFwU3koCZdTqiH6VE4fj"
-				}
+				*ethUrl = "wss://mainnet.infura.io/ws"
 			}
 			if *controllerAddr == "" {
 				*controllerAddr = MainnetControllerAddr

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -316,6 +316,11 @@ func main() {
 			return true
 		})
 
+		defer n.StopEthServices()
+
+		// Setup unbonding service to manage unbonding locks
+		n.EthServices["UnbondingService"] = eventservices.NewUnbondingService(n.Eth, dbh)
+
 		if *transcoder {
 			addrMap := n.Eth.ContractAddresses()
 			em := eth.NewEventMonitor(backend, addrMap)
@@ -327,8 +332,6 @@ func main() {
 				glog.Errorf("Error setting up transcoder: %v", err)
 				return
 			}
-
-			defer n.StopEthServices()
 		}
 	}
 

--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -92,6 +92,7 @@ func (w *wizard) initializeOptions() []wizardOpt {
 		{desc: "Invoke \"initialize round\"", invoke: w.initializeRound},
 		{desc: "Invoke \"bond\"", invoke: w.bond},
 		{desc: "Invoke \"unbond\"", invoke: w.unbond},
+		{desc: "Invoke \"rebond\"", invoke: w.rebond},
 		{desc: "Invoke \"withdraw stake\" (LPT)", invoke: w.withdrawStake},
 		{desc: "Invoke \"withdraw fees\" (ETH)", invoke: w.withdrawFees},
 		{desc: "Invoke \"claim\" (for rewards and fees)", invoke: w.claimRewardsAndFees},

--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -81,6 +81,69 @@ func (w *wizard) getRegisteredTranscoders() ([]lpTypes.Transcoder, error) {
 	return transcoders, nil
 }
 
+func (w *wizard) unbondingLockStats(withdrawable bool) map[int64]bool {
+	unbondingLocks, err := w.getUnbondingLocks(withdrawable)
+	if err != nil {
+		glog.Errorf("Error getting unbonding locks: %v", err)
+		return nil
+	}
+
+	unbondingLockIDs := make(map[int64]bool)
+
+	if len(unbondingLocks) == 0 {
+		return unbondingLockIDs
+	}
+
+	fmt.Println("+---------------+")
+	fmt.Println("|UNBONDING LOCKS|")
+	fmt.Println("+---------------+")
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"ID", "Amount", "Withdraw Round"})
+
+	for _, u := range unbondingLocks {
+		table.Append([]string{
+			strconv.FormatInt(u.ID, 10),
+			eth.FormatUnits(u.Amount, "LPT"),
+			strconv.FormatInt(u.WithdrawRound, 10),
+		})
+
+		unbondingLockIDs[u.ID] = true
+	}
+
+	table.Render()
+
+	return unbondingLockIDs
+}
+
+func (w *wizard) getUnbondingLocks(withdrawable bool) ([]lpcommon.DBUnbondingLock, error) {
+	var url string
+	if withdrawable {
+		url = fmt.Sprintf("http://%v:%v/unbondingLocks?withdrawable=true", w.host, w.httpPort)
+	} else {
+		url = fmt.Sprintf("http://%v:%v/unbondingLocks", w.host, w.httpPort)
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	result, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var unbondingLocks []lpcommon.DBUnbondingLock
+	err = json.Unmarshal(result, &unbondingLocks)
+	if err != nil {
+		return nil, err
+	}
+
+	return unbondingLocks, nil
+}
+
 func (w *wizard) bond() {
 	transcoderIds := w.registeredTranscoderStats()
 	var tAddr common.Address
@@ -120,12 +183,149 @@ func (w *wizard) bond() {
 	httpPostWithParams(fmt.Sprintf("http://%v:%v/bond", w.host, w.httpPort), val)
 }
 
+func (w *wizard) rebond() {
+	dInfo, err := w.getDelegatorInfo()
+	if err != nil {
+		glog.Errorf("Error getting delegator info: %v", err)
+		return
+	}
+
+	fmt.Printf("Current Bonded Amount: %v\n", eth.FormatUnits(dInfo.BondedAmount, "LPT"))
+	if (dInfo.DelegateAddress != common.Address{}) {
+		fmt.Printf("Current Delegate: %v\n", dInfo.DelegateAddress.Hex())
+	}
+
+	unbondingLockIDs := w.unbondingLockStats(false)
+
+	if unbondingLockIDs == nil || len(unbondingLockIDs) == 0 {
+		fmt.Printf("No unbonding locks")
+		return
+	}
+
+	unbondingLockID := int64(-1)
+
+	for {
+		fmt.Printf("Enter the identifier of the unbonding lock you would like to rebond with - ")
+		unbondingLockID = int64(w.readInt())
+		if _, ok := unbondingLockIDs[unbondingLockID]; ok {
+			break
+		}
+		fmt.Printf("Must enter a valid unbonding lock ID\n")
+	}
+
+	val := url.Values{
+		"unbondingLockId": {fmt.Sprintf("%v", strconv.FormatInt(unbondingLockID, 10))},
+	}
+
+	if dInfo.Status == "Unbonded" {
+		fmt.Printf("You are unbonded - you will need to choose an address to rebond to.\n")
+
+		var toAddr common.Address
+
+		transcoderIds := w.registeredTranscoderStats()
+
+		if transcoderIds == nil {
+			fmt.Printf("Enter the address of the transcoder you would like to rebond to - ")
+			strAddr := w.readString()
+			if err := toAddr.UnmarshalText([]byte(strAddr)); err != nil {
+				fmt.Println(err)
+				return
+			}
+		} else {
+			fmt.Printf("Enter the identifier of the transcoder you would like to rebond to - ")
+			transcoderID := w.readInt()
+			toAddr = transcoderIds[transcoderID]
+		}
+
+		val["toAddr"] = []string{fmt.Sprintf("%v", toAddr.Hex())}
+	}
+
+	httpPostWithParams(fmt.Sprintf("http://%v:%v/rebond", w.host, w.httpPort), val)
+}
+
 func (w *wizard) unbond() {
-	httpPost(fmt.Sprintf("http://%v:%v/unbond", w.host, w.httpPort))
+	dInfo, err := w.getDelegatorInfo()
+	if err != nil {
+		glog.Errorf("Error getting delegator info: %v", err)
+		return
+	}
+
+	if dInfo.BondedAmount.Cmp(big.NewInt(0)) < 0 {
+		fmt.Printf("You are not bonded\n")
+		return
+	}
+
+	fmt.Printf("Current Bonded Amount: %v\n", eth.FormatUnits(dInfo.BondedAmount, "LPT"))
+	fmt.Printf("Current Delegate: %v\n", dInfo.DelegateAddress.Hex())
+
+	fmt.Printf("Would you like to fully unbond? (y/n) - ")
+
+	input := ""
+	for {
+		input = w.readString()
+		if input == "y" || input == "n" {
+			break
+		}
+		fmt.Printf("Enter (y)es or (n)o \n")
+	}
+
+	var amount *big.Int
+	if input == "y" {
+		amount = dInfo.BondedAmount
+	} else {
+		amount = big.NewInt(0)
+	}
+
+	for amount.Cmp(big.NewInt(0)) == 0 || dInfo.BondedAmount.Cmp(amount) < 0 {
+		fmt.Printf("Enter unbond amount - ")
+		amount = w.readBigInt()
+		if dInfo.BondedAmount.Cmp(amount) < 0 {
+			fmt.Printf("Must enter an amount less than or equal to the current bonded amount.")
+		}
+	}
+
+	val := url.Values{
+		"amount": {fmt.Sprintf("%v", amount.String())},
+	}
+
+	httpPostWithParams(fmt.Sprintf("http://%v:%v/unbond", w.host, w.httpPort), val)
 }
 
 func (w *wizard) withdrawStake() {
-	httpPost(fmt.Sprintf("http://%v:%v/withdrawStake", w.host, w.httpPort))
+	dInfo, err := w.getDelegatorInfo()
+	if err != nil {
+		glog.Error("Error getting delegator info: %v", err)
+		return
+	}
+
+	fmt.Printf("Current Bonded Amount: %v\n", eth.FormatUnits(dInfo.BondedAmount, "LPT"))
+	if (dInfo.DelegateAddress != common.Address{}) {
+		fmt.Printf("Current Delegate: %v\n", dInfo.DelegateAddress.Hex())
+	}
+
+	unbondingLockIDs := w.unbondingLockStats(true)
+
+	if unbondingLockIDs == nil || len(unbondingLockIDs) == 0 {
+		fmt.Printf("No withdrawable unbonding locks")
+		return
+	}
+
+	unbondingLockID := int64(-1)
+
+	for {
+		fmt.Printf("Enter the identifier of the unbonding lock you would like to withdraw with - ")
+		unbondingLockID = int64(w.readInt())
+		if _, ok := unbondingLockIDs[unbondingLockID]; ok {
+			break
+		}
+		fmt.Printf("Must enter a valid unbonding lock ID\n")
+	}
+
+	val := url.Values{
+		"unbondingLockId": {fmt.Sprintf("%v", strconv.FormatInt(unbondingLockID, 10))},
+	}
+
+	httpPostWithParams(fmt.Sprintf("http://%v:%v/withdrawStake", w.host, w.httpPort), val)
 }
 
 func (w *wizard) withdrawFees() {

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -247,7 +247,6 @@ func (w *wizard) delegatorStats() {
 		[]string{"Delegate Address", d.DelegateAddress.Hex()},
 		[]string{"Last Claim Round", d.LastClaimRound.String()},
 		[]string{"Start Round", d.StartRound.String()},
-		[]string{"Withdraw Round", d.WithdrawRound.String()},
 	}
 
 	for _, v := range data {

--- a/common/db.go
+++ b/common/db.go
@@ -748,6 +748,20 @@ func (db *DB) UseUnbondingLock(id *big.Int, delegator ethcommon.Address, usedBlo
 	return nil
 }
 
+func (db *DB) LatestUnbondingLockID() (*big.Int, error) {
+	glog.V(DEBUG).Infof("db: Getting latest unbonding lock ID")
+
+	var latestUnbondingLockID int64
+	row := db.dbh.QueryRow("SELECT MAX(id) FROM unbondingLocks")
+	err := row.Scan(&latestUnbondingLockID)
+	if err != nil {
+		glog.Error("db: Got err in retrieving latest unbonding lockID ", err)
+		return nil, err
+	}
+
+	return big.NewInt(latestUnbondingLockID), nil
+}
+
 func (db *DB) UnbondingLocks(currentRound *big.Int) ([]*DBUnbondingLock, error) {
 	if db == nil {
 		return []*DBUnbondingLock{}, nil

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -408,6 +408,17 @@ func TestDBUnbondingLocks(t *testing.T) {
 		return
 	}
 
+	// Check latest unbonding lock ID
+	id, err := dbh.LatestUnbondingLockID()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if id.Cmp(big.NewInt(2)) != 0 {
+		t.Error("Unexpected latest unbonding lock ID; expected 2, got ", id)
+		return
+	}
+
 	// Check # of unbonding locks
 	var numUnbondingLocks int
 	row := dbraw.QueryRow("SELECT count(*) FROM unbondingLocks")

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -408,17 +408,6 @@ func TestDBUnbondingLocks(t *testing.T) {
 		return
 	}
 
-	// Check latest unbonding lock ID
-	id, err := dbh.LatestUnbondingLockID()
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	if id.Cmp(big.NewInt(2)) != 0 {
-		t.Error("Unexpected latest unbonding lock ID; expected 2, got ", id)
-		return
-	}
-
 	// Check # of unbonding locks
 	var numUnbondingLocks int
 	row := dbraw.QueryRow("SELECT count(*) FROM unbondingLocks")
@@ -429,6 +418,21 @@ func TestDBUnbondingLocks(t *testing.T) {
 	}
 	if numUnbondingLocks != 3 {
 		t.Error("Unexpected number of unbonding locks; expected 3 total, got ", numUnbondingLocks)
+		return
+	}
+
+	// Check unbonding lock IDs
+	unbondingLockIDs, err := dbh.UnbondingLockIDs()
+	if err != nil {
+		t.Error("Error retrieving unbonding lock IDs ", err)
+		return
+	}
+	if len(unbondingLockIDs) != 3 {
+		t.Error("Unexpected number of unbonding lock IDs; expected 3, got ", len(unbondingLockIDs))
+		return
+	}
+	if unbondingLockIDs[0].Cmp(big.NewInt(0)) != 0 {
+		t.Error("Unexpected unbonding lock ID; expected 0, got ", unbondingLockIDs[0])
 		return
 	}
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -456,9 +456,21 @@ func (n *LivepeerNode) UnsubscribeFromNetwork(strmID StreamID) error {
 
 func (n *LivepeerNode) StartEthServices() error {
 	var err error
-	for _, s := range n.EthServices {
+	for k, s := range n.EthServices {
+		// Skip BlockService until the end
+		if k == "BlockService" {
+			continue
+		}
 		err = s.Start(context.Background())
 		if err != nil {
+			return err
+		}
+	}
+
+	// Make sure to initialize BlockService last so other services can
+	// create filters starting from the last seen block
+	if s, ok := n.EthServices["BlockService"]; ok {
+		if err := s.Start(context.Background()); err != nil {
 			return err
 		}
 	}

--- a/eth/client.go
+++ b/eth/client.go
@@ -76,6 +76,7 @@ type LivepeerEthClient interface {
 	ClaimEarnings(endRound *big.Int) error
 	GetTranscoder(addr ethcommon.Address) (*lpTypes.Transcoder, error)
 	GetDelegator(addr ethcommon.Address) (*lpTypes.Delegator, error)
+	GetDelegatorUnbondingLock(addr ethcommon.Address, unbondingLockId *big.Int) (*lpTypes.UnbondingLock, error)
 	GetTranscoderEarningsPoolForRound(addr ethcommon.Address, round *big.Int) (*lpTypes.TokenPools, error)
 	RegisteredTranscoders() ([]*lpTypes.Transcoder, error)
 	IsActiveTranscoder() (bool, error)
@@ -740,6 +741,20 @@ func (c *client) GetDelegator(addr ethcommon.Address) (*lpTypes.Delegator, error
 		PendingStake:        pendingStake,
 		PendingFees:         pendingFees,
 		Status:              status,
+	}, nil
+}
+
+func (c *client) GetDelegatorUnbondingLock(addr ethcommon.Address, unbondingLockId *big.Int) (*lpTypes.UnbondingLock, error) {
+	lock, err := c.BondingManagerSession.GetDelegatorUnbondingLock(addr, unbondingLockId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lpTypes.UnbondingLock{
+		ID:               unbondingLockId,
+		DelegatorAddress: addr,
+		Amount:           lock.Amount,
+		WithdrawRound:    lock.WithdrawRound,
 	}, nil
 }
 

--- a/eth/client.go
+++ b/eth/client.go
@@ -112,11 +112,14 @@ type LivepeerEthClient interface {
 	VerificationCodeHash() (string, error)
 	Paused() (bool, error)
 
-	// Watchers
+	// Events
 	WatchForJob(string) (*lpTypes.Job, error)
-	WatchForUnbond(*big.Int, chan *contracts.BondingManagerUnbond) (ethereum.Subscription, error)
-	WatchForRebond(*big.Int, chan *contracts.BondingManagerRebond) (ethereum.Subscription, error)
-	WatchForWithdrawStake(*big.Int, chan *contracts.BondingManagerWithdrawStake) (ethereum.Subscription, error)
+	ProcessHistoricalUnbond(*big.Int, func(*contracts.BondingManagerUnbond) error) error
+	WatchForUnbond(chan *contracts.BondingManagerUnbond) (ethereum.Subscription, error)
+	ProcessHistoricalRebond(*big.Int, func(*contracts.BondingManagerRebond) error) error
+	WatchForRebond(chan *contracts.BondingManagerRebond) (ethereum.Subscription, error)
+	ProcessHistoricalWithdrawStake(*big.Int, func(*contracts.BondingManagerWithdrawStake) error) error
+	WatchForWithdrawStake(chan *contracts.BondingManagerWithdrawStake) (ethereum.Subscription, error)
 
 	// Helpers
 	ContractAddresses() map[string]ethcommon.Address
@@ -1053,17 +1056,32 @@ func (c *client) LatestBlockNum() (*big.Int, error) {
 	return blk.Number, nil
 }
 
-func (c *client) WatchForUnbond(startBlock *big.Int, sink chan *contracts.BondingManagerUnbond) (ethereum.Subscription, error) {
+func (c *client) ProcessHistoricalUnbond(startBlock *big.Int, cb func(*contracts.BondingManagerUnbond) error) error {
+	// Retrieve historical logs starting from startBlock
+	// WatchForUnbond() will not emit past logs
+	filterOpts := &bind.FilterOpts{Start: startBlock.Uint64()}
+	it, err := c.BondingManagerSession.Contract.BondingManagerFilterer.FilterUnbond(filterOpts, nil, []ethcommon.Address{c.Account().Address})
+	if err != nil {
+		return err
+	}
+
+	for it.Next() {
+		if err := cb(it.Event); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *client) WatchForUnbond(sink chan *contracts.BondingManagerUnbond) (ethereum.Subscription, error) {
 	var (
 		sub ethereum.Subscription
 		err error
 	)
 
-	sb := startBlock.Uint64()
-	watchOpts := &bind.WatchOpts{Start: &sb}
-
 	unbondWatcher := func() error {
-		sub, err = c.BondingManagerSession.Contract.BondingManagerFilterer.WatchUnbond(watchOpts, sink, nil, []ethcommon.Address{c.Account().Address})
+		sub, err = c.BondingManagerSession.Contract.BondingManagerFilterer.WatchUnbond(nil, sink, nil, []ethcommon.Address{c.Account().Address})
 		if err != nil {
 			glog.Error("Unable to start Unbond watcher ", err)
 			return err
@@ -1077,17 +1095,32 @@ func (c *client) WatchForUnbond(startBlock *big.Int, sink chan *contracts.Bondin
 	return sub, err
 }
 
-func (c *client) WatchForRebond(startBlock *big.Int, sink chan *contracts.BondingManagerRebond) (ethereum.Subscription, error) {
+func (c *client) ProcessHistoricalRebond(startBlock *big.Int, cb func(*contracts.BondingManagerRebond) error) error {
+	// Retrieve historical logs starting from startBlock
+	// WatchRebond() will not emit past logs
+	filterOpts := &bind.FilterOpts{Start: startBlock.Uint64()}
+	it, err := c.BondingManagerSession.Contract.BondingManagerFilterer.FilterRebond(filterOpts, nil, []ethcommon.Address{c.Account().Address})
+	if err != nil {
+		return err
+	}
+
+	for it.Next() {
+		if err := cb(it.Event); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *client) WatchForRebond(sink chan *contracts.BondingManagerRebond) (ethereum.Subscription, error) {
 	var (
 		sub ethereum.Subscription
 		err error
 	)
 
-	sb := startBlock.Uint64()
-	watchOpts := &bind.WatchOpts{Start: &sb}
-
 	rebondWatcher := func() error {
-		sub, err = c.BondingManagerSession.Contract.BondingManagerFilterer.WatchRebond(watchOpts, sink, nil, []ethcommon.Address{c.Account().Address})
+		sub, err = c.BondingManagerSession.Contract.BondingManagerFilterer.WatchRebond(nil, sink, nil, []ethcommon.Address{c.Account().Address})
 		if err != nil {
 			glog.Error("Unable to start Rebond watcher ", err)
 			return err
@@ -1101,17 +1134,33 @@ func (c *client) WatchForRebond(startBlock *big.Int, sink chan *contracts.Bondin
 	return sub, err
 }
 
-func (c *client) WatchForWithdrawStake(startBlock *big.Int, sink chan *contracts.BondingManagerWithdrawStake) (ethereum.Subscription, error) {
+func (c *client) ProcessHistoricalWithdrawStake(startBlock *big.Int, cb func(*contracts.BondingManagerWithdrawStake) error) error {
+	// Retrieve historical logs starting from startBlock
+	// WatchWithdrawStake() will not emit past logs
+	filterOpts := &bind.FilterOpts{Start: startBlock.Uint64()}
+	it, err := c.BondingManagerSession.Contract.BondingManagerFilterer.FilterWithdrawStake(filterOpts, []ethcommon.Address{c.Account().Address})
+	if err != nil {
+		return err
+	}
+
+	// Pass any relevant events into sink
+	for it.Next() {
+		if err := cb(it.Event); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *client) WatchForWithdrawStake(sink chan *contracts.BondingManagerWithdrawStake) (ethereum.Subscription, error) {
 	var (
 		sub ethereum.Subscription
 		err error
 	)
 
-	sb := startBlock.Uint64()
-	watchOpts := &bind.WatchOpts{Start: &sb}
-
 	withdrawStakeWatcher := func() error {
-		sub, err = c.BondingManagerSession.Contract.BondingManagerFilterer.WatchWithdrawStake(watchOpts, sink, []ethcommon.Address{c.Account().Address})
+		sub, err = c.BondingManagerSession.Contract.BondingManagerFilterer.WatchWithdrawStake(nil, sink, []ethcommon.Address{c.Account().Address})
 		if err != nil {
 			glog.Error("Unable start WithdrawStake watcher ", err)
 			return err

--- a/eth/contracts/bondingManager.go
+++ b/eth/contracts/bondingManager.go
@@ -16,7 +16,7 @@ import (
 )
 
 // BondingManagerABI is the input ABI used to generate the binding from.
-const BondingManagerABI = "[{\"constant\":true,\"inputs\":[],\"name\":\"maxEarningsClaimsRounds\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"activeTranscoderSet\",\"outputs\":[{\"name\":\"totalStake\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"targetContractId\",\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"numActiveTranscoders\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"unbondingPeriod\",\"outputs\":[{\"name\":\"\",\"type\":\"uint64\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_controller\",\"type\":\"address\"}],\"name\":\"setController\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"controller\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_controller\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"transcoder\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"pendingRewardCut\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"pendingFeeShare\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"pendingPricePerSegment\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"registered\",\"type\":\"bool\"}],\"name\":\"TranscoderUpdate\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"transcoder\",\"type\":\"address\"}],\"name\":\"TranscoderEvicted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"transcoder\",\"type\":\"address\"}],\"name\":\"TranscoderResigned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"transcoder\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"finder\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"penalty\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"finderReward\",\"type\":\"uint256\"}],\"name\":\"TranscoderSlashed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"transcoder\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"Reward\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"delegate\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"delegator\",\"type\":\"address\"}],\"name\":\"Bond\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"delegate\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"delegator\",\"type\":\"address\"}],\"name\":\"Unbond\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"delegator\",\"type\":\"address\"}],\"name\":\"WithdrawStake\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"delegator\",\"type\":\"address\"}],\"name\":\"WithdrawFees\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"controller\",\"type\":\"address\"}],\"name\":\"SetController\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"param\",\"type\":\"string\"}],\"name\":\"ParameterUpdate\",\"type\":\"event\"},{\"constant\":false,\"inputs\":[{\"name\":\"_unbondingPeriod\",\"type\":\"uint64\"}],\"name\":\"setUnbondingPeriod\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_numTranscoders\",\"type\":\"uint256\"}],\"name\":\"setNumTranscoders\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_numActiveTranscoders\",\"type\":\"uint256\"}],\"name\":\"setNumActiveTranscoders\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_maxEarningsClaimsRounds\",\"type\":\"uint256\"}],\"name\":\"setMaxEarningsClaimsRounds\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_rewardCut\",\"type\":\"uint256\"},{\"name\":\"_feeShare\",\"type\":\"uint256\"},{\"name\":\"_pricePerSegment\",\"type\":\"uint256\"}],\"name\":\"transcoder\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_amount\",\"type\":\"uint256\"},{\"name\":\"_to\",\"type\":\"address\"}],\"name\":\"bond\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"unbond\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"withdrawStake\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"withdrawFees\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"setActiveTranscoders\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"reward\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"},{\"name\":\"_fees\",\"type\":\"uint256\"},{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"updateTranscoderWithFees\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"},{\"name\":\"_finder\",\"type\":\"address\"},{\"name\":\"_slashAmount\",\"type\":\"uint256\"},{\"name\":\"_finderFee\",\"type\":\"uint256\"}],\"name\":\"slashTranscoder\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_maxPricePerSegment\",\"type\":\"uint256\"},{\"name\":\"_blockHash\",\"type\":\"bytes32\"},{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"electActiveTranscoder\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_endRound\",\"type\":\"uint256\"}],\"name\":\"claimEarnings\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_delegator\",\"type\":\"address\"},{\"name\":\"_endRound\",\"type\":\"uint256\"}],\"name\":\"pendingStake\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_delegator\",\"type\":\"address\"},{\"name\":\"_endRound\",\"type\":\"uint256\"}],\"name\":\"pendingFees\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"},{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"activeTranscoderTotalStake\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"}],\"name\":\"transcoderTotalStake\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"}],\"name\":\"transcoderStatus\",\"outputs\":[{\"name\":\"\",\"type\":\"uint8\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_delegator\",\"type\":\"address\"}],\"name\":\"delegatorStatus\",\"outputs\":[{\"name\":\"\",\"type\":\"uint8\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"}],\"name\":\"getTranscoder\",\"outputs\":[{\"name\":\"lastRewardRound\",\"type\":\"uint256\"},{\"name\":\"rewardCut\",\"type\":\"uint256\"},{\"name\":\"feeShare\",\"type\":\"uint256\"},{\"name\":\"pricePerSegment\",\"type\":\"uint256\"},{\"name\":\"pendingRewardCut\",\"type\":\"uint256\"},{\"name\":\"pendingFeeShare\",\"type\":\"uint256\"},{\"name\":\"pendingPricePerSegment\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"},{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"getTranscoderEarningsPoolForRound\",\"outputs\":[{\"name\":\"rewardPool\",\"type\":\"uint256\"},{\"name\":\"feePool\",\"type\":\"uint256\"},{\"name\":\"totalStake\",\"type\":\"uint256\"},{\"name\":\"claimableStake\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_delegator\",\"type\":\"address\"}],\"name\":\"getDelegator\",\"outputs\":[{\"name\":\"bondedAmount\",\"type\":\"uint256\"},{\"name\":\"fees\",\"type\":\"uint256\"},{\"name\":\"delegateAddress\",\"type\":\"address\"},{\"name\":\"delegatedAmount\",\"type\":\"uint256\"},{\"name\":\"startRound\",\"type\":\"uint256\"},{\"name\":\"withdrawRound\",\"type\":\"uint256\"},{\"name\":\"lastClaimRound\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getTranscoderPoolMaxSize\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getTranscoderPoolSize\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getFirstTranscoderInPool\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"}],\"name\":\"getNextTranscoderInPool\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getTotalBonded\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"getTotalActiveStake\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"},{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"isActiveTranscoder\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"}],\"name\":\"isRegisteredTranscoder\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"}]"
+const BondingManagerABI = "[{\"constant\":true,\"inputs\":[],\"name\":\"maxEarningsClaimsRounds\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_delegator\",\"type\":\"address\"},{\"name\":\"_unbondingLockId\",\"type\":\"uint256\"}],\"name\":\"isValidUnbondingLock\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_delegator\",\"type\":\"address\"}],\"name\":\"delegatorStatus\",\"outputs\":[{\"name\":\"\",\"type\":\"uint8\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"reward\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"},{\"name\":\"_finder\",\"type\":\"address\"},{\"name\":\"_slashAmount\",\"type\":\"uint256\"},{\"name\":\"_finderFee\",\"type\":\"uint256\"}],\"name\":\"slashTranscoder\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"}],\"name\":\"getNextTranscoderInPool\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"setActiveTranscoders\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"},{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"getTranscoderEarningsPoolForRound\",\"outputs\":[{\"name\":\"rewardPool\",\"type\":\"uint256\"},{\"name\":\"feePool\",\"type\":\"uint256\"},{\"name\":\"totalStake\",\"type\":\"uint256\"},{\"name\":\"claimableStake\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_endRound\",\"type\":\"uint256\"}],\"name\":\"claimEarnings\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_unbondingLockId\",\"type\":\"uint256\"}],\"name\":\"withdrawStake\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_amount\",\"type\":\"uint256\"}],\"name\":\"unbond\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getTranscoderPoolSize\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_to\",\"type\":\"address\"},{\"name\":\"_unbondingLockId\",\"type\":\"uint256\"}],\"name\":\"rebondFromUnbonded\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"},{\"name\":\"_fees\",\"type\":\"uint256\"},{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"updateTranscoderWithFees\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"activeTranscoderSet\",\"outputs\":[{\"name\":\"totalStake\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_delegator\",\"type\":\"address\"},{\"name\":\"_unbondingLockId\",\"type\":\"uint256\"}],\"name\":\"getDelegatorUnbondingLock\",\"outputs\":[{\"name\":\"amount\",\"type\":\"uint256\"},{\"name\":\"withdrawRound\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[],\"name\":\"withdrawFees\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"targetContractId\",\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getTranscoderPoolMaxSize\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getTotalBonded\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"}],\"name\":\"getTranscoder\",\"outputs\":[{\"name\":\"lastRewardRound\",\"type\":\"uint256\"},{\"name\":\"rewardCut\",\"type\":\"uint256\"},{\"name\":\"feeShare\",\"type\":\"uint256\"},{\"name\":\"pricePerSegment\",\"type\":\"uint256\"},{\"name\":\"pendingRewardCut\",\"type\":\"uint256\"},{\"name\":\"pendingFeeShare\",\"type\":\"uint256\"},{\"name\":\"pendingPricePerSegment\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_numTranscoders\",\"type\":\"uint256\"}],\"name\":\"setNumTranscoders\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"numActiveTranscoders\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_numActiveTranscoders\",\"type\":\"uint256\"}],\"name\":\"setNumActiveTranscoders\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"}],\"name\":\"isRegisteredTranscoder\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"unbondingPeriod\",\"outputs\":[{\"name\":\"\",\"type\":\"uint64\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_maxEarningsClaimsRounds\",\"type\":\"uint256\"}],\"name\":\"setMaxEarningsClaimsRounds\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"getTotalActiveStake\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"},{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"isActiveTranscoder\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_rewardCut\",\"type\":\"uint256\"},{\"name\":\"_feeShare\",\"type\":\"uint256\"},{\"name\":\"_pricePerSegment\",\"type\":\"uint256\"}],\"name\":\"transcoder\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"getFirstTranscoderInPool\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"}],\"name\":\"transcoderStatus\",\"outputs\":[{\"name\":\"\",\"type\":\"uint8\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_maxPricePerSegment\",\"type\":\"uint256\"},{\"name\":\"_blockHash\",\"type\":\"bytes32\"},{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"electActiveTranscoder\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_controller\",\"type\":\"address\"}],\"name\":\"setController\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_delegator\",\"type\":\"address\"},{\"name\":\"_endRound\",\"type\":\"uint256\"}],\"name\":\"pendingStake\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"}],\"name\":\"transcoderTotalStake\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_delegator\",\"type\":\"address\"}],\"name\":\"getDelegator\",\"outputs\":[{\"name\":\"bondedAmount\",\"type\":\"uint256\"},{\"name\":\"fees\",\"type\":\"uint256\"},{\"name\":\"delegateAddress\",\"type\":\"address\"},{\"name\":\"delegatedAmount\",\"type\":\"uint256\"},{\"name\":\"startRound\",\"type\":\"uint256\"},{\"name\":\"lastClaimRound\",\"type\":\"uint256\"},{\"name\":\"nextUnbondingLockId\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_amount\",\"type\":\"uint256\"},{\"name\":\"_to\",\"type\":\"address\"}],\"name\":\"bond\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_unbondingLockId\",\"type\":\"uint256\"}],\"name\":\"rebond\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_unbondingPeriod\",\"type\":\"uint64\"}],\"name\":\"setUnbondingPeriod\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_transcoder\",\"type\":\"address\"},{\"name\":\"_round\",\"type\":\"uint256\"}],\"name\":\"activeTranscoderTotalStake\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"_delegator\",\"type\":\"address\"},{\"name\":\"_endRound\",\"type\":\"uint256\"}],\"name\":\"pendingFees\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"controller\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_controller\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"transcoder\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"pendingRewardCut\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"pendingFeeShare\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"pendingPricePerSegment\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"registered\",\"type\":\"bool\"}],\"name\":\"TranscoderUpdate\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"transcoder\",\"type\":\"address\"}],\"name\":\"TranscoderEvicted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"transcoder\",\"type\":\"address\"}],\"name\":\"TranscoderResigned\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"transcoder\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"finder\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"penalty\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"finderReward\",\"type\":\"uint256\"}],\"name\":\"TranscoderSlashed\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"transcoder\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"Reward\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"delegate\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"delegator\",\"type\":\"address\"}],\"name\":\"Bond\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"delegate\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"delegator\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"unbondingLockId\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"withdrawRound\",\"type\":\"uint256\"}],\"name\":\"Unbond\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"delegate\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"delegator\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"unbondingLockId\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"Rebond\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"delegator\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"unbondingLockId\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"amount\",\"type\":\"uint256\"},{\"indexed\":false,\"name\":\"withdrawRound\",\"type\":\"uint256\"}],\"name\":\"WithdrawStake\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"delegator\",\"type\":\"address\"}],\"name\":\"WithdrawFees\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"controller\",\"type\":\"address\"}],\"name\":\"SetController\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"param\",\"type\":\"string\"}],\"name\":\"ParameterUpdate\",\"type\":\"event\"}]"
 
 // BondingManager is an auto generated Go binding around an Ethereum contract.
 type BondingManager struct {
@@ -292,24 +292,24 @@ func (_BondingManager *BondingManagerCallerSession) ElectActiveTranscoder(_maxPr
 
 // GetDelegator is a free data retrieval call binding the contract method 0xa64ad595.
 //
-// Solidity: function getDelegator(_delegator address) constant returns(bondedAmount uint256, fees uint256, delegateAddress address, delegatedAmount uint256, startRound uint256, withdrawRound uint256, lastClaimRound uint256)
+// Solidity: function getDelegator(_delegator address) constant returns(bondedAmount uint256, fees uint256, delegateAddress address, delegatedAmount uint256, startRound uint256, lastClaimRound uint256, nextUnbondingLockId uint256)
 func (_BondingManager *BondingManagerCaller) GetDelegator(opts *bind.CallOpts, _delegator common.Address) (struct {
-	BondedAmount    *big.Int
-	Fees            *big.Int
-	DelegateAddress common.Address
-	DelegatedAmount *big.Int
-	StartRound      *big.Int
-	WithdrawRound   *big.Int
-	LastClaimRound  *big.Int
+	BondedAmount        *big.Int
+	Fees                *big.Int
+	DelegateAddress     common.Address
+	DelegatedAmount     *big.Int
+	StartRound          *big.Int
+	LastClaimRound      *big.Int
+	NextUnbondingLockId *big.Int
 }, error) {
 	ret := new(struct {
-		BondedAmount    *big.Int
-		Fees            *big.Int
-		DelegateAddress common.Address
-		DelegatedAmount *big.Int
-		StartRound      *big.Int
-		WithdrawRound   *big.Int
-		LastClaimRound  *big.Int
+		BondedAmount        *big.Int
+		Fees                *big.Int
+		DelegateAddress     common.Address
+		DelegatedAmount     *big.Int
+		StartRound          *big.Int
+		LastClaimRound      *big.Int
+		NextUnbondingLockId *big.Int
 	})
 	out := ret
 	err := _BondingManager.contract.Call(opts, out, "getDelegator", _delegator)
@@ -318,32 +318,68 @@ func (_BondingManager *BondingManagerCaller) GetDelegator(opts *bind.CallOpts, _
 
 // GetDelegator is a free data retrieval call binding the contract method 0xa64ad595.
 //
-// Solidity: function getDelegator(_delegator address) constant returns(bondedAmount uint256, fees uint256, delegateAddress address, delegatedAmount uint256, startRound uint256, withdrawRound uint256, lastClaimRound uint256)
+// Solidity: function getDelegator(_delegator address) constant returns(bondedAmount uint256, fees uint256, delegateAddress address, delegatedAmount uint256, startRound uint256, lastClaimRound uint256, nextUnbondingLockId uint256)
 func (_BondingManager *BondingManagerSession) GetDelegator(_delegator common.Address) (struct {
-	BondedAmount    *big.Int
-	Fees            *big.Int
-	DelegateAddress common.Address
-	DelegatedAmount *big.Int
-	StartRound      *big.Int
-	WithdrawRound   *big.Int
-	LastClaimRound  *big.Int
+	BondedAmount        *big.Int
+	Fees                *big.Int
+	DelegateAddress     common.Address
+	DelegatedAmount     *big.Int
+	StartRound          *big.Int
+	LastClaimRound      *big.Int
+	NextUnbondingLockId *big.Int
 }, error) {
 	return _BondingManager.Contract.GetDelegator(&_BondingManager.CallOpts, _delegator)
 }
 
 // GetDelegator is a free data retrieval call binding the contract method 0xa64ad595.
 //
-// Solidity: function getDelegator(_delegator address) constant returns(bondedAmount uint256, fees uint256, delegateAddress address, delegatedAmount uint256, startRound uint256, withdrawRound uint256, lastClaimRound uint256)
+// Solidity: function getDelegator(_delegator address) constant returns(bondedAmount uint256, fees uint256, delegateAddress address, delegatedAmount uint256, startRound uint256, lastClaimRound uint256, nextUnbondingLockId uint256)
 func (_BondingManager *BondingManagerCallerSession) GetDelegator(_delegator common.Address) (struct {
-	BondedAmount    *big.Int
-	Fees            *big.Int
-	DelegateAddress common.Address
-	DelegatedAmount *big.Int
-	StartRound      *big.Int
-	WithdrawRound   *big.Int
-	LastClaimRound  *big.Int
+	BondedAmount        *big.Int
+	Fees                *big.Int
+	DelegateAddress     common.Address
+	DelegatedAmount     *big.Int
+	StartRound          *big.Int
+	LastClaimRound      *big.Int
+	NextUnbondingLockId *big.Int
 }, error) {
 	return _BondingManager.Contract.GetDelegator(&_BondingManager.CallOpts, _delegator)
+}
+
+// GetDelegatorUnbondingLock is a free data retrieval call binding the contract method 0x412f83b6.
+//
+// Solidity: function getDelegatorUnbondingLock(_delegator address, _unbondingLockId uint256) constant returns(amount uint256, withdrawRound uint256)
+func (_BondingManager *BondingManagerCaller) GetDelegatorUnbondingLock(opts *bind.CallOpts, _delegator common.Address, _unbondingLockId *big.Int) (struct {
+	Amount        *big.Int
+	WithdrawRound *big.Int
+}, error) {
+	ret := new(struct {
+		Amount        *big.Int
+		WithdrawRound *big.Int
+	})
+	out := ret
+	err := _BondingManager.contract.Call(opts, out, "getDelegatorUnbondingLock", _delegator, _unbondingLockId)
+	return *ret, err
+}
+
+// GetDelegatorUnbondingLock is a free data retrieval call binding the contract method 0x412f83b6.
+//
+// Solidity: function getDelegatorUnbondingLock(_delegator address, _unbondingLockId uint256) constant returns(amount uint256, withdrawRound uint256)
+func (_BondingManager *BondingManagerSession) GetDelegatorUnbondingLock(_delegator common.Address, _unbondingLockId *big.Int) (struct {
+	Amount        *big.Int
+	WithdrawRound *big.Int
+}, error) {
+	return _BondingManager.Contract.GetDelegatorUnbondingLock(&_BondingManager.CallOpts, _delegator, _unbondingLockId)
+}
+
+// GetDelegatorUnbondingLock is a free data retrieval call binding the contract method 0x412f83b6.
+//
+// Solidity: function getDelegatorUnbondingLock(_delegator address, _unbondingLockId uint256) constant returns(amount uint256, withdrawRound uint256)
+func (_BondingManager *BondingManagerCallerSession) GetDelegatorUnbondingLock(_delegator common.Address, _unbondingLockId *big.Int) (struct {
+	Amount        *big.Int
+	WithdrawRound *big.Int
+}, error) {
+	return _BondingManager.Contract.GetDelegatorUnbondingLock(&_BondingManager.CallOpts, _delegator, _unbondingLockId)
 }
 
 // GetFirstTranscoderInPool is a free data retrieval call binding the contract method 0x88a6c749.
@@ -654,6 +690,32 @@ func (_BondingManager *BondingManagerCallerSession) IsRegisteredTranscoder(_tran
 	return _BondingManager.Contract.IsRegisteredTranscoder(&_BondingManager.CallOpts, _transcoder)
 }
 
+// IsValidUnbondingLock is a free data retrieval call binding the contract method 0x0fd02fc1.
+//
+// Solidity: function isValidUnbondingLock(_delegator address, _unbondingLockId uint256) constant returns(bool)
+func (_BondingManager *BondingManagerCaller) IsValidUnbondingLock(opts *bind.CallOpts, _delegator common.Address, _unbondingLockId *big.Int) (bool, error) {
+	var (
+		ret0 = new(bool)
+	)
+	out := ret0
+	err := _BondingManager.contract.Call(opts, out, "isValidUnbondingLock", _delegator, _unbondingLockId)
+	return *ret0, err
+}
+
+// IsValidUnbondingLock is a free data retrieval call binding the contract method 0x0fd02fc1.
+//
+// Solidity: function isValidUnbondingLock(_delegator address, _unbondingLockId uint256) constant returns(bool)
+func (_BondingManager *BondingManagerSession) IsValidUnbondingLock(_delegator common.Address, _unbondingLockId *big.Int) (bool, error) {
+	return _BondingManager.Contract.IsValidUnbondingLock(&_BondingManager.CallOpts, _delegator, _unbondingLockId)
+}
+
+// IsValidUnbondingLock is a free data retrieval call binding the contract method 0x0fd02fc1.
+//
+// Solidity: function isValidUnbondingLock(_delegator address, _unbondingLockId uint256) constant returns(bool)
+func (_BondingManager *BondingManagerCallerSession) IsValidUnbondingLock(_delegator common.Address, _unbondingLockId *big.Int) (bool, error) {
+	return _BondingManager.Contract.IsValidUnbondingLock(&_BondingManager.CallOpts, _delegator, _unbondingLockId)
+}
+
 // MaxEarningsClaimsRounds is a free data retrieval call binding the contract method 0x038424c3.
 //
 // Solidity: function maxEarningsClaimsRounds() constant returns(uint256)
@@ -904,6 +966,48 @@ func (_BondingManager *BondingManagerTransactorSession) ClaimEarnings(_endRound 
 	return _BondingManager.Contract.ClaimEarnings(&_BondingManager.TransactOpts, _endRound)
 }
 
+// Rebond is a paid mutator transaction binding the contract method 0xeaffb3f9.
+//
+// Solidity: function rebond(_unbondingLockId uint256) returns()
+func (_BondingManager *BondingManagerTransactor) Rebond(opts *bind.TransactOpts, _unbondingLockId *big.Int) (*types.Transaction, error) {
+	return _BondingManager.contract.Transact(opts, "rebond", _unbondingLockId)
+}
+
+// Rebond is a paid mutator transaction binding the contract method 0xeaffb3f9.
+//
+// Solidity: function rebond(_unbondingLockId uint256) returns()
+func (_BondingManager *BondingManagerSession) Rebond(_unbondingLockId *big.Int) (*types.Transaction, error) {
+	return _BondingManager.Contract.Rebond(&_BondingManager.TransactOpts, _unbondingLockId)
+}
+
+// Rebond is a paid mutator transaction binding the contract method 0xeaffb3f9.
+//
+// Solidity: function rebond(_unbondingLockId uint256) returns()
+func (_BondingManager *BondingManagerTransactorSession) Rebond(_unbondingLockId *big.Int) (*types.Transaction, error) {
+	return _BondingManager.Contract.Rebond(&_BondingManager.TransactOpts, _unbondingLockId)
+}
+
+// RebondFromUnbonded is a paid mutator transaction binding the contract method 0x3a080e93.
+//
+// Solidity: function rebondFromUnbonded(_to address, _unbondingLockId uint256) returns()
+func (_BondingManager *BondingManagerTransactor) RebondFromUnbonded(opts *bind.TransactOpts, _to common.Address, _unbondingLockId *big.Int) (*types.Transaction, error) {
+	return _BondingManager.contract.Transact(opts, "rebondFromUnbonded", _to, _unbondingLockId)
+}
+
+// RebondFromUnbonded is a paid mutator transaction binding the contract method 0x3a080e93.
+//
+// Solidity: function rebondFromUnbonded(_to address, _unbondingLockId uint256) returns()
+func (_BondingManager *BondingManagerSession) RebondFromUnbonded(_to common.Address, _unbondingLockId *big.Int) (*types.Transaction, error) {
+	return _BondingManager.Contract.RebondFromUnbonded(&_BondingManager.TransactOpts, _to, _unbondingLockId)
+}
+
+// RebondFromUnbonded is a paid mutator transaction binding the contract method 0x3a080e93.
+//
+// Solidity: function rebondFromUnbonded(_to address, _unbondingLockId uint256) returns()
+func (_BondingManager *BondingManagerTransactorSession) RebondFromUnbonded(_to common.Address, _unbondingLockId *big.Int) (*types.Transaction, error) {
+	return _BondingManager.Contract.RebondFromUnbonded(&_BondingManager.TransactOpts, _to, _unbondingLockId)
+}
+
 // Reward is a paid mutator transaction binding the contract method 0x228cb733.
 //
 // Solidity: function reward() returns()
@@ -1093,25 +1197,25 @@ func (_BondingManager *BondingManagerTransactorSession) Transcoder(_rewardCut *b
 	return _BondingManager.Contract.Transcoder(&_BondingManager.TransactOpts, _rewardCut, _feeShare, _pricePerSegment)
 }
 
-// Unbond is a paid mutator transaction binding the contract method 0x5df6a6bc.
+// Unbond is a paid mutator transaction binding the contract method 0x27de9e32.
 //
-// Solidity: function unbond() returns()
-func (_BondingManager *BondingManagerTransactor) Unbond(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _BondingManager.contract.Transact(opts, "unbond")
+// Solidity: function unbond(_amount uint256) returns()
+func (_BondingManager *BondingManagerTransactor) Unbond(opts *bind.TransactOpts, _amount *big.Int) (*types.Transaction, error) {
+	return _BondingManager.contract.Transact(opts, "unbond", _amount)
 }
 
-// Unbond is a paid mutator transaction binding the contract method 0x5df6a6bc.
+// Unbond is a paid mutator transaction binding the contract method 0x27de9e32.
 //
-// Solidity: function unbond() returns()
-func (_BondingManager *BondingManagerSession) Unbond() (*types.Transaction, error) {
-	return _BondingManager.Contract.Unbond(&_BondingManager.TransactOpts)
+// Solidity: function unbond(_amount uint256) returns()
+func (_BondingManager *BondingManagerSession) Unbond(_amount *big.Int) (*types.Transaction, error) {
+	return _BondingManager.Contract.Unbond(&_BondingManager.TransactOpts, _amount)
 }
 
-// Unbond is a paid mutator transaction binding the contract method 0x5df6a6bc.
+// Unbond is a paid mutator transaction binding the contract method 0x27de9e32.
 //
-// Solidity: function unbond() returns()
-func (_BondingManager *BondingManagerTransactorSession) Unbond() (*types.Transaction, error) {
-	return _BondingManager.Contract.Unbond(&_BondingManager.TransactOpts)
+// Solidity: function unbond(_amount uint256) returns()
+func (_BondingManager *BondingManagerTransactorSession) Unbond(_amount *big.Int) (*types.Transaction, error) {
+	return _BondingManager.Contract.Unbond(&_BondingManager.TransactOpts, _amount)
 }
 
 // UpdateTranscoderWithFees is a paid mutator transaction binding the contract method 0x3aeb512c.
@@ -1156,25 +1260,25 @@ func (_BondingManager *BondingManagerTransactorSession) WithdrawFees() (*types.T
 	return _BondingManager.Contract.WithdrawFees(&_BondingManager.TransactOpts)
 }
 
-// WithdrawStake is a paid mutator transaction binding the contract method 0xbed9d861.
+// WithdrawStake is a paid mutator transaction binding the contract method 0x25d5971f.
 //
-// Solidity: function withdrawStake() returns()
-func (_BondingManager *BondingManagerTransactor) WithdrawStake(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _BondingManager.contract.Transact(opts, "withdrawStake")
+// Solidity: function withdrawStake(_unbondingLockId uint256) returns()
+func (_BondingManager *BondingManagerTransactor) WithdrawStake(opts *bind.TransactOpts, _unbondingLockId *big.Int) (*types.Transaction, error) {
+	return _BondingManager.contract.Transact(opts, "withdrawStake", _unbondingLockId)
 }
 
-// WithdrawStake is a paid mutator transaction binding the contract method 0xbed9d861.
+// WithdrawStake is a paid mutator transaction binding the contract method 0x25d5971f.
 //
-// Solidity: function withdrawStake() returns()
-func (_BondingManager *BondingManagerSession) WithdrawStake() (*types.Transaction, error) {
-	return _BondingManager.Contract.WithdrawStake(&_BondingManager.TransactOpts)
+// Solidity: function withdrawStake(_unbondingLockId uint256) returns()
+func (_BondingManager *BondingManagerSession) WithdrawStake(_unbondingLockId *big.Int) (*types.Transaction, error) {
+	return _BondingManager.Contract.WithdrawStake(&_BondingManager.TransactOpts, _unbondingLockId)
 }
 
-// WithdrawStake is a paid mutator transaction binding the contract method 0xbed9d861.
+// WithdrawStake is a paid mutator transaction binding the contract method 0x25d5971f.
 //
-// Solidity: function withdrawStake() returns()
-func (_BondingManager *BondingManagerTransactorSession) WithdrawStake() (*types.Transaction, error) {
-	return _BondingManager.Contract.WithdrawStake(&_BondingManager.TransactOpts)
+// Solidity: function withdrawStake(_unbondingLockId uint256) returns()
+func (_BondingManager *BondingManagerTransactorSession) WithdrawStake(_unbondingLockId *big.Int) (*types.Transaction, error) {
+	return _BondingManager.Contract.WithdrawStake(&_BondingManager.TransactOpts, _unbondingLockId)
 }
 
 // BondingManagerBondIterator is returned from FilterBond and is used to iterate over the raw logs and unpacked data for Bond events raised by the BondingManager contract.
@@ -1420,6 +1524,149 @@ func (_BondingManager *BondingManagerFilterer) WatchParameterUpdate(opts *bind.W
 				// New log arrived, parse the event and forward to the user
 				event := new(BondingManagerParameterUpdate)
 				if err := _BondingManager.contract.UnpackLog(event, "ParameterUpdate", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// BondingManagerRebondIterator is returned from FilterRebond and is used to iterate over the raw logs and unpacked data for Rebond events raised by the BondingManager contract.
+type BondingManagerRebondIterator struct {
+	Event *BondingManagerRebond // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BondingManagerRebondIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BondingManagerRebond)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BondingManagerRebond)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BondingManagerRebondIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BondingManagerRebondIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BondingManagerRebond represents a Rebond event raised by the BondingManager contract.
+type BondingManagerRebond struct {
+	Delegate        common.Address
+	Delegator       common.Address
+	UnbondingLockId *big.Int
+	Amount          *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
+}
+
+// FilterRebond is a free log retrieval operation binding the contract event 0x9f5b64cc71e1e26ff178caaa7877a04d8ce66fde989251870e80e6fbee690c17.
+//
+// Solidity: event Rebond(delegate indexed address, delegator indexed address, unbondingLockId uint256, amount uint256)
+func (_BondingManager *BondingManagerFilterer) FilterRebond(opts *bind.FilterOpts, delegate []common.Address, delegator []common.Address) (*BondingManagerRebondIterator, error) {
+
+	var delegateRule []interface{}
+	for _, delegateItem := range delegate {
+		delegateRule = append(delegateRule, delegateItem)
+	}
+	var delegatorRule []interface{}
+	for _, delegatorItem := range delegator {
+		delegatorRule = append(delegatorRule, delegatorItem)
+	}
+
+	logs, sub, err := _BondingManager.contract.FilterLogs(opts, "Rebond", delegateRule, delegatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BondingManagerRebondIterator{contract: _BondingManager.contract, event: "Rebond", logs: logs, sub: sub}, nil
+}
+
+// WatchRebond is a free log subscription operation binding the contract event 0x9f5b64cc71e1e26ff178caaa7877a04d8ce66fde989251870e80e6fbee690c17.
+//
+// Solidity: event Rebond(delegate indexed address, delegator indexed address, unbondingLockId uint256, amount uint256)
+func (_BondingManager *BondingManagerFilterer) WatchRebond(opts *bind.WatchOpts, sink chan<- *BondingManagerRebond, delegate []common.Address, delegator []common.Address) (event.Subscription, error) {
+
+	var delegateRule []interface{}
+	for _, delegateItem := range delegate {
+		delegateRule = append(delegateRule, delegateItem)
+	}
+	var delegatorRule []interface{}
+	for _, delegatorItem := range delegator {
+		delegatorRule = append(delegatorRule, delegatorItem)
+	}
+
+	logs, sub, err := _BondingManager.contract.WatchLogs(opts, "Rebond", delegateRule, delegatorRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BondingManagerRebond)
+				if err := _BondingManager.contract.UnpackLog(event, "Rebond", log); err != nil {
 					return err
 				}
 				event.Raw = log
@@ -2299,14 +2546,17 @@ func (it *BondingManagerUnbondIterator) Close() error {
 
 // BondingManagerUnbond represents a Unbond event raised by the BondingManager contract.
 type BondingManagerUnbond struct {
-	Delegate  common.Address
-	Delegator common.Address
-	Raw       types.Log // Blockchain specific contextual infos
+	Delegate        common.Address
+	Delegator       common.Address
+	UnbondingLockId *big.Int
+	Amount          *big.Int
+	WithdrawRound   *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
 }
 
-// FilterUnbond is a free log retrieval operation binding the contract event 0x4907de7e87b3873cb501376a57df5a00ff20db617b18f56eb5768717564a00e4.
+// FilterUnbond is a free log retrieval operation binding the contract event 0x2d5d98d189bee5496a08db2a5948cb7e5e786f09d17d0c3f228eb41776c24a06.
 //
-// Solidity: event Unbond(delegate indexed address, delegator indexed address)
+// Solidity: event Unbond(delegate indexed address, delegator indexed address, unbondingLockId uint256, amount uint256, withdrawRound uint256)
 func (_BondingManager *BondingManagerFilterer) FilterUnbond(opts *bind.FilterOpts, delegate []common.Address, delegator []common.Address) (*BondingManagerUnbondIterator, error) {
 
 	var delegateRule []interface{}
@@ -2325,9 +2575,9 @@ func (_BondingManager *BondingManagerFilterer) FilterUnbond(opts *bind.FilterOpt
 	return &BondingManagerUnbondIterator{contract: _BondingManager.contract, event: "Unbond", logs: logs, sub: sub}, nil
 }
 
-// WatchUnbond is a free log subscription operation binding the contract event 0x4907de7e87b3873cb501376a57df5a00ff20db617b18f56eb5768717564a00e4.
+// WatchUnbond is a free log subscription operation binding the contract event 0x2d5d98d189bee5496a08db2a5948cb7e5e786f09d17d0c3f228eb41776c24a06.
 //
-// Solidity: event Unbond(delegate indexed address, delegator indexed address)
+// Solidity: event Unbond(delegate indexed address, delegator indexed address, unbondingLockId uint256, amount uint256, withdrawRound uint256)
 func (_BondingManager *BondingManagerFilterer) WatchUnbond(opts *bind.WatchOpts, sink chan<- *BondingManagerUnbond, delegate []common.Address, delegator []common.Address) (event.Subscription, error) {
 
 	var delegateRule []interface{}
@@ -2572,13 +2822,16 @@ func (it *BondingManagerWithdrawStakeIterator) Close() error {
 
 // BondingManagerWithdrawStake represents a WithdrawStake event raised by the BondingManager contract.
 type BondingManagerWithdrawStake struct {
-	Delegator common.Address
-	Raw       types.Log // Blockchain specific contextual infos
+	Delegator       common.Address
+	UnbondingLockId *big.Int
+	Amount          *big.Int
+	WithdrawRound   *big.Int
+	Raw             types.Log // Blockchain specific contextual infos
 }
 
-// FilterWithdrawStake is a free log retrieval operation binding the contract event 0x32b4834046d70a9d8d9c79995359892376424492753f04a190f871bbbc8d26ce.
+// FilterWithdrawStake is a free log retrieval operation binding the contract event 0x1340f1a8f3d456a649e1a12071dfa15655e3d09252131d0f980c3b405cc8dd2e.
 //
-// Solidity: event WithdrawStake(delegator indexed address)
+// Solidity: event WithdrawStake(delegator indexed address, unbondingLockId uint256, amount uint256, withdrawRound uint256)
 func (_BondingManager *BondingManagerFilterer) FilterWithdrawStake(opts *bind.FilterOpts, delegator []common.Address) (*BondingManagerWithdrawStakeIterator, error) {
 
 	var delegatorRule []interface{}
@@ -2593,9 +2846,9 @@ func (_BondingManager *BondingManagerFilterer) FilterWithdrawStake(opts *bind.Fi
 	return &BondingManagerWithdrawStakeIterator{contract: _BondingManager.contract, event: "WithdrawStake", logs: logs, sub: sub}, nil
 }
 
-// WatchWithdrawStake is a free log subscription operation binding the contract event 0x32b4834046d70a9d8d9c79995359892376424492753f04a190f871bbbc8d26ce.
+// WatchWithdrawStake is a free log subscription operation binding the contract event 0x1340f1a8f3d456a649e1a12071dfa15655e3d09252131d0f980c3b405cc8dd2e.
 //
-// Solidity: event WithdrawStake(delegator indexed address)
+// Solidity: event WithdrawStake(delegator indexed address, unbondingLockId uint256, amount uint256, withdrawRound uint256)
 func (_BondingManager *BondingManagerFilterer) WatchWithdrawStake(opts *bind.WatchOpts, sink chan<- *BondingManagerWithdrawStake, delegator []common.Address) (event.Subscription, error) {
 
 	var delegatorRule []interface{}

--- a/eth/eventservices/blockservice.go
+++ b/eth/eventservices/blockservice.go
@@ -1,0 +1,64 @@
+package eventservices
+
+import (
+	"context"
+	"fmt"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/eth"
+)
+
+var (
+	ErrBlockServiceStarted = fmt.Errorf("block service already started")
+	ErrBlockServiceStopped = fmt.Errorf("block service already stopped")
+)
+
+type BlockService struct {
+	eventMonitor eth.EventMonitor
+	db           *common.DB
+	working      bool
+	sub          ethereum.Subscription
+}
+
+func NewBlockService(eventMonitor eth.EventMonitor, db *common.DB) *BlockService {
+	return &BlockService{
+		eventMonitor: eventMonitor,
+		db:           db,
+	}
+}
+
+func (s *BlockService) Start(ctx context.Context) error {
+	if s.working {
+		return ErrBlockServiceStarted
+	}
+
+	sub, err := s.eventMonitor.SubscribeNewBlock(ctx, "BlockWatcher", make(chan *types.Header), func(h *types.Header) (bool, error) {
+		s.db.SetLastSeenBlock(h.Number)
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	s.sub = sub
+
+	return nil
+}
+
+func (s *BlockService) Stop() error {
+	if !s.working {
+		return ErrBlockServiceStopped
+	}
+
+	s.sub.Unsubscribe()
+
+	s.sub = nil
+
+	return nil
+}
+
+func (s *BlockService) IsWorking() bool {
+	return s.sub != nil
+}

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -87,11 +87,6 @@ func (s *JobService) Start(ctx context.Context) error {
 		return err
 	}
 
-	s.eventMonitor.SubscribeNewBlock(context.Background(), "BlockWatcher", make(chan *types.Header), func(h *types.Header) (bool, error) {
-		s.node.Database.SetLastSeenBlock(h.Number)
-		return true, nil
-	})
-
 	s.logsCh = logsCh
 	s.sub = sub
 

--- a/eth/eventservices/unbondingservice.go
+++ b/eth/eventservices/unbondingservice.go
@@ -1,0 +1,164 @@
+package eventservices
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/contracts"
+)
+
+var (
+	ErrUnbondingServiceStarted = fmt.Errorf("unbonding service already started")
+	ErrUnbondingServiceStopped = fmt.Errorf("unbonding service already stopped")
+)
+
+type UnbondingService struct {
+	client                   eth.LivepeerEthClient
+	db                       *common.DB
+	working                  bool
+	cancelWorker             context.CancelFunc
+	unbondResubscribe        bool
+	rebondResubscribe        bool
+	withdrawStakeResubscribe bool
+}
+
+func NewUnbondingService(client eth.LivepeerEthClient, db *common.DB) *UnbondingService {
+	return &UnbondingService{
+		client:                   client,
+		db:                       db,
+		unbondResubscribe:        true,
+		rebondResubscribe:        true,
+		withdrawStakeResubscribe: true,
+	}
+}
+
+func (s *UnbondingService) Start(ctx context.Context) error {
+	if s.working {
+		return ErrUnbondingServiceStarted
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	s.cancelWorker = cancel
+
+	go func() {
+		var (
+			unbondSink        = make(chan *contracts.BondingManagerUnbond)
+			rebondSink        = make(chan *contracts.BondingManagerRebond)
+			withdrawStakeSink = make(chan *contracts.BondingManagerWithdrawStake)
+			unbondSub         ethereum.Subscription
+			rebondSub         ethereum.Subscription
+			withdrawStakeSub  ethereum.Subscription
+			err               error
+		)
+
+		resubscribe := func(subFunc func(*big.Int) (ethereum.Subscription, error)) (ethereum.Subscription, error) {
+			startBlock, err := s.db.LastSeenBlock()
+			if err != nil {
+				return nil, err
+			}
+
+			return subFunc(startBlock)
+		}
+
+		for {
+			if s.unbondResubscribe {
+				unbondSub, err = resubscribe(func(startBlock *big.Int) (ethereum.Subscription, error) {
+					return s.client.WatchForUnbond(startBlock, unbondSink)
+				})
+				if err != nil {
+					glog.Error(err)
+				} else {
+					s.unbondResubscribe = false
+				}
+			}
+
+			if s.rebondResubscribe {
+				rebondSub, err = resubscribe(func(startBlock *big.Int) (ethereum.Subscription, error) {
+					return s.client.WatchForRebond(startBlock, rebondSink)
+				})
+				if err != nil {
+					glog.Error(err)
+				} else {
+					s.rebondResubscribe = false
+				}
+			}
+
+			if s.withdrawStakeResubscribe {
+				withdrawStakeSub, err = resubscribe(func(startBlock *big.Int) (ethereum.Subscription, error) {
+					return s.client.WatchForWithdrawStake(startBlock, withdrawStakeSink)
+				})
+				if err != nil {
+					glog.Error(err)
+				} else {
+					s.withdrawStakeResubscribe = false
+				}
+			}
+
+			select {
+			case newUnbond := <-unbondSink:
+				// Insert new unbonding lock into database
+				err := s.db.InsertUnbondingLock(newUnbond.UnbondingLockId, newUnbond.Delegator, newUnbond.Amount, newUnbond.WithdrawRound)
+				if err != nil {
+					glog.Error(err)
+				}
+			case newRebond := <-rebondSink:
+				// Update unbonding lock in database as used
+				err := s.db.UseUnbondingLock(newRebond.UnbondingLockId, newRebond.Delegator, new(big.Int).SetUint64(newRebond.Raw.BlockNumber))
+				if err != nil {
+					glog.Error(err)
+				}
+			case newWithdrawStake := <-withdrawStakeSink:
+				// Update unbonding lock in database as used
+				err := s.db.UseUnbondingLock(newWithdrawStake.UnbondingLockId, newWithdrawStake.Delegator, new(big.Int).SetUint64(newWithdrawStake.Raw.BlockNumber))
+				if err != nil {
+					glog.Error(err)
+				}
+			case unbondErr := <-unbondSub.Err():
+				unbondSub.Unsubscribe()
+				s.unbondResubscribe = true
+
+				glog.Error("Error with Unbond subscription ", unbondErr)
+			case rebondErr := <-rebondSub.Err():
+				rebondSub.Unsubscribe()
+				s.rebondResubscribe = true
+
+				glog.Error("Error with Rebond subscription ", rebondErr)
+			case withdrawStakeErr := <-withdrawStakeSub.Err():
+				withdrawStakeSub.Unsubscribe()
+				s.withdrawStakeResubscribe = true
+
+				glog.Error("Error with WithdrawStake subscription ", withdrawStakeErr)
+			case <-ctx.Done():
+				unbondSub.Unsubscribe()
+				rebondSub.Unsubscribe()
+				withdrawStakeSub.Unsubscribe()
+
+				glog.Infof("Received cancellation for unbonding service; stopping")
+
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (s *UnbondingService) Stop() error {
+	if !s.working {
+		return ErrUnbondingServiceStopped
+	}
+
+	s.cancelWorker()
+	s.working = false
+
+	return nil
+}
+
+func (s *UnbondingService) IsWorking() bool {
+	return s.working
+}

--- a/eth/eventservices/unbondingservice.go
+++ b/eth/eventservices/unbondingservice.go
@@ -42,6 +42,10 @@ func (s *UnbondingService) Start(ctx context.Context) error {
 		return ErrUnbondingServiceStarted
 	}
 
+	if err := s.processHistoricalEvents(); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	s.cancelWorker = cancel
 
@@ -56,20 +60,9 @@ func (s *UnbondingService) Start(ctx context.Context) error {
 			err               error
 		)
 
-		resubscribe := func(subFunc func(*big.Int) (ethereum.Subscription, error)) (ethereum.Subscription, error) {
-			startBlock, err := s.db.LastSeenBlock()
-			if err != nil {
-				return nil, err
-			}
-
-			return subFunc(startBlock)
-		}
-
 		for {
 			if s.unbondResubscribe {
-				unbondSub, err = resubscribe(func(startBlock *big.Int) (ethereum.Subscription, error) {
-					return s.client.WatchForUnbond(startBlock, unbondSink)
-				})
+				unbondSub, err = s.client.WatchForUnbond(unbondSink)
 				if err != nil {
 					glog.Error(err)
 				} else {
@@ -78,9 +71,7 @@ func (s *UnbondingService) Start(ctx context.Context) error {
 			}
 
 			if s.rebondResubscribe {
-				rebondSub, err = resubscribe(func(startBlock *big.Int) (ethereum.Subscription, error) {
-					return s.client.WatchForRebond(startBlock, rebondSink)
-				})
+				rebondSub, err = s.client.WatchForRebond(rebondSink)
 				if err != nil {
 					glog.Error(err)
 				} else {
@@ -89,9 +80,7 @@ func (s *UnbondingService) Start(ctx context.Context) error {
 			}
 
 			if s.withdrawStakeResubscribe {
-				withdrawStakeSub, err = resubscribe(func(startBlock *big.Int) (ethereum.Subscription, error) {
-					return s.client.WatchForWithdrawStake(startBlock, withdrawStakeSink)
-				})
+				withdrawStakeSub, err = s.client.WatchForWithdrawStake(withdrawStakeSink)
 				if err != nil {
 					glog.Error(err)
 				} else {
@@ -102,20 +91,17 @@ func (s *UnbondingService) Start(ctx context.Context) error {
 			select {
 			case newUnbond := <-unbondSink:
 				// Insert new unbonding lock into database
-				err := s.db.InsertUnbondingLock(newUnbond.UnbondingLockId, newUnbond.Delegator, newUnbond.Amount, newUnbond.WithdrawRound)
-				if err != nil {
+				if err := s.db.InsertUnbondingLock(newUnbond.UnbondingLockId, newUnbond.Delegator, newUnbond.Amount, newUnbond.WithdrawRound); err != nil {
 					glog.Error(err)
 				}
 			case newRebond := <-rebondSink:
 				// Update unbonding lock in database as used
-				err := s.db.UseUnbondingLock(newRebond.UnbondingLockId, newRebond.Delegator, new(big.Int).SetUint64(newRebond.Raw.BlockNumber))
-				if err != nil {
+				if err := s.db.UseUnbondingLock(newRebond.UnbondingLockId, newRebond.Delegator, new(big.Int).SetUint64(newRebond.Raw.BlockNumber)); err != nil {
 					glog.Error(err)
 				}
 			case newWithdrawStake := <-withdrawStakeSink:
 				// Update unbonding lock in database as used
-				err := s.db.UseUnbondingLock(newWithdrawStake.UnbondingLockId, newWithdrawStake.Delegator, new(big.Int).SetUint64(newWithdrawStake.Raw.BlockNumber))
-				if err != nil {
+				if err := s.db.UseUnbondingLock(newWithdrawStake.UnbondingLockId, newWithdrawStake.Delegator, new(big.Int).SetUint64(newWithdrawStake.Raw.BlockNumber)); err != nil {
 					glog.Error(err)
 				}
 			case unbondErr := <-unbondSub.Err():
@@ -161,4 +147,46 @@ func (s *UnbondingService) Stop() error {
 
 func (s *UnbondingService) IsWorking() bool {
 	return s.working
+}
+
+func (s *UnbondingService) processHistoricalEvents() error {
+	startBlock, err := s.db.LastSeenBlock()
+	if err != nil {
+		return err
+	}
+
+	if err := s.client.ProcessHistoricalUnbond(startBlock, func(newUnbond *contracts.BondingManagerUnbond) error {
+		// Insert new unbonding lock into database
+		if err := s.db.InsertUnbondingLock(newUnbond.UnbondingLockId, newUnbond.Delegator, newUnbond.Amount, newUnbond.WithdrawRound); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := s.client.ProcessHistoricalRebond(startBlock, func(newRebond *contracts.BondingManagerRebond) error {
+		// Update unbonding lock in database as used
+		if err := s.db.UseUnbondingLock(newRebond.UnbondingLockId, newRebond.Delegator, new(big.Int).SetUint64(newRebond.Raw.BlockNumber)); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := s.client.ProcessHistoricalWithdrawStake(startBlock, func(newWithdrawStake *contracts.BondingManagerWithdrawStake) error {
+		// Update unbonding lock in database as used
+		if err := s.db.UseUnbondingLock(newWithdrawStake.UnbondingLockId, newWithdrawStake.Delegator, new(big.Int).SetUint64(newWithdrawStake.Raw.BlockNumber)); err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -180,12 +180,21 @@ func (c *StubClient) SetGasInfo(uint64, *big.Int) error { return nil }
 func (c *StubClient) WatchForJob(j string) (*lpTypes.Job, error) {
 	return c.JobsMap[j], c.WatchJobError
 }
-func (c *StubClient) WatchForUnbond(*big.Int, chan *contracts.BondingManagerUnbond) (ethereum.Subscription, error) {
+func (c *StubClient) ProcessHistoricalUnbond(*big.Int, func(chan *contracts.BondingManagerUnbond) error) error {
+	return nil
+}
+func (c *StubClient) WatchForUnbond(chan *contracts.BondingManagerUnbond) (ethereum.Subscription, error) {
 	return nil, nil
 }
-func (c *StubClient) WatchForRebond(*big.Int, chan *contracts.BondingManagerRebond) (ethereum.Subscription, error) {
+func (c *StubClient) ProcessHistoricalRebond(*big.Int, func(chan *contracts.BondingManagerRebond) error) error {
+	return nil
+}
+func (c *StubClient) WatchForRebond(chan *contracts.BondingManagerRebond) (ethereum.Subscription, error) {
 	return nil, nil
 }
-func (c *StubClient) WatchForWithdrawStake(*big.Int, chan *contracts.BondingManagerWithdrawStake) (ethereum.Subscription, error) {
+func (c *StubClient) ProcessHistoricalWithdrawStake(*big.Int, func(chan *contracts.BondingManagerWithdrawStake) error) error {
+	return nil
+}
+func (c *StubClient) WatchForWithdrawStake(chan *contracts.BondingManagerWithdrawStake) (ethereum.Subscription, error) {
 	return nil, nil
 }

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -3,10 +3,12 @@ package eth
 import (
 	"math/big"
 
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/livepeer/go-livepeer/eth/contracts"
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
 )
 
@@ -75,9 +77,15 @@ func (e *StubClient) Reward() (*types.Transaction, error) { return nil, nil }
 func (e *StubClient) Bond(amount *big.Int, toAddr common.Address) (*types.Transaction, error) {
 	return nil, nil
 }
-func (e *StubClient) Unbond() (*types.Transaction, error)        { return nil, nil }
-func (e *StubClient) WithdrawStake() (*types.Transaction, error) { return nil, nil }
-func (e *StubClient) WithdrawFees() (*types.Transaction, error)  { return nil, nil }
+func (e *StubClient) Rebond(*big.Int) (*types.Transaction, error) { return nil, nil }
+func (e *StubClient) RebondFromUnbonded(common.Address, *big.Int) (*types.Transaction, error) {
+	return nil, nil
+}
+func (e *StubClient) Unbond(*big.Int) (*types.Transaction, error) { return nil, nil }
+func (e *StubClient) WithdrawStake(*big.Int) (*types.Transaction, error) {
+	return nil, nil
+}
+func (e *StubClient) WithdrawFees() (*types.Transaction, error) { return nil, nil }
 func (e *StubClient) ClaimEarnings(endRound *big.Int) error {
 	return nil
 }
@@ -171,4 +179,13 @@ func (c *StubClient) GetGasInfo() (uint64, *big.Int)    { return 0, nil }
 func (c *StubClient) SetGasInfo(uint64, *big.Int) error { return nil }
 func (c *StubClient) WatchForJob(j string) (*lpTypes.Job, error) {
 	return c.JobsMap[j], c.WatchJobError
+}
+func (c *StubClient) WatchForUnbond(*big.Int, chan *contracts.BondingManagerUnbond) (ethereum.Subscription, error) {
+	return nil, nil
+}
+func (c *StubClient) WatchForRebond(*big.Int, chan *contracts.BondingManagerRebond) (ethereum.Subscription, error) {
+	return nil, nil
+}
+func (c *StubClient) WatchForWithdrawStake(*big.Int, chan *contracts.BondingManagerWithdrawStake) (ethereum.Subscription, error) {
+	return nil, nil
 }

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -91,6 +91,9 @@ func (e *StubClient) ClaimEarnings(endRound *big.Int) error {
 }
 func (e *StubClient) GetTranscoder(addr common.Address) (*lpTypes.Transcoder, error) { return nil, nil }
 func (e *StubClient) GetDelegator(addr common.Address) (*lpTypes.Delegator, error)   { return nil, nil }
+func (e *StubClient) GetDelegatorUnbondingLock(addr common.Address, unbondingLockId *big.Int) (*lpTypes.UnbondingLock, error) {
+	return nil, nil
+}
 func (e *StubClient) GetTranscoderEarningsPoolForRound(addr common.Address, round *big.Int) (*lpTypes.TokenPools, error) {
 	return nil, nil
 }
@@ -180,19 +183,19 @@ func (c *StubClient) SetGasInfo(uint64, *big.Int) error { return nil }
 func (c *StubClient) WatchForJob(j string) (*lpTypes.Job, error) {
 	return c.JobsMap[j], c.WatchJobError
 }
-func (c *StubClient) ProcessHistoricalUnbond(*big.Int, func(chan *contracts.BondingManagerUnbond) error) error {
+func (c *StubClient) ProcessHistoricalUnbond(*big.Int, func(*contracts.BondingManagerUnbond) error) error {
 	return nil
 }
 func (c *StubClient) WatchForUnbond(chan *contracts.BondingManagerUnbond) (ethereum.Subscription, error) {
 	return nil, nil
 }
-func (c *StubClient) ProcessHistoricalRebond(*big.Int, func(chan *contracts.BondingManagerRebond) error) error {
+func (c *StubClient) ProcessHistoricalRebond(*big.Int, func(*contracts.BondingManagerRebond) error) error {
 	return nil
 }
 func (c *StubClient) WatchForRebond(chan *contracts.BondingManagerRebond) (ethereum.Subscription, error) {
 	return nil, nil
 }
-func (c *StubClient) ProcessHistoricalWithdrawStake(*big.Int, func(chan *contracts.BondingManagerWithdrawStake) error) error {
+func (c *StubClient) ProcessHistoricalWithdrawStake(*big.Int, func(*contracts.BondingManagerWithdrawStake) error) error {
 	return nil
 }
 func (c *StubClient) WatchForWithdrawStake(chan *contracts.BondingManagerWithdrawStake) (ethereum.Subscription, error) {

--- a/eth/types/contracts.go
+++ b/eth/types/contracts.go
@@ -68,6 +68,13 @@ func ParseDelegatorStatus(s uint8) (string, error) {
 	}
 }
 
+type UnbondingLock struct {
+	ID               *big.Int
+	DelegatorAddress common.Address
+	Amount           *big.Int
+	WithdrawRound    *big.Int
+}
+
 type TokenPools struct {
 	RewardPool     *big.Int
 	FeePool        *big.Int

--- a/eth/types/contracts.go
+++ b/eth/types/contracts.go
@@ -42,17 +42,17 @@ func ParseTranscoderStatus(s uint8) (string, error) {
 }
 
 type Delegator struct {
-	Address         common.Address
-	BondedAmount    *big.Int
-	Fees            *big.Int
-	DelegateAddress common.Address
-	DelegatedAmount *big.Int
-	StartRound      *big.Int
-	WithdrawRound   *big.Int
-	LastClaimRound  *big.Int
-	PendingStake    *big.Int
-	PendingFees     *big.Int
-	Status          string
+	Address             common.Address
+	BondedAmount        *big.Int
+	Fees                *big.Int
+	DelegateAddress     common.Address
+	DelegatedAmount     *big.Int
+	StartRound          *big.Int
+	LastClaimRound      *big.Int
+	NextUnbondingLockId *big.Int
+	PendingStake        *big.Int
+	PendingFees         *big.Int
+	Status              string
 }
 
 func ParseDelegatorStatus(s uint8) (string, error) {
@@ -62,8 +62,6 @@ func ParseDelegatorStatus(s uint8) (string, error) {
 	case 1:
 		return "Bonded", nil
 	case 2:
-		return "Unbonding", nil
-	case 3:
 		return "Unbonded", nil
 	default:
 		return "", ErrUnknownDelegatorStatus


### PR DESCRIPTION
Fixes #484 

- Created an `UnbondingService` responsible for watching for the `Unbond`, `Rebond` and `WithdrawStake` contract events that pertain to the creation and use of unbonding locks. If a subscription fails the service will try to resubscribe by applying a log filter with a start block defined by the node's last seen block (stored in local DB)
- Created a DB table for unbonding lock - when an unbonding lock is used, the node stores the block that it was used in
- Updated the CLI/server to allow partial unbonding as well as rebonding. When activating as a transcoder, if users have any unbonding locks they are asked if they would like to use an unbonding lock to rebond

Note: Not usable on Rinkeby and mainnet until the relevant contract upgrade for [LIP-8](https://github.com/livepeer/LIPs/blob/master/LIPs/LIP-8.md) is deployed.