### PR TITLE
Split orchestrator and transcoder

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -180,6 +180,9 @@ func main() {
 		n.NodeType = core.OrchestratorNode
 	} else if transcoder {
 		n.NodeType = core.TranscoderNode
+		glog.Info("***Livepeer is in transcoder mode ***")
+		server.RunTranscoder(n, *orchAddr)
+		return
 	} else {
 		n.NodeType = core.BroadcasterNode
 	}

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -172,6 +172,10 @@ func main() {
 		n.OrchSecret = *orchSecret
 	}
 
+	if transcoder {
+		n.Transcoder = core.NewLocalTranscoder(*datadir)
+	}
+
 	if *orchestrator {
 		n.NodeType = core.OrchestratorNode
 	} else if transcoder {

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -181,7 +181,7 @@ func main() {
 	} else if transcoder {
 		n.NodeType = core.TranscoderNode
 	} else {
-		n.NodeType = core.Broadcaster
+		n.NodeType = core.BroadcasterNode
 	}
 
 	if *offchain {
@@ -283,7 +283,7 @@ func main() {
 		drivers.NodeStorage = drivers.NewS3Driver(br[0], br[1], cr[0], cr[1])
 	}
 
-	if n.NodeType == core.Broadcaster {
+	if n.NodeType == core.BroadcasterNode {
 		// default lpms listener for broadcaster; same as default rpc port
 		// TODO provide an option to disable this?
 		*rtmpAddr = defaultAddr(*rtmpAddr, "127.0.0.1", RtmpPort)
@@ -375,7 +375,7 @@ func main() {
 	switch n.NodeType {
 	case core.OrchestratorNode:
 		glog.Infof("***Livepeer Running in Orchestrator Mode***")
-	case core.Broadcaster:
+	case core.BroadcasterNode:
 		glog.Infof("***Livepeer Running in Broadcaster Mode***")
 		glog.Infof("Video Ingest Endpoint - rtmp://%v", *rtmpAddr)
 	case core.TranscoderNode:

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -385,6 +385,7 @@ func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMoni
 		glog.Infof("Transcoder %v is active", n.Eth.Account().Address.Hex())
 	}
 
+	serviceUriSpecified := false
 	if serviceUri == "" {
 		// TODO probably should put this (along w wizard GETs) into common code
 		resp, err := http.Get("https://api.ipify.org?format=text")
@@ -397,6 +398,7 @@ func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMoni
 		serviceUri = "https://" + strings.TrimSpace(string(body)) + ":" + RpcPort
 	} else {
 		serviceUri = "https://" + serviceUri
+		serviceUriSpecified = true
 	}
 	suri, err := url.ParseRequestURI(serviceUri)
 	if err != nil {
@@ -419,6 +421,9 @@ func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMoni
 		if active && false {
 			return fmt.Errorf("Mismatched service address")
 		}
+	}
+	if serviceUriSpecified {
+		uri = suri
 	}
 
 	// Set up IPFS

--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -51,7 +51,7 @@ func main() {
 			host:     c.String("host"),
 			in:       bufio.NewReader(os.Stdin),
 		}
-		w.transcoder = w.isTranscoder()
+		w.orchestrator = w.isOrchestrator()
 		w.testnet = w.onTestnet()
 		w.run()
 
@@ -62,27 +62,27 @@ func main() {
 }
 
 type wizard struct {
-	endpoint   string // Local livepeer node
-	httpPort   string
-	host       string
-	transcoder bool
-	testnet    bool
-	in         *bufio.Reader // Wrapper around stdin to allow reading user input
+	endpoint     string // Local livepeer node
+	httpPort     string
+	host         string
+	orchestrator bool
+	testnet      bool
+	in           *bufio.Reader // Wrapper around stdin to allow reading user input
 }
 
 type wizardOpt struct {
-	desc          string
-	invoke        func()
-	testnet       bool
-	transcoder    bool
-	notTranscoder bool
+	desc            string
+	invoke          func()
+	testnet         bool
+	orchestrator    bool
+	notOrchestrator bool
 }
 
 func (w *wizard) initializeOptions() []wizardOpt {
 	options := []wizardOpt{
-		{desc: "Get node status", invoke: func() { w.stats(w.transcoder) }},
+		{desc: "Get node status", invoke: func() { w.stats(w.orchestrator) }},
 		{desc: "View protocol parameters", invoke: w.protocolStats},
-		{desc: "List registered transcoders", invoke: func() { w.registeredTranscoderStats() }},
+		{desc: "List registered orchestrators", invoke: func() { w.registeredOrchestratorStats() }},
 		{desc: "Print latest jobs", invoke: w.printLast5Jobs},
 		{desc: "Invoke \"initialize round\"", invoke: w.initializeRound},
 		{desc: "Invoke \"bond\"", invoke: w.bond},
@@ -92,12 +92,12 @@ func (w *wizard) initializeOptions() []wizardOpt {
 		{desc: "Invoke \"withdraw fees\" (ETH)", invoke: w.withdrawFees},
 		{desc: "Invoke \"claim\" (for rewards and fees)", invoke: w.claimRewardsAndFees},
 		{desc: "Invoke \"transfer\" (LPT)", invoke: w.transferTokens},
-		{desc: "Invoke \"reward\"", invoke: w.callReward, transcoder: true},
-		{desc: "Invoke multi-step \"become a transcoder\"", invoke: w.activateTranscoder, transcoder: true},
-		{desc: "Set transcoder config", invoke: w.setTranscoderConfig, transcoder: true},
-		{desc: "Invoke \"deposit\" (ETH)", invoke: w.deposit, notTranscoder: true},
-		{desc: "Invoke \"withdraw deposit\" (ETH)", invoke: w.withdraw, notTranscoder: true},
-		{desc: "Set broadcast config", invoke: w.setBroadcastConfig, notTranscoder: true},
+		{desc: "Invoke \"reward\"", invoke: w.callReward, orchestrator: true},
+		{desc: "Invoke multi-step \"become an orchestrator\"", invoke: w.activateOrchestrator, orchestrator: true},
+		{desc: "Set orchestrator config", invoke: w.setOrchestratorConfig, orchestrator: true},
+		{desc: "Invoke \"deposit\" (ETH)", invoke: w.deposit, notOrchestrator: true},
+		{desc: "Invoke \"withdraw deposit\" (ETH)", invoke: w.withdraw, notOrchestrator: true},
+		{desc: "Set broadcast config", invoke: w.setBroadcastConfig, notOrchestrator: true},
 		{desc: "Set Eth gas price", invoke: w.setGasPrice},
 		{desc: "Get test LPT", invoke: w.requestTokens, testnet: true},
 		{desc: "Get test ETH", invoke: func() {
@@ -114,7 +114,7 @@ func (w *wizard) filterOptions(options []wizardOpt) []wizardOpt {
 		if opt.testnet && !w.testnet {
 			continue
 		}
-		if !opt.transcoder && !opt.notTranscoder || w.transcoder && opt.transcoder || !w.transcoder && opt.notTranscoder {
+		if !opt.orchestrator && !opt.notOrchestrator || w.orchestrator && opt.orchestrator || !w.orchestrator && opt.notOrchestrator {
 			filtered = append(filtered, opt)
 		}
 	}
@@ -139,7 +139,7 @@ func (w *wizard) run() {
 	fmt.Println("+-----------------------------------------------------------+")
 	fmt.Println()
 
-	w.stats(w.transcoder)
+	w.stats(w.orchestrator)
 	options := w.filterOptions(w.initializeOptions())
 
 	// Basics done, loop ad infinitum about what to do

--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -19,24 +19,24 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-func (w *wizard) registeredTranscoderStats() map[int]common.Address {
-	transcoders, err := w.getRegisteredTranscoders()
+func (w *wizard) registeredOrchestratorStats() map[int]common.Address {
+	orchestrators, err := w.getRegisteredOrchestrators()
 	if err != nil {
-		glog.Errorf("Error getting registered transcoders: %v", err)
+		glog.Errorf("Error getting registered orchestrators: %v", err)
 		return nil
 	}
 
-	transcoderIDs := make(map[int]common.Address)
+	orchestratorIDs := make(map[int]common.Address)
 	nextId := 0
 
-	fmt.Println("+----------------------+")
-	fmt.Println("|REGISTERED TRANSCODERS|")
-	fmt.Println("+----------------------+")
+	fmt.Println("+------------------------+")
+	fmt.Println("|REGISTERED ORCHESTRATORS|")
+	fmt.Println("+------------------------+")
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"ID", "Address", "Active", "Delegated Stake", "Reward Cut (%)", "Fee Share (%)", "Price", "Pending Reward Cut (%)", "Pending Fee Share (%)", "Pending Price", "Service URI"})
 
-	for _, t := range transcoders {
+	for _, t := range orchestrators {
 		table.Append([]string{
 			strconv.FormatInt(int64(nextId), 10),
 			t.Address.Hex(),
@@ -51,17 +51,17 @@ func (w *wizard) registeredTranscoderStats() map[int]common.Address {
 			t.ServiceURI,
 		})
 
-		transcoderIDs[nextId] = t.Address
+		orchestratorIDs[nextId] = t.Address
 		nextId++
 	}
 
 	table.Render()
 
-	return transcoderIDs
+	return orchestratorIDs
 }
 
-func (w *wizard) getRegisteredTranscoders() ([]lpTypes.Transcoder, error) {
-	resp, err := http.Get(fmt.Sprintf("http://%v:%v/registeredTranscoders", w.host, w.httpPort))
+func (w *wizard) getRegisteredOrchestrators() ([]lpTypes.Transcoder, error) {
+	resp, err := http.Get(fmt.Sprintf("http://%v:%v/registeredOrchestrators", w.host, w.httpPort))
 	if err != nil {
 		return nil, err
 	}
@@ -73,13 +73,13 @@ func (w *wizard) getRegisteredTranscoders() ([]lpTypes.Transcoder, error) {
 		return nil, err
 	}
 
-	var transcoders []lpTypes.Transcoder
-	err = json.Unmarshal(result, &transcoders)
+	var orchestrators []lpTypes.Transcoder
+	err = json.Unmarshal(result, &orchestrators)
 	if err != nil {
 		return nil, err
 	}
 
-	return transcoders, nil
+	return orchestrators, nil
 }
 
 func (w *wizard) unbondingLockStats(withdrawable bool) map[int64]bool {
@@ -146,19 +146,19 @@ func (w *wizard) getUnbondingLocks(withdrawable bool) ([]lpcommon.DBUnbondingLoc
 }
 
 func (w *wizard) bond() {
-	transcoderIds := w.registeredTranscoderStats()
+	orchestratorIds := w.registeredOrchestratorStats()
 	var tAddr common.Address
-	if transcoderIds == nil {
-		fmt.Printf("Enter the address of the transcoder you would like to bond to - ")
+	if orchestratorIds == nil {
+		fmt.Printf("Enter the address of the orchestrator you would like to bond to - ")
 		strAddr := w.readString()
 		if err := tAddr.UnmarshalText([]byte(strAddr)); err != nil {
 			fmt.Println(err)
 			return
 		}
 	} else {
-		fmt.Printf("Enter the identifier of the transcoder you would like to bond to - ")
+		fmt.Printf("Enter the identifier of the orchestrator you would like to bond to - ")
 		id := w.readInt()
-		tAddr = transcoderIds[id]
+		tAddr = orchestratorIds[id]
 	}
 
 	balBigInt, err := lpcommon.ParseBigInt(w.getTokenBalance())
@@ -226,19 +226,19 @@ func (w *wizard) rebond() {
 
 		var toAddr common.Address
 
-		transcoderIds := w.registeredTranscoderStats()
+		orchestratorIds := w.registeredOrchestratorStats()
 
-		if transcoderIds == nil {
-			fmt.Printf("Enter the address of the transcoder you would like to rebond to - ")
+		if orchestratorIds == nil {
+			fmt.Printf("Enter the address of the orchestrator you would like to rebond to - ")
 			strAddr := w.readString()
 			if err := toAddr.UnmarshalText([]byte(strAddr)); err != nil {
 				fmt.Println(err)
 				return
 			}
 		} else {
-			fmt.Printf("Enter the identifier of the transcoder you would like to rebond to - ")
-			transcoderID := w.readInt()
-			toAddr = transcoderIds[transcoderID]
+			fmt.Printf("Enter the identifier of the orchestrator you would like to rebond to - ")
+			orchestratorID := w.readInt()
+			toAddr = orchestratorIds[orchestratorID]
 		}
 
 		val["toAddr"] = []string{fmt.Sprintf("%v", toAddr.Hex())}

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -16,7 +16,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 )
 
-func (w *wizard) stats(showTranscoder bool) {
+func (w *wizard) stats(showOrchestrator bool) {
 	addrMap, err := w.getContractAddresses()
 	if err != nil {
 		glog.Errorf("Error getting contract addresses: %v", err)
@@ -48,9 +48,9 @@ func (w *wizard) stats(showTranscoder bool) {
 	table.SetColumnSeparator("|")
 	table.Render()
 
-	if showTranscoder {
-		w.transcoderStats()
-		w.transcoderEventSubscriptions()
+	if showOrchestrator {
+		w.orchestratorStats()
+		w.orchestratorEventSubscriptions()
 		w.delegatorStats()
 	} else {
 		w.broadcastStats()
@@ -89,7 +89,7 @@ func (w *wizard) protocolStats() {
 	table := tablewriter.NewWriter(os.Stdout)
 	data := [][]string{
 		[]string{"Protocol Paused", fmt.Sprintf("%t", params.Paused)},
-		[]string{"Max # Active Transcoders", params.NumActiveTranscoders.String()},
+		[]string{"Max # Active Orchestrators", params.NumActiveTranscoders.String()},
 		[]string{"RoundLength (Blocks)", params.RoundLength.String()},
 		[]string{"RoundLockAmount (%)", eth.FormatPerc(params.RoundLockAmount)},
 		[]string{"UnbondingPeriod (Rounds)", strconv.Itoa(int(params.UnbondingPeriod))},
@@ -145,16 +145,16 @@ func (w *wizard) broadcastStats() {
 	table.Render()
 }
 
-func (w *wizard) transcoderStats() {
-	t, err := w.getTranscoderInfo()
+func (w *wizard) orchestratorStats() {
+	t, err := w.getOrchestratorInfo()
 	if err != nil {
-		glog.Errorf("Error getting transcoder info: %v", err)
+		glog.Errorf("Error getting orchestrator info: %v", err)
 		return
 	}
 
-	fmt.Println("+----------------+")
-	fmt.Println("|TRANSCODER STATS|")
-	fmt.Println("+----------------+")
+	fmt.Println("+------------------+")
+	fmt.Println("|ORCHESTRATOR STATS|")
+	fmt.Println("+------------------+")
 
 	table := tablewriter.NewWriter(os.Stdout)
 	data := [][]string{
@@ -182,16 +182,16 @@ func (w *wizard) transcoderStats() {
 	table.Render()
 }
 
-func (w *wizard) transcoderEventSubscriptions() {
-	subMap, err := w.getTranscoderEventSubscriptions()
+func (w *wizard) orchestratorEventSubscriptions() {
+	subMap, err := w.getOrchestratorEventSubscriptions()
 	if err != nil {
-		glog.Errorf("Error getting transcoder event subscriptions: %v", err)
+		glog.Errorf("Error getting orchestrator event subscriptions: %v", err)
 		return
 	}
 
-	fmt.Println("+------------------------------+")
-	fmt.Println("|TRANSCODER EVENT SUBSCRIPTIONS|")
-	fmt.Println("+------------------------------+")
+	fmt.Println("+--------------------------------+")
+	fmt.Println("|ORCHESTRATOR EVENT SUBSCRIPTIONS|")
+	fmt.Println("+--------------------------------+")
 
 	table := tablewriter.NewWriter(os.Stdout)
 	data := [][]string{
@@ -360,8 +360,8 @@ func (w *wizard) getBroadcastConfig() (*big.Int, string) {
 	return config.MaxPricePerSegment, config.TranscodingOptions
 }
 
-func (w *wizard) getTranscoderInfo() (lpTypes.Transcoder, error) {
-	resp, err := http.Get(fmt.Sprintf("http://%v:%v/transcoderInfo", w.host, w.httpPort))
+func (w *wizard) getOrchestratorInfo() (lpTypes.Transcoder, error) {
+	resp, err := http.Get(fmt.Sprintf("http://%v:%v/orchestratorInfo", w.host, w.httpPort))
 	if err != nil {
 		return lpTypes.Transcoder{}, err
 	}
@@ -382,8 +382,8 @@ func (w *wizard) getTranscoderInfo() (lpTypes.Transcoder, error) {
 	return tInfo, nil
 }
 
-func (w *wizard) getTranscoderEventSubscriptions() (map[string]bool, error) {
-	resp, err := http.Get(fmt.Sprintf("http://%v:%v/transcoderEventSubscriptions", w.host, w.httpPort))
+func (w *wizard) getOrchestratorEventSubscriptions() (map[string]bool, error) {
+	resp, err := http.Get(fmt.Sprintf("http://%v:%v/orchestratorEventSubscriptions", w.host, w.httpPort))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/livepeer_cli/wizard_transcoder.go
+++ b/cmd/livepeer_cli/wizard_transcoder.go
@@ -13,8 +13,8 @@ import (
 
 const defaultRPCPort = "8935"
 
-func (w *wizard) isTranscoder() bool {
-	isT := httpGet(fmt.Sprintf("http://%v:%v/IsTranscoder", w.host, w.httpPort))
+func (w *wizard) isOrchestrator() bool {
+	isT := httpGet(fmt.Sprintf("http://%v:%v/IsOrchestrator", w.host, w.httpPort))
 	return isT == "true"
 }
 
@@ -28,7 +28,7 @@ func myHostPort() string {
 	return ip + ":" + defaultRPCPort
 }
 
-func (w *wizard) promptTranscoderConfig() (float64, float64, *big.Int, string) {
+func (w *wizard) promptOrchestratorConfig() (float64, float64, *big.Int, string) {
 	var (
 		blockRewardCut  float64
 		feeShare        float64
@@ -64,7 +64,7 @@ func (w *wizard) promptTranscoderConfig() (float64, float64, *big.Int, string) {
 	return blockRewardCut, feeShare, pricePerSegment, serviceURI
 }
 
-func (w *wizard) activateTranscoder() {
+func (w *wizard) activateOrchestrator() {
 	d, err := w.getDelegatorInfo()
 	if err != nil {
 		glog.Errorf("Error getting delegator info: %v", err)
@@ -74,7 +74,7 @@ func (w *wizard) activateTranscoder() {
 	fmt.Printf("Current token balance: %v\n", w.getTokenBalance())
 	fmt.Printf("Current bonded amount: %v\n", d.BondedAmount.String())
 
-	blockRewardCut, feeShare, pricePerSegment, serviceURI := w.promptTranscoderConfig()
+	blockRewardCut, feeShare, pricePerSegment, serviceURI := w.promptOrchestratorConfig()
 
 	val := url.Values{
 		"blockRewardCut":  {fmt.Sprintf("%v", blockRewardCut)},
@@ -84,7 +84,7 @@ func (w *wizard) activateTranscoder() {
 	}
 
 	if d.BondedAmount.Cmp(big.NewInt(0)) <= 0 || d.DelegateAddress != d.Address {
-		fmt.Printf("You must bond to yourself in order to become a transcoder\n")
+		fmt.Printf("You must bond to yourself in order to become a orchestrator\n")
 
 		rebond := false
 
@@ -142,15 +142,15 @@ func (w *wizard) activateTranscoder() {
 		}
 	}
 
-	httpPostWithParams(fmt.Sprintf("http://%v:%v/activateTranscoder", w.host, w.httpPort), val)
+	httpPostWithParams(fmt.Sprintf("http://%v:%v/activateOrchestrator", w.host, w.httpPort), val)
 	// TODO we should confirm if the transaction was actually sent
 	fmt.Println("\nTransaction sent. Once confirmed, please restart your node.")
 }
 
-func (w *wizard) setTranscoderConfig() {
+func (w *wizard) setOrchestratorConfig() {
 	fmt.Printf("Current token balance: %v\n", w.getTokenBalance())
 
-	blockRewardCut, feeShare, pricePerSegment, serviceURI := w.promptTranscoderConfig()
+	blockRewardCut, feeShare, pricePerSegment, serviceURI := w.promptOrchestratorConfig()
 
 	val := url.Values{
 		"blockRewardCut":  {fmt.Sprintf("%v", blockRewardCut)},
@@ -159,15 +159,15 @@ func (w *wizard) setTranscoderConfig() {
 		"serviceURI":      {fmt.Sprintf("%v", serviceURI)},
 	}
 
-	httpPostWithParams(fmt.Sprintf("http://%v:%v/setTranscoderConfig", w.host, w.httpPort), val)
+	httpPostWithParams(fmt.Sprintf("http://%v:%v/setOrchestratorConfig", w.host, w.httpPort), val)
 	// TODO we should confirm if the transaction was actually sent
 	fmt.Println("\nTransaction sent. Once confirmed, please restart your node if the ServiceURI has been reset")
 }
 
 func (w *wizard) callReward() {
-	t, err := w.getTranscoderInfo()
+	t, err := w.getOrchestratorInfo()
 	if err != nil {
-		fmt.Printf("Error getting transcoder info: %v\n", err)
+		fmt.Printf("Error getting orchestrator info: %v\n", err)
 		return
 	}
 	c, err := strconv.ParseInt(w.currentRound(), 10, 64)

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -54,6 +54,7 @@ func TestTranscode(t *testing.T) {
 	n, _ := NewLivepeerNode(seth, tmp, db)
 	defer os.RemoveAll(tmp)
 	job := StubJob(n)
+	n.Transcoder = NewLocalTranscoder(tmp)
 	ffmpeg.InitFFmpeg()
 
 	// Sanity check full flow.

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -29,7 +29,7 @@ var LivepeerVersion = "0.3.1-unstable"
 type NodeType int
 
 const (
-	Broadcaster NodeType = iota
+	BroadcasterNode NodeType = iota
 	OrchestratorNode
 	TranscoderNode
 )

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -51,6 +51,7 @@ type LivepeerNode struct {
 	Ipfs          ipfs.IpfsApi
 	ServiceURI    *url.URL
 	OrchSecret    string
+	Transcoder    Transcoder
 
 	// Transcoder private fields
 	claimMutex   *sync.Mutex

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -30,7 +30,8 @@ type NodeType int
 
 const (
 	Broadcaster NodeType = iota
-	Transcoder
+	OrchestratorNode
+	TranscoderNode
 )
 
 //LivepeerNode handles videos going in and coming out of the Livepeer network.
@@ -49,6 +50,7 @@ type LivepeerNode struct {
 	SegmentChans  map[int64]SegmentChan
 	Ipfs          ipfs.IpfsApi
 	ServiceURI    *url.URL
+	OrchSecret    string
 
 	// Transcoder private fields
 	claimMutex   *sync.Mutex

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -56,6 +56,10 @@ type LivepeerNode struct {
 	// Transcoder private fields
 	claimMutex   *sync.Mutex
 	segmentMutex *sync.Mutex
+	tcoderMutex  *sync.RWMutex
+	taskMutex    *sync.RWMutex
+	taskChans    map[int64]TranscoderChan
+	taskCount    int64
 }
 
 //NewLivepeerNode creates a new Livepeer Node. Eth can be nil.
@@ -69,7 +73,11 @@ func NewLivepeerNode(e eth.LivepeerEthClient, wd string, dbh *common.DB) (*Livep
 		SegmentChans:  make(map[int64]SegmentChan),
 		claimMutex:    &sync.Mutex{},
 		segmentMutex:  &sync.Mutex{},
+		tcoderMutex:   &sync.RWMutex{},
+		taskMutex:     &sync.RWMutex{},
+		taskChans:     make(map[int64]TranscoderChan),
 	}, nil
+
 }
 
 func (n *LivepeerNode) StartEthServices() error {

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -35,7 +35,7 @@ type StubTranscoder struct {
 	FailTranscode bool
 }
 
-func (t *StubTranscoder) Transcode(fname string) ([][]byte, error) {
+func (t *StubTranscoder) Transcode(fname string, profiles []ffmpeg.VideoProfile) ([][]byte, error) {
 	d, err := ioutil.ReadFile(fname)
 	if err != nil || t.FailTranscode {
 		return nil, ErrTranscode
@@ -64,7 +64,7 @@ func TestTranscodeAndBroadcast(t *testing.T) {
 	}
 	strmIds := []StreamID{mkid(p[0]), mkid(p[1])}
 	cm := StubClaimManager{}
-	config := transcodeConfig{StrmID: strmID.String(), Profiles: p, ResultStrmIDs: strmIds, ClaimManager: &cm, JobID: jid, Transcoder: tr}
+	config := transcodeConfig{StrmID: strmID.String(), Profiles: p, ResultStrmIDs: strmIds, ClaimManager: &cm, JobID: jid}
 
 	tmpdir, _ := ioutil.TempDir("", "")
 	n, err := NewLivepeerNode(&eth.StubClient{}, tmpdir, nil)
@@ -72,6 +72,7 @@ func TestTranscodeAndBroadcast(t *testing.T) {
 		t.Errorf("Error: %v", err)
 	}
 	defer os.RemoveAll(tmpdir)
+	n.Transcoder = tr
 
 	ss := StubSegment()
 	res := n.transcodeAndCacheSeg(config, ss)

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1,16 +1,22 @@
 package core
 
 import (
+	"context"
+	"fmt"
 	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/eth"
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
+	"github.com/livepeer/go-livepeer/net"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	"google.golang.org/grpc/metadata"
 )
 
 func TestCurrentBlock(t *testing.T) {
@@ -129,4 +135,176 @@ func TestGetJob(t *testing.T) {
 	if err != nil || j.TranscoderAddress != sj.TranscoderAddress {
 		t.Error("Got error or unexpected transcoder address ", err, j.TranscoderAddress)
 	}
+}
+
+func TestServeTranscoder(t *testing.T) {
+	n, _ := NewLivepeerNode(nil, "", nil)
+	strm := &StubTranscoderServer{}
+
+	// test that a transcoder was created
+	go n.serveTranscoder(strm)
+	time.Sleep(1 * time.Second)
+	if n.Transcoder == nil {
+		t.Error("Transcoder nil")
+	}
+	tc, ok := n.Transcoder.(*RemoteTranscoder)
+	if !ok {
+		t.Error("Unexpected transcoder type")
+	}
+
+	// test shutdown
+	tc.eof <- struct{}{}
+	time.Sleep(1 * time.Second)
+	if n.Transcoder != nil {
+		t.Error("Transcoder not nil")
+	}
+}
+
+func TestRemoteTranscoder(t *testing.T) {
+	n, _ := NewLivepeerNode(nil, "", nil)
+	initTranscoder := func() (*RemoteTranscoder, *StubTranscoderServer) {
+		strm := &StubTranscoderServer{node: n}
+		tc := NewRemoteTranscoder(n, strm)
+		return tc, strm
+	}
+
+	// happy path
+	tc, strm := initTranscoder()
+	res, err := tc.Transcode("", nil)
+	if err != nil || string(res[0]) != "asdf" {
+		t.Error("Error transcoding ", err)
+	}
+
+	// error on remote while transcoding
+	tc, strm = initTranscoder()
+	strm.TranscodeError = fmt.Errorf("TranscodeError")
+	res, err = tc.Transcode("", nil)
+	if err != strm.TranscodeError {
+		t.Error("Unexpected error ", err, res)
+	}
+
+	// simulate error with sending
+	tc, strm = initTranscoder()
+	strm.SendError = fmt.Errorf("SendError")
+	_, err = tc.Transcode("", nil)
+	if err != strm.SendError {
+		t.Error("Unexpected error ", err)
+	}
+
+	// simulate timeout
+	tc, strm = initTranscoder()
+	strm.WithholdResults = true
+	RemoteTranscoderTimeout = 1 * time.Millisecond
+	_, err = tc.Transcode("", nil)
+	if err.Error() != "Remote transcoder took too long" {
+		t.Error("Unexpected error ", err)
+	}
+	RemoteTranscoderTimeout = 8 * time.Second
+}
+
+func TestTaskChan(t *testing.T) {
+	n, _ := NewLivepeerNode(nil, "", nil)
+	// Sanity check task ID
+	if n.taskCount != 0 {
+		t.Error("Unexpected taskid")
+	}
+	if len(n.taskChans) != int(n.taskCount) {
+		t.Error("Unexpected task chan length")
+	}
+
+	// Adding task chans
+	const MaxTasks = 1000
+	for i := 0; i < MaxTasks; i++ {
+		go n.addTaskChan() // hopefully concurrently...
+	}
+	for j := 0; j < 10; j++ {
+		n.taskMutex.RLock()
+		tid := n.taskCount
+		n.taskMutex.RUnlock()
+		if tid >= MaxTasks {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if n.taskCount != MaxTasks {
+		t.Error("Time elapsed")
+	}
+	if len(n.taskChans) != int(n.taskCount) {
+		t.Error("Unexpected task chan length")
+	}
+
+	// Accessing task chans
+	existingIds := []int64{0, 1, MaxTasks / 2, MaxTasks - 2, MaxTasks - 1}
+	for _, id := range existingIds {
+		_, err := n.getTaskChan(int64(id))
+		if err != nil {
+			t.Error("Unexpected error getting task chan for ", id, err)
+		}
+	}
+	missingIds := []int64{-1, MaxTasks}
+	testNonexistentChans := func(ids []int64) {
+		for _, id := range ids {
+			_, err := n.getTaskChan(int64(id))
+			if err == nil || err.Error() != "No transcoder channel" {
+				t.Error("Did not get expected error for ", id, err)
+			}
+		}
+	}
+	testNonexistentChans(missingIds)
+
+	// Removing task chans
+	for i := 0; i < MaxTasks; i++ {
+		go n.removeTaskChan(int64(i)) // hopefully concurrently...
+	}
+	for j := 0; j < 10; j++ {
+		n.taskMutex.RLock()
+		tlen := len(n.taskChans)
+		n.taskMutex.RUnlock()
+		if tlen <= 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(n.taskChans) != 0 {
+		t.Error("Time elapsed")
+	}
+	testNonexistentChans(existingIds) // sanity check for removal
+}
+
+type StubTranscoderServer struct {
+	node            *LivepeerNode
+	SendError       error
+	TranscodeError  error
+	WithholdResults bool
+
+	StubServerStream
+}
+
+func (s *StubTranscoderServer) Send(n *net.NotifySegment) error {
+	res := RemoteTranscoderResult{Segments: [][]byte{[]byte("asdf")}, Err: s.TranscodeError}
+	if !s.WithholdResults {
+		s.node.transcoderResults(n.TaskId, &res)
+	}
+	return s.SendError
+}
+
+type StubServerStream struct {
+}
+
+func (s *StubServerStream) Context() context.Context {
+	return context.Background()
+}
+func (s *StubServerStream) SetHeader(md metadata.MD) error {
+	return nil
+}
+func (s *StubServerStream) SendHeader(md metadata.MD) error {
+	return nil
+}
+func (s *StubServerStream) SetTrailer(md metadata.MD) {
+}
+func (s *StubServerStream) SendMsg(m interface{}) error {
+	return nil
+}
+func (s *StubServerStream) RecvMsg(m interface{}) error {
+	return nil
 }

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -93,6 +93,10 @@ func (orch *orchestrator) Address() ethcommon.Address {
 	return orch.address
 }
 
+func (orch *orchestrator) TranscoderSecret() string {
+	return orch.node.OrchSecret
+}
+
 func (orch *orchestrator) StreamIDs(job *ethTypes.Job) ([]StreamID, error) {
 	streamIds := make([]StreamID, len(job.Profiles))
 	sid := StreamID(job.StreamId)
@@ -110,6 +114,14 @@ func (orch *orchestrator) StreamIDs(job *ethTypes.Job) ([]StreamID, error) {
 
 func (orch *orchestrator) TranscodeSeg(job *ethTypes.Job, ss *SignedSegment) (*TranscodeResult, error) {
 	return orch.node.TranscodeSegment(job, ss)
+}
+
+func (orch *orchestrator) ServeTranscoder(stream net.Transcoder_RegisterTranscoderServer) {
+	orch.node.serveTranscoder(stream)
+}
+
+func (orch *orchestrator) TranscoderResults(tcId int64, res *RemoteTranscoderResult) {
+	orch.node.transcoderResults(tcId, res)
 }
 
 func NewOrchestrator(n *LivepeerNode) *orchestrator {
@@ -137,7 +149,13 @@ type SegChanData struct {
 	res chan *TranscodeResult
 }
 
+type RemoteTranscoderResult struct {
+	Segments [][]byte
+	Err      error
+}
+
 type SegmentChan chan *SegChanData
+type TranscoderChan chan *RemoteTranscoderResult
 
 type transcodeConfig struct {
 	StrmID        string
@@ -147,6 +165,38 @@ type transcodeConfig struct {
 	JobID         *big.Int
 	Transcoder    transcoder.Transcoder
 	OS            drivers.OSSession
+	LocalOS       drivers.OSSession
+}
+
+func (n *LivepeerNode) getTaskChan(taskId int64) (TranscoderChan, error) {
+	n.taskMutex.RLock()
+	defer n.taskMutex.RUnlock()
+	if tc, ok := n.taskChans[taskId]; ok {
+		return tc, nil
+	}
+	return nil, fmt.Errorf("No transcoder channel")
+}
+func (n *LivepeerNode) addTaskChan() (int64, TranscoderChan) {
+	n.taskMutex.Lock()
+	defer n.taskMutex.Unlock()
+	taskId := n.taskCount
+	n.taskCount++
+	if tc, ok := n.taskChans[taskId]; ok {
+		// should really never happen
+		glog.V(common.DEBUG).Info("Transcoder channel already exists for ", taskId)
+		return taskId, tc
+	}
+	n.taskChans[taskId] = make(TranscoderChan, 1)
+	return taskId, n.taskChans[taskId]
+}
+func (n *LivepeerNode) removeTaskChan(taskId int64) {
+	n.taskMutex.Lock()
+	defer n.taskMutex.Unlock()
+	if _, ok := n.taskChans[taskId]; !ok {
+		glog.V(common.DEBUG).Info("Transcoder channel nonexistent for job ", taskId)
+		return
+	}
+	delete(n.taskChans, taskId)
 }
 
 func (n *LivepeerNode) getSegmentChan(job *ethTypes.Job, os *net.OSInfo) (SegmentChan, error) {
@@ -246,19 +296,34 @@ func (n *LivepeerNode) transcodeAndCacheSeg(config transcodeConfig, ss *SignedSe
 		glog.Errorf("Media length check failed: %v", err)
 		return terr(err)
 	}
-	seg.Name = fmt.Sprintf("%s_%d.ts", config.StrmID, seg.SeqNo)
-	url := fmt.Sprintf("%v/stream/%s", n.ServiceURI, seg.Name)
 
 	// Check if there's a transcoder available
 	var transcoder Transcoder
+	n.tcoderMutex.RLock()
 	if n.Transcoder == nil {
+		n.tcoderMutex.RUnlock()
 		return terr(fmt.Errorf("No transcoders available on orchestrator"))
 	}
 	transcoder = n.Transcoder
+	n.tcoderMutex.RUnlock()
 
-	// Small optimization so we aren't using http for local transcoding
+	var url string
+	// Small optimization: serve from disk for local transcoding
 	if _, ok := transcoder.(*LocalTranscoder); ok {
 		url = fname
+	} else if drivers.IsOwnExternal(seg.Name) {
+		// We're using a remote TC and segment is already in our own OS
+		// Incurs an additional download for topologies with T on local network!
+		url = seg.Name
+	} else {
+		// Need to store segment in our local OS
+		sid := StreamID(config.StrmID)
+		name := fmt.Sprintf("%s/%d.ts", sid.GetRendition(), seg.SeqNo)
+		url, err = config.LocalOS.SaveData(name, seg.Data)
+		if err != nil {
+			return terr(err)
+		}
+		seg.Name = url
 	}
 
 	//Do the transcoding
@@ -318,18 +383,21 @@ func (n *LivepeerNode) transcodeSegmentLoop(job *ethTypes.Job, osInfo *net.OSInf
 		resultStrmIDs[i] = strmID
 	}
 
+	// Set up local OS for any remote transcoders to use if necessary
+	if drivers.NodeStorage == nil {
+		return fmt.Errorf("Missing local storage")
+	}
+	mid, err := sid.ManifestIDFromStreamID()
+	if err != nil {
+		return err
+	}
+	los := drivers.NodeStorage.NewSession(string(mid))
+
 	// determine appropriate OS to use
 	os := drivers.NewSession(osInfo)
 	if os == nil {
 		// no preference (or unknown pref), so use our own
-		if drivers.NodeStorage == nil {
-			return fmt.Errorf("Missing local storage")
-		}
-		mid, err := sid.ManifestIDFromStreamID()
-		if err != nil {
-			return err
-		}
-		os = drivers.NodeStorage.NewSession(string(mid))
+		os = los
 	}
 
 	tr := transcoder.NewFFMpegSegmentTranscoder(job.Profiles, n.WorkDir)
@@ -341,6 +409,7 @@ func (n *LivepeerNode) transcodeSegmentLoop(job *ethTypes.Job, osInfo *net.OSInf
 		ClaimManager:  cm,
 		Transcoder:    tr,
 		OS:            os,
+		LocalOS:       los,
 	}
 	go func() {
 		for {
@@ -351,6 +420,7 @@ func (n *LivepeerNode) transcodeSegmentLoop(job *ethTypes.Job, osInfo *net.OSInf
 				// timeout; clean up goroutine here
 				jid := job.JobId.Int64()
 				os.EndSession()
+				los.EndSession()
 				glog.V(common.DEBUG).Info("Segment loop timed out; closing ", jid)
 				n.segmentMutex.Lock()
 				if _, ok := n.SegmentChans[jid]; ok {
@@ -399,6 +469,75 @@ func (n *LivepeerNode) GetClaimManager(job *ethTypes.Job) (eth.ClaimManager, err
 	cm := eth.NewBasicClaimManager(job, n.Eth, n.Ipfs, n.Database)
 	n.ClaimManagers[jobId] = cm
 	return cm, nil
+}
+
+func (n *LivepeerNode) serveTranscoder(stream net.Transcoder_RegisterTranscoderServer) {
+	transcoder := NewRemoteTranscoder(n, stream)
+
+	n.tcoderMutex.Lock()
+	n.Transcoder = transcoder
+	n.tcoderMutex.Unlock()
+
+	select {
+	case <-transcoder.eof:
+		glog.V(common.DEBUG).Info("Closing transcoder channel") // XXX cxn info
+		n.tcoderMutex.Lock()
+		n.Transcoder = nil
+		n.tcoderMutex.Unlock()
+		return
+	}
+}
+
+func (n *LivepeerNode) transcoderResults(tcId int64, res *RemoteTranscoderResult) {
+	remoteChan, err := n.getTaskChan(tcId)
+	if err != nil {
+		return // do we need to return anything?
+	}
+	remoteChan <- res
+}
+
+type RemoteTranscoder struct {
+	node   *LivepeerNode
+	stream net.Transcoder_RegisterTranscoderServer
+	eof    chan struct{}
+}
+
+var RemoteTranscoderTimeout = 8 * time.Second
+
+func (rt *RemoteTranscoder) Transcode(fname string, profiles []ffmpeg.VideoProfile) ([][]byte, error) {
+	taskId, taskChan := rt.node.addTaskChan()
+	defer rt.node.removeTaskChan(taskId)
+	msg := &net.NotifySegment{
+		Url:      fname,
+		TaskId:   taskId,
+		Profiles: common.ProfilesToTranscodeOpts(profiles),
+	}
+	err := rt.stream.Send(msg)
+	if err != nil {
+		glog.Error("Error sending message to remote transcoder ", err)
+		rt.eof <- struct{}{}
+		return [][]byte{}, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), RemoteTranscoderTimeout)
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		// XXX remove transcoder from streams
+		rt.eof <- struct{}{}
+		return [][]byte{}, fmt.Errorf("Remote transcoder took too long")
+	case chanData := <-taskChan:
+		glog.Info("Successfully received results from remote transcoder ", len(chanData.Segments))
+		return chanData.Segments, chanData.Err
+	}
+	return [][]byte{}, fmt.Errorf("Unknown error")
+}
+
+func NewRemoteTranscoder(n *LivepeerNode, stream net.Transcoder_RegisterTranscoderServer) *RemoteTranscoder {
+	return &RemoteTranscoder{
+		node:   n,
+		stream: stream,
+		eof:    make(chan struct{}, 1),
+	}
 }
 
 func randName() string {

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -1,0 +1,23 @@
+package core
+
+import (
+	"github.com/livepeer/lpms/ffmpeg"
+	"github.com/livepeer/lpms/transcoder"
+)
+
+type Transcoder interface {
+	Transcode(fname string, profiles []ffmpeg.VideoProfile) ([][]byte, error)
+}
+
+type LocalTranscoder struct {
+	workDir string
+}
+
+func (lt *LocalTranscoder) Transcode(fname string, profiles []ffmpeg.VideoProfile) ([][]byte, error) {
+	tr := transcoder.NewFFMpegSegmentTranscoder(profiles, lt.workDir)
+	return tr.Transcode(fname)
+}
+
+func NewLocalTranscoder(workDir string) Transcoder {
+	return &LocalTranscoder{workDir: workDir}
+}

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -1,0 +1,31 @@
+package core
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/livepeer/lpms/ffmpeg"
+)
+
+func TestLocalTranscoder(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(tmp)
+	tc := NewLocalTranscoder(tmp)
+	ffmpeg.InitFFmpeg()
+
+	profiles := []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9, ffmpeg.P240p30fps16x9}
+	res, err := tc.Transcode("test.ts", profiles)
+	if err != nil {
+		t.Error("Error transcoding ", err)
+	}
+	if len(res) != len(profiles) {
+		t.Error("Mismatched results")
+	}
+	if Over1Pct(len(res[0]), 155476) {
+		t.Errorf("Wrong data %v", len(res[0]))
+	}
+	if Over1Pct(len(res[1]), 208304) {
+		t.Errorf("Wrong data %v", len(res[1]))
+	}
+}

--- a/drivers/local.go
+++ b/drivers/local.go
@@ -40,7 +40,7 @@ func (ostore *MemoryOS) NewSession(path string) OSSession {
 	}
 	session := &MemorySession{
 		os:     ostore,
-		path:   path + "/",
+		path:   path,
 		dCache: make(map[string]*dataCache),
 		dLock:  sync.RWMutex{},
 	}
@@ -94,7 +94,7 @@ func (ostore *MemorySession) GetInfo() *net.OSInfo {
 
 func (ostore *MemorySession) SaveData(name string, data []byte) (string, error) {
 
-	path, file := path.Split(ostore.path + name)
+	path, file := path.Split(ostore.getAbsolutePath(name))
 
 	ostore.dLock.Lock()
 	defer ostore.dLock.Unlock()
@@ -118,8 +118,12 @@ func (ostore *MemorySession) getCacheForStream(streamID string) *dataCache {
 	return sc
 }
 
+func (ostore *MemorySession) getAbsolutePath(name string) string {
+	return path.Clean(ostore.path + "/" + name)
+}
+
 func (ostore *MemorySession) getAbsoluteURI(name string) string {
-	name = ostore.path + name
+	name = ostore.getAbsolutePath(name)
 	if ostore.os.baseURI != "" {
 		return ostore.os.baseURI + "/stream/" + name
 	}

--- a/net/lp_rpc.pb.go
+++ b/net/lp_rpc.pb.go
@@ -3,12 +3,13 @@
 
 package net
 
+import proto "github.com/golang/protobuf/proto"
+import fmt "fmt"
+import math "math"
+
 import (
-	context "context"
-	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -35,7 +36,6 @@ var OSInfo_StorageType_name = map[int32]string{
 	1: "S3",
 	2: "IPFS",
 }
-
 var OSInfo_StorageType_value = map[string]int32{
 	"DIRECT": 0,
 	"S3":     1,
@@ -45,9 +45,8 @@ var OSInfo_StorageType_value = map[string]int32{
 func (x OSInfo_StorageType) String() string {
 	return proto.EnumName(OSInfo_StorageType_name, int32(x))
 }
-
 func (OSInfo_StorageType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{2, 0}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{2, 0}
 }
 
 type PingPong struct {
@@ -62,17 +61,16 @@ func (m *PingPong) Reset()         { *m = PingPong{} }
 func (m *PingPong) String() string { return proto.CompactTextString(m) }
 func (*PingPong) ProtoMessage()    {}
 func (*PingPong) Descriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{0}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{0}
 }
-
 func (m *PingPong) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PingPong.Unmarshal(m, b)
 }
 func (m *PingPong) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_PingPong.Marshal(b, m, deterministic)
 }
-func (m *PingPong) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PingPong.Merge(m, src)
+func (dst *PingPong) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PingPong.Merge(dst, src)
 }
 func (m *PingPong) XXX_Size() int {
 	return xxx_messageInfo_PingPong.Size(m)
@@ -94,7 +92,7 @@ func (m *PingPong) GetValue() []byte {
 // information on which transcoder to use.
 type TranscoderRequest struct {
 	// ID of the job that the broadcaster needs a transcoder for
-	JobId int64 `protobuf:"varint,1,opt,name=jobId,proto3" json:"jobId,omitempty"`
+	JobId int64 `protobuf:"varint,1,opt,name=jobId" json:"jobId,omitempty"`
 	// Broadcaster's signature over the jobId
 	Sig                  []byte   `protobuf:"bytes,2,opt,name=sig,proto3" json:"sig,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -106,17 +104,16 @@ func (m *TranscoderRequest) Reset()         { *m = TranscoderRequest{} }
 func (m *TranscoderRequest) String() string { return proto.CompactTextString(m) }
 func (*TranscoderRequest) ProtoMessage()    {}
 func (*TranscoderRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{1}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{1}
 }
-
 func (m *TranscoderRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TranscoderRequest.Unmarshal(m, b)
 }
 func (m *TranscoderRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TranscoderRequest.Marshal(b, m, deterministic)
 }
-func (m *TranscoderRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TranscoderRequest.Merge(m, src)
+func (dst *TranscoderRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TranscoderRequest.Merge(dst, src)
 }
 func (m *TranscoderRequest) XXX_Size() int {
 	return xxx_messageInfo_TranscoderRequest.Size(m)
@@ -142,12 +139,12 @@ func (m *TranscoderRequest) GetSig() []byte {
 }
 
 //
-//OSInfo needed to negotiate storages that will be used.
-//It carries info needed to write to the storage.
+// OSInfo needed to negotiate storages that will be used.
+// It carries info needed to write to the storage.
 type OSInfo struct {
 	// Storage type: direct, s3, ipfs.
-	StorageType          OSInfo_StorageType `protobuf:"varint,1,opt,name=storageType,proto3,enum=net.OSInfo_StorageType" json:"storageType,omitempty"`
-	S3Info               *S3OSInfo          `protobuf:"bytes,16,opt,name=s3info,proto3" json:"s3info,omitempty"`
+	StorageType          OSInfo_StorageType `protobuf:"varint,1,opt,name=storageType,enum=net.OSInfo_StorageType" json:"storageType,omitempty"`
+	S3Info               *S3OSInfo          `protobuf:"bytes,16,opt,name=s3info" json:"s3info,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -157,17 +154,16 @@ func (m *OSInfo) Reset()         { *m = OSInfo{} }
 func (m *OSInfo) String() string { return proto.CompactTextString(m) }
 func (*OSInfo) ProtoMessage()    {}
 func (*OSInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{2}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{2}
 }
-
 func (m *OSInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_OSInfo.Unmarshal(m, b)
 }
 func (m *OSInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_OSInfo.Marshal(b, m, deterministic)
 }
-func (m *OSInfo) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OSInfo.Merge(m, src)
+func (dst *OSInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_OSInfo.Merge(dst, src)
 }
 func (m *OSInfo) XXX_Size() int {
 	return xxx_messageInfo_OSInfo.Size(m)
@@ -194,17 +190,17 @@ func (m *OSInfo) GetS3Info() *S3OSInfo {
 
 type S3OSInfo struct {
 	// Host to use to connect to S3
-	Host string `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Host string `protobuf:"bytes,1,opt,name=host" json:"host,omitempty"`
 	// Key (prefix) to use when uploading the object.
-	Key string `protobuf:"bytes,2,opt,name=key,proto3" json:"key,omitempty"`
+	Key string `protobuf:"bytes,2,opt,name=key" json:"key,omitempty"`
 	// POST policy that S3 owner node creates to give write access to other node.
-	Policy string `protobuf:"bytes,3,opt,name=policy,proto3" json:"policy,omitempty"`
+	Policy string `protobuf:"bytes,3,opt,name=policy" json:"policy,omitempty"`
 	// Signature for POST policy.
-	Signature string `protobuf:"bytes,4,opt,name=signature,proto3" json:"signature,omitempty"`
+	Signature string `protobuf:"bytes,4,opt,name=signature" json:"signature,omitempty"`
 	// Needed for POST policy.
-	XAmzCredential string `protobuf:"bytes,5,opt,name=xAmzCredential,proto3" json:"xAmzCredential,omitempty"`
+	XAmzCredential string `protobuf:"bytes,5,opt,name=xAmzCredential" json:"xAmzCredential,omitempty"`
 	// Needed for POST policy.
-	XAmzDate             string   `protobuf:"bytes,6,opt,name=xAmzDate,proto3" json:"xAmzDate,omitempty"`
+	XAmzDate             string   `protobuf:"bytes,6,opt,name=xAmzDate" json:"xAmzDate,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -214,17 +210,16 @@ func (m *S3OSInfo) Reset()         { *m = S3OSInfo{} }
 func (m *S3OSInfo) String() string { return proto.CompactTextString(m) }
 func (*S3OSInfo) ProtoMessage()    {}
 func (*S3OSInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{3}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{3}
 }
-
 func (m *S3OSInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_S3OSInfo.Unmarshal(m, b)
 }
 func (m *S3OSInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_S3OSInfo.Marshal(b, m, deterministic)
 }
-func (m *S3OSInfo) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_S3OSInfo.Merge(m, src)
+func (dst *S3OSInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_S3OSInfo.Merge(dst, src)
 }
 func (m *S3OSInfo) XXX_Size() int {
 	return xxx_messageInfo_S3OSInfo.Size(m)
@@ -282,17 +277,17 @@ func (m *S3OSInfo) GetXAmzDate() string {
 // use the transcoder, and miscellaneous data related to the job.
 type TranscoderInfo struct {
 	// URI of the transcoder to use for submitting segments.
-	Transcoder string `protobuf:"bytes,1,opt,name=transcoder,proto3" json:"transcoder,omitempty"`
+	Transcoder string `protobuf:"bytes,1,opt,name=transcoder" json:"transcoder,omitempty"`
 	// Signals the authentication method to expect within `credentials`. This
 	// field is opaque to the broadcaster, and should be passed to the transcoder.
-	AuthType string `protobuf:"bytes,2,opt,name=authType,proto3" json:"authType,omitempty"`
+	AuthType string `protobuf:"bytes,2,opt,name=authType" json:"authType,omitempty"`
 	// Credentials to verify the request has been authorized by an orchestrator.
 	// This field is opaque to the broadcaster.
-	Credentials string `protobuf:"bytes,3,opt,name=credentials,proto3" json:"credentials,omitempty"`
+	Credentials string `protobuf:"bytes,3,opt,name=credentials" json:"credentials,omitempty"`
 	// Transcoded streamId list to update the master manifest on the broadcaster.
-	StreamIds map[string]string `protobuf:"bytes,16,rep,name=streamIds,proto3" json:"streamIds,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	StreamIds map[string]string `protobuf:"bytes,16,rep,name=streamIds" json:"streamIds,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Orchestrator returns info about own input object storage, if it wants it to be used.
-	Storage              []*OSInfo `protobuf:"bytes,32,rep,name=storage,proto3" json:"storage,omitempty"`
+	Storage              []*OSInfo `protobuf:"bytes,32,rep,name=storage" json:"storage,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -302,17 +297,16 @@ func (m *TranscoderInfo) Reset()         { *m = TranscoderInfo{} }
 func (m *TranscoderInfo) String() string { return proto.CompactTextString(m) }
 func (*TranscoderInfo) ProtoMessage()    {}
 func (*TranscoderInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{4}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{4}
 }
-
 func (m *TranscoderInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TranscoderInfo.Unmarshal(m, b)
 }
 func (m *TranscoderInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TranscoderInfo.Marshal(b, m, deterministic)
 }
-func (m *TranscoderInfo) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TranscoderInfo.Merge(m, src)
+func (dst *TranscoderInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TranscoderInfo.Merge(dst, src)
 }
 func (m *TranscoderInfo) XXX_Size() int {
 	return xxx_messageInfo_TranscoderInfo.Size(m)
@@ -364,7 +358,7 @@ func (m *TranscoderInfo) GetStorage() []*OSInfo {
 type AuthToken struct {
 	// Signature of the orchestrator over the remaining fields
 	Sig                  []byte   `protobuf:"bytes,1,opt,name=sig,proto3" json:"sig,omitempty"`
-	JobId                int64    `protobuf:"varint,16,opt,name=jobId,proto3" json:"jobId,omitempty"`
+	JobId                int64    `protobuf:"varint,16,opt,name=jobId" json:"jobId,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -374,17 +368,16 @@ func (m *AuthToken) Reset()         { *m = AuthToken{} }
 func (m *AuthToken) String() string { return proto.CompactTextString(m) }
 func (*AuthToken) ProtoMessage()    {}
 func (*AuthToken) Descriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{5}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{5}
 }
-
 func (m *AuthToken) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AuthToken.Unmarshal(m, b)
 }
 func (m *AuthToken) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_AuthToken.Marshal(b, m, deterministic)
 }
-func (m *AuthToken) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AuthToken.Merge(m, src)
+func (dst *AuthToken) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AuthToken.Merge(dst, src)
 }
 func (m *AuthToken) XXX_Size() int {
 	return xxx_messageInfo_AuthToken.Size(m)
@@ -412,14 +405,14 @@ func (m *AuthToken) GetJobId() int64 {
 // Data included by the broadcaster when submitting a segment for transcoding.
 type SegData struct {
 	// Sequence number of the segment to be transcoded
-	Seq int64 `protobuf:"varint,1,opt,name=seq,proto3" json:"seq,omitempty"`
+	Seq int64 `protobuf:"varint,1,opt,name=seq" json:"seq,omitempty"`
 	// Hash of the segment data to be transcoded
 	Hash []byte `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
 	// Broadcaster signature for the segment. Corresponds to:
 	// broadcaster.sign(streamId | seqNo | dataHash)
 	// where streamId is derived from the jobId
 	Sig                  []byte    `protobuf:"bytes,3,opt,name=sig,proto3" json:"sig,omitempty"`
-	Storage              []*OSInfo `protobuf:"bytes,4,rep,name=storage,proto3" json:"storage,omitempty"`
+	Storage              []*OSInfo `protobuf:"bytes,4,rep,name=storage" json:"storage,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -429,17 +422,16 @@ func (m *SegData) Reset()         { *m = SegData{} }
 func (m *SegData) String() string { return proto.CompactTextString(m) }
 func (*SegData) ProtoMessage()    {}
 func (*SegData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{6}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{6}
 }
-
 func (m *SegData) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SegData.Unmarshal(m, b)
 }
 func (m *SegData) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SegData.Marshal(b, m, deterministic)
 }
-func (m *SegData) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SegData.Merge(m, src)
+func (dst *SegData) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SegData.Merge(dst, src)
 }
 func (m *SegData) XXX_Size() int {
 	return xxx_messageInfo_SegData.Size(m)
@@ -481,7 +473,7 @@ func (m *SegData) GetStorage() []*OSInfo {
 // Individual transcoded segment data.
 type TranscodedSegmentData struct {
 	// URL where the transcoded data can be downloaded from.
-	Url                  string   `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	Url                  string   `protobuf:"bytes,1,opt,name=url" json:"url,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -491,17 +483,16 @@ func (m *TranscodedSegmentData) Reset()         { *m = TranscodedSegmentData{} }
 func (m *TranscodedSegmentData) String() string { return proto.CompactTextString(m) }
 func (*TranscodedSegmentData) ProtoMessage()    {}
 func (*TranscodedSegmentData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{7}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{7}
 }
-
 func (m *TranscodedSegmentData) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TranscodedSegmentData.Unmarshal(m, b)
 }
 func (m *TranscodedSegmentData) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TranscodedSegmentData.Marshal(b, m, deterministic)
 }
-func (m *TranscodedSegmentData) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TranscodedSegmentData.Merge(m, src)
+func (dst *TranscodedSegmentData) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TranscodedSegmentData.Merge(dst, src)
 }
 func (m *TranscodedSegmentData) XXX_Size() int {
 	return xxx_messageInfo_TranscodedSegmentData.Size(m)
@@ -522,7 +513,7 @@ func (m *TranscodedSegmentData) GetUrl() string {
 // A set of transcoded segments following the profiles specified in the job.
 type TranscodeData struct {
 	// Transcoded data, in the order specified in the job options
-	Segments []*TranscodedSegmentData `protobuf:"bytes,1,rep,name=segments,proto3" json:"segments,omitempty"`
+	Segments []*TranscodedSegmentData `protobuf:"bytes,1,rep,name=segments" json:"segments,omitempty"`
 	// Signature of the hash of the concatenated hashes
 	Sig                  []byte   `protobuf:"bytes,2,opt,name=sig,proto3" json:"sig,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -534,17 +525,16 @@ func (m *TranscodeData) Reset()         { *m = TranscodeData{} }
 func (m *TranscodeData) String() string { return proto.CompactTextString(m) }
 func (*TranscodeData) ProtoMessage()    {}
 func (*TranscodeData) Descriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{8}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{8}
 }
-
 func (m *TranscodeData) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TranscodeData.Unmarshal(m, b)
 }
 func (m *TranscodeData) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TranscodeData.Marshal(b, m, deterministic)
 }
-func (m *TranscodeData) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TranscodeData.Merge(m, src)
+func (dst *TranscodeData) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TranscodeData.Merge(dst, src)
 }
 func (m *TranscodeData) XXX_Size() int {
 	return xxx_messageInfo_TranscodeData.Size(m)
@@ -572,7 +562,7 @@ func (m *TranscodeData) GetSig() []byte {
 // Response that a transcoder sends after transcoding a segment.
 type TranscodeResult struct {
 	// Sequence number of the transcoded results.
-	Seq int64 `protobuf:"varint,1,opt,name=seq,proto3" json:"seq,omitempty"`
+	Seq int64 `protobuf:"varint,1,opt,name=seq" json:"seq,omitempty"`
 	// Result of transcoding can be an error, or successful with more info
 	//
 	// Types that are valid to be assigned to Result:
@@ -588,17 +578,16 @@ func (m *TranscodeResult) Reset()         { *m = TranscodeResult{} }
 func (m *TranscodeResult) String() string { return proto.CompactTextString(m) }
 func (*TranscodeResult) ProtoMessage()    {}
 func (*TranscodeResult) Descriptor() ([]byte, []int) {
-	return fileDescriptor_034e29c79f9ba827, []int{9}
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{9}
 }
-
 func (m *TranscodeResult) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TranscodeResult.Unmarshal(m, b)
 }
 func (m *TranscodeResult) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_TranscodeResult.Marshal(b, m, deterministic)
 }
-func (m *TranscodeResult) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TranscodeResult.Merge(m, src)
+func (dst *TranscodeResult) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TranscodeResult.Merge(dst, src)
 }
 func (m *TranscodeResult) XXX_Size() int {
 	return xxx_messageInfo_TranscodeResult.Size(m)
@@ -609,34 +598,32 @@ func (m *TranscodeResult) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_TranscodeResult proto.InternalMessageInfo
 
-func (m *TranscodeResult) GetSeq() int64 {
-	if m != nil {
-		return m.Seq
-	}
-	return 0
-}
-
 type isTranscodeResult_Result interface {
 	isTranscodeResult_Result()
 }
 
 type TranscodeResult_Error struct {
-	Error string `protobuf:"bytes,2,opt,name=error,proto3,oneof"`
+	Error string `protobuf:"bytes,2,opt,name=error,oneof"`
 }
-
 type TranscodeResult_Data struct {
-	Data *TranscodeData `protobuf:"bytes,3,opt,name=data,proto3,oneof"`
+	Data *TranscodeData `protobuf:"bytes,3,opt,name=data,oneof"`
 }
 
 func (*TranscodeResult_Error) isTranscodeResult_Result() {}
-
-func (*TranscodeResult_Data) isTranscodeResult_Result() {}
+func (*TranscodeResult_Data) isTranscodeResult_Result()  {}
 
 func (m *TranscodeResult) GetResult() isTranscodeResult_Result {
 	if m != nil {
 		return m.Result
 	}
 	return nil
+}
+
+func (m *TranscodeResult) GetSeq() int64 {
+	if m != nil {
+		return m.Seq
+	}
+	return 0
 }
 
 func (m *TranscodeResult) GetError() string {
@@ -723,8 +710,102 @@ func _TranscodeResult_OneofSizer(msg proto.Message) (n int) {
 	return n
 }
 
+// Sent by the transcoder to register itself to the orchestrator.
+type RegisterRequest struct {
+	// Shared secret for auth
+	Secret               string   `protobuf:"bytes,1,opt,name=secret" json:"secret,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *RegisterRequest) Reset()         { *m = RegisterRequest{} }
+func (m *RegisterRequest) String() string { return proto.CompactTextString(m) }
+func (*RegisterRequest) ProtoMessage()    {}
+func (*RegisterRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{10}
+}
+func (m *RegisterRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_RegisterRequest.Unmarshal(m, b)
+}
+func (m *RegisterRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_RegisterRequest.Marshal(b, m, deterministic)
+}
+func (dst *RegisterRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RegisterRequest.Merge(dst, src)
+}
+func (m *RegisterRequest) XXX_Size() int {
+	return xxx_messageInfo_RegisterRequest.Size(m)
+}
+func (m *RegisterRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_RegisterRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RegisterRequest proto.InternalMessageInfo
+
+func (m *RegisterRequest) GetSecret() string {
+	if m != nil {
+		return m.Secret
+	}
+	return ""
+}
+
+// Sent by the transcoder
+type NotifySegment struct {
+	Url                  string   `protobuf:"bytes,1,opt,name=url" json:"url,omitempty"`
+	TaskId               int64    `protobuf:"varint,16,opt,name=taskId" json:"taskId,omitempty"`
+	Profiles             []byte   `protobuf:"bytes,17,opt,name=profiles,proto3" json:"profiles,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *NotifySegment) Reset()         { *m = NotifySegment{} }
+func (m *NotifySegment) String() string { return proto.CompactTextString(m) }
+func (*NotifySegment) ProtoMessage()    {}
+func (*NotifySegment) Descriptor() ([]byte, []int) {
+	return fileDescriptor_lp_rpc_2b2da253fcde9137, []int{11}
+}
+func (m *NotifySegment) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_NotifySegment.Unmarshal(m, b)
+}
+func (m *NotifySegment) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_NotifySegment.Marshal(b, m, deterministic)
+}
+func (dst *NotifySegment) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NotifySegment.Merge(dst, src)
+}
+func (m *NotifySegment) XXX_Size() int {
+	return xxx_messageInfo_NotifySegment.Size(m)
+}
+func (m *NotifySegment) XXX_DiscardUnknown() {
+	xxx_messageInfo_NotifySegment.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_NotifySegment proto.InternalMessageInfo
+
+func (m *NotifySegment) GetUrl() string {
+	if m != nil {
+		return m.Url
+	}
+	return ""
+}
+
+func (m *NotifySegment) GetTaskId() int64 {
+	if m != nil {
+		return m.TaskId
+	}
+	return 0
+}
+
+func (m *NotifySegment) GetProfiles() []byte {
+	if m != nil {
+		return m.Profiles
+	}
+	return nil
+}
+
 func init() {
-	proto.RegisterEnum("net.OSInfo_StorageType", OSInfo_StorageType_name, OSInfo_StorageType_value)
 	proto.RegisterType((*PingPong)(nil), "net.PingPong")
 	proto.RegisterType((*TranscoderRequest)(nil), "net.TranscoderRequest")
 	proto.RegisterType((*OSInfo)(nil), "net.OSInfo")
@@ -736,51 +817,9 @@ func init() {
 	proto.RegisterType((*TranscodedSegmentData)(nil), "net.TranscodedSegmentData")
 	proto.RegisterType((*TranscodeData)(nil), "net.TranscodeData")
 	proto.RegisterType((*TranscodeResult)(nil), "net.TranscodeResult")
-}
-
-func init() { proto.RegisterFile("net/lp_rpc.proto", fileDescriptor_034e29c79f9ba827) }
-
-var fileDescriptor_034e29c79f9ba827 = []byte{
-	// 624 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x54, 0x5d, 0x6f, 0xd3, 0x3c,
-	0x14, 0x5e, 0xda, 0x2e, 0x4b, 0x4f, 0xb6, 0xbe, 0x79, 0x0d, 0x8c, 0xa8, 0x42, 0x28, 0x8a, 0x18,
-	0x2a, 0x42, 0x2a, 0x52, 0x2b, 0x21, 0x3e, 0x76, 0xc1, 0xd8, 0x06, 0xeb, 0xd5, 0x26, 0x67, 0x37,
-	0x5c, 0x21, 0xaf, 0xf1, 0xd2, 0xb0, 0xcc, 0xee, 0x6c, 0x07, 0x51, 0xfe, 0x07, 0xe2, 0x3f, 0xf0,
-	0x2b, 0x51, 0xec, 0x7c, 0x75, 0x2a, 0x77, 0xe7, 0x1c, 0x3f, 0xe7, 0xe3, 0x39, 0x7e, 0x6c, 0xf0,
-	0x18, 0x55, 0xaf, 0xb2, 0xe5, 0x57, 0xb1, 0x9c, 0x8f, 0x97, 0x82, 0x2b, 0x8e, 0xba, 0x8c, 0xaa,
-	0x30, 0x00, 0xe7, 0x22, 0x65, 0xc9, 0x05, 0x67, 0x09, 0x7a, 0x08, 0xdb, 0xdf, 0x49, 0x96, 0x53,
-	0xdf, 0x0a, 0xac, 0xd1, 0x2e, 0x36, 0x4e, 0xf8, 0x1e, 0xfe, 0xbf, 0x14, 0x84, 0xc9, 0x39, 0x8f,
-	0xa9, 0xc0, 0xf4, 0x2e, 0xa7, 0x52, 0x15, 0xd0, 0x6f, 0xfc, 0x6a, 0x16, 0x6b, 0x68, 0x17, 0x1b,
-	0x07, 0x79, 0xd0, 0x95, 0x69, 0xe2, 0x77, 0x74, 0x7a, 0x61, 0x86, 0xbf, 0x2d, 0xb0, 0xcf, 0xa3,
-	0x19, 0xbb, 0xe6, 0xe8, 0x2d, 0xb8, 0x52, 0x71, 0x41, 0x12, 0x7a, 0xb9, 0x5a, 0x9a, 0x1e, 0x83,
-	0xc9, 0xe3, 0x31, 0xa3, 0x6a, 0x6c, 0x10, 0xe3, 0xa8, 0x39, 0xc6, 0x6d, 0x2c, 0x3a, 0x00, 0x5b,
-	0x4e, 0x53, 0x76, 0xcd, 0x7d, 0x2f, 0xb0, 0x46, 0xee, 0x64, 0x4f, 0x67, 0x45, 0x53, 0x93, 0x87,
-	0xcb, 0xc3, 0xf0, 0x25, 0xb8, 0xad, 0x12, 0x08, 0xc0, 0x3e, 0x99, 0xe1, 0xd3, 0xe3, 0x4b, 0x6f,
-	0x0b, 0xd9, 0xd0, 0x89, 0xa6, 0x9e, 0x85, 0x1c, 0xe8, 0xcd, 0x2e, 0x3e, 0x45, 0x5e, 0x27, 0xfc,
-	0x63, 0x81, 0x53, 0x55, 0x40, 0x08, 0x7a, 0x0b, 0x2e, 0x95, 0x1e, 0xaa, 0x8f, 0xb5, 0x5d, 0x90,
-	0xb9, 0xa1, 0x2b, 0x4d, 0xa6, 0x8f, 0x0b, 0x13, 0xed, 0x83, 0xbd, 0xe4, 0x59, 0x3a, 0x5f, 0xf9,
-	0x5d, 0x1d, 0x2c, 0x3d, 0xf4, 0x04, 0xfa, 0x32, 0x4d, 0x18, 0x51, 0xb9, 0xa0, 0x7e, 0x4f, 0x1f,
-	0x35, 0x01, 0xf4, 0x1c, 0x06, 0x3f, 0x8e, 0x6e, 0x7f, 0x1e, 0x0b, 0x1a, 0x53, 0xa6, 0x52, 0x92,
-	0xf9, 0xdb, 0x1a, 0x72, 0x2f, 0x8a, 0x86, 0xe0, 0x14, 0x91, 0x13, 0xa2, 0xa8, 0x6f, 0x6b, 0x44,
-	0xed, 0x87, 0xbf, 0x3a, 0x30, 0x68, 0x2e, 0x41, 0x8f, 0xfc, 0x14, 0x40, 0xd5, 0x91, 0x72, 0xf0,
-	0x56, 0xa4, 0x28, 0x47, 0x72, 0xb5, 0xd0, 0xbb, 0x36, 0x1c, 0x6a, 0x1f, 0x05, 0xe0, 0xce, 0xeb,
-	0xc6, 0xb2, 0x64, 0xd3, 0x0e, 0xa1, 0x0f, 0xd0, 0x97, 0x4a, 0x50, 0x72, 0x3b, 0x8b, 0xa5, 0xef,
-	0x05, 0xdd, 0x91, 0x3b, 0x09, 0xf5, 0xd2, 0xd7, 0xa7, 0x18, 0x47, 0x15, 0xe8, 0x94, 0x29, 0xb1,
-	0xc2, 0x4d, 0x12, 0x3a, 0x80, 0x9d, 0xf2, 0x0a, 0xfd, 0x40, 0xe7, 0xbb, 0xad, 0xab, 0xc6, 0xd5,
-	0xd9, 0xf0, 0x10, 0x06, 0xeb, 0x35, 0xaa, 0xbd, 0x5b, 0xcd, 0xde, 0x6b, 0x5d, 0x1a, 0x1e, 0xc6,
-	0x79, 0xd7, 0x79, 0x63, 0x85, 0x53, 0xe8, 0x1f, 0x15, 0xa4, 0xf8, 0x0d, 0x65, 0x95, 0xfa, 0xac,
-	0x5a, 0x7d, 0x8d, 0x4a, 0xbd, 0x96, 0x4a, 0xc3, 0x05, 0xec, 0x44, 0x34, 0x39, 0x21, 0x8a, 0xe8,
-	0x14, 0x7a, 0x57, 0x8a, 0xb8, 0x30, 0xb5, 0x12, 0x88, 0x5c, 0x94, 0x1a, 0xd6, 0x76, 0x55, 0xb8,
-	0xdb, 0x14, 0x6e, 0x91, 0xeb, 0xfd, 0x9b, 0x5c, 0xf8, 0x02, 0x1e, 0xd5, 0xfb, 0x8a, 0x23, 0x9a,
-	0xdc, 0x52, 0xa6, 0xaa, 0xbe, 0xb9, 0xc8, 0x2a, 0x8e, 0xb9, 0xc8, 0xc2, 0x2f, 0xb0, 0x57, 0x43,
-	0x35, 0xe4, 0x35, 0x38, 0xd2, 0x64, 0x48, 0xdf, 0xd2, 0x3d, 0x86, 0xeb, 0x17, 0xd0, 0x2e, 0x88,
-	0x6b, 0xec, 0x86, 0x37, 0xc8, 0xe1, 0xbf, 0x3a, 0x09, 0x53, 0x99, 0x67, 0x6a, 0x03, 0xef, 0x7d,
-	0xd8, 0xa6, 0x42, 0x70, 0x61, 0x76, 0x7c, 0xb6, 0x85, 0x8d, 0x8b, 0x46, 0xd0, 0x8b, 0x89, 0x22,
-	0x9a, 0xbc, 0x3b, 0x41, 0xeb, 0x23, 0x14, 0xad, 0xcf, 0xb6, 0xb0, 0x46, 0x7c, 0x74, 0xc0, 0x16,
-	0xba, 0xfa, 0x44, 0xc0, 0xee, 0xb9, 0x98, 0x2f, 0xa8, 0x54, 0x82, 0x28, 0x2e, 0xd0, 0x21, 0xec,
-	0x7d, 0xa6, 0xaa, 0x51, 0x0e, 0xda, 0xbf, 0x27, 0xa5, 0xf2, 0x57, 0x19, 0x3e, 0xd8, 0x20, 0x31,
-	0xf4, 0x0c, 0x7a, 0xc5, 0x0f, 0x85, 0xcc, 0xa3, 0xaf, 0x3e, 0xab, 0xe1, 0xba, 0x7b, 0x65, 0xeb,
-	0x3f, 0x6d, 0xfa, 0x37, 0x00, 0x00, 0xff, 0xff, 0x89, 0xfa, 0x08, 0x75, 0xe7, 0x04, 0x00, 0x00,
+	proto.RegisterType((*RegisterRequest)(nil), "net.RegisterRequest")
+	proto.RegisterType((*NotifySegment)(nil), "net.NotifySegment")
+	proto.RegisterEnum("net.OSInfo_StorageType", OSInfo_StorageType_name, OSInfo_StorageType_value)
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -888,4 +927,149 @@ var _Orchestrator_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "net/lp_rpc.proto",
+}
+
+// TranscoderClient is the client API for Transcoder service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+type TranscoderClient interface {
+	// Called by the transcoder to register to an orchestrator. The orchestrator
+	// notifies registered transcoders of segments as they come in.
+	RegisterTranscoder(ctx context.Context, in *RegisterRequest, opts ...grpc.CallOption) (Transcoder_RegisterTranscoderClient, error)
+}
+
+type transcoderClient struct {
+	cc *grpc.ClientConn
+}
+
+func NewTranscoderClient(cc *grpc.ClientConn) TranscoderClient {
+	return &transcoderClient{cc}
+}
+
+func (c *transcoderClient) RegisterTranscoder(ctx context.Context, in *RegisterRequest, opts ...grpc.CallOption) (Transcoder_RegisterTranscoderClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_Transcoder_serviceDesc.Streams[0], "/net.Transcoder/RegisterTranscoder", opts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &transcoderRegisterTranscoderClient{stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+type Transcoder_RegisterTranscoderClient interface {
+	Recv() (*NotifySegment, error)
+	grpc.ClientStream
+}
+
+type transcoderRegisterTranscoderClient struct {
+	grpc.ClientStream
+}
+
+func (x *transcoderRegisterTranscoderClient) Recv() (*NotifySegment, error) {
+	m := new(NotifySegment)
+	if err := x.ClientStream.RecvMsg(m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// TranscoderServer is the server API for Transcoder service.
+type TranscoderServer interface {
+	// Called by the transcoder to register to an orchestrator. The orchestrator
+	// notifies registered transcoders of segments as they come in.
+	RegisterTranscoder(*RegisterRequest, Transcoder_RegisterTranscoderServer) error
+}
+
+func RegisterTranscoderServer(s *grpc.Server, srv TranscoderServer) {
+	s.RegisterService(&_Transcoder_serviceDesc, srv)
+}
+
+func _Transcoder_RegisterTranscoder_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(RegisterRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(TranscoderServer).RegisterTranscoder(m, &transcoderRegisterTranscoderServer{stream})
+}
+
+type Transcoder_RegisterTranscoderServer interface {
+	Send(*NotifySegment) error
+	grpc.ServerStream
+}
+
+type transcoderRegisterTranscoderServer struct {
+	grpc.ServerStream
+}
+
+func (x *transcoderRegisterTranscoderServer) Send(m *NotifySegment) error {
+	return x.ServerStream.SendMsg(m)
+}
+
+var _Transcoder_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "net.Transcoder",
+	HandlerType: (*TranscoderServer)(nil),
+	Methods:     []grpc.MethodDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "RegisterTranscoder",
+			Handler:       _Transcoder_RegisterTranscoder_Handler,
+			ServerStreams: true,
+		},
+	},
+	Metadata: "net/lp_rpc.proto",
+}
+
+func init() { proto.RegisterFile("net/lp_rpc.proto", fileDescriptor_lp_rpc_2b2da253fcde9137) }
+
+var fileDescriptor_lp_rpc_2b2da253fcde9137 = []byte{
+	// 703 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x54, 0x5d, 0x4f, 0xdb, 0x48,
+	0x14, 0xc5, 0x49, 0x30, 0xc9, 0x35, 0x09, 0x66, 0x96, 0xcd, 0x5a, 0xd1, 0x6a, 0x15, 0x59, 0x4b,
+	0x15, 0x54, 0x29, 0xad, 0x12, 0xa9, 0xea, 0x07, 0x0f, 0x50, 0xa0, 0x25, 0x2f, 0x80, 0xc6, 0xf4,
+	0xa1, 0x4f, 0xd5, 0x90, 0xdc, 0x38, 0x2e, 0xc6, 0x13, 0x66, 0xc6, 0x55, 0xd3, 0xff, 0x51, 0xf5,
+	0x3f, 0xf4, 0x57, 0x56, 0x1e, 0x7f, 0x86, 0xd2, 0xb7, 0xb9, 0xd7, 0xe7, 0x7e, 0x9c, 0x33, 0xc7,
+	0x03, 0x76, 0x84, 0xea, 0x59, 0xb8, 0xfc, 0x24, 0x96, 0xd3, 0xe1, 0x52, 0x70, 0xc5, 0x49, 0x3d,
+	0x42, 0xe5, 0xf6, 0xa1, 0x79, 0x15, 0x44, 0xfe, 0x15, 0x8f, 0x7c, 0xb2, 0x07, 0x9b, 0x5f, 0x58,
+	0x18, 0xa3, 0x63, 0xf4, 0x8d, 0xc1, 0x36, 0x4d, 0x03, 0xf7, 0x0d, 0xec, 0x5e, 0x0b, 0x16, 0xc9,
+	0x29, 0x9f, 0xa1, 0xa0, 0x78, 0x1f, 0xa3, 0x54, 0x09, 0xf4, 0x33, 0xbf, 0x99, 0xcc, 0x34, 0xb4,
+	0x4e, 0xd3, 0x80, 0xd8, 0x50, 0x97, 0x81, 0xef, 0xd4, 0x74, 0x79, 0x72, 0x74, 0x7f, 0x18, 0x60,
+	0x5e, 0x7a, 0x93, 0x68, 0xce, 0xc9, 0x2b, 0xb0, 0xa4, 0xe2, 0x82, 0xf9, 0x78, 0xbd, 0x5a, 0xa6,
+	0x33, 0x3a, 0xa3, 0x7f, 0x86, 0x11, 0xaa, 0x61, 0x8a, 0x18, 0x7a, 0xe5, 0x67, 0x5a, 0xc5, 0x92,
+	0x7d, 0x30, 0xe5, 0x38, 0x88, 0xe6, 0xdc, 0xb1, 0xfb, 0xc6, 0xc0, 0x1a, 0xb5, 0x75, 0x95, 0x37,
+	0x4e, 0xeb, 0x68, 0xf6, 0xd1, 0x7d, 0x0a, 0x56, 0xa5, 0x05, 0x01, 0x30, 0x4f, 0x27, 0xf4, 0xec,
+	0xe4, 0xda, 0xde, 0x20, 0x26, 0xd4, 0xbc, 0xb1, 0x6d, 0x90, 0x26, 0x34, 0x26, 0x57, 0xef, 0x3c,
+	0xbb, 0xe6, 0xfe, 0x34, 0xa0, 0x99, 0x77, 0x20, 0x04, 0x1a, 0x0b, 0x2e, 0x95, 0x5e, 0xaa, 0x45,
+	0xf5, 0x39, 0x21, 0x73, 0x8b, 0x2b, 0x4d, 0xa6, 0x45, 0x93, 0x23, 0xe9, 0x82, 0xb9, 0xe4, 0x61,
+	0x30, 0x5d, 0x39, 0x75, 0x9d, 0xcc, 0x22, 0xf2, 0x2f, 0xb4, 0x64, 0xe0, 0x47, 0x4c, 0xc5, 0x02,
+	0x9d, 0x86, 0xfe, 0x54, 0x26, 0xc8, 0x13, 0xe8, 0x7c, 0x3d, 0xbe, 0xfb, 0x76, 0x22, 0x70, 0x86,
+	0x91, 0x0a, 0x58, 0xe8, 0x6c, 0x6a, 0xc8, 0x83, 0x2c, 0xe9, 0x41, 0x33, 0xc9, 0x9c, 0x32, 0x85,
+	0x8e, 0xa9, 0x11, 0x45, 0xec, 0x7e, 0xaf, 0x41, 0xa7, 0xbc, 0x04, 0xbd, 0xf2, 0x7f, 0x00, 0xaa,
+	0xc8, 0x64, 0x8b, 0x57, 0x32, 0x49, 0x3b, 0x16, 0xab, 0x85, 0xd6, 0x3a, 0xe5, 0x50, 0xc4, 0xa4,
+	0x0f, 0xd6, 0xb4, 0x18, 0x2c, 0x33, 0x36, 0xd5, 0x14, 0x39, 0x82, 0x96, 0x54, 0x02, 0xd9, 0xdd,
+	0x64, 0x26, 0x1d, 0xbb, 0x5f, 0x1f, 0x58, 0x23, 0x57, 0x8b, 0xbe, 0xbe, 0xc5, 0xd0, 0xcb, 0x41,
+	0x67, 0x91, 0x12, 0x2b, 0x5a, 0x16, 0x91, 0x7d, 0xd8, 0xca, 0xae, 0xd0, 0xe9, 0xeb, 0x7a, 0xab,
+	0x72, 0xd5, 0x34, 0xff, 0xd6, 0x3b, 0x84, 0xce, 0x7a, 0x8f, 0x5c, 0x77, 0xa3, 0xd4, 0xbd, 0xf0,
+	0x65, 0xca, 0x23, 0x0d, 0x5e, 0xd7, 0x5e, 0x1a, 0xee, 0x18, 0x5a, 0xc7, 0x09, 0x29, 0x7e, 0x8b,
+	0x51, 0xee, 0x3e, 0xa3, 0x70, 0x5f, 0xe9, 0x52, 0xbb, 0xe2, 0x52, 0x77, 0x01, 0x5b, 0x1e, 0xfa,
+	0xa7, 0x4c, 0x31, 0x5d, 0x82, 0xf7, 0x99, 0x89, 0x93, 0xa3, 0x76, 0x02, 0x93, 0x8b, 0xcc, 0xc3,
+	0xfa, 0x9c, 0x37, 0xae, 0x97, 0x8d, 0x2b, 0xe4, 0x1a, 0x7f, 0x26, 0xe7, 0x1e, 0xc0, 0xdf, 0x85,
+	0x5e, 0x33, 0x0f, 0xfd, 0x3b, 0x8c, 0x54, 0x3e, 0x37, 0x16, 0x61, 0xce, 0x31, 0x16, 0xa1, 0xfb,
+	0x11, 0xda, 0x05, 0x54, 0x43, 0x5e, 0x40, 0x53, 0xa6, 0x15, 0xd2, 0x31, 0xf4, 0x8c, 0xde, 0xfa,
+	0x05, 0x54, 0x1b, 0xd2, 0x02, 0xfb, 0xc8, 0x3f, 0xc8, 0x61, 0xa7, 0x28, 0xa2, 0x28, 0xe3, 0x50,
+	0x3d, 0xc2, 0xbb, 0x0b, 0x9b, 0x28, 0x04, 0x17, 0xa9, 0xc6, 0xe7, 0x1b, 0x34, 0x0d, 0xc9, 0x00,
+	0x1a, 0x33, 0xa6, 0x98, 0x26, 0x6f, 0x8d, 0xc8, 0xfa, 0x0a, 0xc9, 0xe8, 0xf3, 0x0d, 0xaa, 0x11,
+	0x6f, 0x9b, 0x60, 0x0a, 0xdd, 0xdd, 0x3d, 0x80, 0x1d, 0x8a, 0x7e, 0x20, 0x55, 0xf9, 0x5e, 0x74,
+	0xc1, 0x94, 0x38, 0x15, 0x98, 0xff, 0x62, 0x59, 0xe4, 0x7e, 0x80, 0xf6, 0x05, 0x57, 0xc1, 0x7c,
+	0x95, 0x91, 0xf9, 0x5d, 0x99, 0xa4, 0x54, 0x31, 0x79, 0x5b, 0xdc, 0x62, 0x16, 0x25, 0x06, 0x5f,
+	0x0a, 0x3e, 0x0f, 0x42, 0x94, 0xce, 0xae, 0x66, 0x5b, 0xc4, 0x23, 0x01, 0xdb, 0x97, 0x62, 0xba,
+	0x40, 0xa9, 0x04, 0x53, 0x5c, 0x90, 0x43, 0x68, 0xbf, 0x47, 0x55, 0x7a, 0x97, 0x74, 0x1f, 0x98,
+	0x39, 0xdb, 0xb3, 0xf7, 0xd7, 0x23, 0x26, 0x27, 0xff, 0x43, 0x23, 0x79, 0x23, 0x49, 0xfa, 0xec,
+	0xe4, 0xcf, 0x65, 0x6f, 0x3d, 0x1c, 0x5d, 0x00, 0x54, 0x06, 0x1c, 0x01, 0xc9, 0x35, 0xa8, 0x64,
+	0xf7, 0x74, 0xc9, 0x03, 0x71, 0x7a, 0xa9, 0xaa, 0x6b, 0x3a, 0x3c, 0x37, 0x6e, 0x4c, 0xfd, 0x4a,
+	0x8f, 0x7f, 0x05, 0x00, 0x00, 0xff, 0xff, 0xe3, 0x50, 0xe7, 0x91, 0xb9, 0x05, 0x00, 0x00,
 }

--- a/net/lp_rpc.proto
+++ b/net/lp_rpc.proto
@@ -10,10 +10,19 @@ service Orchestrator {
   rpc Ping(PingPong) returns (PingPong);
 }
 
+service Transcoder {
+
+  // Called by the transcoder to register to an orchestrator. The orchestrator
+  // notifies registered transcoders of segments as they come in.
+  rpc RegisterTranscoder(RegisterRequest) returns (stream NotifySegment);
+}
+
 message PingPong {
   // Implementation defined
   bytes value = 1;
+
 }
+
 
 // This request is sent by the broadcaster in `GetTranscoder` to request
 // information on which transcoder to use.
@@ -144,4 +153,20 @@ message TranscodeResult {
         string error = 2;
         TranscodeData data = 3;
     }
+}
+
+// Sent by the transcoder to register itself to the orchestrator.
+message RegisterRequest {
+
+    // Shared secret for auth
+    string secret = 1;
+}
+
+// Sent by the transcoder
+message NotifySegment {
+
+    string url      = 1;
+
+    int64 taskId   = 16;
+    bytes profiles = 17;
 }

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -85,7 +85,7 @@ func NewLivepeerServer(rtmpAddr string, httpAddr string, lpNode *core.LivepeerNo
 	switch lpNode.NodeType {
 	case core.Broadcaster:
 		opts.RtmpDisabled = false
-	case core.Transcoder:
+	case core.OrchestratorNode:
 		opts.HttpMux = http.NewServeMux()
 	}
 	server := lpmscore.New(&opts)

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -83,7 +83,7 @@ func NewLivepeerServer(rtmpAddr string, httpAddr string, lpNode *core.LivepeerNo
 		WorkDir:  lpNode.WorkDir,
 	}
 	switch lpNode.NodeType {
-	case core.Broadcaster:
+	case core.BroadcasterNode:
 		opts.RtmpDisabled = false
 	case core.OrchestratorNode:
 		opts.HttpMux = http.NewServeMux()

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -1,0 +1,242 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strconv"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/golang/glog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
+
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/net"
+)
+
+const ProtoVer_LPT = "Livepeer-Transcoder-1.0"
+const TranscodingErrorMimeType = "livepeer/transcoding-error"
+
+var SecretErr = errors.New("Invalid secret")
+
+// Transcoder
+
+func RunTranscoder(n *core.LivepeerNode, orchAddr string) {
+	expb := backoff.NewExponentialBackOff()
+	expb.MaxInterval = time.Minute
+	expb.MaxElapsedTime = 0
+	backoff.Retry(func() error {
+		glog.Info("Registering transcoder to ", orchAddr)
+		err := runTranscoder(n, orchAddr)
+		glog.Info("Unregistering transcoder: ", err)
+		if err != SecretErr {
+			return err
+		}
+		glog.Info("Terminating transcoder")
+		return nil
+	}, expb)
+}
+
+func runTranscoder(n *core.LivepeerNode, orchAddr string) error {
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	conn, err := grpc.Dial(orchAddr,
+		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	if err != nil {
+		glog.Error("Did not connect transcoder to orchesrator: ", err)
+		return err
+	}
+	defer conn.Close()
+
+	c := net.NewTranscoderClient(conn)
+	ctx := context.Background()
+	r, err := c.RegisterTranscoder(ctx, &net.RegisterRequest{Secret: n.OrchSecret})
+	if err != nil {
+		glog.Error("Could not register transcoder to orchestrator ", err)
+		status := status.Convert(err)
+		if status.Message() == SecretErr.Error() { // consider this unrecoverable
+			return SecretErr
+		}
+		return err
+	}
+
+	httpc := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	for {
+		notify, err := r.Recv()
+		if err != nil {
+			status := status.Convert(err)
+			if status.Message() == SecretErr.Error() { // consider this unrecoverable
+				return SecretErr
+			}
+			return err
+		}
+		profiles, err := common.TxDataToVideoProfile(hex.EncodeToString(notify.Profiles))
+		if err != nil {
+			glog.Info("Unable to deserialize profiles ", err)
+		}
+
+		glog.Info("Transcoding ", notify.TaskId)
+		var contentType string
+		var body bytes.Buffer
+
+		tData, err := n.Transcoder.Transcode(notify.Url, profiles)
+		if err != nil {
+			glog.Error("Unable to transcode ", err)
+			body.Write([]byte(err.Error()))
+			contentType = TranscodingErrorMimeType
+		} else {
+			boundary := randName()
+			w := multipart.NewWriter(&body)
+			for _, v := range tData {
+				w.SetBoundary(boundary)
+				hdrs := textproto.MIMEHeader{
+					"Content-Type":   {"video/MP2T"},
+					"Content-Length": {strconv.Itoa(len(v))},
+				}
+				fw, err := w.CreatePart(hdrs)
+				if err != nil {
+					glog.Error("Could not create multipart part ", err)
+					return err // XXX respond w error to orchestrator
+				}
+				io.Copy(fw, bytes.NewBuffer(v))
+			}
+			w.Close()
+			contentType = "multipart/mixed; boundary=" + boundary
+		}
+		req, err := http.NewRequest("POST", "https://"+orchAddr+"/transcodeResults", &body)
+		if err != nil {
+			glog.Error("Error posting results ", err)
+			return err
+		}
+		req.Header.Set("Authorization", ProtoVer_LPT)
+		req.Header.Set("Credentials", n.OrchSecret)
+		req.Header.Set("Content-Type", contentType)
+		req.Header.Set("TaskId", strconv.FormatInt(notify.TaskId, 10))
+		resp, err := httpc.Do(req)
+		if err != nil {
+			glog.Error("Error submitting results ", err)
+			return err
+		}
+		ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
+	return nil
+}
+
+// Orchestrator gRPC
+
+func (h *lphttp) RegisterTranscoder(req *net.RegisterRequest, stream net.Transcoder_RegisterTranscoderServer) error {
+	glog.Info("Got a RegisterTranscoder request for ", req.Secret)
+
+	if req.Secret != h.orchestrator.TranscoderSecret() {
+		glog.Info(SecretErr.Error())
+		return SecretErr
+	}
+
+	// blocks until stream is finished
+	h.orchestrator.ServeTranscoder(stream)
+	return nil
+}
+
+// Orchestrator HTTP
+
+func (h *lphttp) TranscodeResults(w http.ResponseWriter, r *http.Request) {
+	orch := h.orchestrator
+
+	authType := r.Header.Get("Authorization")
+	creds := r.Header.Get("Credentials")
+	if ProtoVer_LPT != authType {
+		glog.Error("Invalid auth type ", authType)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if creds != orch.TranscoderSecret() {
+		glog.Error("Invalid shared secret")
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		glog.Error("Error getting mime type ", err)
+		http.Error(w, err.Error(), http.StatusUnsupportedMediaType)
+		return
+	}
+
+	tid, err := strconv.ParseInt(r.Header.Get("TaskId"), 10, 64)
+	if err != nil {
+		glog.Error("Could not parse task ID ", err)
+		http.Error(w, "Invalid Task ID", http.StatusBadRequest)
+		return
+	}
+
+	var res core.RemoteTranscoderResult
+	if TranscodingErrorMimeType == mediaType {
+		w.Write([]byte("OK"))
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			glog.Error("Unable to read transcoding error body ", err)
+			res.Err = err
+		} else {
+			res.Err = fmt.Errorf(string(body))
+		}
+		glog.Error("Trascoding error ", res.Err)
+		orch.TranscoderResults(tid, &res)
+		return
+	}
+
+	var segments [][]byte
+	if "multipart/mixed" == mediaType {
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			p, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				glog.Error("Could not process multipart part ", err)
+				res.Err = err
+				break
+			}
+			body, err := ioutil.ReadAll(p)
+			if err != nil {
+				glog.Error("Error reading body ", err)
+				res.Err = err
+				break
+			}
+			segments = append(segments, body)
+		}
+		res.Segments = segments
+		orch.TranscoderResults(tid, &res)
+	}
+	if res.Err != nil {
+		http.Error(w, res.Err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write([]byte("OK"))
+}
+
+// utils
+
+func randName() string {
+	rand.Seed(time.Now().UnixNano())
+	x := make([]byte, 10, 10)
+	for i := 0; i < len(x); i++ {
+		x[i] = byte(rand.Uint32())
+	}
+	return hex.EncodeToString(x)
+}

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -118,7 +118,6 @@ func startOrchestratorClient(url_string string) (net.OrchestratorClient, error) 
 		glog.Error("Did not connect: ", err)
 		return nil, errors.New("Did not connect: " + err.Error())
 	}
-	defer conn.Close()
 	c := net.NewOrchestratorClient(conn)
 
 	return c, nil

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -96,7 +96,7 @@ func CheckTranscoderAvailability(orch Orchestrator) bool {
 		return false
 	}
 
-	return verifyMsgSig(orch.Address(), string(pong.Value), ping)
+	return verifyMsgSig(orch.Address(), string(ping), pong.Value)
 }
 
 func startOrchestratorClient(url_string string) (net.OrchestratorClient, error) {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -101,6 +101,13 @@ func (r *stubOrchestrator) GetTranscoderInfo() *net.TranscoderInfo {
 }
 func (r *stubOrchestrator) SetTranscoderInfo(ti *net.TranscoderInfo) {
 }
+func (r *stubOrchestrator) ServeTranscoder(stream net.Transcoder_RegisterTranscoderServer) {
+}
+func (r *stubOrchestrator) TranscoderResults(job int64, res *core.RemoteTranscoderResult) {
+}
+func (r *stubOrchestrator) TranscoderSecret() string {
+	return ""
+}
 func StubBroadcaster2() *stubOrchestrator {
 	return StubOrchestrator() // lazy; leverage subtyping for interface commonalities
 }

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -292,7 +292,7 @@ func TestRPCSeg(t *testing.T) {
 	}
 }
 
-func testPing(t *testing.T) {
+func TestPing(t *testing.T) {
 	o := StubOrchestrator()
 
 	tsSignature, _ := o.Sign([]byte(fmt.Sprintf("%v", time.Now())))
@@ -304,7 +304,7 @@ func testPing(t *testing.T) {
 		t.Error("Unable to send Ping request")
 	}
 
-	verified := verifyMsgSig(o.Address(), string(pong.Value), pingSent)
+	verified := verifyMsgSig(o.Address(), string(pingSent), pong.Value)
 
 	if !verified {
 		t.Error("Unable to verify response from ping request")

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -1167,7 +1167,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 	})
 
 	mux.HandleFunc("/IsTranscoder", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(fmt.Sprintf("%v", s.LivepeerNode.NodeType == core.Transcoder)))
+		w.Write([]byte(fmt.Sprintf("%v", s.LivepeerNode.NodeType == core.OrchestratorNode)))
 	})
 
 	mux.HandleFunc("/EthNetworkID", func(w http.ResponseWriter, r *http.Request) {

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -178,8 +178,8 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 		}
 	})
 
-	//Activate the transcoder on-chain.
-	mux.HandleFunc("/activateTranscoder", func(w http.ResponseWriter, r *http.Request) {
+	//Activate the orchestrator on-chain.
+	mux.HandleFunc("/activateOrchestrator", func(w http.ResponseWriter, r *http.Request) {
 		t, err := s.LivepeerNode.Eth.GetTranscoder(s.LivepeerNode.Eth.Account().Address)
 		if err != nil {
 			glog.Error(err)
@@ -187,7 +187,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 		}
 
 		if t.Status == "Registered" {
-			glog.Error("Transcoder is already registered")
+			glog.Error("Orchestrator is already registered")
 			return
 		}
 
@@ -287,7 +287,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 			}
 		}
 
-		glog.Infof("Registering transcoder %v", s.LivepeerNode.Eth.Account().Address.Hex())
+		glog.Infof("Registering orchestrator %v", s.LivepeerNode.Eth.Account().Address.Hex())
 
 		tx, err := s.LivepeerNode.Eth.Transcoder(eth.FromPerc(blockRewardCut), eth.FromPerc(feeShare), price)
 		if err != nil {
@@ -347,7 +347,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 	})
 
 	//Set transcoder config on-chain.
-	mux.HandleFunc("/setTranscoderConfig", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/setOrchestratorConfig", func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			glog.Errorf("Parse Form Error: %v", err)
 			return
@@ -399,7 +399,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 		}
 
 		if t.PendingRewardCut.Cmp(eth.FromPerc(blockRewardCut)) != 0 || t.PendingFeeShare.Cmp(eth.FromPerc(feeShare)) != 0 || t.PendingPricePerSegment.Cmp(price) != 0 {
-			glog.Infof("Setting transcoder config - Reward Cut: %v Fee Share: %v Price: %v", eth.FromPerc(blockRewardCut), eth.FromPerc(feeShare), price)
+			glog.Infof("Setting orchestrator config - Reward Cut: %v Fee Share: %v Price: %v", eth.FromPerc(blockRewardCut), eth.FromPerc(feeShare), price)
 
 			tx, err := s.LivepeerNode.Eth.Transcoder(eth.FromPerc(blockRewardCut), eth.FromPerc(feeShare), price)
 			if err != nil {
@@ -421,7 +421,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 		}
 	})
 
-	//Bond some amount of tokens to a transcoder.
+	//Bond some amount of tokens to an orchestrator.
 	mux.HandleFunc("/bond", func(w http.ResponseWriter, r *http.Request) {
 		if s.LivepeerNode.Eth != nil {
 			if err := r.ParseForm(); err != nil {
@@ -716,7 +716,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 		}
 	})
 
-	mux.HandleFunc("/transcoderEarningPoolsForRound", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orchestratorEarningPoolsForRound", func(w http.ResponseWriter, r *http.Request) {
 		if s.LivepeerNode.Eth != nil {
 			roundStr := r.URL.Query().Get("round")
 			round, err := lpcommon.ParseBigInt(roundStr)
@@ -856,7 +856,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 		}
 	})
 
-	mux.HandleFunc("/transcoderEventSubscriptions", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orchestratorEventSubscriptions", func(w http.ResponseWriter, r *http.Request) {
 		if s.LivepeerNode.Eth != nil && s.LivepeerNode.EthEventMonitor != nil {
 			rewardWorking := false
 			if s.LivepeerNode.EthServices["RewardService"] != nil && s.LivepeerNode.EthServices["RewardService"].IsWorking() {
@@ -887,7 +887,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 		if s.LivepeerNode.Eth != nil {
 			lp := s.LivepeerNode.Eth
 
-			numActiveTranscoders, err := lp.NumActiveTranscoders()
+			numActiveOrchestrators, err := lp.NumActiveTranscoders()
 			if err != nil {
 				glog.Error(err)
 				return
@@ -996,7 +996,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 			}
 
 			params := &lpTypes.ProtocolParameters{
-				NumActiveTranscoders:          numActiveTranscoders,
+				NumActiveTranscoders:          numActiveOrchestrators,
 				RoundLength:                   roundLength,
 				RoundLockAmount:               roundLockAmount,
 				UnbondingPeriod:               unbondingPeriod,
@@ -1075,15 +1075,15 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 		}
 	})
 
-	mux.HandleFunc("/registeredTranscoders", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/registeredOrchestrators", func(w http.ResponseWriter, r *http.Request) {
 		if s.LivepeerNode.Eth != nil {
-			transcoders, err := s.LivepeerNode.Eth.RegisteredTranscoders()
+			orchestrators, err := s.LivepeerNode.Eth.RegisteredTranscoders()
 			if err != nil {
 				glog.Error(err)
 				return
 			}
 
-			data, err := json.Marshal(transcoders)
+			data, err := json.Marshal(orchestrators)
 			if err != nil {
 				glog.Error(err)
 				return
@@ -1094,7 +1094,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 		}
 	})
 
-	mux.HandleFunc("/transcoderInfo", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orchestratorInfo", func(w http.ResponseWriter, r *http.Request) {
 		if s.LivepeerNode.Eth != nil {
 			t, err := s.LivepeerNode.Eth.GetTranscoder(s.LivepeerNode.Eth.Account().Address)
 			if err != nil {
@@ -1166,7 +1166,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 		}
 	})
 
-	mux.HandleFunc("/IsTranscoder", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/IsOrchestrator", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(fmt.Sprintf("%v", s.LivepeerNode.NodeType == core.OrchestratorNode)))
 	})
 


### PR DESCRIPTION
The mechanics of the split are as follows:

Add a `Transcoder` interface, along with concrete implementations of `LocalTranscoder` and `RemoteTranscoder` . 

```golang
type Transcoder interface {
	Transcode(fname string, profiles []ffmpeg.VideoProfile) ([][]byte, error)
}
```
Each orchestrator maintains a transcoder, which can be a local transcoder or a remote transcoder. Which transcoder is used depends on whether the orchestrator uses the `-transcoder` flag (which enables local transcoding) or the `-orchestrator` flag (which disables local transcoding). Discussion of the flags happened [here](https://github.com/livepeer/go-livepeer/issues/567).

To test remote transcoders, run the orchestrator in `-orchestrator` mode and connect a transcoder by starting another Livepeer node with `-orchAddr` .

The networking follows the "Orchestrator-Transcoder Network Flow" as described [here]( https://gist.github.com/j0sh/7cfb580cdacfe44700db4e6315a46491#orchestrator-transcoder-network-flow) with only minor changes to the message definitions.

Remote transcoders are asynchronously assigned "tasks" via streaming RPC. Results are POST'd directly via HTTP multipart along with the the task ID. Notification from HTTP to the transcode loop is done via channels, which unblocks the pending segment in the transcode loop. Remote transcoders have a timeout of 8 seconds before cancellation, which partially mitigates https://github.com/livepeer/go-livepeer/issues/570 .

TODOs for this PR

- [x] Fix existing tests
- [x] Add new tests
- [x] Reconnect remote transcoder if connection drops
- [x] Don't reconnect on unrecoverable errors (eg, invalid secret)
- [x] Disable geth connectivity for transcoder-only nodes
- [x] Use "Orchestrator" rather than "Transcoder" in CLI

TODOs for later PRs

- [ ] Come to a conclusion on https://github.com/livepeer/go-livepeer/issues/576 and reinstate timeouts
- [ ] Graceful shutdown of transcoder-only nodes (exit listening loop)
- [ ] Fallbacks in case a transcoder fails
- [ ] Send each profile to a separate transcoder
- [ ] Transcoder rotation, LRU style
- [ ] Capacity limits (eg, N concurrent transcodes)
- [ ] Write transcoder info to orchestrator DB, incl. remote IP