### PR TITLE
jobservice: Only process historical jobs from a nonzero block.

### DIFF
--- a/eth/eventservices/jobservice.go
+++ b/eth/eventservices/jobservice.go
@@ -213,6 +213,10 @@ func (s *JobService) processHistoricalEvents(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	//Exit early if LastSeenBlock is zero (starting with a new db)
+	if startBlock.Cmp(big.NewInt(0)) == 0 {
+		return nil
+	}
 
 	if err := s.node.Eth.ProcessHistoricalNewJob(startBlock, true, func(newJob *contracts.JobsManagerNewJob) error {
 		if err := s.processNewJob(ctx, newJob); err != nil {

--- a/eth/eventservices/jobservice_test.go
+++ b/eth/eventservices/jobservice_test.go
@@ -1,0 +1,33 @@
+package eventservices
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/eth"
+)
+
+func TestProcessHistoricalJobs(t *testing.T) {
+	seth := &eth.StubClient{}
+	seth.WatchJobError = fmt.Errorf("Historical job error")
+	n, err := core.NewLivepeerNode(seth, ".", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	js := NewJobService(n)
+
+	//Test that we exit early because startBlock is 0 in this case
+	err = js.processHistoricalEvents(context.Background(), big.NewInt(0))
+	if err != nil {
+		t.Error("Unexpected error ", err)
+	}
+
+	//Set last seen block to be 10, this should result in an error because we don't exit early anymore and we set a stubbed error
+	err = js.processHistoricalEvents(context.Background(), big.NewInt(10))
+	if err != seth.WatchJobError {
+		t.Error("Expected WatchJobError, got ", err)
+	}
+}

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -185,7 +185,7 @@ func (c *StubClient) WatchForJob(j string) (*lpTypes.Job, error) {
 	return c.JobsMap[j], c.WatchJobError
 }
 func (c *StubClient) ProcessHistoricalNewJob(*big.Int, bool, func(*contracts.JobsManagerNewJob) error) error {
-	return nil
+	return c.WatchJobError
 }
 func (c *StubClient) WatchForNewJob(bool, chan *contracts.JobsManagerNewJob) (ethereum.Subscription, error) {
 	return nil, nil

--- a/test.sh
+++ b/test.sh
@@ -20,12 +20,17 @@ go test -logtostderr=true
 t4=$?
 cd ..
 
-cd common
+cd eth/eventservices
 go test -logtostderr=true
 t5=$?
+cd ../..
+
+cd common
+go test -logtostderr=true
+t6=$?
 cd ..
 
-if (($t1!=0||$t2!=0||$t3!=0||$t4!=0||$t5!=0))
+if (($t1!=0||$t2!=0||$t3!=0||$t4!=0||$t5!=0||$t6!=0))
 then
     printf "\n\nSome Tests Failed\n\n"
     exit -1


### PR DESCRIPTION
Prevents the jobservice from hanging while it scans the blockchain
starting from the beginning.

Ignore Circle for now, the particular test that's failing is timing sensitive.