### PR TITLE
PM recipient

### DIFF
--- a/pm/helpers.go
+++ b/pm/helpers.go
@@ -1,0 +1,48 @@
+package pm
+
+import (
+	"crypto/rand"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+func randHashOrFatal(t *testing.T) ethcommon.Hash {
+	key, err := randBytes(32)
+
+	if err != nil {
+		t.Fatalf("failed generating random hash: %v", err)
+		return ethcommon.Hash{}
+	}
+
+	return ethcommon.BytesToHash(key[:])
+}
+
+func randAddressOrFatal(t *testing.T) ethcommon.Address {
+	key, err := randBytes(addressSize)
+
+	if err != nil {
+		t.Fatalf("failed generating random address: %v", err)
+		return ethcommon.Address{}
+	}
+
+	return ethcommon.BytesToAddress(key[:])
+}
+
+func randBytesOrFatal(size int, t *testing.T) []byte {
+	res, err := randBytes(size)
+
+	if err != nil {
+		t.Fatalf("failed generating random bytes: %v", err)
+		return nil
+	}
+
+	return res
+}
+
+func randBytes(size int) ([]byte, error) {
+	key := make([]byte, size)
+	_, err := rand.Read(key)
+
+	return key, err
+}

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -1,0 +1,207 @@
+package pm
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"math/big"
+	"sync"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/pkg/errors"
+)
+
+var (
+	errInvalidRecipientRandFromSeed = errors.New("invalid recipientRand generated from seed")
+	errInvalidRecipientRandRevealed = errors.New("invalid already revealed recipientRand")
+
+	errInvalidTicketFaceValue   = errors.New("invalid ticket faceValue")
+	errInvalidTicketWinProb     = errors.New("invalid ticket winProb")
+	errInvalidTicketSenderNonce = errors.New("invalid ticket senderNonce")
+
+	errZeroDepositAndPenaltyEscrow = errors.New("sender has zero deposit and penalty escrow")
+)
+
+// Recipient is an interface which describes an object capable
+// of receiving tickets
+type Recipient interface {
+	// ReceiveTicket validates and processes a received ticket
+	ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (won bool, err error)
+
+	// RedeemWinningTicket redeems a winning ticket with the broker
+	RedeemWinningTicket(ticketID ethcommon.Hash) error
+
+	// TicketParams returns the recipient's currently accepted ticket parameters
+	// for a provided sender ETH adddress
+	TicketParams(sender ethcommon.Address) (*TicketParams, error)
+}
+
+// recipient is an implementation of the Recipient interface that
+// receives tickets and redeems winning tickets
+type recipient struct {
+	val    Validator
+	broker Broker
+	store  TicketStore
+
+	secret [32]byte
+
+	invalidRands sync.Map
+
+	senderNonces     map[string]uint64
+	senderNoncesLock sync.Mutex
+
+	faceValue *big.Int
+	winProb   *big.Int
+}
+
+// NewRecipient creates an instance of a recipient
+func NewRecipient(broker Broker, val Validator, store TicketStore, secret [32]byte, faceValue *big.Int, winProb *big.Int) Recipient {
+	return &recipient{
+		broker:       broker,
+		val:          val,
+		store:        store,
+		secret:       secret,
+		faceValue:    faceValue,
+		senderNonces: make(map[string]uint64),
+		winProb:      winProb,
+	}
+}
+
+// ReceiveTicket validates and processes a received ticket
+func (r *recipient) ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (bool, error) {
+	recipientRand := r.rand(seed, ticket.Sender)
+
+	if crypto.Keccak256Hash(ethcommon.LeftPadBytes(recipientRand.Bytes(), uint256Size)) != ticket.RecipientRandHash {
+		return false, errInvalidRecipientRandFromSeed
+	}
+
+	if ticket.FaceValue.Cmp(r.faceValue) != 0 {
+		return false, errInvalidTicketFaceValue
+	}
+
+	if ticket.WinProb.Cmp(r.winProb) != 0 {
+		return false, errInvalidTicketWinProb
+	}
+
+	if err := r.val.ValidateTicket(ticket, sig, recipientRand); err != nil {
+		return false, err
+	}
+
+	if !r.validRand(recipientRand) {
+		return false, errInvalidRecipientRandRevealed
+	}
+
+	if err := r.updateSenderNonce(recipientRand, ticket.SenderNonce); err != nil {
+		return false, err
+	}
+
+	if r.val.IsWinningTicket(ticket, sig, recipientRand) {
+		if err := r.store.Store(ticket, sig, recipientRand); err != nil {
+			return true, err
+		}
+
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// RedeemWinningTicket redeems a winning ticket with the broker
+func (r *recipient) RedeemWinningTicket(ticketID ethcommon.Hash) error {
+	ticket, sig, recipientRand, err := r.store.Load(ticketID)
+	if err != nil {
+		return err
+	}
+
+	deposit, err := r.broker.GetDeposit(ticket.Sender)
+	if err != nil {
+		return err
+	}
+
+	penaltyEscrow, err := r.broker.GetPenaltyEscrow(ticket.Sender)
+	if err != nil {
+		return err
+	}
+
+	if deposit.Cmp(big.NewInt(0)) == 0 && penaltyEscrow.Cmp(big.NewInt(0)) == 0 {
+		return errZeroDepositAndPenaltyEscrow
+	}
+
+	// We are about to reveal recipientRand on-chain so invalidate it locally
+	if err := r.updateInvalidRands(recipientRand); err != nil {
+		return err
+	}
+
+	// After we invalidate recipientRand we can clear the memory used to track
+	// its latest senderNonce
+	r.clearSenderNonce(recipientRand)
+
+	if err := r.broker.RedeemWinningTicket(ticket, sig, recipientRand); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TicketParams returns the recipient's currently accepted ticket parameters
+func (r *recipient) TicketParams(sender ethcommon.Address) (*TicketParams, error) {
+	randBytes := make([]byte, 32)
+	if _, err := rand.Read(randBytes); err != nil {
+		return nil, err
+	}
+
+	seed := new(big.Int).SetBytes(randBytes)
+	recipientRand := r.rand(seed, sender)
+	recipientRandHash := crypto.Keccak256Hash(ethcommon.LeftPadBytes(recipientRand.Bytes(), uint256Size))
+
+	return &TicketParams{
+		FaceValue:         r.faceValue,
+		WinProb:           r.winProb,
+		RecipientRandHash: recipientRandHash,
+		Seed:              seed,
+	}, nil
+}
+
+func (r *recipient) rand(seed *big.Int, sender ethcommon.Address) *big.Int {
+	h := hmac.New(sha256.New, r.secret[:])
+	h.Write(append(seed.Bytes(), sender.Bytes()...))
+
+	return new(big.Int).SetBytes(h.Sum(nil))
+}
+
+func (r *recipient) validRand(rand *big.Int) bool {
+	_, ok := r.invalidRands.Load(rand.String())
+	return !ok
+}
+
+func (r *recipient) updateInvalidRands(rand *big.Int) error {
+	_, loaded := r.invalidRands.LoadOrStore(rand.String(), true)
+	if loaded {
+		return errInvalidRecipientRandRevealed
+	}
+
+	return nil
+}
+
+func (r *recipient) updateSenderNonce(rand *big.Int, senderNonce uint64) error {
+	r.senderNoncesLock.Lock()
+	defer r.senderNoncesLock.Unlock()
+
+	randStr := rand.String()
+	nonce, ok := r.senderNonces[randStr]
+	if ok && senderNonce <= nonce {
+		return errInvalidTicketSenderNonce
+	}
+
+	r.senderNonces[randStr] = senderNonce
+
+	return nil
+}
+
+func (r *recipient) clearSenderNonce(rand *big.Int) {
+	r.senderNoncesLock.Lock()
+	defer r.senderNoncesLock.Unlock()
+
+	delete(r.senderNonces, rand.String())
+}

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -16,7 +16,7 @@ import (
 // of receiving tickets
 type Recipient interface {
 	// ReceiveTicket validates and processes a received ticket
-	ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (won bool, err error)
+	ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (sessionID string, won bool, err error)
 
 	// RedeemWinningTicket redeems all winning tickets with the broker
 	// for a session ID
@@ -75,42 +75,44 @@ func NewRecipientWithSecret(broker Broker, val Validator, store TicketStore, sec
 }
 
 // ReceiveTicket validates and processes a received ticket
-func (r *recipient) ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (bool, error) {
+func (r *recipient) ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (string, bool, error) {
 	recipientRand := r.rand(seed, ticket.Sender)
 
 	if crypto.Keccak256Hash(ethcommon.LeftPadBytes(recipientRand.Bytes(), uint256Size)) != ticket.RecipientRandHash {
-		return false, errors.Errorf("invalid recipientRand generated from seed %v", seed)
+		return "", false, errors.Errorf("invalid recipientRand generated from seed %v", seed)
 	}
 
 	if ticket.FaceValue.Cmp(r.faceValue) != 0 {
-		return false, errors.Errorf("invalid ticket faceValue %v", ticket.FaceValue)
+		return "", false, errors.Errorf("invalid ticket faceValue %v", ticket.FaceValue)
 	}
 
 	if ticket.WinProb.Cmp(r.winProb) != 0 {
-		return false, errors.Errorf("invalid ticket winProb %v", ticket.WinProb)
+		return "", false, errors.Errorf("invalid ticket winProb %v", ticket.WinProb)
 	}
 
 	if err := r.val.ValidateTicket(ticket, sig, recipientRand); err != nil {
-		return false, err
+		return "", false, err
 	}
 
 	if !r.validRand(recipientRand) {
-		return false, errors.Errorf("invalid already revealed recipientRand %v", recipientRand)
+		return "", false, errors.Errorf("invalid already revealed recipientRand %v", recipientRand)
 	}
 
 	if err := r.updateSenderNonce(recipientRand, ticket.SenderNonce); err != nil {
-		return false, err
+		return "", false, err
 	}
 
 	if r.val.IsWinningTicket(ticket, sig, recipientRand) {
-		if err := r.store.Store(ticket.RecipientRandHash.Hex(), ticket, sig, recipientRand); err != nil {
-			return true, err
+		sessionID := ticket.RecipientRandHash.Hex()
+
+		if err := r.store.Store(sessionID, ticket, sig, recipientRand); err != nil {
+			return "", true, err
 		}
 
-		return true, nil
+		return sessionID, true, nil
 	}
 
-	return false, nil
+	return "", false, nil
 }
 
 // RedeemWinningTicket redeems all winning tickets with the broker

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -1,0 +1,436 @@
+package pm
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestReceiveTicket(t *testing.T) {
+	sender := ethcommon.HexToAddress("A69cdA26600c155cF2c150964Bdb5371ac3f606F")
+	b := newStubBroker()
+	v := &stubValidator{}
+	ts := newStubTicketStore()
+	secret := [32]byte{3}
+	faceValue := big.NewInt(100)
+	winProb := big.NewInt(100)
+	sig := []byte("foo")
+
+	r := NewRecipient(b, v, ts, secret, faceValue, winProb)
+
+	// Config stub validator with valid non-winning tickets
+	v.SetIsValidTicket(true)
+
+	params, err := r.TicketParams(sender)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Test invalid recipientRand from seed (invalid seed)
+	ticket := &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            sender,
+		FaceValue:         faceValue,
+		WinProb:           winProb,
+		SenderNonce:       0,
+		RecipientRandHash: params.RecipientRandHash,
+	}
+
+	// Using invalid seed
+	_, err = r.ReceiveTicket(ticket, sig, big.NewInt(12312))
+	if err == nil {
+		t.Error("expected invalid recipientRand from seed error")
+	}
+	if err != nil && err != errInvalidRecipientRandFromSeed {
+		t.Errorf("expected invalid recipientRand from seed error, got %v", err)
+	}
+
+	// Test invalid recipientRand from seed (invalid sender)
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            ethcommon.Address{}, // Using invalid sender
+		FaceValue:         faceValue,
+		WinProb:           winProb,
+		SenderNonce:       0,
+		RecipientRandHash: params.RecipientRandHash,
+	}
+
+	_, err = r.ReceiveTicket(ticket, sig, params.Seed)
+	if err == nil {
+		t.Error("expected invalid recipientRand from seed error")
+	}
+	if err != nil && err != errInvalidRecipientRandFromSeed {
+		t.Errorf("expected invalid recipientRand from seed error, got %v", err)
+	}
+
+	// Test invalid faceValue
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            sender,
+		FaceValue:         big.NewInt(0), // Using invalid faceValue
+		WinProb:           winProb,
+		SenderNonce:       0,
+		RecipientRandHash: params.RecipientRandHash,
+	}
+
+	_, err = r.ReceiveTicket(ticket, sig, params.Seed)
+	if err == nil {
+		t.Error("expected invalid faceValue error")
+	}
+	if err != nil && err != errInvalidTicketFaceValue {
+		t.Errorf("expected invalid faceValue error, got %v", err)
+	}
+
+	// Test invalid winProb
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            sender,
+		FaceValue:         faceValue,
+		WinProb:           big.NewInt(0), // Using invalid winProb
+		SenderNonce:       0,
+		RecipientRandHash: params.RecipientRandHash,
+	}
+
+	_, err = r.ReceiveTicket(ticket, sig, params.Seed)
+	if err == nil {
+		t.Error("expected invalid winProb error")
+	}
+	if err != nil && err != errInvalidTicketWinProb {
+		t.Errorf("expected invalid winProb error, got %v", err)
+	}
+
+	// Test invalid ticket
+	// Config stub validator with invalid non-winning tickets
+	v.SetIsValidTicket(false)
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            sender,
+		FaceValue:         faceValue,
+		WinProb:           winProb,
+		SenderNonce:       0,
+		RecipientRandHash: params.RecipientRandHash,
+	}
+
+	if _, err := r.ReceiveTicket(ticket, sig, params.Seed); err == nil {
+		t.Error("expected invalid ticket error")
+	}
+
+	// Test valid non-winning ticket
+	// Config stub validator with valid non-winning tickets
+	v.SetIsValidTicket(true)
+
+	won, err := r.ReceiveTicket(ticket, sig, params.Seed)
+	if err != nil {
+		t.Error(err)
+	}
+	if won {
+		t.Errorf("expected valid non-winning ticket")
+	}
+
+	// Test valid winning ticket
+	// Config stub validator with valid winnning tickets
+	v.SetIsWinningTicket(true)
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            sender,
+		FaceValue:         faceValue,
+		WinProb:           winProb,
+		SenderNonce:       1,
+		RecipientRandHash: params.RecipientRandHash,
+	}
+
+	won, err = r.ReceiveTicket(ticket, sig, params.Seed)
+	if err != nil {
+		t.Error(err)
+	}
+	if !won {
+		t.Errorf("expected valid winning ticket")
+	}
+
+	storeTicket, storeSig, storeRecipientRand, err := ts.Load(ticket.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if storeTicket.Hash() != ticket.Hash() {
+		t.Errorf("expected store ticket hash %v, got %v", ticket.Hash(), storeTicket.Hash())
+	}
+
+	if hex.EncodeToString(storeSig) != hex.EncodeToString(sig) {
+		t.Errorf("expected store sig 0x%x, got 0x%x", sig, storeSig)
+	}
+
+	if crypto.Keccak256Hash(ethcommon.LeftPadBytes(storeRecipientRand.Bytes(), uint256Size)) != ticket.RecipientRandHash {
+		t.Error("expected store recipientRand to match ticket recipientRandHash")
+	}
+
+	// Test invalid recipientRand revealed
+	// Config stub broker with zero deposit and non-zero penalty escrow
+	b.SetDeposit(sender, big.NewInt(0))
+	b.SetPenaltyEscrow(sender, big.NewInt(500))
+	// Redeem ticket to invalidate recipientRand
+	if err := r.RedeemWinningTicket(ticket.Hash()); err != nil {
+		t.Fatal(err)
+	}
+
+	// New ticket with same invalid recipientRand, but updated senderNonce
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            sender,
+		FaceValue:         faceValue,
+		WinProb:           winProb,
+		SenderNonce:       1,
+		RecipientRandHash: params.RecipientRandHash,
+	}
+
+	_, err = r.ReceiveTicket(ticket, sig, params.Seed)
+	if err == nil {
+		t.Error("expected invalid recipientRand revealed error")
+	}
+	if err != nil && err != errInvalidRecipientRandRevealed {
+		t.Errorf("expected invalid recipientRand revealed error, got %v", err)
+	}
+
+	// Test invalid senderNonce
+	params, err = r.TicketParams(sender)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Receive senderNonce = 0
+	ticket0 := &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            sender,
+		FaceValue:         faceValue,
+		WinProb:           winProb,
+		SenderNonce:       0,
+		RecipientRandHash: params.RecipientRandHash,
+	}
+
+	_, err = r.ReceiveTicket(ticket0, sig, params.Seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Receive senderNonce = 1
+	ticket1 := &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            sender,
+		FaceValue:         faceValue,
+		WinProb:           winProb,
+		SenderNonce:       1,
+		RecipientRandHash: params.RecipientRandHash,
+	}
+
+	_, err = r.ReceiveTicket(ticket1, sig, params.Seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Replay senderNonce = 1 (new nonce = highest seen nonce)
+	_, err = r.ReceiveTicket(ticket1, sig, params.Seed)
+	if err == nil {
+		t.Error("expected invalid senderNonce (new nonce = highest seen nonce) error")
+	}
+	if err != nil && err != errInvalidTicketSenderNonce {
+		t.Errorf("expected invalid senderNonce (new nonce = highest seen nonce) error, got %v", err)
+	}
+
+	// Replay senderNonce = 0 (new nonce < highest seen nonce)
+	_, err = r.ReceiveTicket(ticket0, sig, params.Seed)
+	if err == nil {
+		t.Error("expected invalid senderNonce (new nonce < highest seen nonce) error")
+	}
+	if err != nil && err != errInvalidTicketSenderNonce {
+		t.Errorf("expected invalid senderNonce (new nonce < highest seen nonce) error, got %v", err)
+	}
+}
+
+func TestRedeemWinningTicket(t *testing.T) {
+	sender := ethcommon.HexToAddress("A69cdA26600c155cF2c150964Bdb5371ac3f606F")
+	b := newStubBroker()
+	v := &stubValidator{}
+	ts := newStubTicketStore()
+	secret := [32]byte{3}
+	faceValue := big.NewInt(100)
+	winProb := big.NewInt(100)
+	sig := []byte("foo")
+
+	r := NewRecipient(b, v, ts, secret, faceValue, winProb)
+
+	params1, err := r.TicketParams(sender)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Config stub validator with valid winning tickets
+	v.SetIsValidTicket(true)
+	v.SetIsWinningTicket(true)
+	// Config stub broker with zero deposit and penalty escrow
+	b.SetDeposit(sender, big.NewInt(0))
+	b.SetPenaltyEscrow(sender, big.NewInt(0))
+
+	// Test zero deposit and penalty escrow error
+	ticket := &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            sender,
+		FaceValue:         faceValue,
+		WinProb:           winProb,
+		SenderNonce:       0,
+		RecipientRandHash: params1.RecipientRandHash,
+	}
+
+	won, err := r.ReceiveTicket(ticket, sig, params1.Seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !won {
+		t.Fail()
+	}
+
+	err = r.RedeemWinningTicket(ticket.Hash())
+	if err == nil {
+		t.Error("expected zero deposit and penalty escrow error")
+	}
+	if err != nil && err != errZeroDepositAndPenaltyEscrow {
+		t.Errorf("expected zero deposit and penalty escrow error, got %v", err)
+	}
+
+	// Test zero deposit and non-zero penalty escrow
+	// Config stub broker with zero deposit and non-zero penalty escrow
+	b.SetDeposit(sender, big.NewInt(0))
+	b.SetPenaltyEscrow(sender, big.NewInt(500))
+
+	if err := r.RedeemWinningTicket(ticket.Hash()); err != nil {
+		t.Error(err)
+	}
+
+	used, err := b.IsUsedTicket(ticket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !used {
+		t.Errorf("expected used ticket for sender with zero deposit and non-zero penalty escrow")
+	}
+
+	// Test non-zero deposit and zero penalty escrow
+	// Config stub broker with non-zero deposit and zero penalty escrow
+	b.SetDeposit(sender, big.NewInt(500))
+	b.SetPenaltyEscrow(sender, big.NewInt(0))
+
+	params2, err := r.TicketParams(sender)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ticket = &Ticket{
+		Recipient:         ethcommon.Address{},
+		Sender:            sender,
+		FaceValue:         faceValue,
+		WinProb:           winProb,
+		SenderNonce:       0,
+		RecipientRandHash: params2.RecipientRandHash,
+	}
+
+	won, err = r.ReceiveTicket(ticket, sig, params2.Seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !won {
+		t.Fatal()
+	}
+
+	if err := r.RedeemWinningTicket(ticket.Hash()); err != nil {
+		t.Error(err)
+	}
+
+	used, err = b.IsUsedTicket(ticket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !used {
+		t.Errorf("expected used ticket for sender with non-zero deopsit and zero penalty escrow")
+	}
+
+	// Test invalid recipientRand revealed error
+	// This should fail because we use the same ticket with a recipientRand
+	// already invalidated
+	err = r.RedeemWinningTicket(ticket.Hash())
+	if err == nil {
+		t.Error("expected invalid recipientRand revealed error")
+	}
+	if err != nil && err != errInvalidRecipientRandRevealed {
+		t.Errorf("expected invalid recipientRand revealed error, got %v", err)
+	}
+
+	// TODO: Unit test for internal clearing of senderNonce memory?
+}
+
+func TestTicketParams(t *testing.T) {
+	sender := ethcommon.HexToAddress("A69cdA26600c155cF2c150964Bdb5371ac3f606F")
+	b := newStubBroker()
+	v := &stubValidator{}
+	ts := newStubTicketStore()
+	secret := [32]byte{3}
+	faceValue := big.NewInt(100)
+	winProb := big.NewInt(100)
+
+	r := NewRecipient(b, v, ts, secret, faceValue, winProb)
+
+	// Test correct params returned
+	params1, err := r.TicketParams(sender)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if params1.FaceValue.Cmp(faceValue) != 0 {
+		t.Errorf("expected faceValue %d got %d", faceValue, params1.FaceValue)
+	}
+
+	if params1.WinProb.Cmp(winProb) != 0 {
+		t.Errorf("expected winProb %d got %d", winProb, params1.WinProb)
+	}
+
+	h := hmac.New(sha256.New, secret[:])
+	h.Write(append(params1.Seed.Bytes(), sender.Bytes()...))
+	recipientRandHash := crypto.Keccak256Hash(ethcommon.LeftPadBytes(h.Sum(nil), uint256Size))
+
+	if params1.RecipientRandHash != recipientRandHash {
+		t.Errorf("expected recipientRandHash %x got %x", recipientRandHash, params1.RecipientRandHash)
+	}
+
+	// Test correct params returned and different seed + recipientRandHash
+	params2, err := r.TicketParams(sender)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if params2.FaceValue.Cmp(faceValue) != 0 {
+		t.Errorf("expected faceValue %d got %d", faceValue, params2.FaceValue)
+	}
+
+	if params2.WinProb.Cmp(winProb) != 0 {
+		t.Errorf("expected winProb %d got %d", winProb, params2.WinProb)
+	}
+
+	if params2.RecipientRandHash == params1.RecipientRandHash {
+		t.Errorf("expected different recipientRandHash value for different params")
+	}
+
+	if params2.Seed == params1.Seed {
+		t.Errorf("expected different seed value for different params")
+	}
+
+	h = hmac.New(sha256.New, secret[:])
+	h.Write(append(params2.Seed.Bytes(), sender.Bytes()...))
+	recipientRandHash = crypto.Keccak256Hash(ethcommon.LeftPadBytes(h.Sum(nil), uint256Size))
+
+	if params2.RecipientRandHash != recipientRandHash {
+		t.Errorf("expected recipientRandHash %x got %x", recipientRandHash, params2.RecipientRandHash)
+	}
+}

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -2,7 +2,6 @@ package pm
 
 import (
 	"bytes"
-	"crypto/rand"
 	"math/big"
 	"strings"
 	"sync"
@@ -206,44 +205,4 @@ func defaultTicketParams(t *testing.T) TicketParams {
 		Seed:              big.NewInt(0),
 		RecipientRandHash: recipientRandHash,
 	}
-}
-
-func randHashOrFatal(t *testing.T) ethcommon.Hash {
-	key, err := randBytes(32)
-
-	if err != nil {
-		t.Fatalf("failed generating random hash: %v", err)
-		return ethcommon.Hash{}
-	}
-
-	return ethcommon.BytesToHash(key[:])
-}
-
-func randAddressOrFatal(t *testing.T) ethcommon.Address {
-	key, err := randBytes(addressSize)
-
-	if err != nil {
-		t.Fatalf("failed generating random address: %v", err)
-		return ethcommon.Address{}
-	}
-
-	return ethcommon.BytesToAddress(key[:])
-}
-
-func randBytesOrFatal(size int, t *testing.T) []byte {
-	res, err := randBytes(size)
-
-	if err != nil {
-		t.Fatalf("failed generating random bytes: %v", err)
-		return nil
-	}
-
-	return res
-}
-
-func randBytes(size int) ([]byte, error) {
-	key := make([]byte, size)
-	_, err := rand.Read(key)
-
-	return key, err
 }

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -10,6 +10,33 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+type stubTicketStore struct {
+	tickets        map[ethcommon.Hash]*Ticket
+	sigs           map[ethcommon.Hash][]byte
+	recipientRands map[ethcommon.Hash]*big.Int
+}
+
+func newStubTicketStore() *stubTicketStore {
+	return &stubTicketStore{
+		tickets:        make(map[ethcommon.Hash]*Ticket),
+		sigs:           make(map[ethcommon.Hash][]byte),
+		recipientRands: make(map[ethcommon.Hash]*big.Int),
+	}
+}
+
+func (ts *stubTicketStore) Store(ticket *Ticket, sig []byte, recipientRand *big.Int) error {
+	ticketID := ticket.Hash()
+	ts.tickets[ticketID] = ticket
+	ts.sigs[ticketID] = sig
+	ts.recipientRands[ticketID] = recipientRand
+
+	return nil
+}
+
+func (ts *stubTicketStore) Load(ticketID ethcommon.Hash) (*Ticket, []byte, *big.Int, error) {
+	return ts.tickets[ticketID], ts.sigs[ticketID], ts.recipientRands[ticketID], nil
+}
+
 type stubSigVerifier struct {
 	verifyResult bool
 }
@@ -95,7 +122,7 @@ func (b *stubBroker) SetDeposit(addr ethcommon.Address, amount *big.Int) {
 func (b *stubBroker) GetDeposit(addr ethcommon.Address) (*big.Int, error) {
 	deposit, ok := b.deposits[addr]
 	if !ok {
-		return nil, fmt.Errorf("no deposit for %x", addr)
+		return nil, fmt.Errorf("no deposit for 0x%x", addr)
 	}
 
 	return deposit, nil
@@ -108,7 +135,7 @@ func (b *stubBroker) SetPenaltyEscrow(addr ethcommon.Address, amount *big.Int) {
 func (b *stubBroker) GetPenaltyEscrow(addr ethcommon.Address) (*big.Int, error) {
 	penaltyEscrow, ok := b.penaltyEscrows[addr]
 	if !ok {
-		return nil, fmt.Errorf("no penalty escrow for %x", addr)
+		return nil, fmt.Errorf("no penalty escrow for 0x%x", addr)
 	}
 
 	return penaltyEscrow, nil

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -11,30 +11,29 @@ import (
 )
 
 type stubTicketStore struct {
-	tickets        map[ethcommon.Hash]*Ticket
-	sigs           map[ethcommon.Hash][]byte
-	recipientRands map[ethcommon.Hash]*big.Int
+	tickets        map[string][]*Ticket
+	sigs           map[string][][]byte
+	recipientRands map[string][]*big.Int
 }
 
 func newStubTicketStore() *stubTicketStore {
 	return &stubTicketStore{
-		tickets:        make(map[ethcommon.Hash]*Ticket),
-		sigs:           make(map[ethcommon.Hash][]byte),
-		recipientRands: make(map[ethcommon.Hash]*big.Int),
+		tickets:        make(map[string][]*Ticket),
+		sigs:           make(map[string][][]byte),
+		recipientRands: make(map[string][]*big.Int),
 	}
 }
 
-func (ts *stubTicketStore) Store(ticket *Ticket, sig []byte, recipientRand *big.Int) error {
-	ticketID := ticket.Hash()
-	ts.tickets[ticketID] = ticket
-	ts.sigs[ticketID] = sig
-	ts.recipientRands[ticketID] = recipientRand
+func (ts *stubTicketStore) Store(sessionID string, ticket *Ticket, sig []byte, recipientRand *big.Int) error {
+	ts.tickets[sessionID] = append(ts.tickets[sessionID], ticket)
+	ts.sigs[sessionID] = append(ts.sigs[sessionID], sig)
+	ts.recipientRands[sessionID] = append(ts.recipientRands[sessionID], recipientRand)
 
 	return nil
 }
 
-func (ts *stubTicketStore) Load(ticketID ethcommon.Hash) (*Ticket, []byte, *big.Int, error) {
-	return ts.tickets[ticketID], ts.sigs[ticketID], ts.recipientRands[ticketID], nil
+func (ts *stubTicketStore) Load(sessionID string) ([]*Ticket, [][]byte, []*big.Int, error) {
+	return ts.tickets[sessionID], ts.sigs[sessionID], ts.recipientRands[sessionID], nil
 }
 
 type stubSigVerifier struct {

--- a/pm/ticketstore.go
+++ b/pm/ticketstore.go
@@ -2,16 +2,16 @@ package pm
 
 import (
 	"math/big"
-
-	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 // TicketStore is an interface which describes an object capable
 // of persisting tickets
 type TicketStore interface {
 	// Store persists a ticket with its signature and recipientRand
-	Store(ticket *Ticket, sig []byte, recipientRand *big.Int) error
+	// for a session ID
+	Store(sessionID string, ticket *Ticket, sig []byte, recipientRand *big.Int) error
 
-	// Load fetches a persisted ticket in the store with its signature and recipientRand
-	Load(ticketID ethcommon.Hash) (ticket *Ticket, sig []byte, recipientRand *big.Int, err error)
+	// Load fetches all persisted tickets in the store with their signatures and recipientRands
+	// for a session ID
+	Load(sessionID string) (tickets []*Ticket, sigs [][]byte, recipientRands []*big.Int, err error)
 }

--- a/pm/ticketstore.go
+++ b/pm/ticketstore.go
@@ -1,0 +1,17 @@
+package pm
+
+import (
+	"math/big"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+// TicketStore is an interface which describes an object capable
+// of persisting tickets
+type TicketStore interface {
+	// Store persists a ticket with its signature and recipientRand
+	Store(ticket *Ticket, sig []byte, recipientRand *big.Int) error
+
+	// Load fetches a persisted ticket in the store with its signature and recipientRand
+	Load(ticketID ethcommon.Hash) (ticket *Ticket, sig []byte, recipientRand *big.Int, err error)
+}

--- a/pm/validator.go
+++ b/pm/validator.go
@@ -1,11 +1,11 @@
 package pm
 
 import (
-	"errors"
 	"math/big"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -29,15 +29,13 @@ type Validator interface {
 // validator is an implementation of the Validator interface
 type validator struct {
 	addr        ethcommon.Address
-	broker      Broker
 	sigVerifier SigVerifier
 }
 
 // NewValidator returns an instance of a validator
-func NewValidator(addr ethcommon.Address, broker Broker, sigVerifier SigVerifier) Validator {
+func NewValidator(addr ethcommon.Address, sigVerifier SigVerifier) Validator {
 	return &validator{
 		addr:        addr,
-		broker:      broker,
 		sigVerifier: sigVerifier,
 	}
 }

--- a/pm/validator_test.go
+++ b/pm/validator_test.go
@@ -15,12 +15,10 @@ func TestValidateTicket(t *testing.T) {
 	recipientRand := big.NewInt(10)
 	recipientRandHash := crypto.Keccak256Hash(ethcommon.LeftPadBytes(recipientRand.Bytes(), uint256Size))
 
-	b := newStubBroker()
-
 	sv := &stubSigVerifier{}
 	sv.SetVerifyResult(true)
 
-	v := NewValidator(recipient, b, sv)
+	v := NewValidator(recipient, sv)
 
 	// Test invalid recipient (null address)
 	ticket := &Ticket{
@@ -131,12 +129,10 @@ func TestIsWinningTicket(t *testing.T) {
 	recipientRand := big.NewInt(10)
 	recipientRandHash := crypto.Keccak256Hash(ethcommon.LeftPadBytes(recipientRand.Bytes(), uint256Size))
 
-	b := newStubBroker()
-
 	sv := &stubSigVerifier{}
 	sv.SetVerifyResult(true)
 
-	v := NewValidator(recipient, b, sv)
+	v := NewValidator(recipient, sv)
 
 	// Test non-winning ticket
 	ticket := &Ticket{


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Adds recipient specific code to the `pm` package.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- `pm/recipient.go`: Recipient specific state management (i.e. HMAC construction for generating `recipientRand`, replay prevention of invalid `recipientRand` and `senderNonce` values, etc.) 
- `pm/ticketstore.go`: The TicketStore interface allows a recipient to persist winning tickets and fetch them when they need to be redeemed on-chain. The implementation will rely on the node's existing DB and will be done as a part of #621
- Introduce the [pkg/errors](https://github.com/pkg/errors) package for error handling with stack trace capture support. The hope is that using this package will assist with debugging errors and keeping logging at the top level of the program when possible. For more reading on this see: https://dave.cheney.net/2016/06/12/stack-traces-and-the-errors-package and http://dave.cheney.net/paste/gocon-spring-2016.pdf

A few design notes for `recipient.go`:
- `recipient.invalidRands` is a [sync.Map](https://golang.org/pkg/sync/#Map) because as an append only cache for detecting replays of invalidated `recipientRand` values it fits into one of the two recommend use cases for `sync.Map`. Using a dedicated data structure from the the Go standard library for this allows us to avoid writing additional unit tests for the correctness of manually implemented locks.
- `recipient.senderNonces` is a plain Go map with read/write access protected by a `sync.RWMutex`. In the happy case (i.e. no one is attacking you), `recipient.senderNonces` fits into one of the two recommend use cases for `sync.Map` in that it usually supports concurrent operations on a disjoint set of keys. However, for every update to a value in `recipient.senderNonces`, we want to check that the new nonce > the current highest nonce. Otherwise, we want to return an error because the new nonce is invalid. `sync.Map` does not support this type of atomic operation - we would have to first load the current highest nonce and check it and then store the new nonce. These two operations would not be atomic thereby still leaving the possibility of a race condition. Instead of using `sync.Map`, we just use `sync.RWMutex` to implement manually locking - we lock, atomically load the current highest nonce, check it, store the new nonce and then we unlock. An alternative to manually locking is to use an open source [concurrent-map](https://github.com/orcaman/concurrent-map) package which allows a caller to pass in a callback to include additional logic when storing a value in the map. The limited code for manual locking seems easier to understand at the moment, but definitely up for other thoughts (with the downside of having to test the manual locking).

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Unit tests for each of the new data structures with stubbed out dependencies
- Used `go test -race` to find race conditions for manually implemented lock code

**Does this pull request close any open issues?**
<!-- Fixes # -->
- Fixes #630 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass

Remaining TODOs:
- [x] Write a unit test for the manual locking used to protect `recipient.senderNonces`
