### PR TITLE
Ticket struct and related interfaces

### DIFF
--- a/pm/broker.go
+++ b/pm/broker.go
@@ -1,0 +1,55 @@
+package pm
+
+import (
+	"math/big"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+// Broker is an interface which serves as an abstraction over an on-chain
+// smart contract that handles the administrative tasks in a probabilistic micropayment protocol
+// including processing deposits and pay outs
+type Broker interface {
+	// FundAndApproveSigners funds a sender's deposit and penalty escrow in addition
+	// to approving a set of ETH addresses to sign on behalf of the sender
+	FundAndApproveSigners(depositAmount *big.Int, penaltyEscrowAmount *big.Int, signers []ethcommon.Address) error
+
+	// FundDeposit funds a sender's deposit
+	FundDeposit(amount *big.Int) error
+
+	// FundPenaltyEscrow funds a sender's penalty escrow
+	FundPenaltyEscrow(amount *big.Int) error
+
+	// ApproveSigners approves a set of ETH addresses to sign on behalf of the sender
+	ApproveSigners(signers []ethcommon.Address) error
+
+	// RequestSignersRevocation requests the revocation of a set of approved ETH address signers
+	RequestSignersRevocation(signers []ethcommon.Address) error
+
+	// Unlock initiates the unlock period for a sender after which a sender can withdraw its
+	// deposit and penalty escrow
+	Unlock() error
+
+	// CancelUnlock stops a sender's active unlock period
+	CancelUnlock() error
+
+	// Withdraw credits a sender with its deposit and penalty escrow after the sender
+	// waits through the unlock period
+	Withdraw() error
+
+	// RedeemWinningTicket submits a ticket to be validated by the broker and if a valid winning ticket
+	// the broker pays the ticket's face value to the ticket's recipient
+	RedeemWinningTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) error
+
+	// IsUsedTicket checks if a ticket has been used
+	IsUsedTicket(ticket *Ticket) (bool, error)
+
+	// IsApprovedSigner checks if a ETH address signer is approved for a sender
+	IsApprovedSigner(sender ethcommon.Address, signer ethcommon.Address) (bool, error)
+
+	// GetDeposit returns the deposit value managed by the broker for a specified user
+	GetDeposit(addr ethcommon.Address) (*big.Int, error)
+
+	// GetPenaltyEscrow returns the penalty escrow value managed by the broker for a specified user
+	GetPenaltyEscrow(addr ethcommon.Address) (*big.Int, error)
+}

