### PR TITLE
cmd/livepeer: Don't show testing flags in usage string

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/eth/eventservices"
+
 	//"github.com/livepeer/go-livepeer/ipfs" until we re-enable IPFS
 	lpmon "github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/server"
@@ -49,6 +50,10 @@ const RpcPort = "8935"
 const CliPort = "7935"
 
 func main() {
+	// Override the default flag set since there are dependencies that
+	// incorrectly add their own flags (specifically, due to the 'testing'
+	// package being linked)
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	flag.Set("logtostderr", "true")
 
 	usr, err := user.Current()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

1. <s>Minor refactor to move out the `testing` package import from non `*_test.go` files. This was not enough to fix the issue though.</s> (removed - not necessary)
2. Reset the default FlagSet in main() because the `go-ipfs` package depends on `go-testutil` which  links the `testing` package, which in turn adds the testing flags. This fixes the issue, though I believe that the `go-ipfs` or `go-testutil` should fix the root cause.

**Specific updates (required)**

All updates related to `cmd/livepeer`.

1. <s>Remove the `common.WaitAssert()` function because it's not used.</s>
2. <s>Move test utilities from `common/testutil.go` to `common/db_test.go` and remove `common/testutil.go`</s>
3. In the `main()` function, reset the default FlagSet before adding go-livepeer's command line flags. This removes the testing flags indirectly added by the `go-ipfs` dependency on `go-testutil` (eg. [go-testutil/gen.go](https://github.com/livepeer/go-livepeer/blob/master/vendor/gx/ipfs/QmVvkK7s5imCiq3JVbL3pGfnhcCnf3LrFJPF4GE2sAoGZf/go-testutil/gen.go#L9))

**How did you test each of these updates (required)**

1. Built `cmd/livepeer` and ran `livepeer -h` to verify that there were no testing flags in the output
2. Ran tests and compared with tests in master. All tests that passed in master passed in this branch.

**Does this pull request close any open issues?**

Fixes #615 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<s>- [ ] README and other documentation updated</s> (not applicable)
- [ ] Node runs in OSX and devenv *Edit* Is this necessary since the changes only affect test cases? I don't have access to OSX unfortunately.
