### PR TITLE
separate folders for each eth network

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -101,7 +101,9 @@ func main() {
 		if *monitor && *monhost == "" {
 			*monhost = "http://metrics-rinkeby.livepeer.org/api/events"
 		}
+		*datadir = *datadir + "/rinkeby"
 	} else if *devenv {
+		*datadir = *datadir + "/dev"
 	} else {
 		if !*offchain {
 			if *ethUrl == "" {
@@ -115,6 +117,7 @@ func main() {
 		if *monitor && *monhost == "" {
 			*monhost = "http://metrics-mainnet.livepeer.org/api/events"
 		}
+		*datadir = *datadir + "/mainnet"
 	}
 
 	//Make sure datadir is present

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -89,9 +89,7 @@ func main() {
 	}
 
 	if *rinkeby {
-		*datadir = *datadir + "/rinkeby"
 		if !*offchain {
-			*datadir = *datadir + "/offchain"
 			if *ethUrl == "" {
 				*ethUrl = "wss://rinkeby.infura.io/ws"
 			}
@@ -99,16 +97,18 @@ func main() {
 				*controllerAddr = RinkebyControllerAddr
 			}
 			glog.Infof("***Livepeer is running on the Rinkeby test network: %v***", RinkebyControllerAddr)
+			*datadir = *datadir + "/rinkeby"
+		} else {
+			*datadir = *datadir + "/offchain"
 		}
+
 		if *monitor && *monhost == "" {
 			*monhost = "http://metrics-rinkeby.livepeer.org/api/events"
 		}
 	} else if *devenv {
 		*datadir = *datadir + "/devenv"
 	} else {
-		*datadir = *datadir + "/mainnet"
 		if !*offchain {
-			*datadir = *datadir + "/offchain"
 			if *ethUrl == "" {
 				*ethUrl = "wss://mainnet.infura.io/ws"
 			}
@@ -116,6 +116,9 @@ func main() {
 				*controllerAddr = MainnetControllerAddr
 			}
 			glog.Infof("***Livepeer is running on the Ethereum main network: %v***", MainnetControllerAddr)
+			*datadir = *datadir + "/mainnet"
+		} else {
+			*datadir = *datadir + "/offchain"
 		}
 		if *monitor && *monhost == "" {
 			*monhost = "http://metrics-mainnet.livepeer.org/api/events"

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -103,7 +103,7 @@ func main() {
 		}
 		*datadir = *datadir + "/rinkeby"
 	} else if *devenv {
-		*datadir = *datadir + "/dev"
+		*datadir = *datadir + "/devenv"
 	} else {
 		if !*offchain {
 			if *ethUrl == "" {

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -89,7 +89,9 @@ func main() {
 	}
 
 	if *rinkeby {
+		*datadir = *datadir + "/rinkeby"
 		if !*offchain {
+			*datadir = *datadir + "/offchain"
 			if *ethUrl == "" {
 				*ethUrl = "wss://rinkeby.infura.io/ws"
 			}
@@ -101,11 +103,12 @@ func main() {
 		if *monitor && *monhost == "" {
 			*monhost = "http://metrics-rinkeby.livepeer.org/api/events"
 		}
-		*datadir = *datadir + "/rinkeby"
 	} else if *devenv {
 		*datadir = *datadir + "/devenv"
 	} else {
+		*datadir = *datadir + "/mainnet"
 		if !*offchain {
+			*datadir = *datadir + "/offchain"
 			if *ethUrl == "" {
 				*ethUrl = "wss://mainnet.infura.io/ws"
 			}
@@ -117,7 +120,6 @@ func main() {
 		if *monitor && *monhost == "" {
 			*monhost = "http://metrics-mainnet.livepeer.org/api/events"
 		}
-		*datadir = *datadir + "/mainnet"
 	}
 
 	//Make sure datadir is present


### PR DESCRIPTION
This implements the enhancement suggested in #537 where it adds `mainnet`, `rinkeby`  and `dev` folders to the `.lpData`. check out the issue for more details.