--- a/pm/sigverifier.go
+++ b/pm/sigverifier.go
@@ -12,7 +12,7 @@ import (
 type SigVerifier interface {
 	// Verify checks if a provided signature over a message
 	// is valid for a given ETH address
-	Verify(addr ethcommon.Address, sig []byte, msg []byte) bool
+	Verify(addr ethcommon.Address, msg, sig []byte) bool
 }
 
 // ApprovedSigVerifier is an implementation of the SigVerifier interface
@@ -33,26 +33,26 @@ func NewApprovedSigVerifier(broker Broker) *ApprovedSigVerifier {
 
 // Verify checks if a provided signature over a message
 // is valid for a given ETH address
-func (sv *ApprovedSigVerifier) Verify(addr ethcommon.Address, sig []byte, msg []byte) (bool, error) {
+func (sv *ApprovedSigVerifier) Verify(addr ethcommon.Address, msg, sig []byte) bool {
 	personalMsg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", 32, msg)
 	personalHash := crypto.Keccak256([]byte(personalMsg))
 
 	pubkey, err := crypto.SigToPub(personalHash, sig)
 	if err != nil {
-		return false, err
+		return false
 	}
 
 	rec := crypto.PubkeyToAddress(*pubkey)
 
 	if addr == rec {
 		// If recovered address matches, return early
-		return true, nil
+		return true
 	}
 
 	approved, err := sv.broker.IsApprovedSigner(addr, rec)
 	if err != nil {
-		return false, err
+		return false
 	}
 
-	return approved, nil
+	return approved
 }

--- a/pm/sigverifier.go
+++ b/pm/sigverifier.go
@@ -1,0 +1,58 @@
+package pm
+
+import (
+	"fmt"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// SigVerifier is an interface which describes an object capable
+// of verification of ECDSA signatures produced by ETH addresses
+type SigVerifier interface {
+	// Verify checks if a provided signature over a message
+	// is valid for a given ETH address
+	Verify(addr ethcommon.Address, sig []byte, msg []byte) bool
+}
+
+// ApprovedSigVerifier is an implementation of the SigVerifier interface
+// that relies on an implementation of the Broker interface to provide a registry
+// mapping ETH addresses to approved signer sets. This implementation will
+// recover a ETH address from a signature and check if the recovered address
+// is approved
+type ApprovedSigVerifier struct {
+	broker Broker
+}
+
+// NewApprovedSigVerifier returns an instance of an approved signature verifier
+func NewApprovedSigVerifier(broker Broker) *ApprovedSigVerifier {
+	return &ApprovedSigVerifier{
+		broker: broker,
+	}
+}
+
+// Verify checks if a provided signature over a message
+// is valid for a given ETH address
+func (sv *ApprovedSigVerifier) Verify(addr ethcommon.Address, sig []byte, msg []byte) (bool, error) {
+	personalMsg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", 32, msg)
+	personalHash := crypto.Keccak256([]byte(personalMsg))
+
+	pubkey, err := crypto.SigToPub(personalHash, sig)
+	if err != nil {
+		return false, err
+	}
+
+	rec := crypto.PubkeyToAddress(*pubkey)
+
+	if addr == rec {
+		// If recovered address matches, return early
+		return true, nil
+	}
+
+	approved, err := sv.broker.IsApprovedSigner(addr, rec)
+	if err != nil {
+		return false, err
+	}
+
+	return approved, nil
+}

--- a/pm/sigverifier_test.go
+++ b/pm/sigverifier_test.go
@@ -1,0 +1,76 @@
+package pm
+
+import (
+	"fmt"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestVerify(t *testing.T) {
+	msg := []byte("foo")
+	personalMsg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", 32, msg)
+	personalHash := crypto.Keccak256([]byte(personalMsg))
+
+	senderPrivKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sender := crypto.PubkeyToAddress(senderPrivKey.PublicKey)
+
+	senderSig, err := crypto.Sign(personalHash, senderPrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signerPrivKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signer := crypto.PubkeyToAddress(signerPrivKey.PublicKey)
+
+	signerSig, err := crypto.Sign(personalHash, signerPrivKey)
+
+	b := &stubBroker{
+		usedTickets:     make(map[ethcommon.Hash]bool),
+		approvedSigners: make(map[ethcommon.Address]bool),
+	}
+
+	sv := NewApprovedSigVerifier(b)
+
+	// Test invalid signature for non-approved signer
+	valid, err := sv.Verify(sender, signerSig, msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if valid {
+		t.Fatal("expected invalid signature for non-approved signer")
+	}
+
+	// Test valid signature for approved signer
+	// Approve signer
+	b.ApproveSigners([]ethcommon.Address{signer})
+
+	valid, err = sv.Verify(sender, signerSig, msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !valid {
+		t.Fatal("expected valid signature for approved signer")
+	}
+
+	// Test valid signature for sender
+	valid, err = sv.Verify(sender, senderSig, msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !valid {
+		t.Fatal("expected valid signature for sender")
+	}
+}

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -1,0 +1,78 @@
+package pm
+
+import (
+	"math/big"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+type stubSigVerifier struct {
+	shouldVerify bool
+}
+
+func (sv *stubSigVerifier) Verify(addr ethcommon.Address, sig []byte, msg []byte) bool {
+	return sv.shouldVerify
+}
+
+type stubBroker struct {
+	usedTickets     map[ethcommon.Hash]bool
+	approvedSigners map[ethcommon.Address]bool
+}
+
+func (b *stubBroker) FundAndApproveSigners(depositAmount *big.Int, penaltyEscrowAmount *big.Int, signers []ethcommon.Address) error {
+	return nil
+}
+
+func (b *stubBroker) FundDeposit(amount *big.Int) error {
+	return nil
+}
+
+func (b *stubBroker) FundPenaltyEscrow(amount *big.Int) error {
+	return nil
+}
+
+func (b *stubBroker) ApproveSigners(signers []ethcommon.Address) error {
+	for i := 0; i < len(signers); i++ {
+		b.approvedSigners[signers[i]] = true
+	}
+
+	return nil
+}
+
+func (b *stubBroker) RequestSignersRevocation(signers []ethcommon.Address) error {
+	return nil
+}
+
+func (b *stubBroker) Unlock() error {
+	return nil
+}
+
+func (b *stubBroker) CancelUnlock() error {
+	return nil
+}
+
+func (b *stubBroker) Withdraw() error {
+	return nil
+}
+
+func (b *stubBroker) RedeemWinningTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) error {
+	b.usedTickets[ticket.Hash()] = true
+
+	return nil
+}
+
+func (b *stubBroker) IsUsedTicket(ticket *Ticket) (bool, error) {
+	return b.usedTickets[ticket.Hash()], nil
+}
+
+func (b *stubBroker) IsApprovedSigner(sender ethcommon.Address, signer ethcommon.Address) (bool, error) {
+	return b.approvedSigners[signer], nil
+}
+
+func (b *stubBroker) GetDeposit(addr ethcommon.Address) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+
+func (b *stubBroker) GetPenaltyEscrow(addr ethcommon.Address) (*big.Int, error) {
+	return big.NewInt(0), nil
+}

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -8,15 +8,15 @@ import (
 )
 
 type stubSigVerifier struct {
-	shouldVerify bool
+	verifyResult bool
 }
 
-func (sv *stubSigVerifier) SetShouldVerify(shouldVerify bool) {
-	sv.shouldVerify = shouldVerify
+func (sv *stubSigVerifier) SetVerifyResult(verifyResult bool) {
+	sv.verifyResult = verifyResult
 }
 
-func (sv *stubSigVerifier) Verify(addr ethcommon.Address, sig []byte, msg []byte) bool {
-	return sv.shouldVerify
+func (sv *stubSigVerifier) Verify(addr ethcommon.Address, msg, sig []byte) bool {
+	return sv.verifyResult
 }
 
 type stubBroker struct {

--- a/pm/ticket.go
+++ b/pm/ticket.go
@@ -1,0 +1,109 @@
+package pm
+
+import (
+	"math/big"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Constants for byte sizes of Solidity types
+const (
+	addressSize = 20
+	uint256Size = 32
+	bytes32Size = 32
+)
+
+// Broker is an interface which serves as an abstraction over an on-chain
+// smart contract that handles the administrative tasks in a probabilistic micropayment protocol
+// including processing deposits and pay outs
+type Broker interface {
+	// FundAndApproveSigners funds a sender's deposit and penalty escrow in addition
+	// to approving a set of ETH addresses to sign on behalf of the sender
+	FundAndApproveSigners(depositAmount *big.Int, penaltyEscrowAmount *big.Int, signers []ethcommon.Address) error
+
+	// FundDeposit funds a sender's deposit
+	FundDeposit(amount *big.Int) error
+
+	// FundPenaltyEscrow funds a sender's penalty escrow
+	FundPenaltyEscrow(amount *big.Int) error
+
+	// ApproveSigners approves a set of ETH addresses to sign on behalf of the sender
+	ApproveSigners(signers []ethcommon.Address) error
+
+	// RequestSignersRevocation requests the revocation of a set of approved ETH address signers
+	RequestSignersRevocation(signers []ethcommon.Address) error
+
+	// Unlock initiates the unlock period for a sender after which a sender can withdraw its
+	// deposit and penalty escrow
+	Unlock() error
+
+	// CancelUnlock stops a sender's active unlock period
+	CancelUnlock() error
+
+	// Withdraw credits a sender with its deposit and penalty escrow after the sender
+	// waits through the unlock period
+	Withdraw() error
+
+	// RedeemWinningTicket submits a ticket to be validated by the broker and if a valid winning ticket
+	// the broker pays the ticket's face value to the ticket's recipient
+	RedeemWinningTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) error
+
+	// IsUsedTicket checks if a ticket has been used
+	IsUsedTicket(ticket *Ticket) (bool, error)
+
+	// IsApprovedSigner checks if a ETH address signer is approved for a sender
+	IsApprovedSigner(sender ethcommon.Address, signer ethcommon.Address) (bool, error)
+
+	// GetDeposit returns the deposit value managed by the broker for a specified user
+	GetDeposit(addr ethcommon.Address) (*big.Int, error)
+
+	// GetPenaltyEscrow returns the penalty escrow value managed by the broker for a specified user
+	GetPenaltyEscrow(addr ethcommon.Address) (*big.Int, error)
+}
+
+// Ticket is lottery ticket payment in a probabilistic micropayment protocol
+// The expected value of the ticket constitutes the payment and can be
+// calculated using the ticket's face value and winning probability
+type Ticket struct {
+	// Recipient is the ETH address of recipient
+	Recipient ethcommon.Address
+
+	// Sender is the ETH address of sender
+	Sender ethcommon.Address
+
+	// FaceValue represents the pay out to
+	// the recipient if the ticket wins
+	FaceValue *big.Int
+
+	// WinProb represents how likely a ticket will win
+	WinProb *big.Int
+
+	// SenderNonce is the monotonically increasing counter that makes
+	// each ticket unique given a particular recipientRand value
+	SenderNonce uint64
+
+	// RecipientRandHash is the 32 byte keccak-256 hash commitment to a random number
+	// provided by the recipient. In order for the recipient to redeem
+	// a winning ticket, it must reveal the preimage to this hash
+	RecipientRandHash ethcommon.Hash
+}
+
+// Hash returns the keccak-256 hash of the ticket's fields as tightly packed
+// arguments as described in the Solidity documentation
+// See: https://solidity.readthedocs.io/en/v0.4.25/units-and-global-variables.html#mathematical-and-cryptographic-functions
+func (t *Ticket) Hash() ethcommon.Hash {
+	return crypto.Keccak256Hash(t.flatten())
+}
+
+func (t *Ticket) flatten() []byte {
+	buf := make([]byte, addressSize+addressSize+uint256Size+uint256Size+uint256Size+bytes32Size)
+	i := copy(buf[0:], t.Recipient.Bytes())
+	i += copy(buf[i:], t.Sender.Bytes())
+	i += copy(buf[i:], ethcommon.LeftPadBytes(t.FaceValue.Bytes(), uint256Size))
+	i += copy(buf[i:], ethcommon.LeftPadBytes(t.WinProb.Bytes(), uint256Size))
+	i += copy(buf[i:], ethcommon.LeftPadBytes(new(big.Int).SetUint64(t.SenderNonce).Bytes(), uint256Size))
+	i += copy(buf[i:], t.RecipientRandHash.Bytes())
+
+	return buf
+}

--- a/pm/ticket.go
+++ b/pm/ticket.go
@@ -14,54 +14,6 @@ const (
 	bytes32Size = 32
 )
 
-// Broker is an interface which serves as an abstraction over an on-chain
-// smart contract that handles the administrative tasks in a probabilistic micropayment protocol
-// including processing deposits and pay outs
-type Broker interface {
-	// FundAndApproveSigners funds a sender's deposit and penalty escrow in addition
-	// to approving a set of ETH addresses to sign on behalf of the sender
-	FundAndApproveSigners(depositAmount *big.Int, penaltyEscrowAmount *big.Int, signers []ethcommon.Address) error
-
-	// FundDeposit funds a sender's deposit
-	FundDeposit(amount *big.Int) error
-
-	// FundPenaltyEscrow funds a sender's penalty escrow
-	FundPenaltyEscrow(amount *big.Int) error
-
-	// ApproveSigners approves a set of ETH addresses to sign on behalf of the sender
-	ApproveSigners(signers []ethcommon.Address) error
-
-	// RequestSignersRevocation requests the revocation of a set of approved ETH address signers
-	RequestSignersRevocation(signers []ethcommon.Address) error
-
-	// Unlock initiates the unlock period for a sender after which a sender can withdraw its
-	// deposit and penalty escrow
-	Unlock() error
-
-	// CancelUnlock stops a sender's active unlock period
-	CancelUnlock() error
-
-	// Withdraw credits a sender with its deposit and penalty escrow after the sender
-	// waits through the unlock period
-	Withdraw() error
-
-	// RedeemWinningTicket submits a ticket to be validated by the broker and if a valid winning ticket
-	// the broker pays the ticket's face value to the ticket's recipient
-	RedeemWinningTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) error
-
-	// IsUsedTicket checks if a ticket has been used
-	IsUsedTicket(ticket *Ticket) (bool, error)
-
-	// IsApprovedSigner checks if a ETH address signer is approved for a sender
-	IsApprovedSigner(sender ethcommon.Address, signer ethcommon.Address) (bool, error)
-
-	// GetDeposit returns the deposit value managed by the broker for a specified user
-	GetDeposit(addr ethcommon.Address) (*big.Int, error)
-
-	// GetPenaltyEscrow returns the penalty escrow value managed by the broker for a specified user
-	GetPenaltyEscrow(addr ethcommon.Address) (*big.Int, error)
-}
-
 // Ticket is lottery ticket payment in a probabilistic micropayment protocol
 // The expected value of the ticket constitutes the payment and can be
 // calculated using the ticket's face value and winning probability

--- a/pm/ticket_test.go
+++ b/pm/ticket_test.go
@@ -1,0 +1,107 @@
+package pm
+
+import (
+	"math"
+	"math/big"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+func hexToHash(in string) ethcommon.Hash {
+	return ethcommon.BytesToHash(ethcommon.FromHex(in))
+}
+func TestHash(t *testing.T) {
+	exp := hexToHash("24d4264d5ea56ba4362c8f535308005b2df1f9f77c34b4a61f6b5c3bef151b53")
+	ticket := &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            ethcommon.Address{},
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       math.MaxUint64,
+		RecipientRandHash: ethcommon.Hash{},
+	}
+	h := ticket.Hash()
+
+	if h != exp {
+		t.Errorf("Expected %v got %v", exp, h)
+	}
+
+	exp = hexToHash("ce0918ba94518293e9712effbe5fca4f1f431089833a5b8c257cb1e024595f68")
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            ethcommon.Address{},
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       1,
+		RecipientRandHash: ethcommon.Hash{},
+	}
+	h = ticket.Hash()
+
+	if h != exp {
+		t.Errorf("Expected %v got %v", exp, h)
+	}
+
+	exp = hexToHash("87ef13f2d37e4d5352a01d3c77b8179d80e0887f1953bfabfd0bfd7b0f689ddd")
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            ethcommon.Address{},
+		FaceValue:         big.NewInt(1),
+		WinProb:           big.NewInt(500),
+		SenderNonce:       0,
+		RecipientRandHash: ethcommon.Hash{},
+	}
+	h = ticket.Hash()
+
+	if h != exp {
+		t.Errorf("Expected %v got %v", exp, h)
+	}
+
+	exp = hexToHash("aa4b35071043587992ac8b9dd1b2cf1d8311130e6458cf0b2342484e21af5f5b")
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            ethcommon.Address{},
+		FaceValue:         big.NewInt(500),
+		WinProb:           big.NewInt(1),
+		SenderNonce:       0,
+		RecipientRandHash: ethcommon.Hash{},
+	}
+	h = ticket.Hash()
+
+	if h != exp {
+		t.Errorf("Expected %v got %v", exp, h)
+	}
+
+	exp = hexToHash("81e353ae39046e2b77b9f996abbaeed527fda559b61ef90f299c4499dd508ccc")
+	ticket = &Ticket{
+		Recipient:         ethcommon.HexToAddress("73AEd7b5dEb30222fa896f399d46cC99c7BEe57F"),
+		Sender:            ethcommon.Address{},
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       0,
+		RecipientRandHash: ethcommon.Hash{},
+	}
+	h = ticket.Hash()
+
+	if h != exp {
+		t.Errorf("Expected %v got %v", exp, h)
+	}
+
+	var recipientRandHash [32]byte
+	copy(recipientRandHash[:], ethcommon.FromHex("41b1a0649752af1b28b3dc29a1556eee781e4a4c3a1f7f53f90fa834de098c4d")[:32])
+
+	exp = hexToHash("be5eaf9a49a39540b9bb02f1a21904f61324a29819e2c032824bfaa10c100b17")
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            ethcommon.Address{},
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       0,
+		RecipientRandHash: recipientRandHash,
+	}
+	h = ticket.Hash()
+
+	if h != exp {
+		t.Errorf("Expected %v got %v", exp, h)
+	}
+}

--- a/pm/validator.go
+++ b/pm/validator.go
@@ -1,0 +1,79 @@
+package pm
+
+import (
+	"fmt"
+	"math/big"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Validator is an interface which describes an object capable
+// of validating tickets
+type Validator interface {
+	// IsValidTicket checks if a ticket is valid
+	IsValidTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) (bool, error)
+
+	// IsWinningTicket checks if a ticket won
+	// Note: This method does not check if a ticket is valid which is done using IsValidTicket
+	IsWinningTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) bool
+}
+
+// validator is an implementation of the Validator interface
+// that relies on an implementation of the Broker interface to provide
+// a set of already used tickets
+type validator struct {
+	addr        ethcommon.Address
+	broker      Broker
+	sigVerifier SigVerifier
+}
+
+// NewValidator returns an instance of a validator
+func NewValidator(addr ethcommon.Address, broker Broker, sigVerifier SigVerifier) Validator {
+	return &validator{
+		addr:        addr,
+		broker:      broker,
+		sigVerifier: sigVerifier,
+	}
+}
+
+// IsValidTicket checks if a ticket is valid
+func (v *validator) IsValidTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) (bool, error) {
+	if ticket.Recipient != v.addr {
+		return false, fmt.Errorf("invalid ticket recipient")
+	}
+
+	if (ticket.Sender == ethcommon.Address{}) {
+		return false, fmt.Errorf("invalid ticket sender")
+	}
+
+	if crypto.Keccak256Hash(recipientRand.Bytes()) != ticket.RecipientRandHash {
+		return false, fmt.Errorf("invalid preimage provided for hash commitment recipientRandHash")
+	}
+
+	used, err := v.broker.IsUsedTicket(ticket)
+	if err != nil {
+		return false, err
+	}
+
+	if used {
+		return false, fmt.Errorf("ticket has already been used")
+	}
+
+	if v.sigVerifier.Verify(ticket.Sender, sig, ticket.Hash().Bytes()) {
+		return false, fmt.Errorf("invalid sender signature over ticket hash")
+	}
+
+	return true, nil
+}
+
+// IsWinningTicket checks if a ticket won
+// Note: This method does not check if a ticket is valid which is done using IsValidTicket
+// A ticket wins if:
+// H(SIG(H(T)), T.RecipientRand) < T.WinProb
+func (v *validator) IsWinningTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) bool {
+	recipientRandBytes := ethcommon.LeftPadBytes(recipientRand.Bytes(), bytes32Size)
+	res := new(big.Int).SetBytes(crypto.Keccak256(sig, recipientRandBytes))
+
+	return res.Cmp(ticket.WinProb) < 0
+}

--- a/pm/validator.go
+++ b/pm/validator.go
@@ -11,11 +11,11 @@ import (
 // Validator is an interface which describes an object capable
 // of validating tickets
 type Validator interface {
-	// IsValidTicket checks if a ticket is valid
-	IsValidTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) (bool, error)
+	// ValidateTicket checks if a ticket is valid
+	ValidateTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) error
 
 	// IsWinningTicket checks if a ticket won
-	// Note: This method does not check if a ticket is valid which is done using IsValidTicket
+	// Note: This method does not check if a ticket is valid which is done using ValidateTicket
 	IsWinningTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) bool
 }
 
@@ -37,34 +37,34 @@ func NewValidator(addr ethcommon.Address, broker Broker, sigVerifier SigVerifier
 	}
 }
 
-// IsValidTicket checks if a ticket is valid
-func (v *validator) IsValidTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) (bool, error) {
+// ValidateTicket checks if a ticket is valid
+func (v *validator) ValidateTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) error {
 	if ticket.Recipient != v.addr {
-		return false, fmt.Errorf("invalid ticket recipient")
+		return fmt.Errorf("invalid ticket recipient")
 	}
 
 	if (ticket.Sender == ethcommon.Address{}) {
-		return false, fmt.Errorf("invalid ticket sender")
+		return fmt.Errorf("invalid ticket sender")
 	}
 
-	if crypto.Keccak256Hash(recipientRand.Bytes()) != ticket.RecipientRandHash {
-		return false, fmt.Errorf("invalid preimage provided for hash commitment recipientRandHash")
+	if crypto.Keccak256Hash(ethcommon.LeftPadBytes(recipientRand.Bytes(), uint256Size)) != ticket.RecipientRandHash {
+		return fmt.Errorf("invalid preimage provided for hash commitment recipientRandHash")
 	}
 
 	used, err := v.broker.IsUsedTicket(ticket)
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	if used {
-		return false, fmt.Errorf("ticket has already been used")
+		return fmt.Errorf("ticket has already been used")
 	}
 
-	if v.sigVerifier.Verify(ticket.Sender, sig, ticket.Hash().Bytes()) {
-		return false, fmt.Errorf("invalid sender signature over ticket hash")
+	if !v.sigVerifier.Verify(ticket.Sender, sig, ticket.Hash().Bytes()) {
+		return fmt.Errorf("invalid sender signature over ticket hash")
 	}
 
-	return true, nil
+	return nil
 }
 
 // IsWinningTicket checks if a ticket won

--- a/pm/validator_test.go
+++ b/pm/validator_test.go
@@ -1,0 +1,176 @@
+package pm
+
+import (
+	"math/big"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestIsValidTicket(t *testing.T) {
+	recipient := ethcommon.HexToAddress("73AEd7b5dEb30222fa896f399d46cC99c7BEe57F")
+	sender := ethcommon.HexToAddress("A69cdA26600c155cF2c150964Bdb5371ac3f606F")
+	sig := []byte("foo")
+	recipientRand := big.NewInt(10)
+	recipientRandHash := crypto.Keccak256Hash(ethcommon.LeftPadBytes(recipientRand.Bytes(), uint256Size))
+
+	b := &stubBroker{
+		usedTickets: make(map[ethcommon.Hash]bool),
+	}
+	sv := &stubSigVerifier{
+		shouldVerify: true,
+	}
+
+	v := NewValidator(recipient, b, sv)
+
+	// Test invalid recipient (null address)
+	ticket := &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            ethcommon.Address{},
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       0,
+		RecipientRandHash: recipientRandHash,
+	}
+
+	valid, err := v.IsValidTicket(ticket, sig, recipientRand)
+	if err == nil || valid {
+		t.Fatal("expected invalid recipient (null address)")
+	}
+
+	// Test invalid recipient (non-null address)
+	ticket = &Ticket{
+		Recipient:         sender,
+		Sender:            ethcommon.Address{},
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       0,
+		RecipientRandHash: recipientRandHash,
+	}
+
+	valid, err = v.IsValidTicket(ticket, sig, recipientRand)
+	if err == nil || valid {
+		t.Fatal("expected invalid recipient (non-null address)")
+	}
+
+	// Test invalid sender
+	ticket = &Ticket{
+		Recipient:         recipient,
+		Sender:            ethcommon.Address{},
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       0,
+		RecipientRandHash: recipientRandHash,
+	}
+
+	valid, err = v.IsValidTicket(ticket, sig, recipientRand)
+	if err == nil || valid {
+		t.Fatal("expected invalid sender")
+	}
+
+	// Test invalid preimage for commitment recipientRandHash
+	ticket = &Ticket{
+		Recipient:         recipient,
+		Sender:            sender,
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       0,
+		RecipientRandHash: ethcommon.Hash{},
+	}
+
+	valid, err = v.IsValidTicket(ticket, sig, recipientRand)
+	if err == nil || valid {
+		t.Fatal("expected invalid preimage for commitment recipientRandHash")
+	}
+
+	// Test used ticket
+	ticket = &Ticket{
+		Recipient:         recipient,
+		Sender:            sender,
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       0,
+		RecipientRandHash: recipientRandHash,
+	}
+	// Set ticket as used in stub broker
+	b.RedeemWinningTicket(ticket, sig, recipientRand)
+
+	valid, err = v.IsValidTicket(ticket, sig, recipientRand)
+	if err == nil || valid {
+		t.Fatal("expected used ticket")
+	}
+
+	// Test invalid signature
+	// Create ticket with new senderNonce
+	ticket = &Ticket{
+		Recipient:         recipient,
+		Sender:            sender,
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       1,
+		RecipientRandHash: recipientRandHash,
+	}
+	// Set signature verification to return false
+	sv.shouldVerify = false
+
+	valid, err = v.IsValidTicket(ticket, sig, recipientRand)
+	if err == nil || valid {
+		t.Fatal("expected invalid signature")
+	}
+
+	// Test valid ticket
+	// Set signature verification to return true
+	sv.shouldVerify = true
+
+	valid, err = v.IsValidTicket(ticket, sig, recipientRand)
+	if err == nil || valid {
+		t.Fatal("expected valid ticket")
+	}
+}
+
+func TestIsWinningTicket(t *testing.T) {
+	recipient := ethcommon.HexToAddress("73AEd7b5dEb30222fa896f399d46cC99c7BEe57F")
+	sender := ethcommon.HexToAddress("A69cdA26600c155cF2c150964Bdb5371ac3f606F")
+	sig := []byte("foo")
+	recipientRand := big.NewInt(10)
+	recipientRandHash := crypto.Keccak256Hash(ethcommon.LeftPadBytes(recipientRand.Bytes(), uint256Size))
+
+	b := &stubBroker{
+		usedTickets: make(map[ethcommon.Hash]bool),
+	}
+	sv := &stubSigVerifier{
+		shouldVerify: true,
+	}
+
+	v := NewValidator(recipient, b, sv)
+
+	// Test non-winning ticket
+	ticket := &Ticket{
+		Recipient:         recipient,
+		Sender:            sender,
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		SenderNonce:       0,
+		RecipientRandHash: recipientRandHash,
+	}
+
+	if v.IsWinningTicket(ticket, sig, recipientRand) {
+		t.Fatal("expected non-winning ticket")
+	}
+
+	// Test winning ticket
+	maxUint256 := new(big.Int).Sub(new(big.Int).Exp(big.NewInt(2), big.NewInt(256), nil), big.NewInt(1))
+	ticket = &Ticket{
+		Recipient:         recipient,
+		Sender:            sender,
+		FaceValue:         big.NewInt(0),
+		WinProb:           maxUint256,
+		SenderNonce:       0,
+		RecipientRandHash: recipientRandHash,
+	}
+
+	if !v.IsWinningTicket(ticket, sig, recipientRand) {
+		t.Fatal("expected winning ticket")
+	}
+}

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -80,7 +80,7 @@ func TestStartBroadcast(t *testing.T) {
 
 	sd := &stubDiscovery{}
 	// Discovery returned no orchestrators
-	s.LivepeerNode.OrchestratorSelector = sd
+	s.LivepeerNode.OrchestratorPool = sd
 	if sess, _ := s.startBroadcast(pl); sess != nil {
 		t.Error("Expected nil session")
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Adds common PM ticket related code that will be used by both a sender and a recipient in the PM protocol.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds the `pm` package
- Adds a `Ticket` struct that reflects the data included in on-chain redemption transactions. Note: The auxiliary data for expiration validation is omitted for the time being until a concrete decision is made on our desired expiration policy
- Adds a `Broker` interface that serves as an abstraction over the on-chain smart contract and its functions
- Adds a `Validator` interface with functions for validating a ticket and checking for a winning ticket. The `BrokerValidator` implementation uses an implementation of the `Broker` interface to check for used tickets (replay prevention) and an implementation of the `SigVerifier` interface to validate signatures over ticket hashes
- Adds a `SigVerifier` interface with functions for verifying signatures. The `BrokerSigVerifier` implementation uses an implementation of the `Broker` interface to check for approved signers when verifying a signature.

**How did you test each of these updates (required)**

- Unit tests for each new component with stubbed out dependencies

**Does this pull request close any open issues?**
<!-- Fixes # -->

- Fixes #626 
- Fixes #628

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
