### PR TITLE
StreamID Refactoring

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -288,7 +288,7 @@ func (n *LivepeerNode) transcodeSeg(config transcodeConfig, seg *stream.HLSSegme
 		seg.Name = url
 	}
 	if isLocal && monitor.Enabled {
-		monitor.LogSegmentTranscodeStarting(seg.SeqNo, md.ManifestID.String())
+		monitor.LogSegmentTranscodeStarting(seg.SeqNo, string(md.ManifestID))
 	}
 
 	//Do the transcoding
@@ -306,7 +306,7 @@ func (n *LivepeerNode) transcodeSeg(config transcodeConfig, seg *stream.HLSSegme
 	tProfileData := make(map[ffmpeg.VideoProfile][]byte, 0)
 	glog.V(common.DEBUG).Infof("Transcoding of segment %v took %v", seg.SeqNo, time.Since(start))
 	if isLocal && monitor.Enabled {
-		monitor.LogSegmentTranscodeEnded(seg.SeqNo, md.ManifestID.String())
+		monitor.LogSegmentTranscodeEnded(seg.SeqNo, string(md.ManifestID))
 	}
 
 	// Prepare the result object

--- a/core/playlistmanager.go
+++ b/core/playlistmanager.go
@@ -65,12 +65,9 @@ func (mgr *BasicPlaylistManager) GetOSSession() drivers.OSSession {
 }
 
 func (mgr *BasicPlaylistManager) isRightStream(streamID StreamID) error {
-	mid, err := streamID.ManifestIDFromStreamID()
-	if err != nil {
-		return err
-	}
+	mid := streamID.ManifestID
 	if mid != mgr.manifestID {
-		return fmt.Errorf("Wrong sream id (%s), should be %s", streamID, mid)
+		return fmt.Errorf("Wrong manifest id (%s), should be %s", mid, mgr.manifestID)
 	}
 	return nil
 }
@@ -100,8 +97,8 @@ func (mgr *BasicPlaylistManager) createPL(streamID StreamID) *m3u8.MediaPlaylist
 	mgr.mapSync.Lock()
 	mgr.mediaLists[streamID] = mpl
 	mgr.mapSync.Unlock()
-	sid := string(streamID)
-	vParams := ffmpeg.VideoProfileToVariantParams(ffmpeg.VideoProfileLookup[streamID.GetRendition()])
+	sid := streamID.String()
+	vParams := ffmpeg.VideoProfileToVariantParams(ffmpeg.VideoProfileLookup[streamID.Rendition])
 	url := sid + ".m3u8"
 	mgr.masterPList.Append(url, mpl, vParams)
 	return mpl

--- a/core/playlistmanager_test.go
+++ b/core/playlistmanager_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestGetMasterPlaylist(t *testing.T) {
 	vProfile := ffmpeg.P144p30fps16x9
-	hlsStrmID, _ := MakeStreamID(RandomVideoID(), vProfile.Name)
-	mid, _ := hlsStrmID.ManifestIDFromStreamID()
+	hlsStrmID := MakeStreamID(RandomManifestID(), &vProfile)
+	mid := hlsStrmID.ManifestID
 	c := NewBasicPlaylistManager(mid, nil)
 	segName := "test_seg/1.ts"
 	err := c.InsertHLSSegment(hlsStrmID, 1, segName, 12)
@@ -21,7 +21,7 @@ func TestGetMasterPlaylist(t *testing.T) {
 		t.Fatal(err)
 	}
 	pl := m3u8.NewMasterPlaylist()
-	pl.Append(string(hlsStrmID)+".m3u8", nil, ffmpeg.VideoProfileToVariantParams(vProfile))
+	pl.Append(hlsStrmID.String()+".m3u8", nil, ffmpeg.VideoProfileToVariantParams(vProfile))
 	testpl := c.GetHLSMasterPlaylist()
 
 	if testpl.String() != pl.String() {
@@ -40,23 +40,23 @@ func TestGetMasterPlaylist(t *testing.T) {
 
 func TestForWrongStream(t *testing.T) {
 	vProfile := ffmpeg.P144p30fps16x9
-	hlsStrmID, _ := MakeStreamID(RandomVideoID(), vProfile.Name)
-	mid, _ := hlsStrmID.ManifestIDFromStreamID()
+	hlsStrmID := MakeStreamID(RandomManifestID(), &vProfile)
+	mid := hlsStrmID.ManifestID
 	c := NewBasicPlaylistManager(mid, nil)
-	hlsStrmID2, _ := MakeStreamID(RandomVideoID(), vProfile.Name)
+	hlsStrmID2 := MakeStreamID(RandomManifestID(), &vProfile)
 	err := c.InsertHLSSegment(hlsStrmID2, 1, "test_uri", 12)
 	if err == nil {
 		t.Fatalf("Should fail here")
 	}
-	if !strings.Contains(err.Error(), "Wrong sream id") {
+	if !strings.Contains(err.Error(), "Wrong manifest id") {
 		t.Fatalf("Wrong error, should contain 'Wrong stream id', but has %s", err.Error())
 	}
 }
 
 func TestCleanup(t *testing.T) {
 	vProfile := ffmpeg.P144p30fps16x9
-	hlsStrmID, _ := MakeStreamID(RandomVideoID(), vProfile.Name)
-	mid, _ := hlsStrmID.ManifestIDFromStreamID()
+	hlsStrmID := MakeStreamID(RandomManifestID(), &vProfile)
+	mid := hlsStrmID.ManifestID
 	osd := drivers.NewMemoryDriver("test://some.host")
 	osSession := osd.NewSession("testPath")
 	memoryOS := osSession.(*drivers.MemorySession)

--- a/core/stream_test.go
+++ b/core/stream_test.go
@@ -22,6 +22,7 @@ func TestSegmentFlatten(t *testing.T) {
 	}
 }
 
+/*
 func TestStreamID(t *testing.T) {
 	vid := RandomVideoID()
 	id, err := MakeStreamID(vid, ffmpeg.P144p30fps16x9.Name)
@@ -95,3 +96,4 @@ func TestManifestID(t *testing.T) {
 		t.Error("did not expect manifestd to be valid")
 	}
 }
+*/

--- a/core/stream_test.go
+++ b/core/stream_test.go
@@ -24,14 +24,24 @@ func TestSegmentFlatten(t *testing.T) {
 	}
 }
 
-func TestStreamID(t *testing.T) {
+func TestRandomIdGenerator(t *testing.T) {
 	rand.Seed(123)
+	res := RandomIdGenerator(DefaultManifestIDLength)
+	if !bytes.Equal(res, []byte{0x17, 0xb3, 0x36, 0xb6}) {
+		t.Error("Unexpected RNG result")
+	}
+}
+
+func TestStreamID(t *testing.T) {
+	RandomIdGenerator = func(length uint) []byte {
+		return []byte{0xFE, 0xED, 0xF0, 0x0D}
+	}
 	mid := RandomManifestID()
 	profile := ffmpeg.P144p30fps16x9
 
 	// Test random manifest ID generation
-	if string(mid) != "17b336b6" {
-		t.Error("Unexxpected ManifestID ", mid)
+	if string(mid) != "feedf00d" {
+		t.Error("Unexpected ManifestID ", mid)
 	}
 
 	// Test normal cases

--- a/core/streamdata.go
+++ b/core/streamdata.go
@@ -43,7 +43,7 @@ func (md *SegTranscodingMetadata) Flatten() []byte {
 	return buf
 }
 
-func RandomIdGenerator(length uint) []byte {
+var RandomIdGenerator = func(length uint) []byte {
 	x := make([]byte, length, length)
 	for i := 0; i < len(x); i++ {
 		x[i] = byte(rand.Uint32())

--- a/drivers/local.go
+++ b/drivers/local.go
@@ -123,9 +123,9 @@ func (ostore *MemorySession) getAbsolutePath(name string) string {
 }
 
 func (ostore *MemorySession) getAbsoluteURI(name string) string {
-	name = ostore.getAbsolutePath(name)
+	name = "/stream/" + ostore.getAbsolutePath(name)
 	if ostore.os.baseURI != "" {
-		return ostore.os.baseURI + "/stream/" + name
+		return ostore.os.baseURI + name
 	}
 	return name
 }

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"path"
 	"regexp"
 	"strings"
 	"sync"
@@ -143,27 +144,15 @@ func (s *LivepeerServer) StartMediaServer(ctx context.Context, maxPricePerSegmen
 //RTMP Publish Handlers
 func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID string) {
 	return func(url *url.URL) (strmID string) {
-		//Create a StreamID
-		//If streamID is passed in, use that one
+		//Create a ManifestID
+		//If manifestID is passed in, use that one
 		//Else create one
-		var vid []byte
-		qid := core.StreamID(url.Query().Get("hlsStrmID"))
-		if qid != "" {
-			vid = qid.GetVideoID()
-			if vid == nil {
-				glog.Error("Error parsing hlsStrmID")
-				return ""
-			}
-		} else {
-			vid = core.RandomVideoID()
+		mid := parseManifestID(url.Query().Get("hlsStrmID"))
+		if mid == "" {
+			mid = core.RandomManifestID()
 		}
 
 		// Ensure there's no concurrent StreamID with the same name
-		mid, err := core.MakeManifestID(vid)
-		if err != nil {
-			glog.Error("Error constructing manifest ID", err)
-			return ""
-		}
 		s.connectionLock.RLock()
 		defer s.connectionLock.RUnlock()
 		if _, exists := s.rtmpConnections[mid]; exists {
@@ -173,13 +162,9 @@ func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID str
 
 		// Generate RTMP part of StreamID
 		key := hex.EncodeToString(core.RandomIdGenerator(StreamKeyBytes))
-		id, err := core.MakeStreamID(vid, key)
-		if err != nil {
-			glog.Errorf("Error making stream ID")
-			return ""
-		}
-		return id.String()
+		return core.MakeStreamIDFromString(string(mid), key).String()
 	}
+
 }
 
 func (s *LivepeerServer) startBroadcast(cpl core.PlaylistManager) (*BroadcastSession, error) {
@@ -230,19 +215,15 @@ func (s *LivepeerServer) startBroadcast(cpl core.PlaylistManager) (*BroadcastSes
 	}, nil
 }
 
-func rtmpManifestID(rtmpStrm stream.RTMPVideoStream) (core.ManifestID, error) {
-	return core.StreamID(rtmpStrm.GetStreamID()).ManifestIDFromStreamID()
+func rtmpManifestID(rtmpStrm stream.RTMPVideoStream) core.ManifestID {
+	return parseManifestID(rtmpStrm.GetStreamID())
 }
 
 func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error) {
 	return func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error) {
 
 		// Set up the connection tracking
-		mid, err := rtmpManifestID(rtmpStrm)
-		if err != nil {
-			glog.Error("Invalid RTMP stream ID")
-			return err
-		}
+		mid := rtmpManifestID(rtmpStrm)
 		if drivers.NodeStorage == nil {
 			glog.Error("Missing node storage")
 			return ErrStorage
@@ -303,13 +284,9 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		//Create a HLS StreamID
 		//If streamID is passed in, use that one to capture the rendition
 		//Else use RTMP manifest ID as base
-		hlsStrmID := core.StreamID(url.Query().Get("hlsStrmID"))
-		if hlsStrmID == "" {
-			hlsStrmID, err = core.MakeStreamID(mid.GetVideoID(), vProfile.Name)
-			if err != nil {
-				glog.Errorf("Error making stream ID")
-				return ErrRTMPPublish
-			}
+		hlsStrmID := parseStreamID(url.Query().Get("hlsStrmID"))
+		if hlsStrmID.ManifestID == "" || hlsStrmID.Rendition == "" {
+			hlsStrmID = core.MakeStreamID(mid, &vProfile)
 		}
 
 		LastHLSStreamID = hlsStrmID
@@ -317,7 +294,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		streamStarted := false
 		//Segment the stream, insert the segments into the broadcaster
 		go func(rtmpStrm stream.RTMPVideoStream) {
-			hid := hex.EncodeToString(core.RandomVideoID()) // ffmpeg m3u8 output name
+			hid := string(core.RandomManifestID()) // ffmpeg m3u8 output name
 			hlsStrm := stream.NewBasicHLSVideoStream(hid, stream.DefaultHLSStreamWin)
 			hlsStrm.SetSubscriber(func(seg *stream.HLSSegment, eof bool) {
 				if eof {
@@ -350,8 +327,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 				}
 				err = cpl.InsertHLSSegment(hlsStrmID, seg.SeqNo, uri, seg.Duration)
 				if monitor.Enabled {
-					mid, _ := hlsStrmID.ManifestIDFromStreamID()
-					monitor.LogSourceSegmentAppeared(nonce, seg.SeqNo, mid.String(), vProfile.Name)
+					monitor.LogSourceSegmentAppeared(nonce, seg.SeqNo, string(mid), vProfile.Name)
 					glog.V(6).Infof("Appeared segment %d", seg.SeqNo)
 				}
 				if err != nil {
@@ -435,7 +411,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 							}
 
 							// hoist this out so we only do it once
-							sid, _ := core.MakeStreamID(hlsStrmID.GetVideoID(), sess.Profiles[i].Name)
+							sid := core.MakeStreamID(mid, &sess.Profiles[i])
 							err = cpl.InsertHLSSegment(sid, seg.SeqNo, url, seg.Duration)
 							if monitor.Enabled {
 								monitor.LogTranscodedSegmentAppeared(nonce, seg.SeqNo, sess.Profiles[i].Name)
@@ -480,7 +456,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		}(rtmpStrm)
 
 		if monitor.Enabled {
-			monitor.LogStreamCreatedEvent(hlsStrmID.String(), nonce)
+			monitor.LogStreamCreatedEvent(string(mid), nonce)
 		}
 
 		glog.Infof("\n\nVideo Created With ManifestID: %v\n\n", mid)
@@ -518,11 +494,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 
 func endRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error {
 	return func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error {
-		mid, err := rtmpManifestID(rtmpStrm)
-		if err != nil {
-			glog.Error("Ending stream with invalid manifest ID ", err)
-			return err
-		}
+		mid := rtmpManifestID(rtmpStrm)
 		//Remove RTMP stream
 		s.connectionLock.Lock()
 		defer s.connectionLock.Unlock()
@@ -550,10 +522,12 @@ func getHLSMasterPlaylistHandler(s *LivepeerServer) func(url *url.URL) (*m3u8.Ma
 		if s.ExposeCurrentManifest && "/stream/current.m3u8" == strings.ToLower(url.Path) {
 			manifestID = LastManifestID
 		} else {
-			var err error
-			if manifestID, err = parseManifestID(url.Path); err != nil {
+			sid := parseStreamID(url.Path)
+			if sid.Rendition != "" {
+				// requesting a media PL, not master PL
 				return nil, vidplayer.ErrNotFound
 			}
+			manifestID = sid.ManifestID
 		}
 
 		s.connectionLock.RLock()
@@ -573,16 +547,8 @@ func getHLSMasterPlaylistHandler(s *LivepeerServer) func(url *url.URL) (*m3u8.Ma
 
 func getHLSMediaPlaylistHandler(s *LivepeerServer) func(url *url.URL) (*m3u8.MediaPlaylist, error) {
 	return func(url *url.URL) (*m3u8.MediaPlaylist, error) {
-		strmID, err := parseStreamID(url.Path)
-		if err != nil {
-			glog.Errorf("Error parsing for stream id: %v", err)
-			return nil, err
-		}
-		mid, err := core.StreamID(strmID).ManifestIDFromStreamID()
-		if err != nil {
-			glog.Errorf("Error parsing manifest ID ", err)
-			return nil, err
-		}
+		strmID := parseStreamID(url.Path)
+		mid := strmID.ManifestID
 		s.connectionLock.RLock()
 		defer s.connectionLock.RUnlock()
 		cxn, ok := s.rtmpConnections[mid]
@@ -602,7 +568,7 @@ func getHLSMediaPlaylistHandler(s *LivepeerServer) func(url *url.URL) (*m3u8.Med
 func getHLSSegmentHandler(s *LivepeerServer) func(url *url.URL) ([]byte, error) {
 	return func(url *url.URL) ([]byte, error) {
 		// Strip the /stream/ prefix
-		segName := parseSegName(url.Path)
+		segName := cleanStreamPrefix(url.Path)
 		if segName == "" || drivers.NodeStorage == nil {
 			glog.Error("SegName not found or storage nil")
 			return nil, vidplayer.ErrNotFound
@@ -635,16 +601,12 @@ func getHLSSegmentHandler(s *LivepeerServer) func(url *url.URL) ([]byte, error) 
 //Start RTMP Play Handlers
 func getRTMPStreamHandler(s *LivepeerServer) func(url *url.URL) (stream.RTMPVideoStream, error) {
 	return func(url *url.URL) (stream.RTMPVideoStream, error) {
-		strmID, err := parseStreamID(url.Path)
-		if err != nil {
-			glog.Errorf("Error parsing streamID with url %v - %v", url.Path, err)
-			return nil, ErrRTMPPlay
-		}
-		sid := core.StreamID(strmID)
-		mid, err := sid.ManifestIDFromStreamID()
+		mid := parseManifestID(url.Path)
+		s.connectionLock.RLock()
 		cxn, ok := s.rtmpConnections[mid]
+		defer s.connectionLock.RUnlock()
 		if !ok {
-			glog.Errorf("Cannot find RTMP stream")
+			glog.Error("Cannot find RTMP stream for ManifestID ", mid)
 			return nil, vidplayer.ErrNotFound
 		}
 
@@ -657,44 +619,21 @@ func getRTMPStreamHandler(s *LivepeerServer) func(url *url.URL) (stream.RTMPVide
 
 //Helper Methods Begin
 
-func parseManifestID(reqPath string) (core.ManifestID, error) {
-	var strmID string
-	regex, _ := regexp.Compile("\\/stream\\/([[:alpha:]]|\\d)*")
-	match := regex.FindString(reqPath)
-	if match != "" {
-		strmID = strings.Replace(match, "/stream/", "", -1)
-	}
-	mid := core.ManifestID(strmID)
-	if mid.IsValid() {
-		return mid, nil
-	} else {
-		return "", vidplayer.ErrNotFound
-	}
+// Match all leading spaces, slashes and optionally `stream/`
+var StreamPrefix = regexp.MustCompile(`^[ /]*(stream/)?`)
+
+func cleanStreamPrefix(reqPath string) string {
+	return StreamPrefix.ReplaceAllString(reqPath, "")
 }
 
-func parseStreamID(reqPath string) (core.StreamID, error) {
-	var strmID string
-	regex, _ := regexp.Compile("\\/stream\\/([[:alpha:]]|\\d)*")
-	match := regex.FindString(reqPath)
-	if match != "" {
-		strmID = strings.Replace(match, "/stream/", "", -1)
-	}
-	sid := core.StreamID(strmID)
-	if sid.IsValid() {
-		return sid, nil
-	} else {
-		return "", vidplayer.ErrNotFound
-	}
+func parseStreamID(reqPath string) core.StreamID {
+	// remove extension and create streamid
+	p := strings.TrimSuffix(reqPath, path.Ext(reqPath))
+	return core.SplitStreamIDString(cleanStreamPrefix(p))
 }
 
-func parseSegName(reqPath string) string {
-	var segName string
-	regex, _ := regexp.Compile("\\/stream\\/.*\\.ts")
-	match := regex.FindString(reqPath)
-	if match != "" {
-		segName = strings.Replace(match, "/stream/", "", -1)
-	}
-	return segName
+func parseManifestID(reqPath string) core.ManifestID {
+	return parseStreamID(reqPath).ManifestID
 }
 
 func (s *LivepeerServer) GetNodeStatus() *net.NodeStatus {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -317,7 +317,8 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		streamStarted := false
 		//Segment the stream, insert the segments into the broadcaster
 		go func(rtmpStrm stream.RTMPVideoStream) {
-			hlsStrm := stream.NewBasicHLSVideoStream(string(hlsStrmID), stream.DefaultHLSStreamWin)
+			hid := hex.EncodeToString(core.RandomVideoID()) // ffmpeg m3u8 output name
+			hlsStrm := stream.NewBasicHLSVideoStream(hid, stream.DefaultHLSStreamWin)
 			hlsStrm.SetSubscriber(func(seg *stream.HLSSegment, eof bool) {
 				if eof {
 					// XXX update HLS manifest

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -308,8 +308,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 	rendition := hlsStrmID.GetRendition()
 	for i := 0; i < 4; i++ {
 		seg := pl.Segments[i]
-		shouldSegName := fmt.Sprintf("%s/%s/%d.ts", mid, rendition, i)
-		t.Log(shouldSegName)
+		shouldSegName := fmt.Sprintf("/stream/%s/%s/%d.ts", mid, rendition, i)
 		if seg.URI != shouldSegName {
 			t.Fatalf("Wrong segment, should have URI %s, has %s", shouldSegName, seg.URI)
 		}

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -163,7 +163,7 @@ func genSegCreds(sess *BroadcastSession, seg *stream.HLSSegment) (string, error)
 
 	// Generate serialized segment info
 	segData := &net.SegData{
-		ManifestId: md.ManifestID.GetVideoID(),
+		ManifestId: []byte(md.ManifestID),
 		Seq:        md.Seq,
 		Hash:       hash,
 		Profiles:   common.ProfilesToTranscodeOpts(sess.Profiles),
@@ -195,11 +195,7 @@ func verifySegCreds(orch Orchestrator, segCreds string) (*core.SegTranscodingMet
 		glog.Error("Unable to deserialize profiles ", err)
 		return nil, err
 	}
-	mid, err := core.MakeManifestID(segData.ManifestId)
-	if err != nil {
-		glog.Error("Unable to deserialize manifest ID ", err)
-		return nil, err
-	}
+	mid := core.ManifestID(segData.ManifestId)
 
 	var os *net.OSInfo
 	if len(segData.Storage) > 0 {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -130,7 +130,7 @@ func TestRPCTranscoderReq(t *testing.T) {
 }
 
 func TestRPCSeg(t *testing.T) {
-	mid, _ := core.MakeManifestID(core.RandomVideoID())
+	mid := core.RandomManifestID()
 	b := StubBroadcaster2()
 	o := StubOrchestrator()
 	s := &BroadcastSession{
@@ -190,22 +190,18 @@ func TestRPCSeg(t *testing.T) {
 		}
 	}
 
-	// corrupt manifest id
-	corruptSegData(&net.SegData{}, core.ErrManifestID)
-	corruptSegData(&net.SegData{ManifestId: []byte("abc")}, core.ErrManifestID)
-
 	// corrupt profiles
 	corruptSegData(&net.SegData{Profiles: []byte("abc")}, common.ErrProfile)
 
 	// corrupt sig
-	sd := &net.SegData{ManifestId: s.ManifestID.GetVideoID()}
+	sd := &net.SegData{ManifestId: []byte(s.ManifestID)}
 	corruptSegData(sd, ErrSegSig) // missing sig
 	sd.Sig = []byte("abc")
 	corruptSegData(sd, ErrSegSig) // invalid sig
 }
 
 func TestGenPayment(t *testing.T) {
-	mid, _ := core.MakeManifestID(core.RandomVideoID())
+	mid := core.RandomManifestID()
 	b := StubBroadcaster2()
 	s := &BroadcastSession{
 		Broadcaster: b,

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -712,7 +712,7 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 
 	//Print the current broadcast HLS streamID
 	mux.HandleFunc("/streamID", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(LastHLSStreamID))
+		w.Write([]byte(LastHLSStreamID.String()))
 	})
 
 	mux.HandleFunc("/manifestID", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What does this pull request do?
Refactors the StreamID and fixes miscellaneous issues found along the way.

## Specific Updates

### Randomize segmenter output filename

Avoid passing in the HLS Stream ID, since that could be user
supplied, and we don't want to open ourselves up to directory
traversal attacks.

### Return  root-relative URLs from memory store

Fixes an issue that happens when we store playlists hierarchically. That is, given a playlist at `<ManifestID>/<Rendition>.m3u8`, the segment at `<ManifestID>/<Rendition>/<Seq>.ts` would have resulted in the HLS player doing a lookup for
    
    <ManifestID>/<ManifestID>/<Rendition>/<Seq>.ts
    
due to the relative path given by the playlist. Fix this by making the returned path unconditionally root-relative; this results in the correct prefix being applied to the request. Local URLs now become
    
    /source/<ManifestID>/<Rendition>/<Seq>.ts

### Refactor StreamIDs

Loosen up the definition of a StreamID to "any valid string" . This greatly simplifies error handling. While a StreamID can technically be empty, the media server will generate a random Stream ID if an empty ID is passed in via the `hlsStreamID` RTMP query parameter.

By convention, we split StreamIDs into two components: the "manifest ID" and the "rendition" . Either can be empty, but non-empty renditions will generally have a non-empty manifest ID.

Components are separated by path-like slashes. When converting from a string into a StreamID, we use the first component as the ManifestID. The rest is considered part of the rendition. For example:

```
String: abc/def/ghi`
ManifestID: abc
Rendition: def/ghi
```

The test cases cover this extensively, including some "odd" scenarios with multiple leading slashes, whitespace, etc. At some point we may want to consider adding a sanitization/canonicalization step, but it doesn't seem to be required at the moment.

**How did you test each of these updates (required)**
* Unit testing
* Manual testing


**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/go-livepeer/issues/622


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ~~README and other documentation updated~~
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
