### PR TITLE
livepeer: Disable IPFS.

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -30,7 +30,7 @@ import (
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/eth/eventservices"
-	"github.com/livepeer/go-livepeer/ipfs"
+	//"github.com/livepeer/go-livepeer/ipfs" until we re-enable IPFS
 	lpmon "github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/server"
 	lumberjack "gopkg.in/natefinch/lumberjack.v2"
@@ -472,13 +472,13 @@ func setupOrchestrator(ctx context.Context, n *core.LivepeerNode, em eth.EventMo
 	}
 
 	// Set up IPFS
-	ipfsApi, err := ipfs.StartIpfs(ctx, ipfsPath)
+	/*ipfsApi, err := ipfs.StartIpfs(ctx, ipfsPath)
 	if err != nil {
 		return err
 	}
 	drivers.SetIpfsAPI(ipfsApi)
 
-	n.Ipfs = ipfsApi
+	n.Ipfs = ipfsApi*/
 	n.EthEventMonitor = em
 
 	if initializeRound {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

IPFS can't be used until OS support is completed. Until then,
disable to improve the UX so users don't have to deal with IPFS
opening hundreds of connections and using up all up file handles.

**How did you test each of these updates (required)**
Run a Livepeer node. Ensure no IPFS-related file handles are open, eg with `lsof`.


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
