### PR TITLE
It/metricserrorsendfix

### DIFF
--- a/monitor/events.go
+++ b/monitor/events.go
@@ -176,22 +176,23 @@ func LogSegmentTranscoded(nonce, seqNo uint64, transcodeDur, totalDur time.Durat
 	sendPost("SegmentTranscoded", nonce, props)
 }
 
-func LogSegmentTranscodeFailed(ev string, nonce, seqNo uint64, err error) {
-	glog.Info("Logging ", ev)
+func LogSegmentTranscodeFailed(subType string, nonce, seqNo uint64, err error) {
+	glog.Info("Logging LogSegmentTranscodeFailed", subType)
 
 	if metrics.lastSegmentNonce == nonce {
 		metrics.segmentsInFlight--
 	}
 	props := map[string]interface{}{
-		"reason": err.Error(),
-		"seqNo":  seqNo,
+		"subType": subType,
+		"reason":  err.Error(),
+		"seqNo":   seqNo,
 	}
 	if metrics.segmentsInFlight != 0 {
 		props["segmentsInFlight"] = metrics.segmentsInFlight
 	}
 	detectSeqDif(props, nonce, seqNo)
 
-	sendPost(ev, nonce, props)
+	sendPost("SegmentTranscodeFailed", nonce, props)
 }
 
 func LogStartBroadcastClientFailed(nonce uint64, serviceURI, transcoderAddress string, jobID uint64, reason string) {
@@ -234,7 +235,7 @@ func _sendPost(name string, nonce uint64, props map[string]interface{}) {
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		glog.Errorf("Error sending event to logger.")
+		glog.Errorf("Error sending event to logger (%s).", eventsURL)
 		return
 	}
 }

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -370,10 +370,10 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 
 						// download transcoded segments from the transcoder
 						gotErr := false // only send one error msg per segment list
-						errFunc := func(ev, url string, err error) {
-							glog.Errorf("%v error with segment %v: %v (URL: %v)", ev, seg.SeqNo, err, url)
+						errFunc := func(subType, url string, err error) {
+							glog.Errorf("%v error with segment %v: %v (URL: %v)", subType, seg.SeqNo, err, url)
 							if monitor.Enabled && !gotErr {
-								monitor.LogSegmentTranscodeFailed(ev, nonce, seg.SeqNo, err)
+								monitor.LogSegmentTranscodeFailed(subType, nonce, seg.SeqNo, err)
 								gotErr = true
 							}
 						}

--- a/vendor/github.com/ethereum/go-ethereum/vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go
+++ b/vendor/github.com/ethereum/go-ethereum/vendor/github.com/rjeczalik/notify/watcher_fsevents_cgo.go
@@ -48,7 +48,7 @@ var wg sync.WaitGroup      // used to wait until the runloop starts
 // started and is ready via the wg. It also serves purpose of a dummy source,
 // thanks to it the runloop does not return as it also has at least one source
 // registered.
-var source = C.CFRunLoopSourceCreate(nil, 0, &C.CFRunLoopSourceContext{
+var source = C.CFRunLoopSourceCreate(C.kCFAllocatorDefault, 0, &C.CFRunLoopSourceContext{
 	perform: (C.CFRunLoopPerformCallBack)(C.gosource),
 })
 
@@ -162,8 +162,8 @@ func (s *stream) Start() error {
 		return nil
 	}
 	wg.Wait()
-	p := C.CFStringCreateWithCStringNoCopy(nil, C.CString(s.path), C.kCFStringEncodingUTF8, nil)
-	path := C.CFArrayCreate(nil, (*unsafe.Pointer)(unsafe.Pointer(&p)), 1, nil)
+	p := C.CFStringCreateWithCStringNoCopy(C.kCFAllocatorDefault, C.CString(s.path), C.kCFStringEncodingUTF8, C.kCFAllocatorDefault)
+	path := C.CFArrayCreate(C.kCFAllocatorDefault, (*unsafe.Pointer)(unsafe.Pointer(&p)), 1, nil)
 	ctx := C.FSEventStreamContext{}
 	ref := C.EventStreamCreate(&ctx, C.uintptr_t(s.info), path, C.FSEventStreamEventId(atomic.LoadUint64(&since)), latency, flags)
 	if ref == nilstream {


### PR DESCRIPTION
fix sending error metrics for SegmentTranscodeFailed event
should use predefined event type, so added new `subType` field to group errors