### PR TITLE
Print withdraw block for broadcaster deposit

### DIFF
--- a/cmd/livepeer_cli/wizard_deposit.go
+++ b/cmd/livepeer_cli/wizard_deposit.go
@@ -18,7 +18,12 @@ func str2eth(v string) string {
 }
 
 func (w *wizard) deposit() {
-	fmt.Printf("Current deposit: %v\n", str2eth(w.getDeposit()))
+	b, err := w.getBroadcaster()
+	if err != nil {
+		fmt.Printf("Error getting deposit: %v", err)
+	} else {
+		fmt.Printf("Current deposit: %v\n", str2eth(b["deposit"]))
+	}
 	fmt.Printf("Current balance: %v\n", str2eth(w.getEthBalance()))
 	fmt.Printf("Enter Deposit Amount in Wei - ")
 	amount := w.readBigInt()
@@ -32,7 +37,15 @@ func (w *wizard) deposit() {
 
 func (w *wizard) withdraw() {
 	// We don't run str2eth here to facilitate copy-pasting
-	fmt.Printf("Current deposit in Wei: %v\n", w.getDeposit())
+	b, err := w.getBroadcaster()
+	if err != nil {
+		fmt.Printf("Error getting deposit: %v", err)
+	} else {
+		fmt.Printf("Current deposit in Wei: %v\n", b["deposit"])
+	}
 
-	httpPost(fmt.Sprintf("http://%v:%v/withdrawDeposit", w.host, w.httpPort))
+	ret := httpPost(fmt.Sprintf("http://%v:%v/withdrawDeposit", w.host, w.httpPort))
+	if ret != "" {
+		fmt.Println(ret)
+	}
 }

--- a/eth/claimmanager.go
+++ b/eth/claimmanager.go
@@ -231,7 +231,7 @@ func (c *BasicClaimManager) AddReceipt(seqNo int64,
 }
 
 func (c *BasicClaimManager) SufficientBroadcasterDeposit() (bool, error) {
-	bDeposit, err := c.client.BroadcasterDeposit(c.broadcasterAddr)
+	b, err := c.client.Broadcaster(c.broadcasterAddr)
 	if err != nil {
 		glog.Errorf("Error getting broadcaster deposit: %v", err)
 		return false, err
@@ -239,7 +239,7 @@ func (c *BasicClaimManager) SufficientBroadcasterDeposit() (bool, error) {
 
 	//If broadcaster does not have enough for a segment, return false
 	//If broadcaster has enough for at least one transcoded segment, return true
-	currDeposit := new(big.Int).Sub(bDeposit, c.cost)
+	currDeposit := new(big.Int).Sub(b.Deposit, c.cost)
 	if new(big.Int).Sub(currDeposit, new(big.Int).Mul(big.NewInt(int64(len(c.profiles))), c.pricePerSegment)).Cmp(big.NewInt(0)) == -1 {
 		return false, nil
 	} else {

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -148,8 +148,8 @@ func (c *StubClient) Deposit(amount *big.Int) (*types.Transaction, error) {
 	return nil, nil
 }
 func (c *StubClient) Withdraw() (*types.Transaction, error) { return nil, nil }
-func (c *StubClient) BroadcasterDeposit(broadcaster common.Address) (*big.Int, error) {
-	return big.NewInt(10), nil
+func (c *StubClient) Broadcaster(broadcaster common.Address) (*BroadcasterEthInfo, error) {
+	return nil, nil
 }
 func (e *StubClient) GetJob(jobID *big.Int) (*lpTypes.Job, error) {
 	return e.JobsMap[jobID.String()], nil

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -278,11 +278,12 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 				return ErrRoundInit
 			}
 			// Check deposit
-			deposit, err := s.LivepeerNode.Eth.BroadcasterDeposit(s.LivepeerNode.Eth.Account().Address)
-			if err != nil {
+			b, err := s.LivepeerNode.Eth.Broadcaster(s.LivepeerNode.Eth.Account().Address)
+			if err != nil || b.Deposit == nil {
 				glog.Errorf("Error getting deposit: %v", err)
 				return ErrBroadcast
 			}
+			deposit := b.Deposit
 
 			glog.V(common.SHORT).Infof("Current deposit is: %v", deposit)
 

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -80,7 +80,7 @@ func TestStartBroadcast(t *testing.T) {
 
 	sd := &stubDiscovery{}
 	// Discovery returned no orchestrators
-	s.LivepeerNode.OrchestratorSelector = sd
+	s.LivepeerNode.OrchestratorPool = sd
 	if sess, _ := s.startBroadcast(pl); sess != nil {
 		t.Error("Expected nil session")
 	}


### PR DESCRIPTION
Currently if you want to withdraw your deposit from the CLI, you don't know if the withdraw will succeed.

This change checks for the withdraw block before submitting the transaction.  It also prints out the withdraw block in the cli.