### PR TITLE
Remove Node ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ For full documentation and a project overview, go to
 ### Option 1: Download executables
 The easiest way to install Livepeer is by downloading the `livepeer` and `livepeer_cli` executables from the [release page on Github](https://github.com/livepeer/go-livepeer/releases). 
 
-1. Download the packages for your OS - darwin for Macs and linux for linux. 
+1. Download the packages for your OS - darwin for Macs and linux for linux.
 2. Untar them and optionally move the executables to your PATH.
 
 ### Option 2: Build from source
-You can also build the executables from scratch.  
+You can also build the executables from scratch.
 
 1. If you have never set up your Go programming environment, do so according to Go's [Getting Started Guide](https://golang.org/doc/install).
 
@@ -40,16 +40,16 @@ You can also build the executables from scratch.
 ### Quick start
 - Make sure you have successfully gone through the steps in 'Installing Livepeer' and 'Additional Dependencies'.
 
-- Run `./livepeer -rinkeby`. 
+- Run `./livepeer -rinkeby`.
 
 - Run `./livepeer_cli`.
-  * You should see a wizard launch in the command line. 
+  * You should see a wizard launch in the command line.
   * The wizard should print out `Account Eth Addr`, `Token balance`, and `Eth balance`
 
 - Get some test eth for the Rinkeby faucet. Make sure to use the Eth account address from above. Remember to add 0x as a prefix to address, if not present.
   * You can check that the request is successful by going to `livepeer_cli` and selecting `Get node status`. You should see a positive `Eth balance`.
 
-- Now get some test Livepeer tokens. Pick `Get test Livepeer Token`.  
+- Now get some test Livepeer tokens. Pick `Get test Livepeer Token`.
   * You can check that the request is successful by going to `livepeer_cli` and selecting `Get node status`. You should see your `Token balance` go up.
 
 - You should have some test Eth and test Livepeer tokens now.  If that's the case, you are ready to broadcast.
@@ -67,7 +67,7 @@ By default, the RTMP port is 1935.  For example, if you are using OSX with ffmpe
 
 Similarly, you can use OBS, and change the Settings->Stream->URL to `rtmp://localhost:1935/movie` , along with the keyframe interval to 4 seconds, via `Settings -> Output -> Output Mode (Advanced) -> Streaming tab -> Keyframe Interval 4`.
 
-If the broadcast is successful, you should be able to get a streamID by querying the local node:
+If the broadcast is successful, you should be able to get a streamID by querying the local node's CLI API:
 
 `curl http://localhost:8935/manifestID`
 
@@ -79,6 +79,8 @@ For example, after you get the streamID, you can view the stream by running:
 
 `ffplay http://localhost:8935/stream/{manifestID}.m3u8`
 
+Note that the default HTTP port or playback (8935) is different from the CLI API port (7935) that is used for node management and diagnostics!
+
 ### Becoming a Transcoder
 
 We'll walk through the steps of becoming a transcoder on the test network.  To learn more about the transcoder, refer to the [Livepeer whitepaper](https://github.com/livepeer/wiki/blob/master/WHITEPAPER.md) and the [Transcoding guide](http://livepeer.readthedocs.io/en/latest/transcoding.html).
@@ -89,11 +91,11 @@ We'll walk through the steps of becoming a transcoder on the test network.  To l
 
 - You should see the Transcoder Status as "Not Registered".
 
-- Pick "Become a transcoder" in the wizard.  Make sure to choose "bond to yourself".  If Successful, you should see the Transcoder Status change to "Registered"
+- Pick "Become a transcoder" in the wizard.  Make sure to choose "bond to yourself".  Follow the rest of the prompts, including confirming the transcoder's public IP and port on the blockchain. If Successful, you should see the Transcoder Status change to "Registered"
 
 - Wait for the next round to start, and your transcoder will become active.
 
-- If running on Rinkeby or mainnet, ensure your transcoder is publicly available in order to receive jobs from broadcasters.
+- If running on Rinkeby or mainnet, ensure your transcoder is *publicly accessible* in order to receive jobs from broadcasters. The only port that is required to be public is the one that was set during the transcoder registration step (default 8935).
 
 ## Contribution
 Thank you for your interest in contributing to the core software of Livepeer.

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -29,7 +29,6 @@ func (w *wizard) stats(showTranscoder bool) {
 
 	table := tablewriter.NewWriter(os.Stdout)
 	data := [][]string{
-		[]string{"Node ID", w.getNodeID()},
 		[]string{"Node Addr", w.getNodeAddr()},
 		[]string{"HTTP Port", w.httpPort},
 		[]string{"Controller Address", addrMap["Controller"].Hex()},
@@ -258,10 +257,6 @@ func (w *wizard) delegatorStats() {
 	table.SetRowLine(true)
 	table.SetColumnSeparator("|")
 	table.Render()
-}
-
-func (w *wizard) getNodeID() string {
-	return httpGet(fmt.Sprintf("http://%v:%v/nodeID", w.host, w.httpPort))
 }
 
 func (w *wizard) getNodeAddr() string {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -30,7 +30,7 @@ func StubSegment() *SignedSegment {
 }
 
 func StubJob(n *LivepeerNode) *lpTypes.Job {
-	streamId, _ := MakeStreamID(n.Identity, RandomVideoID(), ffmpeg.P720p30fps4x3.Name)
+	streamId, _ := MakeStreamID(RandomVideoID(), ffmpeg.P720p30fps4x3.Name)
 	return &lpTypes.Job{
 		JobId:              big.NewInt(0),
 		StreamId:           string(streamId),
@@ -50,7 +50,7 @@ func TestTranscode(t *testing.T) {
 	db, _ := common.InitDB("file:TestTranscode?mode=memory&cache=shared")
 	defer db.Close()
 	tmp, _ := ioutil.TempDir("", "")
-	n, _ := NewLivepeerNode(seth, "12209433a695c8bf34ef6a40863cfe7ed64266d876176aee13732293b63ba1637fd2", tmp, db)
+	n, _ := NewLivepeerNode(seth, tmp, db)
 	defer os.RemoveAll(tmp)
 	job := StubJob(n)
 	ffmpeg.InitFFmpeg()
@@ -189,7 +189,7 @@ func monitorChan(intChan chan int) {
 
 func TestCreateTranscodeJob(t *testing.T) {
 	seth := &eth.StubClient{JobsMap: make(map[string]*lpTypes.Job)}
-	n, _ := NewLivepeerNode(seth, "", "./tmp", nil)
+	n, _ := NewLivepeerNode(seth, "./tmp", nil)
 	j := StubJob(n)
 	seth.JobsMap[j.StreamId] = j
 
@@ -207,7 +207,7 @@ func TestCreateTranscodeJob(t *testing.T) {
 	}
 
 	// test missing eth client
-	n1, _ := NewLivepeerNode(nil, "", "./tmp", nil)
+	n1, _ := NewLivepeerNode(nil, "./tmp", nil)
 	if _, err := cjt(n1); err != ErrNotFound {
 		t.Error("Did not receive expected error; got ", err)
 	}

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -26,9 +26,6 @@ var ErrTranscode = errors.New("ErrTranscode")
 var DefaultJobLength = int64(5760) //Avg 1 day in 15 sec blocks
 var LivepeerVersion = "0.2.4-unstable"
 
-//NodeID can be converted from libp2p PeerID.
-type NodeID string
-
 type NodeType int
 
 const (
@@ -40,7 +37,6 @@ const (
 type LivepeerNode struct {
 
 	// Common fields
-	Identity        NodeID
 	VideoSource     VideoSource
 	Eth             eth.LivepeerEthClient
 	EthEventMonitor eth.EventMonitor
@@ -61,9 +57,9 @@ type LivepeerNode struct {
 }
 
 //NewLivepeerNode creates a new Livepeer Node. Eth can be nil.
-func NewLivepeerNode(e eth.LivepeerEthClient, nodeId NodeID, wd string, dbh *common.DB) (*LivepeerNode, error) {
+func NewLivepeerNode(e eth.LivepeerEthClient, wd string, dbh *common.DB) (*LivepeerNode, error) {
 
-	return &LivepeerNode{VideoSource: NewBasicVideoSource(), Identity: nodeId, Eth: e, WorkDir: wd, Database: dbh, EthServices: make(map[string]eth.EventService), ClaimManagers: make(map[int64]eth.ClaimManager), SegmentChans: make(map[int64]SegmentChan), claimMutex: &sync.Mutex{}, segmentMutex: &sync.Mutex{}}, nil
+	return &LivepeerNode{VideoSource: NewBasicVideoSource(), Eth: e, WorkDir: wd, Database: dbh, EthServices: make(map[string]eth.EventService), ClaimManagers: make(map[int64]eth.ClaimManager), SegmentChans: make(map[int64]SegmentChan), claimMutex: &sync.Mutex{}, segmentMutex: &sync.Mutex{}}, nil
 }
 
 func (n *LivepeerNode) StartEthServices() error {

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -51,21 +51,20 @@ func (t *StubTranscoder) Transcode(fname string) ([][]byte, error) {
 }
 
 func TestTranscodeAndBroadcast(t *testing.T) {
-	nid := NodeID("12201c23641663bf06187a8c154a6c97266d138cb8379c1bc0828122dcc51c83698d")
-	strmID, _ := MakeStreamID(nid, RandomVideoID(), ffmpeg.P720p30fps4x3.Name)
+	strmID, _ := MakeStreamID(RandomVideoID(), ffmpeg.P720p30fps4x3.Name)
 	jid := big.NewInt(0)
 	ffmpeg.InitFFmpeg()
 	p := []ffmpeg.VideoProfile{ffmpeg.P720p60fps16x9, ffmpeg.P144p30fps16x9}
 	tr := &StubTranscoder{Profiles: p}
 	mkid := func(p ffmpeg.VideoProfile) StreamID {
-		s, _ := MakeStreamID(nid, strmID.GetVideoID(), p.Name)
+		s, _ := MakeStreamID(strmID.GetVideoID(), p.Name)
 		return s
 	}
 	strmIds := []StreamID{mkid(p[0]), mkid(p[1])}
 	cm := StubClaimManager{}
 	config := transcodeConfig{StrmID: strmID.String(), Profiles: p, ResultStrmIDs: strmIds, ClaimManager: &cm, JobID: jid, Transcoder: tr}
 
-	n, err := NewLivepeerNode(&eth.StubClient{}, nid, ".", nil) // TODO fix empty work dir
+	n, err := NewLivepeerNode(&eth.StubClient{}, ".", nil) // TODO fix empty work dir
 	if err != nil {
 		t.Errorf("Error: %v", err)
 	}
@@ -122,8 +121,7 @@ func TestTranscodeAndBroadcast(t *testing.T) {
 }
 
 func TestNodeClaimManager(t *testing.T) {
-	nid := NodeID("12201c23641663bf06187a8c154a6c97266d138cb8379c1bc0828122dcc51c83698d")
-	n, err := NewLivepeerNode(nil, nid, ".", nil)
+	n, err := NewLivepeerNode(nil, ".", nil)
 
 	job := &lpTypes.Job{
 		JobId:              big.NewInt(15),

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -79,7 +79,7 @@ func (orch *orchestrator) StreamIDs(job *ethTypes.Job) ([]StreamID, error) {
 	sid := StreamID(job.StreamId)
 	vid := sid.GetVideoID()
 	for i, p := range job.Profiles {
-		strmId, err := MakeStreamID(orch.node.Identity, vid, p.Name)
+		strmId, err := MakeStreamID(vid, p.Name)
 		if err != nil {
 			glog.Error("Error making stream ID: ", err)
 			return []StreamID{}, err
@@ -273,7 +273,7 @@ func (n *LivepeerNode) transcodeSegmentLoop(job *ethTypes.Job, segChan SegmentCh
 	resultStrmIDs := make([]StreamID, len(job.Profiles), len(job.Profiles))
 	sid := StreamID(job.StreamId)
 	for i, vp := range job.Profiles {
-		strmID, err := MakeStreamID(n.Identity, sid.GetVideoID(), vp.Name)
+		strmID, err := MakeStreamID(sid.GetVideoID(), vp.Name)
 		if err != nil {
 			glog.Error("Error making stream ID: ", err)
 			return err

--- a/core/stream_test.go
+++ b/core/stream_test.go
@@ -6,31 +6,47 @@ import (
 	ffmpeg "github.com/livepeer/lpms/ffmpeg"
 
 	"bytes"
-
-	peer "gx/ipfs/QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS/go-libp2p-peer"
-	crypto "gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto"
 )
 
 func TestStreamID(t *testing.T) {
 	vid := RandomVideoID()
-	_, err := MakeStreamID(NodeID("nid"), vid, ffmpeg.P144p30fps16x9.Name)
-	if err == nil {
-		t.Errorf("Expecting error because NodeID is too short")
-	}
-
-	_, pub, _ := crypto.GenerateKeyPair(crypto.RSA, 2048)
-	pid, err := peer.IDFromPublicKey(pub)
-	id, err := MakeStreamID(NodeID(peer.IDHexEncode(pid)), vid, ffmpeg.P144p30fps16x9.Name)
+	id, err := MakeStreamID(vid, ffmpeg.P144p30fps16x9.Name)
 	if err != nil {
-		t.Errorf("Error creating Node ID: %v", err)
-	}
-
-	nid := id.GetNodeID()
-	if nid != NodeID(peer.IDHexEncode(pid)) {
-		t.Errorf("Expecting: %v, got %v", NodeID(peer.IDHexEncode(pid)), nid)
+		t.Error("Error making StreamID ", err)
 	}
 
 	if bytes.Compare(vid, id.GetVideoID()) != 0 {
 		t.Errorf("Expecting: %v, got %v", vid, id.GetVideoID())
+	}
+
+	if ffmpeg.P144p30fps16x9.Name != id.GetRendition() {
+		t.Error("Rendition not matching")
+	}
+	if !id.IsValid() {
+		t.Error("Streamid not valid")
+	}
+
+	bad := StreamID("streamid")
+	if bad.IsValid() {
+		t.Error("Did not expect streamid to be valid")
+	}
+}
+
+func TestManifestID(t *testing.T) {
+	vid := RandomVideoID()
+	mid, _ := MakeManifestID(vid)
+
+	if bytes.Compare(mid.GetVideoID(), vid) != 0 {
+		t.Error("Manifest ID did not match video ID")
+	}
+
+	sid, _ := MakeStreamID(vid, ffmpeg.P144p30fps16x9.Name)
+	msid := sid.ManifestIDFromStreamID()
+	if mid.String() != msid.String() {
+		t.Error("Manifest was not properly derived from stream ID")
+	}
+
+	if bytes.Compare(vid, msid.GetVideoID()) != 0 {
+		t.Error("Derived manifest did not match video ID")
 	}
 }

--- a/core/streamdata.go
+++ b/core/streamdata.go
@@ -17,8 +17,7 @@ var ErrStreamID = errors.New("ErrStreamID")
 var ErrManifestID = errors.New("ErrManifestID")
 
 const (
-	HashLength   = 32
-	NodeIDLength = 68
+	HashLength = 32
 )
 
 func RandomVideoID() []byte {
@@ -30,22 +29,18 @@ func RandomVideoID() []byte {
 	return x
 }
 
-//StreamID is NodeID|VideoID|Rendition
+//StreamID is VideoID|Rendition
 type StreamID string
 
-func MakeStreamID(nodeID NodeID, id []byte, rendition string) (StreamID, error) {
-	if len(nodeID) != NodeIDLength || len(id) == 0 || rendition == "" {
+func MakeStreamID(id []byte, rendition string) (StreamID, error) {
+	if len(id) != HashLength || rendition == "" {
 		return "", ErrManifestID
 	}
-	return StreamID(fmt.Sprintf("%v%x%v", nodeID, id, rendition)), nil
-}
-
-func (id *StreamID) GetNodeID() NodeID {
-	return NodeID((*id)[:NodeIDLength])
+	return StreamID(fmt.Sprintf("%x%v", id, rendition)), nil
 }
 
 func (id *StreamID) GetVideoID() []byte {
-	vid, err := hex.DecodeString(string((*id)[NodeIDLength : NodeIDLength+(2*HashLength)]))
+	vid, err := hex.DecodeString(string((*id)[:2*HashLength]))
 	if err != nil {
 		return nil
 	}
@@ -53,33 +48,26 @@ func (id *StreamID) GetVideoID() []byte {
 }
 
 func (id *StreamID) GetRendition() string {
-	return string((*id)[NodeIDLength+2*HashLength:])
+	return string((*id)[2*HashLength:])
 }
 
 func (id *StreamID) IsValid() bool {
-	return len(*id) > (NodeIDLength + 2*HashLength)
+	return len(*id) > 2*HashLength
 }
 
 func (id StreamID) String() string {
 	return string(id)
 }
 
-//ManifestID is NodeID|VideoID
+//ManifestID is VideoID
 type ManifestID string
 
-func MakeManifestID(nodeID NodeID, id []byte) (ManifestID, error) {
-	if nodeID == "" || len(nodeID) != NodeIDLength {
-		return "", ErrStreamID
-	}
-	return ManifestID(fmt.Sprintf("%v%x", nodeID, id)), nil
-}
-
-func (id *ManifestID) GetNodeID() NodeID {
-	return NodeID((*id)[:NodeIDLength])
+func MakeManifestID(id []byte) (ManifestID, error) {
+	return ManifestID(fmt.Sprintf("%x", id)), nil
 }
 
 func (id *ManifestID) GetVideoID() []byte {
-	vid, err := hex.DecodeString(string((*id)[NodeIDLength : NodeIDLength+(2*HashLength)]))
+	vid, err := hex.DecodeString(string((*id)[:2*HashLength]))
 	if err != nil {
 		return nil
 	}
@@ -89,12 +77,12 @@ func (id *ManifestID) GetVideoID() []byte {
 func (id StreamID) ManifestIDFromStreamID() ManifestID {
 	// Ignore error since StreamID should be a valid object;
 	// getting the node and video IDs don't fail (unless it segfaults)
-	mid, _ := MakeManifestID(id.GetNodeID(), id.GetVideoID())
+	mid, _ := MakeManifestID(id.GetVideoID())
 	return mid
 }
 
 func (id *ManifestID) IsValid() bool {
-	return len(*id) == (NodeIDLength + 2*HashLength)
+	return len(*id) == 2*HashLength
 }
 
 func (id ManifestID) String() string {

--- a/core/videosource.go
+++ b/core/videosource.go
@@ -22,7 +22,7 @@ type VideoSource interface {
 	GetHLSSegment(streamID StreamID, segName string) *stream.HLSSegment
 	EvictHLSStream(streamID StreamID) error
 
-	GetNodeStatus(nodeID string) *net.NodeStatus
+	GetNodeStatus() *net.NodeStatus
 }
 
 type segCache struct {
@@ -142,7 +142,7 @@ func (c *BasicVideoSource) EvictHLSStream(streamID StreamID) error {
 	return nil
 }
 
-func (c *BasicVideoSource) GetNodeStatus(nodeID string) *net.NodeStatus {
+func (c *BasicVideoSource) GetNodeStatus() *net.NodeStatus {
 	// not threadsafe; need to deep copy the playlist
 	c.masterPLock.Lock()
 	defer c.masterPLock.Unlock()
@@ -150,5 +150,5 @@ func (c *BasicVideoSource) GetNodeStatus(nodeID string) *net.NodeStatus {
 	for k, v := range c.masterPList {
 		m[string(k)] = v
 	}
-	return &net.NodeStatus{NodeID: nodeID, Manifests: m}
+	return &net.NodeStatus{Manifests: m}
 }

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -61,6 +61,12 @@ func (s *JobService) Start(ctx context.Context) error {
 				glog.Errorf("Got empty job for id:%v. Should try again.", jid.Int64())
 				return errors.New("ErrGetJob")
 			}
+			assignedAddr, err := s.node.Eth.AssignedTranscoder(j)
+			if err != nil {
+				glog.Errorf("Error checking for job %v assignment: %v", jid, err)
+				return err
+			}
+			j.TranscoderAddress = assignedAddr
 			job = j
 			return err
 		}
@@ -69,13 +75,7 @@ func (s *JobService) Start(ctx context.Context) error {
 			return false, err
 		}
 
-		assignedAddr, err := s.node.Eth.AssignedTranscoder(job)
-		if err != nil {
-			glog.Errorf("Error checking for assignment: %v", err)
-			return false, err
-		}
-
-		if assignedAddr == s.node.Eth.Account().Address {
+		if job.TranscoderAddress == s.node.Eth.Account().Address {
 			dbjob := lpcommon.NewDBJob(
 				job.JobId, job.StreamId,
 				job.MaxPricePerSegment, job.Profiles,

--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -44,7 +44,11 @@ func (s *JobService) Start(ctx context.Context) error {
 
 	logsCh := make(chan types.Log)
 	sub, err := s.eventMonitor.SubscribeNewJob(ctx, "NewJob", logsCh, common.Address{}, func(l types.Log) (bool, error) {
-		_, jid, _, _ := parseNewJobLog(l)
+		jid := parseNewJobLog(l)
+		if jid == nil {
+			// Return true to ignore this log and continue monitoring for new jobs
+			return true, errors.New("InvalidJobLog")
+		}
 
 		var job *lpTypes.Job
 		getJob := func() error {
@@ -161,6 +165,10 @@ func (s *JobService) firstClaim(job *lpTypes.Job) {
 	}
 }
 
-func parseNewJobLog(log types.Log) (broadcasterAddr common.Address, jid *big.Int, streamID string, transOptions string) {
-	return common.BytesToAddress(log.Topics[1].Bytes()), new(big.Int).SetBytes(log.Data[0:32]), string(log.Data[192:338]), string(log.Data[338:])
+func parseNewJobLog(log types.Log) (jid *big.Int) {
+	if len(log.Data) < 32 {
+		glog.Error("Malformed job event log!")
+		return nil
+	}
+	return new(big.Int).SetBytes(log.Data[0:32])
 }

--- a/net/interface.go
+++ b/net/interface.go
@@ -1,7 +1,6 @@
 package net
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -10,7 +9,6 @@ import (
 )
 
 type NodeStatus struct {
-	NodeID    string
 	Manifests map[string]*m3u8.MasterPlaylist
 }
 
@@ -19,20 +17,14 @@ func (n NodeStatus) String() string {
 	for mid, m := range n.Manifests {
 		mstrs = append(mstrs, fmt.Sprintf("%v[]%v", mid, m.String()))
 	}
-	str := fmt.Sprintf("%v|%v", n.NodeID, strings.Join(mstrs, "|"))
-	return str
+	return strings.Join(mstrs, "|")
 }
 
 func (n *NodeStatus) FromString(str string) error {
 	arr := strings.Split(str, "|")
-	if len(arr[0]) != 68 {
-		return errors.New("Wrong format for NodeStatus")
-	} else {
-		n.NodeID = arr[0]
-	}
 
 	manifests := make(map[string]*m3u8.MasterPlaylist, 0)
-	for _, mstr := range arr[1:] {
+	for _, mstr := range arr {
 		//Decode the playlist from a string
 		mstrArr := strings.Split(mstr, "[]")
 		if len(mstrArr) == 2 {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -137,7 +137,7 @@ func (s *LivepeerServer) StartMediaServer(ctx context.Context, maxPricePerSegmen
 //RTMP Publish Handlers
 func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID string) {
 	return func(url *url.URL) (strmID string) {
-		id, err := core.MakeStreamID(s.LivepeerNode.Identity, core.RandomVideoID(), "RTMP")
+		id, err := core.MakeStreamID(core.RandomVideoID(), "RTMP")
 		if err != nil {
 			glog.Errorf("Error making stream ID")
 			return ""
@@ -292,15 +292,11 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		//Create a new HLS StreamID.  If streamID is passed in, use that one.  Otherwise, generate a random ID.
 		hlsStrmID := core.StreamID(url.Query().Get("hlsStrmID"))
 		if hlsStrmID == "" {
-			hlsStrmID, err = core.MakeStreamID(s.LivepeerNode.Identity, core.RandomVideoID(), vProfile.Name)
+			hlsStrmID, err = core.MakeStreamID(core.RandomVideoID(), vProfile.Name)
 			if err != nil {
 				glog.Errorf("Error making stream ID")
 				return ErrRTMPPublish
 			}
-		}
-		if hlsStrmID.GetNodeID() != s.LivepeerNode.Identity {
-			glog.Errorf("Cannot create a HLS stream with Node ID: %v", hlsStrmID.GetNodeID())
-			return ErrRTMPPublish
 		}
 
 		pl, err := m3u8.NewMediaPlaylist(stream.DefaultHLSStreamWin, stream.DefaultHLSStreamCap)
@@ -399,7 +395,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		}(rtmpStrm)
 
 		//Create the manifest and broadcast it (so the video can be consumed by itself without transcoding)
-		mid, err := core.MakeManifestID(hlsStrmID.GetNodeID(), hlsStrmID.GetVideoID())
+		mid, err := core.MakeManifestID(hlsStrmID.GetVideoID())
 		if err != nil {
 			glog.Errorf("Error creating manifest id: %v", err)
 			return ErrRTMPPublish

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -175,7 +175,10 @@ func (s *LivepeerServer) startBroadcast(job *ethTypes.Job, manifest *m3u8.Master
 	}
 
 	// Update the master playlist on the network
-	mid := core.StreamID(job.StreamId).ManifestIDFromStreamID()
+	mid, err := core.StreamID(job.StreamId).ManifestIDFromStreamID()
+	if err != nil {
+		return nil, err
+	}
 	s.LivepeerNode.VideoSource.UpdateHLSMasterPlaylist(mid, manifest)
 
 	return rpcBcast, nil

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -21,7 +21,7 @@ var S *LivepeerServer
 
 func setupServer() *LivepeerServer {
 	if S == nil {
-		n, _ := core.NewLivepeerNode(nil, "12209433a695c8bf34ef6a40863cfe7ed64266d876176aee13732293b63ba1637fd2", "./tmp", nil)
+		n, _ := core.NewLivepeerNode(nil, "./tmp", nil)
 		S = NewLivepeerServer("127.0.0.1:1938", "127.0.0.1:8080", n)
 		go S.StartMediaServer(context.Background(), big.NewInt(0), "")
 		go S.StartWebserver("127.0.0.1:8938")
@@ -88,7 +88,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 	s.RTMPSegmenter = &StubSegmenter{}
 	handler := gotRTMPStreamHandler(s)
 
-	hlsStrmID := string(s.LivepeerNode.Identity + "10f6afa01868f11f5722434aa4a0769842e04fac75dfaccece208c5710fd52e0")
+	hlsStrmID := "10f6afa01868f11f5722434aa4a0769842e04fac75dfaccece208c5710fd52e0"
 	url, _ := url.Parse(fmt.Sprintf("rtmp://localhost:1935/movie?hlsStrmID=%v", hlsStrmID))
 	strm := stream.NewBasicRTMPVideoStream("strmID")
 
@@ -145,13 +145,13 @@ func TestGetHLSMasterPlaylistHandler(t *testing.T) {
 	//Set up the stubnet so it already has a manifest with a local stream
 	mpl := m3u8.NewMasterPlaylist()
 	mpl.Append("strm.m3u8", nil, m3u8.VariantParams{Bandwidth: 100})
-	s.LivepeerNode.VideoSource.UpdateHLSMasterPlaylist("12209433a695c8bf34ef6a40863cfe7ed64266d876176aee13732293b63ba1637fd210f6afa01868f11f5722434aa4a0769842e04fac75dfaccece208c5710fd52e0", mpl)
+	s.LivepeerNode.VideoSource.UpdateHLSMasterPlaylist("10f6afa01868f11f5722434aa4a0769842e04fac75dfaccece208c5710fd52e0", mpl)
 	if len(mpl.Variants) != 1 {
 		t.Errorf("Expecting 1 variant, but got %v", mpl)
 	}
 
 	handler := getHLSMasterPlaylistHandler(s)
-	url, _ := url.Parse("http://localhost/stream/12209433a695c8bf34ef6a40863cfe7ed64266d876176aee13732293b63ba1637fd210f6afa01868f11f5722434aa4a0769842e04fac75dfaccece208c5710fd52e0.m3u8")
+	url, _ := url.Parse("http://localhost/stream/10f6afa01868f11f5722434aa4a0769842e04fac75dfaccece208c5710fd52e0.m3u8")
 
 	//Test get master playlist
 	pl, err := handler(url)

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -796,23 +796,15 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 	})
 
 	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
-		nid := r.FormValue("nodeID")
-
-		if nid == "" {
-			nid = string(s.LivepeerNode.Identity)
-		}
-
-		status := s.LivepeerNode.VideoSource.GetNodeStatus(nid)
+		status := s.LivepeerNode.VideoSource.GetNodeStatus()
 		if status != nil {
 			mstrs := make(map[string]string, 0)
 			for mid, m := range status.Manifests {
 				mstrs[string(mid)] = m.String()
 			}
 			d := struct {
-				NodeID    string
 				Manifests map[string]string
 			}{
-				NodeID:    status.NodeID,
 				Manifests: mstrs,
 			}
 			if data, err := json.Marshal(d); err == nil {
@@ -821,10 +813,6 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 				return
 			}
 		}
-	})
-
-	mux.HandleFunc("/nodeID", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(s.LivepeerNode.Identity))
 	})
 
 	mux.HandleFunc("/contractAddresses", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Leaving this PR open for discussion; we don't have to merge it if folks feel strongly about the issue.

The Node ID is an artifact leftover from libp2p. With basicnet removed, the Node ID doesn't add anything to the streaming setup. Removing it simplifies internal APIs, makes the IDs shorter (we pay per byte to store jobs on the blockchain), and allows us to clear up a lot of supporting code, eg storing and loading keys.

Is there a reason to keep the Node ID around?