### PR TITLE
Stop stream upon expired job (WIP)

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -365,6 +365,10 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 						glog.Infof("starting to submit segment %d", seg.SeqNo)
 						res, err := SubmitSegment(rpcBcast, seg, nonce)
 						if err != nil {
+							if shouldStopStream(err) {
+								glog.Warningf("Stopping current stream due to: %v", err)
+								rtmpStrm.Close()
+							}
 							return
 						}
 
@@ -662,4 +666,9 @@ func parseSegName(reqPath string) string {
 		segName = strings.Replace(match, "/stream/", "", -1)
 	}
 	return segName
+}
+
+func shouldStopStream(err error) bool {
+	trimmed := strings.TrimSpace(err.Error())
+	return trimmed == JobOutOfRangeError
 }

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -669,6 +669,5 @@ func parseSegName(reqPath string) string {
 }
 
 func shouldStopStream(err error) bool {
-	trimmed := strings.TrimSpace(err.Error())
-	return trimmed == JobOutOfRangeError
+	return err.Error() == JobOutOfRangeError
 }

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -174,3 +174,13 @@ func TestParseSegname(t *testing.T) {
 		t.Errorf("Expecting %v, but %v", "1220c50f8bc4d2a807aace1e1376496a9d7f7c1408dec2512763c3ca16fe828f6631_01.ts", segName)
 	}
 }
+
+func TestShouldStopStream(t *testing.T) {
+	if shouldStopStream(fmt.Errorf("some random error string")) {
+		t.Error("Expected shouldStopStream=false for a random error")
+	}
+
+	if !shouldStopStream(fmt.Errorf(JobOutOfRangeError)) {
+		t.Errorf("Expected shouldStopStream=true for %v", JobOutOfRangeError)
+	}
+}

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -38,6 +38,8 @@ const GRPCConnectTimeout = 3 * time.Second
 
 const AuthType_LPE = "Livepeer-Eth-1"
 
+const JobOutOfRangeError = "Job out of range"
+
 type Orchestrator interface {
 	ServiceURI() *url.URL
 	Address() ethcommon.Address
@@ -94,8 +96,8 @@ func verifyTranscoderReq(orch Orchestrator, req *net.TranscoderRequest, job *lpT
 		return fmt.Errorf("Transcoder was not assigned")
 	}
 	if !jobClaimable(orch, job) {
-		glog.Error("Job out of range")
-		return fmt.Errorf("Job out of range")
+		glog.Error(JobOutOfRangeError)
+		return fmt.Errorf(JobOutOfRangeError)
 	}
 	if !verifyMsgSig(job.BroadcasterAddress, fmt.Sprintf("%v", job.JobId), req.Sig) {
 		glog.Error("transcoder req sig check failed")
@@ -140,7 +142,7 @@ func verifyToken(orch Orchestrator, creds string) (*lpTypes.Job, error) {
 	}
 	if !jobClaimable(orch, job) {
 		glog.Errorf("Job %v too early or expired", job.JobId)
-		return nil, fmt.Errorf("Job out of range")
+		return nil, fmt.Errorf(JobOutOfRangeError)
 	}
 	return job, nil
 }

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -443,12 +443,13 @@ func SubmitSegment(bcast Broadcaster, seg *stream.HLSSegment, nonce uint64) (*ne
 
 	if resp.StatusCode != 200 {
 		data, _ := ioutil.ReadAll(resp.Body)
+		errorString := strings.TrimSpace(string(data))
 		glog.Errorf("Error submitting segment %d: code %d error %v", seg.SeqNo, resp.StatusCode, string(data))
 		if monitor.Enabled {
-			monitor.LogSegmentUploadFailed(nonce, seg.SeqNo, fmt.Sprintf("Code: %d Error: %s", resp.StatusCode,
-				strings.TrimSpace(string(data))))
+			monitor.LogSegmentUploadFailed(nonce, seg.SeqNo,
+				fmt.Sprintf("Code: %d Error: %s", resp.StatusCode, errorString))
 		}
-		return nil, fmt.Errorf(string(data))
+		return nil, fmt.Errorf(errorString)
 	}
 	glog.Infof("Uploaded segment %v", seg.SeqNo)
 	if monitor.Enabled {


### PR DESCRIPTION
This change is an optimization, not a bug fix, since T already denies
any segments that belong to an expired job.

Solving [this issue](https://github.com/livepeer/go-livepeer/issues/498).