### PR TITLE
Misc bug fixes

### DIFF
--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -170,6 +170,9 @@ func (w *wizard) bond() {
 	for amount.Cmp(big.NewInt(0)) == 0 || balBigInt.Cmp(amount) < 0 {
 		fmt.Printf("Enter bond amount - ")
 		amount = w.readBigInt()
+		if amount.Cmp(big.NewInt(0)) == 0 {
+			break
+		}
 		if balBigInt.Cmp(amount) < 0 {
 			fmt.Printf("Must enter an amount smaller than the current balance. ")
 		}

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -29,7 +29,6 @@ func (w *wizard) stats(showTranscoder bool) {
 
 	table := tablewriter.NewWriter(os.Stdout)
 	data := [][]string{
-		[]string{"Node Addr", w.getNodeAddr()},
 		[]string{"HTTP Port", w.httpPort},
 		[]string{"Controller Address", addrMap["Controller"].Hex()},
 		[]string{"LivepeerToken Address", addrMap["LivepeerToken"].Hex()},
@@ -257,10 +256,6 @@ func (w *wizard) delegatorStats() {
 	table.SetRowLine(true)
 	table.SetColumnSeparator("|")
 	table.Render()
-}
-
-func (w *wizard) getNodeAddr() string {
-	return httpGet(fmt.Sprintf("http://%v:%v/nodeAddrs", w.host, w.httpPort))
 }
 
 func (w *wizard) getProtocolParameters() (lpTypes.ProtocolParameters, error) {

--- a/common/db.go
+++ b/common/db.go
@@ -189,6 +189,10 @@ func InitDB(dbPath string) (*DB, error) {
 		glog.Error("Unable to open DB ", dbPath, err)
 		return nil, err
 	}
+	// The DB connection might be used in multiple goroutines (i.e. when recovering claims during node restart)
+	// resulting in concurrent access. SQLite can only handle one writer at a time, so if concurrent writes occur
+	// we can encounter a `database is locked` error. To avoid concurrent writes, we limit SQLite to a single connection
+	db.SetMaxOpenConns(1)
 	d.dbh = db
 	schemaBuf := new(bytes.Buffer)
 	tmpl := template.Must(template.New("schema").Parse(schema))

--- a/eth/claimmanager.go
+++ b/eth/claimmanager.go
@@ -335,7 +335,11 @@ func (c *BasicClaimManager) ClaimVerifyAndDistributeFees() error {
 		claimID := c.claims
 		if c.db != nil {
 			// check db in case we had any concurrent claims
-			claimIDp, _ := c.db.InsertClaim(c.jobID, segRange, root.Hash)
+			claimIDp, err := c.db.InsertClaim(c.jobID, segRange, root.Hash)
+			if err != nil {
+				glog.Errorf("Job %v Error: %v - inserting claim into DB", c.jobID, err)
+				continue
+			}
 			claimID = *claimIDp
 		}
 


### PR DESCRIPTION
- When checking for existing jobs to reuse, make sure that the existing job has matching transcoding options, an acceptable price (less than or equal to the current broadcast price) and a valid assigned transcoder that is still registered. Fixes #519 
- Remove node addr from CLI. Fixes #522 
- Limit SQLite to a single connection since SQLite cannot handle concurrent writes. Fixes #494 
- Allow users to enter a bond amount of 0 in the CLI such that they can change delegates