### PR TITLE
Fix offchain mode.

### DIFF
--- a/core/broadcaster.go
+++ b/core/broadcaster.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"errors"
-	"fmt"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -18,7 +17,7 @@ type broadcaster struct {
 
 func (bcast *broadcaster) Sign(msg []byte) ([]byte, error) {
 	if bcast.node == nil || bcast.node.Eth == nil {
-		return []byte{}, fmt.Errorf("Cannot sign; missing eth client")
+		return []byte{}, nil
 	}
 	return bcast.node.Eth.Sign(crypto.Keccak256(msg))
 }

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -47,9 +47,16 @@ func (orch *orchestrator) CurrentBlock() *big.Int {
 
 func (orch *orchestrator) Sign(msg []byte) ([]byte, error) {
 	if orch.node == nil || orch.node.Eth == nil {
-		return []byte{}, fmt.Errorf("Cannot sign; missing eth client")
+		return []byte{}, nil
 	}
 	return orch.node.Eth.Sign(crypto.Keccak256(msg))
+}
+
+func (orch *orchestrator) VerifySig(addr ethcommon.Address, msg string, sig []byte) bool {
+	if orch.node == nil || orch.node.Eth == nil {
+		return true
+	}
+	return eth.VerifySig(addr, crypto.Keccak256([]byte(msg)), sig)
 }
 
 func (orch *orchestrator) Address() ethcommon.Address {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/lpms/stream"
 )
@@ -44,6 +45,11 @@ func (r *stubOrchestrator) Sign(msg []byte) ([]byte, error) {
 	ethMsg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", 32, hash)
 	return ethcrypto.Sign(ethcrypto.Keccak256([]byte(ethMsg)), r.priv)
 }
+
+func (r *stubOrchestrator) VerifySig(addr ethcommon.Address, msg string, sig []byte) bool {
+	return eth.VerifySig(addr, ethcrypto.Keccak256([]byte(msg)), sig)
+}
+
 func (r *stubOrchestrator) Address() ethcommon.Address {
 	return ethcrypto.PubkeyToAddress(r.priv.PublicKey)
 }
@@ -199,7 +205,7 @@ func TestPing(t *testing.T) {
 		t.Error("Unable to send Ping request")
 	}
 
-	verified := verifyMsgSig(o.Address(), string(pingSent), pong.Value)
+	verified := o.VerifySig(o.Address(), string(pingSent), pong.Value)
 
 	if !verified {
 		t.Error("Unable to verify response from ping request")


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Makes offchain mode work for broadcasters and orchestrators.

There are two dependencies for this PR: https://github.com/livepeer/go-livepeer/pull/608 and https://github.com/livepeer/go-livepeer/pull/604. Once #608 is merged, we can pull this PR into #604.

**Specific updates (required)**
- Return default values instead of errors when trying to sign or verify sigs
- Add a VerifySig to the RPC Orchestrator interface. Needed to determine whether we're offchain.

**How did you test each of these updates (required)**
Run B and O with an `-offchain` flag on top of the O Discovery PR. https://github.com/livepeer/go-livepeer/pull/604

* B needs `-orchAddr` specified to select the O to connect to for transcoding.
* O needs `-serviceAddr` specified to substitute for the on-chain ServiceURI. See https://github.com/livepeer/go-livepeer/pull/608#issuecomment-444363685 about renaming this option.

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->
https://github.com/livepeer/go-livepeer/issues/609

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
