### PR TITLE
Rendition handling updates

### DIFF
--- a/core/playlistmanager.go
+++ b/core/playlistmanager.go
@@ -18,11 +18,11 @@ type PlaylistManager interface {
 	ManifestID() ManifestID
 	// Implicitly creates master and media playlists
 	// Inserts in media playlist given a link to a segment
-	InsertHLSSegment(streamID StreamID, seqNo uint64, uri string, duration float64) error
+	InsertHLSSegment(profile *ffmpeg.VideoProfile, seqNo uint64, uri string, duration float64) error
 
 	GetHLSMasterPlaylist() *m3u8.MasterPlaylist
 
-	GetHLSMediaPlaylist(streamID StreamID) *m3u8.MediaPlaylist
+	GetHLSMediaPlaylist(rendition string) *m3u8.MediaPlaylist
 
 	GetOSSession() drivers.OSSession
 
@@ -34,7 +34,7 @@ type BasicPlaylistManager struct {
 	manifestID     ManifestID
 	// Live playlist used for broadcasting
 	masterPList *m3u8.MasterPlaylist
-	mediaLists  map[StreamID]*m3u8.MediaPlaylist
+	mediaLists  map[string]*m3u8.MediaPlaylist
 	mapSync     *sync.RWMutex
 }
 
@@ -46,7 +46,7 @@ func NewBasicPlaylistManager(manifestID ManifestID,
 		storageSession: storageSession,
 		manifestID:     manifestID,
 		masterPList:    m3u8.NewMasterPlaylist(),
-		mediaLists:     make(map[StreamID]*m3u8.MediaPlaylist),
+		mediaLists:     make(map[string]*m3u8.MediaPlaylist),
 		mapSync:        &sync.RWMutex{},
 	}
 	return bplm
@@ -64,55 +64,34 @@ func (mgr *BasicPlaylistManager) GetOSSession() drivers.OSSession {
 	return mgr.storageSession
 }
 
-func (mgr *BasicPlaylistManager) isRightStream(streamID StreamID) error {
-	mid := streamID.ManifestID
-	if mid != mgr.manifestID {
-		return fmt.Errorf("Wrong manifest id (%s), should be %s", mid, mgr.manifestID)
-	}
-	return nil
-}
-
-func (mgr *BasicPlaylistManager) hasSegment(mpl *m3u8.MediaPlaylist, seqNum uint64) bool {
-	for _, seg := range mpl.Segments {
-		if seg != nil && seg.SeqId == seqNum {
-			return true
-		}
-	}
-	return false
-}
-
-func (mgr *BasicPlaylistManager) getPL(streamID StreamID) *m3u8.MediaPlaylist {
+func (mgr *BasicPlaylistManager) getPL(rendition string) *m3u8.MediaPlaylist {
 	mgr.mapSync.RLock()
-	mpl := mgr.mediaLists[streamID]
+	mpl := mgr.mediaLists[rendition]
 	mgr.mapSync.RUnlock()
 	return mpl
 }
 
-func (mgr *BasicPlaylistManager) createPL(streamID StreamID) *m3u8.MediaPlaylist {
+func (mgr *BasicPlaylistManager) createPL(profile *ffmpeg.VideoProfile) *m3u8.MediaPlaylist {
 	mpl, err := m3u8.NewMediaPlaylist(LIVE_LIST_LENGTH, LIVE_LIST_LENGTH)
 	if err != nil {
 		glog.Error(err)
 		return nil
 	}
 	mgr.mapSync.Lock()
-	mgr.mediaLists[streamID] = mpl
+	mgr.mediaLists[profile.Name] = mpl
 	mgr.mapSync.Unlock()
-	sid := streamID.String()
-	vParams := ffmpeg.VideoProfileToVariantParams(ffmpeg.VideoProfileLookup[streamID.Rendition])
-	url := sid + ".m3u8"
+	vParams := ffmpeg.VideoProfileToVariantParams(*profile)
+	url := fmt.Sprintf("%v/%v.m3u8", mgr.manifestID, profile.Name)
 	mgr.masterPList.Append(url, mpl, vParams)
 	return mpl
 }
 
-func (mgr *BasicPlaylistManager) InsertHLSSegment(streamID StreamID, seqNo uint64, uri string,
+func (mgr *BasicPlaylistManager) InsertHLSSegment(profile *ffmpeg.VideoProfile, seqNo uint64, uri string,
 	duration float64) error {
 
-	if err := mgr.isRightStream(streamID); err != nil {
-		return err
-	}
-	mpl := mgr.getPL(streamID)
+	mpl := mgr.getPL(profile.Name)
 	if mpl == nil {
-		mpl = mgr.createPL(streamID)
+		mpl = mgr.createPL(profile)
 	}
 	return mgr.addToMediaPlaylist(uri, seqNo, duration, mpl)
 }
@@ -153,6 +132,6 @@ func (mgr *BasicPlaylistManager) GetHLSMasterPlaylist() *m3u8.MasterPlaylist {
 }
 
 // GetHLSMediaPlaylist ...
-func (mgr *BasicPlaylistManager) GetHLSMediaPlaylist(streamID StreamID) *m3u8.MediaPlaylist {
-	return mgr.mediaLists[streamID]
+func (mgr *BasicPlaylistManager) GetHLSMediaPlaylist(rendition string) *m3u8.MediaPlaylist {
+	return mgr.getPL(rendition)
 }

--- a/core/playlistmanager_test.go
+++ b/core/playlistmanager_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/ericxtang/m3u8"
@@ -16,7 +15,7 @@ func TestGetMasterPlaylist(t *testing.T) {
 	mid := hlsStrmID.ManifestID
 	c := NewBasicPlaylistManager(mid, nil)
 	segName := "test_seg/1.ts"
-	err := c.InsertHLSSegment(hlsStrmID, 1, segName, 12)
+	err := c.InsertHLSSegment(&vProfile, 1, segName, 12)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +27,7 @@ func TestGetMasterPlaylist(t *testing.T) {
 		t.Errorf("Expecting %v, got %v", pl.String(), testpl.String())
 	}
 
-	mpl := c.GetHLSMediaPlaylist(hlsStrmID)
+	mpl := c.GetHLSMediaPlaylist(vProfile.Name)
 	if mpl == nil {
 		t.Fatalf("Expecting pl, got nil")
 	}
@@ -39,18 +38,19 @@ func TestGetMasterPlaylist(t *testing.T) {
 }
 
 func TestForWrongStream(t *testing.T) {
+	/* Mismatched streams don't really happen anymore
 	vProfile := ffmpeg.P144p30fps16x9
 	hlsStrmID := MakeStreamID(RandomManifestID(), &vProfile)
 	mid := hlsStrmID.ManifestID
 	c := NewBasicPlaylistManager(mid, nil)
-	hlsStrmID2 := MakeStreamID(RandomManifestID(), &vProfile)
-	err := c.InsertHLSSegment(hlsStrmID2, 1, "test_uri", 12)
+	err := c.InsertHLSSegment(&vProfile, 1, "test_uri", 12)
 	if err == nil {
 		t.Fatalf("Should fail here")
 	}
 	if !strings.Contains(err.Error(), "Wrong manifest id") {
 		t.Fatalf("Wrong error, should contain 'Wrong stream id', but has %s", err.Error())
 	}
+	*/
 }
 
 func TestCleanup(t *testing.T) {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -147,7 +147,7 @@ func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID str
 		//Create a ManifestID
 		//If manifestID is passed in, use that one
 		//Else create one
-		mid := parseManifestID(url.Query().Get("hlsStrmID"))
+		mid := parseManifestID(url.Query().Get("manifestID"))
 		if mid == "" {
 			mid = core.RandomManifestID()
 		}
@@ -275,13 +275,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 			// TODO: Check broadcaster's deposit with TicketBroker
 		}
 
-		//Create a HLS StreamID
-		//If streamID is passed in, use that one to capture the rendition
-		//Else use RTMP manifest ID as base
-		hlsStrmID := parseStreamID(url.Query().Get("hlsStrmID"))
-		if hlsStrmID.ManifestID == "" || hlsStrmID.Rendition == "" {
-			hlsStrmID = core.MakeStreamID(mid, &vProfile)
-		}
+		hlsStrmID := core.MakeStreamID(mid, &vProfile)
 
 		LastHLSStreamID = hlsStrmID
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -246,18 +246,12 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		s.connectionLock.Unlock()
 		LastManifestID = mid
 
-		//We try to automatically determine the video profile from the RTMP stream.
-		var vProfile ffmpeg.VideoProfile
+		// Build the source video profile from the RTMP stream.
 		resolution := fmt.Sprintf("%vx%v", rtmpStrm.Width(), rtmpStrm.Height())
-		for _, vp := range ffmpeg.VideoProfileLookup {
-			if vp.Resolution == resolution {
-				vProfile = vp
-				break
-			}
-		}
-		if vProfile.Name == "" {
-			vProfile = ffmpeg.P720p30fps16x9
-			glog.V(common.SHORT).Infof("Cannot automatically detect the video profile - setting it to %v", vProfile)
+		vProfile := ffmpeg.VideoProfile{
+			Name:       "source",
+			Resolution: resolution,
+			Bitrate:    "4000k", // Fix this
 		}
 
 		startSeq := 0
@@ -325,7 +319,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 				if cpl.GetOSSession().IsExternal() {
 					seg.Name = uri // hijack seg.Name to convey the uploaded URI
 				}
-				err = cpl.InsertHLSSegment(hlsStrmID, seg.SeqNo, uri, seg.Duration)
+				err = cpl.InsertHLSSegment(&vProfile, seg.SeqNo, uri, seg.Duration)
 				if monitor.Enabled {
 					monitor.LogSourceSegmentAppeared(nonce, seg.SeqNo, string(mid), vProfile.Name)
 					glog.V(6).Infof("Appeared segment %d", seg.SeqNo)
@@ -410,12 +404,10 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 								SegHashLock.Unlock()
 							}
 
-							// hoist this out so we only do it once
-							sid := core.MakeStreamID(mid, &sess.Profiles[i])
-							err = cpl.InsertHLSSegment(sid, seg.SeqNo, url, seg.Duration)
 							if monitor.Enabled {
 								monitor.LogTranscodedSegmentAppeared(nonce, seg.SeqNo, sess.Profiles[i].Name)
 							}
+							err = cpl.InsertHLSSegment(&sess.Profiles[i], seg.SeqNo, url, seg.Duration)
 							if err != nil {
 								errFunc("Playlist", url, err)
 								return
@@ -557,7 +549,7 @@ func getHLSMediaPlaylistHandler(s *LivepeerServer) func(url *url.URL) (*m3u8.Med
 		}
 
 		//Get the hls playlist
-		pl := cxn.pl.GetHLSMediaPlaylist(strmID)
+		pl := cxn.pl.GetHLSMediaPlaylist(strmID.Rendition)
 		if pl == nil {
 			return nil, vidplayer.ErrNotFound
 		}

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -172,12 +172,12 @@ func TestCreateRTMPStreamHandler(t *testing.T) {
 	// Test hlsStreamID query param
 	key := hex.EncodeToString(core.RandomIdGenerator(StreamKeyBytes))
 	expectedSid := core.MakeStreamIDFromString("ghijkl", key)
-	u, _ := url.Parse("rtmp://localhost?hlsStrmID=" + expectedSid.String()) // with key
+	u, _ := url.Parse("rtmp://localhost?manifestID=" + expectedSid.String()) // with key
 	if sid := createSid(u); sid != expectedSid.String() {
 		t.Error("Unexpected streamid")
 	}
 	expectedMid := "mnopq"
-	u, _ = url.Parse("rtmp://localhost?hlsStrmID=" + string(expectedMid)) // without key
+	u, _ = url.Parse("rtmp://localhost?manifestID=" + string(expectedMid)) // without key
 	if sid := createSid(u); sid != string(expectedMid)+"/"+key {
 		t.Error("Unexpected streamid")
 	}
@@ -206,15 +206,17 @@ func TestCreateRTMPStreamHandler(t *testing.T) {
 	// Test a couple of odd cases; subset of parseManifestID checks
 	// (Would be nice to stub out parseManifestID to receive stronger
 	//  transitive assurance via existing parseManifestID tests)
-	testHlsQueryParam := func(inp string) {
-		u, _ := url.Parse("rtmp://localhost?hlsStrmID=" + url.QueryEscape(inp))
+	testManifestIDQueryParam := func(inp string) {
+		// This isn't a great test because if the query param ever changes,
+		// this test will still pass
+		u, _ := url.Parse("rtmp://localhost?manifestID=" + url.QueryEscape(inp))
 		if sid := createSid(u); sid != st.GetStreamID() {
 			t.Errorf("Unexpected StreamID for '%v' ; expected '%v' for input '%v'", sid, st.GetStreamID(), inp)
 		}
 	}
 	inputs := []string{"  /  ", ".m3u8", "/stream/", "stream/.m3u8"}
 	for _, v := range inputs {
-		testHlsQueryParam(v)
+		testManifestIDQueryParam(v)
 	}
 }
 
@@ -253,7 +255,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 
 	vProfile := ffmpeg.P720p30fps16x9
 	hlsStrmID := core.MakeStreamID(core.ManifestID("ghijkl"), &vProfile)
-	u, _ := url.Parse(fmt.Sprintf("rtmp://localhost:1935/movie?hlsStrmID=%v", url.QueryEscape(hlsStrmID.String())))
+	u, _ := url.Parse("rtmp://localhost:1935/movie")
 	strm := stream.NewBasicRTMPVideoStream(hlsStrmID.String())
 	expectedSid := core.MakeStreamIDFromString(string(hlsStrmID.ManifestID), "source")
 
@@ -275,8 +277,8 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 	if s.LatestPlaylist().ManifestID() != mid || LastManifestID != mid {
 		t.Error("Unexpected Manifest ID")
 	}
-	if LastHLSStreamID != hlsStrmID {
-		t.Error("Unexpected Stream ID ", LastHLSStreamID, hlsStrmID)
+	if LastHLSStreamID != expectedSid {
+		t.Error("Unexpected Stream ID ", LastHLSStreamID, expectedSid)
 	}
 
 	//Stream already exists
@@ -309,28 +311,6 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 		if seg.URI != shouldSegName {
 			t.Fatalf("Wrong segment, should have URI %s, has %s", shouldSegName, seg.URI)
 		}
-	}
-
-	// Test a couple of odd cases; subset of parseStreamID checks
-	// (Would be nice to stub out parseStreamID to receive stronger
-	//  transitive assurance via existing parseStreamID tests)
-	mid = core.RandomManifestID()
-	st := stream.NewBasicRTMPVideoStream(string(mid))
-	expectedStrm := core.MakeStreamIDFromString(string(mid), "source")
-	testHlsQueryParam := func(inp string) {
-		u, _ := url.Parse("rtmp://localhost?hlsStrmID=" + url.QueryEscape(inp))
-		if err := handler(u, st); err != nil {
-			t.Errorf("Unexpected error handling '%v' ; error %v", inp, err)
-		}
-		if LastHLSStreamID.String() != expectedStrm.String() {
-			t.Errorf("Unexpected StreamID for '%v' ; expected '%v' for input '%v'", LastHLSStreamID, expectedStrm, inp)
-		}
-		endHandler := endRTMPStreamHandler(s)
-		endHandler(u, st)
-	}
-	inputs := []string{"  /  ", ".m3u8", "/stream/", "stream/.m3u8", expectedStrm.String(), "/stream/" + expectedStrm.String()}
-	for _, v := range inputs {
-		testHlsQueryParam(v)
 	}
 }
 
@@ -395,7 +375,7 @@ func TestGetHLSMasterPlaylistHandler(t *testing.T) {
 
 	vProfile := ffmpeg.P720p30fps16x9
 	hlsStrmID := core.MakeStreamID(core.RandomManifestID(), &vProfile)
-	url, _ := url.Parse(fmt.Sprintf("rtmp://localhost:1935/movie?hlsStrmID=%v", hlsStrmID))
+	url, _ := url.Parse("rtmp://localhost:1935/movie")
 	strm := stream.NewBasicRTMPVideoStream(string(hlsStrmID.ManifestID) + "/source")
 
 	if err := handler(url, strm); err != nil {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Some more refactoring on top of Stream ID related to profile/rendition handling. This is open for discussion: we can refine this further. See https://github.com/livepeer/go-livepeer/pull/625

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
1. Use the source stream dimensions to construct the VideoProfile rather than selecting the profile from a preset list which is often incorrect and will lead to collisions if there's a transcoding preference matching the profile.

As part of this, the source stream rendition name is set to "source". Most of the work here involves making the playlist accept non-standard VideoProfiles.

2. Change the `hlsStreamID` RTMP query parameter to `manifestID` . This removes the ability to set the source stream rendition but seems safer since there's less potential for collisions with transcoding preferences. This also has the benefit that we only need to check the RTMP query string once, when we generate the StreamID. The RTMP handler itself can use the ManifestID that's extracted.


Note that StreamID parsing rules still apply here: if an ID is in the form `abc/def` then only `abc` will be used as the ManifestID. Once we have RTMP ingest authentication, users can take advantage of this to append auth info as part of the `manifestID` parameter.

Example playlist :
```
$ curl http://localhost:8935/stream/current.m3u8
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=4000000,RESOLUTION=854x480
1b1c8eed/source.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1200000,RESOLUTION=640x360
1b1c8eed/P360p30fps16x9.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=600000,RESOLUTION=320x240
1b1c8eed/P240p30fps4x3.m3u8

...

$ curl http://localhost:8935/stream/1b1c8eed/source.m3u8
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-MEDIA-SEQUENCE:46
#EXT-X-TARGETDURATION:2
#EXTINF:2.000,
/stream/1b1c8eed/source/46.ts
#EXTINF:2.000,
/stream/1b1c8eed/source/47.ts
#EXTINF:2.000,
/stream/1b1c8eed/source/48.ts
#EXTINF:2.000,
/stream/1b1c8eed/source/49.ts
#EXTINF:2.000,
/stream/1b1c8eed/source/50.ts
#EXTINF:2.000,
/stream/1b1c8eed/source/51.ts
```

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit testing, manual testing

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ~~README and other documentation updated~~
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
