### PR TITLE
Self check related changes.

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -385,6 +385,7 @@ func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMoni
 		glog.Infof("Transcoder %v is active", n.Eth.Account().Address.Hex())
 	}
 
+	serviceUriSpecified := false
 	if serviceUri == "" {
 		// TODO probably should put this (along w wizard GETs) into common code
 		resp, err := http.Get("https://api.ipify.org?format=text")
@@ -397,6 +398,7 @@ func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMoni
 		serviceUri = "https://" + strings.TrimSpace(string(body)) + ":" + RpcPort
 	} else {
 		serviceUri = "https://" + serviceUri
+		serviceUriSpecified = true
 	}
 	suri, err := url.ParseRequestURI(serviceUri)
 	if err != nil {
@@ -419,6 +421,9 @@ func setupTranscoder(ctx context.Context, n *core.LivepeerNode, em eth.EventMoni
 		if active && false {
 			return fmt.Errorf("Mismatched service address")
 		}
+	}
+	if serviceUriSpecified {
+		uri = suri
 	}
 
 	// Set up IPFS

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -118,7 +118,6 @@ func startOrchestratorClient(url_string string) (net.OrchestratorClient, error) 
 		glog.Error("Did not connect: ", err)
 		return nil, errors.New("Did not connect: " + err.Error())
 	}
-	defer conn.Close()
 	c := net.NewOrchestratorClient(conn)
 
 	return c, nil

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -96,7 +96,7 @@ func CheckTranscoderAvailability(orch Orchestrator) bool {
 		return false
 	}
 
-	return verifyMsgSig(orch.Address(), string(pong.Value), ping)
+	return verifyMsgSig(orch.Address(), string(ping), pong.Value)
 }
 
 func startOrchestratorClient(url_string string) (net.OrchestratorClient, error) {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -292,7 +292,7 @@ func TestRPCSeg(t *testing.T) {
 	}
 }
 
-func testPing(t *testing.T) {
+func TestPing(t *testing.T) {
 	o := StubOrchestrator()
 
 	tsSignature, _ := o.Sign([]byte(fmt.Sprintf("%v", time.Now())))
@@ -304,7 +304,7 @@ func testPing(t *testing.T) {
 		t.Error("Unable to send Ping request")
 	}
 
-	verified := verifyMsgSig(o.Address(), string(pong.Value), pingSent)
+	verified := verifyMsgSig(o.Address(), string(pingSent), pong.Value)
 
 	if !verified {
 		t.Error("Unable to verify response from ping request")


### PR DESCRIPTION
* Fix verification param transposition. This wasn't caught by unit testing because of a typo in the test name.
* Use manually specified ServiceURI if not set. Not strictly necessary at the moment, but useful for quick testing. Will become necessary for offchain mode. Perhaps we should also rename this to "orchAddr" following the O/T split.
* rpc: Return the underlying orchestrator connection so we don't close the cxn immediately after creating it.

Fixes https://github.com/livepeer/go-livepeer/issues/600