### PR TITLE
Refactor transcoder first claim process + reject unclaimable jobs

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -388,7 +388,7 @@ func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMoni
 	n.EthServices["RewardService"] = rs
 
 	// Create job service to listen for new jobs and transcode if assigned to the job
-	js := eventservices.NewJobService(em, n)
+	js := eventservices.NewJobService(n)
 	n.EthServices["JobService"] = js
 
 	// Restart jobs as necessary

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -24,10 +24,9 @@ func (cm *StubClaimManager) AddReceipt(seqNo int64, fname string, data []byte, b
 	cm.receiptAdded = true
 	return []byte{}, nil
 }
-func (cm *StubClaimManager) SufficientBroadcasterDeposit() (bool, error) { return true, nil }
-func (cm *StubClaimManager) ClaimVerifyAndDistributeFees() error         { return nil }
-func (cm *StubClaimManager) DidFirstClaim() bool                         { return false }
-func (cm *StubClaimManager) CanClaim() (bool, error)                     { return true, nil }
+func (cm *StubClaimManager) SufficientBroadcasterDeposit() (bool, error)   { return true, nil }
+func (cm *StubClaimManager) ClaimVerifyAndDistributeFees() error           { return nil }
+func (cm *StubClaimManager) CanClaim(*big.Int, *lpTypes.Job) (bool, error) { return true, nil }
 
 type StubTranscoder struct {
 	Profiles      []ffmpeg.VideoProfile

--- a/eth/helpers.go
+++ b/eth/helpers.go
@@ -1,19 +1,18 @@
 package eth
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/golang/glog"
+	lpcommon "github.com/livepeer/go-livepeer/common"
 )
 
 var (
-	BlocksUntilFirstClaimDeadline = big.NewInt(230)
+	BlocksUntilFirstClaimDeadline = big.NewInt(200)
 )
 
 func VerifySig(addr common.Address, msg, sig []byte) bool {
@@ -86,24 +85,34 @@ func FromPerc(perc float64) *big.Int {
 	return big.NewInt(int64(value))
 }
 
-func Wait(backend *ethclient.Client, rpcTimeout time.Duration, blocks *big.Int) error {
-	ctx, _ := context.WithTimeout(context.Background(), rpcTimeout)
+func Wait(db *lpcommon.DB, blocks *big.Int) error {
+	var (
+		lastSeenBlock *big.Int
+		err           error
+	)
 
-	block, err := backend.BlockByNumber(ctx, nil)
+	lastSeenBlock, err = db.LastSeenBlock()
 	if err != nil {
 		return err
 	}
 
-	targetBlockNum := new(big.Int).Add(block.Number(), blocks)
+	targetBlock := new(big.Int).Add(lastSeenBlock, blocks)
+	tickCh := time.NewTicker(15 * time.Second).C
 
 	glog.Infof("Waiting %v blocks...", blocks)
 
-	for block.Number().Cmp(targetBlockNum) == -1 {
-		ctx, _ = context.WithTimeout(context.Background(), rpcTimeout)
+	for {
+		select {
+		case <-tickCh:
+			if lastSeenBlock.Cmp(targetBlock) >= 0 {
+				break
+			}
 
-		block, err = backend.BlockByNumber(ctx, nil)
-		if err != nil {
-			return err
+			lastSeenBlock, err = db.LastSeenBlock()
+			if err != nil {
+				glog.Error("Error getting last seen block ", err)
+				continue
+			}
 		}
 	}
 

--- a/eth/helpers.go
+++ b/eth/helpers.go
@@ -105,7 +105,7 @@ func Wait(db *lpcommon.DB, blocks *big.Int) error {
 		select {
 		case <-tickCh:
 			if lastSeenBlock.Cmp(targetBlock) >= 0 {
-				break
+				return nil
 			}
 
 			lastSeenBlock, err = db.LastSeenBlock()

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -183,6 +183,12 @@ func (c *StubClient) SetGasInfo(uint64, *big.Int) error { return nil }
 func (c *StubClient) WatchForJob(j string) (*lpTypes.Job, error) {
 	return c.JobsMap[j], c.WatchJobError
 }
+func (c *StubClient) ProcessHistoricalNewJob(*big.Int, bool, func(*contracts.JobsManagerNewJob) error) error {
+	return nil
+}
+func (c *StubClient) WatchForNewJob(bool, chan *contracts.JobsManagerNewJob) (ethereum.Subscription, error) {
+	return nil, nil
+}
 func (c *StubClient) ProcessHistoricalUnbond(*big.Int, func(*contracts.BondingManagerUnbond) error) error {
 	return nil
 }

--- a/eth/types/contracts.go
+++ b/eth/types/contracts.go
@@ -83,18 +83,19 @@ type TokenPools struct {
 }
 
 type Job struct {
-	JobId              *big.Int
-	StreamId           string
-	Profiles           []ffmpeg.VideoProfile
-	MaxPricePerSegment *big.Int
-	BroadcasterAddress common.Address
-	TranscoderAddress  common.Address
-	CreationRound      *big.Int
-	CreationBlock      *big.Int
-	EndBlock           *big.Int
-	Escrow             *big.Int
-	TotalClaims        *big.Int
-	Status             string
+	JobId               *big.Int
+	StreamId            string
+	Profiles            []ffmpeg.VideoProfile
+	MaxPricePerSegment  *big.Int
+	BroadcasterAddress  common.Address
+	TranscoderAddress   common.Address
+	CreationRound       *big.Int
+	CreationBlock       *big.Int
+	EndBlock            *big.Int
+	Escrow              *big.Int
+	TotalClaims         *big.Int
+	Status              string
+	FirstClaimSubmitted bool
 }
 
 func ParseJobStatus(s uint8) (string, error) {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -72,7 +72,10 @@ func blockInRange(orch Orchestrator, job *lpTypes.Job) bool {
 		// May be offchain or have internal errors in fetching a block.
 		return true
 	}
-	return !(blk.Cmp(job.CreationBlock) == -1 || blk.Cmp(job.EndBlock) == 1)
+
+	canClaim := job.FirstClaimSubmitted || blk.Cmp(new(big.Int).Add(job.CreationBlock, big.NewInt(256))) <= 0
+
+	return canClaim && !(blk.Cmp(job.CreationBlock) == -1 || blk.Cmp(job.EndBlock) == 1)
 }
 
 func verifyMsgSig(addr ethcommon.Address, msg string, sig []byte) bool {


### PR DESCRIPTION
- Refactored `jobservice.go` so the first claim watching loop polls the last seen block stored in the local database since the block service already updates the local database with the latest block number
- Refactored the `Wait` function in `eth/helpers` to poll the last seen block stored in the local database since the block service already updates the local database with the latest block number
- When recovering claims check if the claims can be submitted
- Orchestrator rejects jobs if it wouldn't be able to submit a claim for it i.e. if the first claim has not been submitted for the job and it is past 256 blocks since the job's creation block. Fixes #521 