### PR TITLE
Rudimentary failover

### DIFF
--- a/core/broadcaster.go
+++ b/core/broadcaster.go
@@ -1,13 +1,9 @@
 package core
 
 import (
-	"errors"
-
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
-
-var ErrNotFound = errors.New("ErrNotFound")
 
 // Broadcaster RPC interface implementation
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -27,9 +27,7 @@ import (
 )
 
 var ErrTranscoderAvail = errors.New("ErrTranscoderUnavailable")
-var ErrLivepeerNode = errors.New("ErrLivepeerNode")
 var ErrTranscode = errors.New("ErrTranscode")
-var DefaultJobLength = int64(5760) //Avg 1 day in 15 sec blocks
 var LivepeerVersion = "0.3.1-unstable"
 
 type NodeType int

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	ogErrors "errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -136,6 +137,8 @@ func NewOrchestrator(n *LivepeerNode) *orchestrator {
 
 // LivepeerNode transcode methods
 
+var ErrOrchBusy = ogErrors.New("OrchestratorBusy")
+
 type TranscodeResult struct {
 	Err  error
 	Sig  []byte
@@ -223,7 +226,7 @@ func (n *LivepeerNode) sendToTranscodeLoop(md *SegTranscodingMetadata, seg *stre
 	default:
 		// sending segChan should not block; if it does, the channel is busy
 		glog.Error("Transcoder was busy with a previous segment!")
-		return nil, fmt.Errorf("TranscoderBusy")
+		return nil, ErrOrchBusy
 	}
 	res := <-segChanData.res
 	return res, res.Err

--- a/core/playlistmanager.go
+++ b/core/playlistmanager.go
@@ -70,27 +70,30 @@ func (mgr *BasicPlaylistManager) getPL(rendition string) *m3u8.MediaPlaylist {
 	return mpl
 }
 
-func (mgr *BasicPlaylistManager) createPL(profile *ffmpeg.VideoProfile) *m3u8.MediaPlaylist {
+func (mgr *BasicPlaylistManager) getOrCreatePL(profile *ffmpeg.VideoProfile) (*m3u8.MediaPlaylist, error) {
+	mgr.mapSync.Lock()
+	defer mgr.mapSync.Unlock()
+	if pl, ok := mgr.mediaLists[profile.Name]; ok {
+		return pl, nil
+	}
 	mpl, err := m3u8.NewMediaPlaylist(LIVE_LIST_LENGTH, LIVE_LIST_LENGTH)
 	if err != nil {
 		glog.Error(err)
-		return nil
+		return nil, err
 	}
-	mgr.mapSync.Lock()
 	mgr.mediaLists[profile.Name] = mpl
-	mgr.mapSync.Unlock()
 	vParams := ffmpeg.VideoProfileToVariantParams(*profile)
 	url := fmt.Sprintf("%v/%v.m3u8", mgr.manifestID, profile.Name)
 	mgr.masterPList.Append(url, mpl, vParams)
-	return mpl
+	return mpl, nil
 }
 
 func (mgr *BasicPlaylistManager) InsertHLSSegment(profile *ffmpeg.VideoProfile, seqNo uint64, uri string,
 	duration float64) error {
 
-	mpl := mgr.getPL(profile.Name)
-	if mpl == nil {
-		mpl = mgr.createPL(profile)
+	mpl, err := mgr.getOrCreatePL(profile)
+	if err != nil {
+		return err
 	}
 	return mgr.addToMediaPlaylist(uri, seqNo, duration, mpl)
 }

--- a/core/playlistmanager_test.go
+++ b/core/playlistmanager_test.go
@@ -37,20 +37,108 @@ func TestGetMasterPlaylist(t *testing.T) {
 	}
 }
 
-func TestForWrongStream(t *testing.T) {
-	/* Mismatched streams don't really happen anymore
-	vProfile := ffmpeg.P144p30fps16x9
-	hlsStrmID := MakeStreamID(RandomManifestID(), &vProfile)
-	mid := hlsStrmID.ManifestID
-	c := NewBasicPlaylistManager(mid, nil)
-	err := c.InsertHLSSegment(&vProfile, 1, "test_uri", 12)
-	if err == nil {
-		t.Fatalf("Should fail here")
+func TestGetOrCreatePL(t *testing.T) {
+
+	c := NewBasicPlaylistManager(RandomManifestID(), nil)
+	vProfile := &ffmpeg.P144p30fps16x9
+
+	// Sanity check some properties of an empty master playlist
+	masterPL := c.GetHLSMasterPlaylist()
+	if len(masterPL.Variants) != 0 {
+		t.Error("Master PL had some unexpected variants")
 	}
-	if !strings.Contains(err.Error(), "Wrong manifest id") {
-		t.Fatalf("Wrong error, should contain 'Wrong stream id', but has %s", err.Error())
+
+	// insert one
+	pl, err := c.getOrCreatePL(vProfile)
+	if err != nil {
+		t.Error("Unexpected error ", err)
 	}
-	*/
+
+	// Sanity check some master PL properties
+	expectedRes := vProfile.Resolution
+	if len(masterPL.Variants) != 1 || masterPL.Variants[0].Resolution != expectedRes {
+		t.Error("Master PL had some unexpected variants or properties")
+	}
+
+	// using the same profile name should return the original profile
+	orig := pl
+	vProfile = &ffmpeg.VideoProfile{Name: vProfile.Name}
+	pl, err = c.getOrCreatePL(vProfile)
+	if err != nil || orig != pl {
+		t.Error("Mismatched profile or error ", err)
+	}
+	// Further sanity check some master PL properties
+	if len(masterPL.Variants) != 1 || masterPL.Variants[0].Resolution != expectedRes {
+		t.Error("Master PL had some unexpected variants or properties")
+	}
+
+	// using a different profile name should return a different profile
+	vProfile = &ffmpeg.P240p30fps16x9
+	pl, err = c.getOrCreatePL(vProfile)
+	if err != nil || orig == pl {
+		t.Error("Matched profile or error ", err)
+	}
+	// Further sanity check some master PL properties
+	if len(masterPL.Variants) != 2 || masterPL.Variants[1].Resolution != vProfile.Resolution {
+		t.Error("Master PL had some unexpected variants or properties")
+	}
+}
+
+func TestPlaylists(t *testing.T) {
+
+	c := NewBasicPlaylistManager(RandomManifestID(), nil)
+	vProfile := &ffmpeg.P144p30fps16x9
+
+	// Check getting a nonexistent media PL
+	if pl := c.GetHLSMediaPlaylist("nonexistent"); pl != nil {
+		t.Error("Recevied a nonexistent playlist ", pl)
+	}
+
+	// Insert one segment
+	compareSeg := func(a, b *m3u8.MediaSegment) bool {
+		return a.SeqId == b.SeqId && a.URI == b.URI && a.Duration == b.Duration
+	}
+	seg := &m3u8.MediaSegment{SeqId: 9, URI: "abc", Duration: -11.1}
+	if err := c.InsertHLSSegment(vProfile, seg.SeqId, seg.URI, seg.Duration); err != nil {
+		t.Error("HLS insertion")
+	}
+	// Sanity check some PL properties
+	pl := c.GetHLSMediaPlaylist(vProfile.Name)
+	if pl == nil {
+		t.Error("No playlist")
+	}
+	if len(pl.Segments) != int(LIVE_LIST_LENGTH) || !compareSeg(seg, pl.Segments[0]) || pl.Segments[1] != nil {
+		t.Error("Unexpected playlist/segment properties")
+	}
+
+	// insert a "duplicate" seqno. Should not work but does. Fix.
+	if err := c.InsertHLSSegment(vProfile, seg.SeqId, seg.URI, seg.Duration); err != nil {
+		t.Error("HLS insertion")
+	}
+	if len(pl.Segments) != int(LIVE_LIST_LENGTH) || !compareSeg(seg, pl.Segments[0]) || !compareSeg(pl.Segments[0], pl.Segments[1]) {
+		t.Error("Unexpected playlist/segment properties")
+	}
+
+	// Insert out of order. Playlist should accommodate this. Fix.
+	seg = &m3u8.MediaSegment{SeqId: 3, URI: "abc", Duration: -11.1}
+	if err := c.InsertHLSSegment(vProfile, seg.SeqId, seg.URI, seg.Duration); err != nil {
+		t.Error("HLS insertion")
+	}
+	if !compareSeg(seg, pl.Segments[2]) {
+		t.Error("Unexpected seg properties")
+	}
+
+	// Ensure we have different segments between two playlists
+	newSeg := &m3u8.MediaSegment{SeqId: 3, URI: "abc", Duration: -11.1}
+	newProfile := &ffmpeg.P240p30fps16x9
+	if err := c.InsertHLSSegment(newProfile, newSeg.SeqId, newSeg.URI, newSeg.Duration); err != nil {
+		t.Error("HLS insertion")
+	}
+	newPL := c.GetHLSMediaPlaylist(newProfile.Name)
+	if !compareSeg(seg, newPL.Segments[0]) || compareSeg(pl.Segments[0], newPL.Segments[0]) {
+		t.Error("Unexpected seg properties in new playlist")
+	}
+
 }
 
 func TestCleanup(t *testing.T) {

--- a/core/streamdata.go
+++ b/core/streamdata.go
@@ -16,7 +16,6 @@ import (
 	"github.com/livepeer/lpms/ffmpeg"
 )
 
-var ErrStreamID = errors.New("ErrStreamID")
 var ErrManifestID = errors.New("ErrManifestID")
 
 const (

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -78,7 +78,7 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) {
 	nonce := cxn.nonce
 	rtmpStrm := cxn.stream
 	cpl := cxn.pl
-	mid := rtmpManifestID(rtmpStrm)
+	mid := cxn.mid
 	vProfile := cxn.profile
 
 	cxn.lock.RLock()

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -2,18 +2,74 @@ package server
 
 import (
 	"fmt"
+	"math/big"
 	"sync"
 
 	"github.com/golang/glog"
 
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/monitor"
+	"github.com/livepeer/go-livepeer/pm"
 
 	"github.com/livepeer/lpms/stream"
 )
+
+func selectOrchestrator(n *core.LivepeerNode, cpl core.PlaylistManager) (*BroadcastSession, error) {
+
+	if n.OrchestratorPool == nil {
+		glog.Info("No orchestrators specified; not transcoding")
+		return nil, ErrDiscovery
+	}
+
+	rpcBcast := core.NewBroadcaster(n)
+
+	tinfos, err := n.OrchestratorPool.GetOrchestrators(1)
+	if len(tinfos) <= 0 {
+		glog.Info("No orchestrators found; not transcoding. Error: ", err)
+		return nil, ErrNoOrchs
+	}
+	if err != nil {
+		return nil, err
+	}
+	tinfo := tinfos[0]
+
+	var sessionID string
+
+	if n.Sender != nil {
+		protoParams := tinfo.TicketParams
+		params := pm.TicketParams{
+			Recipient:         ethcommon.BytesToAddress(protoParams.Recipient),
+			FaceValue:         new(big.Int).SetBytes(protoParams.FaceValue),
+			WinProb:           new(big.Int).SetBytes(protoParams.WinProb),
+			RecipientRandHash: ethcommon.BytesToHash(protoParams.RecipientRandHash),
+			Seed:              new(big.Int).SetBytes(protoParams.Seed),
+		}
+
+		sessionID = n.Sender.StartSession(params)
+	}
+
+	// set OSes
+	var orchOS drivers.OSSession
+	if len(tinfo.Storage) > 0 {
+		orchOS = drivers.NewSession(tinfo.Storage[0])
+	}
+
+	return &BroadcastSession{
+		Broadcaster:      rpcBcast,
+		ManifestID:       cpl.ManifestID(),
+		Profiles:         BroadcastJobVideoProfiles,
+		OrchestratorInfo: tinfo,
+		OrchestratorOS:   orchOS,
+		BroadcasterOS:    cpl.GetOSSession(),
+		Sender:           n.Sender,
+		PMSessionID:      sessionID,
+	}, nil
+}
 
 func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) {
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -1,0 +1,162 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/golang/glog"
+
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/drivers"
+	"github.com/livepeer/go-livepeer/monitor"
+
+	"github.com/livepeer/lpms/stream"
+)
+
+func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) {
+
+	nonce := cxn.nonce
+	rtmpStrm := cxn.stream
+	sess := cxn.sess
+	cpl := cxn.pl
+	mid := rtmpManifestID(rtmpStrm)
+	vProfile := cxn.profile
+
+	if monitor.Enabled {
+		monitor.LogSegmentEmerged(nonce, seg.SeqNo)
+	}
+
+	seg.Name = "" // hijack seg.Name to convey the uploaded URI
+	name := fmt.Sprintf("%s/%d.ts", vProfile.Name, seg.SeqNo)
+	uri, err := cpl.GetOSSession().SaveData(name, seg.Data)
+	if err != nil {
+		glog.Errorf("Error saving segment %d: %v", seg.SeqNo, err)
+		if monitor.Enabled {
+			monitor.LogSegmentUploadFailed(nonce, seg.SeqNo, err.Error())
+		}
+		return
+	}
+	if cpl.GetOSSession().IsExternal() {
+		seg.Name = uri // hijack seg.Name to convey the uploaded URI
+	}
+	err = cpl.InsertHLSSegment(vProfile, seg.SeqNo, uri, seg.Duration)
+	if monitor.Enabled {
+		monitor.LogSourceSegmentAppeared(nonce, seg.SeqNo, string(mid), vProfile.Name)
+		glog.V(6).Infof("Appeared segment %d", seg.SeqNo)
+	}
+	if err != nil {
+		glog.Errorf("Error inserting segment %d: %v", seg.SeqNo, err)
+		if monitor.Enabled {
+			monitor.LogSegmentUploadFailed(nonce, seg.SeqNo, err.Error())
+		}
+	}
+
+	// Return early under a few circumstances:
+	// View-only (non-transcoded) streams or mid-failover
+	if sess == nil {
+		return
+	}
+
+	// Process the rest of the segment asynchronously - transcode
+	go func() {
+		// storage the orchestrator prefers
+		if ios := sess.OrchestratorOS; ios != nil {
+			// XXX handle case when orch expects direct upload
+			uri, err := ios.SaveData(name, seg.Data)
+			if err != nil {
+				glog.Error("Error saving segment to OS ", err)
+				if monitor.Enabled {
+					monitor.LogSegmentUploadFailed(nonce, seg.SeqNo, err.Error())
+				}
+				return
+			}
+			seg.Name = uri // hijack seg.Name to convey the uploaded URI
+		}
+
+		// send segment to the orchestrator
+		glog.V(common.DEBUG).Infof("Submitting segment %d", seg.SeqNo)
+
+		res, err := SubmitSegment(sess, seg, nonce)
+		if err != nil {
+			if shouldStopStream(err) {
+				glog.Warningf("Stopping current stream due to: %v", err)
+				rtmpStrm.Close()
+			}
+			return
+		}
+
+		// download transcoded segments from the transcoder
+		gotErr := false // only send one error msg per segment list
+		errFunc := func(subType, url string, err error) {
+			glog.Errorf("%v error with segment %v: %v (URL: %v)", subType, seg.SeqNo, err, url)
+			if monitor.Enabled && !gotErr {
+				monitor.LogSegmentTranscodeFailed(subType, nonce, seg.SeqNo, err)
+				gotErr = true
+			}
+		}
+
+		segHashes := make([][]byte, len(res.Segments))
+		n := len(res.Segments)
+		segHashLock := &sync.Mutex{}
+		cond := sync.NewCond(segHashLock)
+
+		dlFunc := func(url string, i int) {
+			defer func() {
+				cond.L.Lock()
+				n--
+				if n == 0 {
+					cond.Signal()
+				}
+				cond.L.Unlock()
+			}()
+
+			if bos := sess.BroadcasterOS; bos != nil && !drivers.IsOwnExternal(url) {
+				data, err := drivers.GetSegmentData(url)
+				if err != nil {
+					errFunc("Download", url, err)
+					return
+				}
+				name := fmt.Sprintf("%s/%d.ts", sess.Profiles[i].Name, seg.SeqNo)
+				newUrl, err := bos.SaveData(name, data)
+				if err != nil {
+					errFunc("SaveData", url, err)
+					return
+				}
+				url = newUrl
+
+				hash := crypto.Keccak256(data)
+				segHashLock.Lock()
+				segHashes[i] = hash
+				segHashLock.Unlock()
+			}
+
+			if monitor.Enabled {
+				monitor.LogTranscodedSegmentAppeared(nonce, seg.SeqNo, sess.Profiles[i].Name)
+			}
+			err = cpl.InsertHLSSegment(&sess.Profiles[i], seg.SeqNo, url, seg.Duration)
+			if err != nil {
+				errFunc("Playlist", url, err)
+				return
+			}
+		}
+
+		for i, v := range res.Segments {
+			go dlFunc(v.Url, i)
+		}
+
+		cond.L.Lock()
+		for n != 0 {
+			cond.Wait()
+		}
+		cond.L.Unlock()
+
+		// if !eth.VerifySig(transcoderAddress, crypto.Keccak256(segHashes...), res.Sig) { // need transcoder address here
+		// 	glog.Error("Sig check failed for segment ", seg.SeqNo)
+		// 	return
+		// }
+
+		glog.V(common.DEBUG).Info("Successfully validated segment ", seg.SeqNo)
+	}()
+}

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -226,11 +226,12 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) {
 	}()
 }
 
+var sessionErrStrings = []string{"dial tcp", "unexpected EOF", core.ErrOrchBusy.Error()}
+
 func generateSessionErrors() *regexp.Regexp {
 	// Given a list [err1, err2, err3] generates a regexp `(err1)|(err2)|(err3)`
-	errStrings := []string{"dial tcp", "unexpected EOF", "TranscoderBusy"}
 	groups := []string{}
-	for _, v := range errStrings {
+	for _, v := range sessionErrStrings {
 		groups = append(groups, fmt.Sprintf("(%v)", v))
 	}
 	return regexp.MustCompile(strings.Join(groups, "|"))

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/livepeer/go-livepeer/core"
+)
+
+func TestStopSessionErrors(t *testing.T) {
+
+	// check error cases
+	errs := []string{
+		"Unable to read response body for segment 4 : unexpected EOF",
+		"Unable to submit segment 5 Post https://127.0.0.1:8936/segment: dial tcp 127.0.0.1:8936: getsockopt: connection refused",
+		core.ErrOrchBusy.Error(),
+	}
+
+	// Sanity check that we're checking each failure case
+	if len(errs) != len(sessionErrStrings) {
+		t.Error("Mismatched error cases for stop session")
+	}
+	for _, v := range errs {
+		if !shouldStopSession(errors.New(v)) {
+			t.Error("Should have stopped session but didn't: ", v)
+		}
+	}
+
+	// check non-error cases
+	errs = []string{
+		"",
+		"not really an error",
+	}
+	for _, v := range errs {
+		if shouldStopSession(errors.New(v)) {
+			t.Error("Should not have stopped session but did: ", v)
+		}
+	}
+
+}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -343,7 +343,11 @@ func (s *LivepeerServer) startSessionListener(cxn *rtmpConnection) {
 		cv.Signal()
 	}
 	glog.V(common.DEBUG).Info("Starting broadcast listener for ", cxn.pl.ManifestID())
+	finished := false
 	for {
+		if finished {
+			break
+		}
 		select {
 
 		case <-cxn.needOrch:
@@ -363,6 +367,7 @@ func (s *LivepeerServer) startSessionListener(cxn *rtmpConnection) {
 			}()
 
 		case <-cxn.eof:
+			finished = true
 			break
 		}
 	}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -35,11 +35,7 @@ import (
 )
 
 var ErrAlreadyExists = errors.New("StreamAlreadyExists")
-var ErrRTMPPublish = errors.New("ErrRTMPPublish")
 var ErrBroadcast = errors.New("ErrBroadcast")
-var ErrHLSPlay = errors.New("ErrHLSPlay")
-var ErrRTMPPlay = errors.New("ErrRTMPPlay")
-var ErrRoundInit = errors.New("ErrRoundInit")
 var ErrStorage = errors.New("ErrStorage")
 var ErrDiscovery = errors.New("ErrDiscovery")
 var ErrNoOrchs = errors.New("ErrNoOrchs")
@@ -51,12 +47,10 @@ const HLSBufferWindow = uint(5)
 const StreamKeyBytes = 6
 
 const SegLen = 2 * time.Second
-const HLSUnsubWorkerFreq = time.Second * 5
 const BroadcastRetry = 15 * time.Second
 
 var BroadcastPrice = big.NewInt(1)
 var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmpeg.P360p30fps16x9}
-var MinDepositSegmentCount = int64(75) // 5 mins assuming 4s segments
 
 type rtmpConnection struct {
 	mid     core.ManifestID

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -43,6 +43,7 @@ var ErrRTMPPlay = errors.New("ErrRTMPPlay")
 var ErrRoundInit = errors.New("ErrRoundInit")
 var ErrStorage = errors.New("ErrStorage")
 var ErrDiscovery = errors.New("ErrDiscovery")
+var ErrNoOrchs = errors.New("ErrNoOrchs")
 var ErrUnknownStream = errors.New("ErrUnknownStream")
 
 const HLSWaitInterval = time.Second
@@ -176,8 +177,11 @@ func (s *LivepeerServer) startBroadcast(cpl core.PlaylistManager) (*BroadcastSes
 	rpcBcast := core.NewBroadcaster(s.LivepeerNode)
 
 	tinfos, err := s.LivepeerNode.OrchestratorPool.GetOrchestrators(1)
-	if len(tinfos) <= 0 || err != nil {
+	if len(tinfos) <= 0 {
 		glog.Info("No orchestrators found; not transcoding. Error: ", err)
+		return nil, ErrNoOrchs
+	}
+	if err != nil {
 		return nil, err
 	}
 	tinfo := tinfos[0]

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -301,7 +301,7 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 
 func (s *LivepeerServer) startSession(cxn *rtmpConnection) *BroadcastSession {
 
-	mid := rtmpManifestID(cxn.stream)
+	mid := cxn.mid
 	cpl := cxn.pl
 	var sess *BroadcastSession
 
@@ -345,14 +345,14 @@ func (s *LivepeerServer) startSessionListener(cxn *rtmpConnection) {
 		// we don't terminate the stream *then* assign the session to the cxn
 		s.connectionLock.RLock()
 		defer s.connectionLock.RUnlock()
-		if _, active := s.rtmpConnections[cxn.pl.ManifestID()]; !active {
+		if _, active := s.rtmpConnections[cxn.mid]; !active {
 			sess = nil // don't assign if stream terminated
 		}
 		mut.Lock()
 		defer mut.Unlock()
 		cxn.sess = sess
 	}
-	glog.V(common.DEBUG).Info("Starting broadcast listener for ", cxn.pl.ManifestID())
+	glog.V(common.DEBUG).Info("Starting broadcast listener for ", cxn.mid)
 	finished := false
 	for {
 		if finished {
@@ -376,7 +376,7 @@ func (s *LivepeerServer) startSessionListener(cxn *rtmpConnection) {
 			break
 		}
 	}
-	glog.V(common.DEBUG).Info("Stopping broadcast listener for ", cxn.pl.ManifestID())
+	glog.V(common.DEBUG).Info("Stopping broadcast listener for ", cxn.mid)
 }
 
 //End RTMP Publish Handlers

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -194,6 +194,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 			Resolution: resolution,
 			Bitrate:    "4000k", // Fix this
 		}
+		hlsStrmID := core.MakeStreamID(mid, &vProfile)
 		s.connectionLock.Lock()
 		_, exists := s.rtmpConnections[mid]
 		if exists {
@@ -213,18 +214,15 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 			eof:      make(chan struct{}),
 		}
 		s.rtmpConnections[mid] = cxn
-		s.connectionLock.Unlock()
 		LastManifestID = mid
+		LastHLSStreamID = hlsStrmID
+		s.connectionLock.Unlock()
 
 		startSeq := 0
 
 		if s.LivepeerNode.Eth != nil {
 			// TODO: Check broadcaster's deposit with TicketBroker
 		}
-
-		hlsStrmID := core.MakeStreamID(mid, &vProfile)
-
-		LastHLSStreamID = hlsStrmID
 
 		streamStarted := false
 		//Segment the stream, insert the segments into the broadcaster

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -59,6 +59,7 @@ var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmp
 var MinDepositSegmentCount = int64(75) // 5 mins assuming 4s segments
 
 type rtmpConnection struct {
+	mid     core.ManifestID
 	nonce   uint64
 	stream  stream.RTMPVideoStream
 	pl      core.PlaylistManager
@@ -182,48 +183,18 @@ func rtmpManifestID(rtmpStrm stream.RTMPVideoStream) core.ManifestID {
 func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error) {
 	return func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error) {
 
-		// Set up the connection tracking
-		mid := rtmpManifestID(rtmpStrm)
-		if drivers.NodeStorage == nil {
-			glog.Error("Missing node storage")
-			return ErrStorage
+		cxn, err := s.registerConnection(rtmpStrm)
+		if err != nil {
+			return err
 		}
-		storage := drivers.NodeStorage.NewSession(string(mid))
-		// Build the source video profile from the RTMP stream.
-		resolution := fmt.Sprintf("%vx%v", rtmpStrm.Width(), rtmpStrm.Height())
-		vProfile := ffmpeg.VideoProfile{
-			Name:       "source",
-			Resolution: resolution,
-			Bitrate:    "4000k", // Fix this
-		}
-		hlsStrmID := core.MakeStreamID(mid, &vProfile)
-		s.connectionLock.Lock()
-		_, exists := s.rtmpConnections[mid]
-		if exists {
-			// We can only have one concurrent stream per ManifestID
-			s.connectionLock.Unlock()
-			return ErrAlreadyExists
-		}
-		nonce := rand.Uint64()
-		cxn := &rtmpConnection{
-			nonce:   nonce,
-			stream:  rtmpStrm,
-			pl:      core.NewBasicPlaylistManager(mid, storage),
-			profile: &vProfile,
-			lock:    &sync.RWMutex{},
 
-			needOrch: make(chan struct{}),
-			eof:      make(chan struct{}),
-		}
-		s.rtmpConnections[mid] = cxn
-		s.lastManifestID = mid
-		s.lastHLSStreamID = hlsStrmID
-		s.connectionLock.Unlock()
-
+		mid := cxn.mid
+		nonce := cxn.nonce
 		startSeq := 0
 
 		if s.LivepeerNode.Eth != nil {
 			// TODO: Check broadcaster's deposit with TicketBroker
+			//       (perhaps within registerConnection?)
 		}
 
 		streamStarted := false
@@ -263,7 +234,6 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		}
 
 		glog.Infof("\n\nVideo Created With ManifestID: %v\n\n", mid)
-		glog.V(common.SHORT).Infof("\n\nhlsStrmID: %v\n\n", hlsStrmID)
 
 		//Create Transcode Job Onchain
 		go s.startSessionListener(cxn)
@@ -292,6 +262,47 @@ func endRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 
 		return nil
 	}
+}
+
+func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*rtmpConnection, error) {
+	// Set up the connection tracking
+	mid := rtmpManifestID(rtmpStrm)
+	if drivers.NodeStorage == nil {
+		glog.Error("Missing node storage")
+		return nil, ErrStorage
+	}
+	storage := drivers.NodeStorage.NewSession(string(mid))
+	// Build the source video profile from the RTMP stream.
+	resolution := fmt.Sprintf("%vx%v", rtmpStrm.Width(), rtmpStrm.Height())
+	vProfile := ffmpeg.VideoProfile{
+		Name:       "source",
+		Resolution: resolution,
+		Bitrate:    "4000k", // Fix this
+	}
+	hlsStrmID := core.MakeStreamID(mid, &vProfile)
+	s.connectionLock.Lock()
+	defer s.connectionLock.Unlock()
+	_, exists := s.rtmpConnections[mid]
+	if exists {
+		// We can only have one concurrent stream per ManifestID
+		return nil, ErrAlreadyExists
+	}
+	cxn := &rtmpConnection{
+		mid:     mid,
+		nonce:   rand.Uint64(),
+		stream:  rtmpStrm,
+		pl:      core.NewBasicPlaylistManager(mid, storage),
+		profile: &vProfile,
+		lock:    &sync.RWMutex{},
+
+		needOrch: make(chan struct{}),
+		eof:      make(chan struct{}),
+	}
+	s.rtmpConnections[mid] = cxn
+	s.lastManifestID = mid
+	s.lastHLSStreamID = hlsStrmID
+
+	return cxn, nil
 }
 
 func (s *LivepeerServer) startSession(cxn *rtmpConnection) *BroadcastSession {

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -70,7 +70,7 @@ func (s *StubSegmenter) SegmentRTMPToHLS(ctx context.Context, rs stream.RTMPVide
 	return nil
 }
 
-func TestStartBroadcast(t *testing.T) {
+func TestSelectOrchestrator(t *testing.T) {
 	s := setupServer()
 
 	defer func() {
@@ -81,14 +81,14 @@ func TestStartBroadcast(t *testing.T) {
 	mid := core.RandomManifestID()
 	storage := drivers.NodeStorage.NewSession(string(mid))
 	pl := core.NewBasicPlaylistManager(mid, storage)
-	if _, err := s.startBroadcast(pl); err != ErrDiscovery {
+	if _, err := selectOrchestrator(s.LivepeerNode, pl); err != ErrDiscovery {
 		t.Error("Expected error with discovery")
 	}
 
 	sd := &stubDiscovery{}
 	// Discovery returned no orchestrators
 	s.LivepeerNode.OrchestratorPool = sd
-	if sess, err := s.startBroadacst(pl); sess != nil || err != ErrNoOrchs {
+	if sess, err := selectOrchestrator(s.LivepeerNode, pl); sess != nil || err != ErrNoOrchs {
 		t.Error("Expected nil session")
 	}
 
@@ -97,7 +97,7 @@ func TestStartBroadcast(t *testing.T) {
 		&net.OrchestratorInfo{},
 		&net.OrchestratorInfo{},
 	}
-	sess, _ := s.startBroadcast(pl)
+	sess, _ := selectOrchestrator(s.LivepeerNode, pl)
 	if sess == nil {
 		t.Error("Expected nil session")
 	}
@@ -146,7 +146,7 @@ func TestStartBroadcast(t *testing.T) {
 	expSessionID := "foo"
 	sender.On("StartSession", params).Return(expSessionID)
 
-	sess, err := s.startBroadcast(pl)
+	sess, err := selectOrchestrator(s.LivepeerNode, pl)
 	require.Nil(t, err)
 
 	assert := assert.New(t)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -291,11 +291,11 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 
 	// Check assigned IDs
 	mid := rtmpManifestID(strm)
-	if s.LatestPlaylist().ManifestID() != mid || LastManifestID != mid {
+	if s.LatestPlaylist().ManifestID() != mid {
 		t.Error("Unexpected Manifest ID")
 	}
-	if LastHLSStreamID != expectedSid {
-		t.Error("Unexpected Stream ID ", LastHLSStreamID, expectedSid)
+	if s.LastHLSStreamID() != expectedSid {
+		t.Error("Unexpected Stream ID ", s.LastHLSStreamID(), expectedSid)
 	}
 
 	//Stream already exists
@@ -323,6 +323,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 	}
 
 	for i := 0; i < 4; i++ {
+		// XXX we shouldn't do this. Need threadsafe accessors for playlist
 		seg := pl.Segments[i]
 		shouldSegName := fmt.Sprintf("/stream/%s/%s/%d.ts", mid, expectedSid.Rendition, i)
 		if seg.URI != shouldSegName {

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -88,7 +88,7 @@ func TestStartBroadcast(t *testing.T) {
 	sd := &stubDiscovery{}
 	// Discovery returned no orchestrators
 	s.LivepeerNode.OrchestratorPool = sd
-	if sess, _ := s.startBroadcast(pl); sess != nil {
+	if sess, err := s.startBroadacst(pl); sess != nil || err != ErrNoOrchs {
 		t.Error("Expected nil session")
 	}
 

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -712,11 +712,11 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 
 	//Print the current broadcast HLS streamID
 	mux.HandleFunc("/streamID", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(LastHLSStreamID.String()))
+		w.Write([]byte(s.LastHLSStreamID().String()))
 	})
 
 	mux.HandleFunc("/manifestID", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(LastManifestID))
+		w.Write([]byte(s.LastManifestID()))
 	})
 
 	mux.HandleFunc("/localStreams", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Still needs a lot more testing before I'm really comfortable with this, but wanted to get it out here for a quick look-over in case there are concerns about the general approach.

## What does this pull request do?
Implements rudimentary failover:

* Doesn't retry the current segment, but subsequent segments will select a new O.
* If a segment fails, lazily goes through the entire O selection process again rather than caching and using the list that was previously selected. This is actually pretty quick as long as at least one O responds, and is probably a better approach for long-running streams.
* We compare error strings to determine whether we should stop the session and failover. Not pretty, but works. Curious if there's a better approach. The list of error strings are compiled into a single regex for that extra oomph.

### Orchestrator Selector Listener

The major bit that is introduced here is the mechanism for setting the `rtmpConnection.sess` field within `startSessionListener`. A worker loop listens to the `rtmpConnection.needOrch` channel and kicks off the orchestrator-selection process. The orchestrator-selection process is mostly unchanged, but it's been extracted into its own function, `startSession`, with a few modifications for thread safety.

Some of this machinery may seem overwrought but it needs to be thread safe under a number of cases. Happy to walk through some of these if folks have questions, or if anyone has ideas for improvement.

The idea is to ensure exclusion of the `startSession` function: only one invocation can run at a time. If multiple requests for `startSession` come in while one is in-flight, they should be ignored. This prevents a pileup or unnecessary resetting of the session. This is accomplished with a traditional setup of a mutex and a condvar, but I'm also interested in exploring other approaches.

Implementation: https://github.com/livepeer/go-livepeer/commit/bc53ce29a2df4b7c3eb7eecc2fb166d43e7c2c56

An alternative is perhaps to do this with two channels, including a limited-length chan that rejects any attempts to write to it during an in-flight request. The transcode loop uses a similar method to indicate the busy state.

```
cxn.needOrch = make(chan struct{}, 1) // length limit of 1
cxn.getOrch = make(chan struct{}) // unlimited length?
cxn.eof = make(chan struct{})
...
if shouldStopSession(err) {
  select {
  case cxn.needOrch <- struct{}{}:
    cxn.getOrch <- struct{}{}
  case <-cxn.eof
     // rtmp stream ended; exit
     return
  case default:
    // already have an in flight request; exit
    return
  }
}
...
go func() {
  for {
    select {
    case <-cxn.getOrch:
      cxn.sess = nil
      cxn.sess = startSession() // select an O and get a session out of it
      <- cxn.needOrch // drain
    }
  }
}()
```

I'm still not convinced that we don't need locking somewhere. Putting on my old-school hat, I'm also not quite comfortable yet with the "golanginess"  of the approach. Explaining how this works would be extra thinking for folks that aren't familiar with golang concurrency constructs and the specific semantics thereof, such as the behavior of `select` when writing to a full chan. However, most developers should be comfortable with standard synchronization primitives.

## Specific updates
<!--- List out all significant updates your code introduces -->
- Split out much of the logic in `gotRTMPStreamHandler` in standalone functions. This is finally straightforward thanks to the latest round of refactors that made the `rtmpConnection` struct available. Primarily `processSegment` and `startSession`.
- Place some code in `server/broadcast.go` to make `mediaserver.go` a bit less heavy. What got moved was pretty arbitrary, but in general, functions that aren't dependent on `LivepeerServer` go into `broadcast.go`

## Testing

1. Run a couple orchestrators in offchain mode. You'll want to set `-offchain` , `-serviceAddr`, `-cliAddr` and probably `-datadir` as well.
2. Run a broadcaster in `-offchain` mode with the above orchestrators specified in `-orchAddr orch1_ip:orch1_port,orch2_ip:orch2_port`
3. Start streaming into the broadcaster
4. Kill the active orchestrator that's working the stream
5. Ensure the second orchestrator picks it up
6. Restart the killed orchestrator
7. GOTO 4

Unit tests forthcoming.


<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
