### PR TITLE
mediaserver: Add stream/current.m3u8 playback endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can also build the executables from scratch.
 ### Quick start
 - Make sure you have successfully gone through the steps in 'Installing Livepeer' and 'Additional Dependencies'.
 
-- Run `./livepeer -rinkeby`.
+- Run `./livepeer -rinkeby -currentManifest`.
 
 - Run `./livepeer_cli`.
   * You should see a wizard launch in the command line.
@@ -69,7 +69,7 @@ Similarly, you can use OBS, and change the Settings->Stream->URL to `rtmp://loca
 
 If the broadcast is successful, you should be able to get a streamID by querying the local node's CLI API:
 
-`curl http://localhost:8935/manifestID`
+`curl http://localhost:7935/manifestID`
 
 ### Streaming
 
@@ -77,7 +77,7 @@ You can use tools like `ffplay` or `VLC` to view the stream.
 
 For example, after you get the streamID, you can view the stream by running:
 
-`ffplay http://localhost:8935/stream/{manifestID}.m3u8`
+`ffplay http://localhost:8935/stream/current.m3u8`
 
 Note that the default HTTP port or playback (8935) is different from the CLI API port (7935) that is used for node management and diagnostics!
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -59,6 +59,7 @@ func main() {
 	transcoder := flag.Bool("transcoder", false, "Set to true to be a transcoder")
 	maxPricePerSegment := flag.String("maxPricePerSegment", "1", "Max price per segment for a broadcast job")
 	transcodingOptions := flag.String("transcodingOptions", "P240p30fps16x9,P360p30fps16x9", "Transcoding options for broadcast job")
+	currentManifest := flag.Bool("currentManifest", false, "Expose the currently active ManifestID as \"/stream/current.m3u8\"")
 	ethAcctAddr := flag.String("ethAcctAddr", "", "Existing Eth account address")
 	ethPassword := flag.String("ethPassword", "", "Password for existing Eth account address")
 	ethKeystorePath := flag.String("ethKeystorePath", "", "Path for the Eth Key")
@@ -268,6 +269,11 @@ func main() {
 	if err != nil {
 		glog.Errorf("Error setting max price per segment: %v", err)
 		return
+	}
+
+	if *currentManifest {
+		glog.Info("Current ManifestID will be available over ", *httpAddr)
+		s.ExposeCurrentManifest = *currentManifest
 	}
 
 	go func() {


### PR DESCRIPTION
Make this optional (default false) to avoid unintentionally
exposing streams to drive-by playbacks on public nodes.

Resolves a number of issues:
* Resolves cases where active StreamID does not match latest
  StreamID on the blockchain
* Mitigates the need for a blockchain lookup during playback
* Mitigates the need to expose `/manifestID` (which is a CLI API)
  with broadcasters that are otherwise public.

Fixes https://github.com/livepeer/go-livepeer/issues/556