### PR TITLE
remove all hls streams from video cache when removing master playlist

### DIFF
--- a/core/videosource.go
+++ b/core/videosource.go
@@ -107,6 +107,17 @@ func (c *BasicVideoSource) UpdateHLSMasterPlaylist(manifestID ManifestID, mpl *m
 }
 
 func (c *BasicVideoSource) EvictHLSMasterPlaylist(manifestID ManifestID) {
+	c.masterPLock.Lock()
+	mpl := c.masterPList[manifestID]
+	if mpl != nil {
+		for _, variant := range mpl.Variants {
+			if len(variant.URI) > 5 {
+				streamID := variant.URI[:len(variant.URI)-5] // remove .m3u8 from end
+				c.DeleteCache(StreamID(streamID))
+			}
+		}
+	}
+	c.masterPLock.Unlock()
 	c.UpdateHLSMasterPlaylist(manifestID, nil)
 }
 

--- a/core/videosource.go
+++ b/core/videosource.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -111,8 +112,8 @@ func (c *BasicVideoSource) EvictHLSMasterPlaylist(manifestID ManifestID) {
 	mpl := c.masterPList[manifestID]
 	if mpl != nil {
 		for _, variant := range mpl.Variants {
-			if len(variant.URI) > 5 {
-				streamID := variant.URI[:len(variant.URI)-5] // remove .m3u8 from end
+			if strings.Contains(variant.URI, ".m3u8") {
+				streamID := strings.Replace(variant.URI, ".m3u8", "", -1) // remove .m3u8 from end
 				c.DeleteCache(StreamID(streamID))
 			}
 		}


### PR DESCRIPTION
VideoSource now caches segments from transcoded streams. After stream ended, these segments wasn't cleaned up from cache, creating memory leak. This commits removes from cache all streams  that associated  with master playlist when stream ended.