### PR TITLE
Clean up a leak, tighten up cleanups, enable gnutls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           keys:
             - v3-pkg-cache
 
-      - run: sudo apt-get update && sudo apt-get -y install build-essential pkg-config autoconf
+      - run: sudo apt-get update && sudo apt-get -y install build-essential pkg-config autoconf gnutls-dev
       - run: ./install_ffmpeg.sh
       - run: go get github.com/golang/glog
       - run: go get github.com/ericxtang/m3u8

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /go/src/github.com/livepeer/go-livepeer
 COPY . .
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-RUN apt-get update && apt-get -y install build-essential pkg-config autoconf nodejs
+RUN apt-get update && apt-get -y install build-essential pkg-config autoconf nodejs gnutls-dev
 RUN ./install_ffmpeg.sh
 RUN go get github.com/golang/glog
 RUN go get github.com/ericxtang/m3u8

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -30,8 +30,8 @@ if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
     --disable-muxers --disable-demuxers --disable-parsers --disable-protocols \
     --disable-encoders --disable-decoders --disable-filters --disable-bsfs \
     --disable-postproc --disable-lzma \
-    --enable-libx264 --enable-gpl \
-    --enable-protocol=rtmp,file \
+    --enable-gnutls --enable-libx264 --enable-gpl \
+    --enable-protocol=https,rtmp,file \
     --enable-muxer=mpegts,hls,segment --enable-demuxer=flv,mpegts \
     --enable-bsf=h264_mp4toannexb,aac_adtstoasc,h264_metadata,h264_redundant_pps \
     --enable-parser=aac,aac_latm,h264 \

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -399,6 +399,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 								errFunc("Retrieval", url, err)
 								return
 							}
+							defer res.Body.Close()
 							// TODO persist this to disk.
 							// Should make videocache read from disk as well
 							data, err := ioutil.ReadAll(res.Body)

--- a/vendor/github.com/livepeer/lpms/core/lpms_test.go
+++ b/vendor/github.com/livepeer/lpms/core/lpms_test.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type TestVideoSegmenter struct {
+	count int
+}
+
+func (t *TestVideoSegmenter) RTMPToHLS(ctx context.Context, cleanup bool) error {
+	t.count++
+	if t.count < RetryCount {
+		return errors.New("Test Retry")
+	}
+	return nil
+}
+
+func (t *TestVideoSegmenter) GetCount() int {
+	return t.count
+}
+
+func TestRetryRTMPToHLS(t *testing.T) {
+	var testVideoSegmenter = &TestVideoSegmenter{}
+	SegmenterRetryWait = time.Millisecond
+	rtmpToHLS(testVideoSegmenter, context.Background(), true)
+	count := testVideoSegmenter.GetCount()
+	if count != RetryCount {
+		t.Error("Not enough retries attempted")
+		t.Fail()
+	}
+}

--- a/vendor/github.com/livepeer/lpms/ffmpeg/ffmpeg.go
+++ b/vendor/github.com/livepeer/lpms/ffmpeg/ffmpeg.go
@@ -11,7 +11,7 @@ import (
 	"unsafe"
 )
 
-// #cgo pkg-config: libavformat libavfilter libavcodec libavutil libswscale
+// #cgo pkg-config: libavformat libavfilter libavcodec libavutil libswscale gnutls
 // #include <stdlib.h>
 // #include "lpms_ffmpeg.h"
 import "C"

--- a/vendor/github.com/livepeer/lpms/install_ffmpeg.sh
+++ b/vendor/github.com/livepeer/lpms/install_ffmpeg.sh
@@ -26,7 +26,7 @@ fi
 if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
   git clone -b n4.0 https://git.ffmpeg.org/ffmpeg.git "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$HOME/ffmpeg"
-  ./configure --prefix="$HOME/compiled" --enable-libx264 --enable-gpl --enable-static
+  ./configure --prefix="$HOME/compiled" --enable-libx264 --enable-gnutls --enable-gpl --enable-static
   make
   make install
 fi

--- a/vendor/github.com/livepeer/lpms/segmenter/video_segmenter.go
+++ b/vendor/github.com/livepeer/lpms/segmenter/video_segmenter.go
@@ -46,7 +46,9 @@ type VideoPlaylist struct {
 	Data *m3u8.MediaPlaylist
 }
 
-type VideoSegmenter interface{}
+type VideoSegmenter interface {
+	RTMPToHLS(ctx context.Context, cleanup bool) error
+}
 
 //FFMpegVideoSegmenter segments a RTMP stream by invoking FFMpeg and monitoring the file system.
 type FFMpegVideoSegmenter struct {


### PR DESCRIPTION
Close request body after downloading transcode results.
This was preventing us from reusing the underlying HTTP connection
 for subsequent downloads, leading to an accumulation of file handles.
https://github.com/livepeer/go-livepeer/commit/ced2c6137c26818e1543486126cef72d9e844406

Also introduce a small change to the orchestrator that guarantees that
any local files are removed if transcoding exits with an error. It is easy
to forget to remove the file manually if additional early exits are introduced
in the transcode flow. This change makes the cleanup a bit more watertight.
https://github.com/livepeer/go-livepeer/commit/905374f15312edb81f618df43f3712b584257296

Also update LPMS to support GnuTLS, paving the way for the O/T split.
https://github.com/livepeer/lpms/pull/91
https://github.com/livepeer/go-livepeer/commit/331ef0b010fd2e2d5347f96ad3c3b1f2934fb11c