### PR TITLE
PM Sender

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
       - run: go get github.com/aws/aws-sdk-go/aws
       - run: go get -u google.golang.org/grpc
       - run: go get github.com/jstemmer/go-junit-report
+      - run: go get github.com/pkg/errors
 
       - run:
           name: Run unit tests

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 .glide/
 
 eth/protocol
+
+# Our compiled binary
+livepeer

--- a/eth/accountmanager.go
+++ b/eth/accountmanager.go
@@ -31,7 +31,7 @@ type AccountManager interface {
 	Account() accounts.Account
 }
 
-type DefaultAccountManager struct {
+type accountManager struct {
 	account accounts.Account
 
 	unlocked bool
@@ -70,7 +70,7 @@ func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string) (Accou
 
 	glog.Infof("Using Ethereum account: %v", acct.Address.Hex())
 
-	return &DefaultAccountManager{
+	return &accountManager{
 		account:  acct,
 		unlocked: false,
 		keyStore: keyStore,
@@ -78,7 +78,7 @@ func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string) (Accou
 }
 
 // Unlock account indefinitely using underlying keystore
-func (am *DefaultAccountManager) Unlock(passphrase string) error {
+func (am *accountManager) Unlock(passphrase string) error {
 	var err error
 
 	err = am.keyStore.Unlock(am.account, passphrase)
@@ -103,7 +103,7 @@ func (am *DefaultAccountManager) Unlock(passphrase string) error {
 }
 
 // Lock account using underlying keystore and remove associated private key from memory
-func (am *DefaultAccountManager) Lock() error {
+func (am *accountManager) Lock() error {
 	err := am.keyStore.Lock(am.account.Address)
 	if err != nil {
 		return err
@@ -116,7 +116,7 @@ func (am *DefaultAccountManager) Lock() error {
 
 // Create transact opts for client use - account must be unlocked
 // Can optionally set gas limit and gas price used
-func (am *DefaultAccountManager) CreateTransactOpts(gasLimit uint64, gasPrice *big.Int) (*bind.TransactOpts, error) {
+func (am *accountManager) CreateTransactOpts(gasLimit uint64, gasPrice *big.Int) (*bind.TransactOpts, error) {
 	if !am.unlocked {
 		return nil, ErrLocked
 	}
@@ -136,7 +136,7 @@ func (am *DefaultAccountManager) CreateTransactOpts(gasLimit uint64, gasPrice *b
 }
 
 // Sign a transaction. Account must be unlocked
-func (am *DefaultAccountManager) SignTx(signer types.Signer, tx *types.Transaction) (*types.Transaction, error) {
+func (am *accountManager) SignTx(signer types.Signer, tx *types.Transaction) (*types.Transaction, error) {
 	signature, err := am.keyStore.SignHash(am.account, signer.Hash(tx).Bytes())
 	if err != nil {
 		return nil, err
@@ -146,14 +146,14 @@ func (am *DefaultAccountManager) SignTx(signer types.Signer, tx *types.Transacti
 }
 
 // Sign byte array message. Account must be unlocked
-func (am *DefaultAccountManager) Sign(msg []byte) ([]byte, error) {
+func (am *accountManager) Sign(msg []byte) ([]byte, error) {
 	personalMsg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", 32, msg)
 	personalHash := crypto.Keccak256([]byte(personalMsg))
 
 	return am.keyStore.SignHash(am.account, personalHash)
 }
 
-func (am *DefaultAccountManager) Account() accounts.Account {
+func (am *accountManager) Account() accounts.Account {
 	return am.account
 }
 

--- a/eth/client.go
+++ b/eth/client.go
@@ -135,7 +135,7 @@ type LivepeerEthClient interface {
 }
 
 type client struct {
-	accountManager *AccountManager
+	accountManager AccountManager
 	backend        *ethclient.Client
 
 	controllerAddr      ethcommon.Address
@@ -400,7 +400,7 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 }
 
 func (c *client) Account() accounts.Account {
-	return c.accountManager.Account
+	return c.accountManager.Account()
 }
 
 func (c *client) Backend() (*ethclient.Client, error) {
@@ -819,7 +819,7 @@ func (c *client) GetClaim(jobID *big.Int, claimID *big.Int) (*lpTypes.Claim, err
 		ClaimBlock:                   cInfo.ClaimBlock,
 		EndVerificationBlock:         cInfo.EndVerificationBlock,
 		EndVerificationSlashingBlock: cInfo.EndVerificationSlashingBlock,
-		Status: status,
+		Status:                       status,
 	}, nil
 }
 

--- a/pm/helpers.go
+++ b/pm/helpers.go
@@ -1,0 +1,11 @@
+package pm
+
+import ethcommon "github.com/ethereum/go-ethereum/common"
+
+func hexToHash(in string) ethcommon.Hash {
+	return ethcommon.BytesToHash(ethcommon.FromHex(in))
+}
+
+func hashToHex(hash ethcommon.Hash) string {
+	return ethcommon.ToHex(hash.Bytes())
+}

--- a/pm/helpers.go
+++ b/pm/helpers.go
@@ -5,7 +5,3 @@ import ethcommon "github.com/ethereum/go-ethereum/common"
 func hexToHash(in string) ethcommon.Hash {
 	return ethcommon.BytesToHash(ethcommon.FromHex(in))
 }
-
-func hashToHex(hash ethcommon.Hash) string {
-	return ethcommon.ToHex(hash.Bytes())
-}

--- a/pm/helpers.go
+++ b/pm/helpers.go
@@ -1,7 +1,0 @@
-package pm
-
-import ethcommon "github.com/ethereum/go-ethereum/common"
-
-func hexToHash(in string) ethcommon.Hash {
-	return ethcommon.BytesToHash(ethcommon.FromHex(in))
-}

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -54,7 +54,7 @@ func (s *defaultSender) StartSession(recipient ethcommon.Address, ticketParams T
 }
 
 func (s *defaultSender) CreateTicket(sessionID string) (*Ticket, *big.Int, []byte, error) {
-	recipientRandHash := hexToHash(sessionID)
+	recipientRandHash := ethcommon.HexToHash(sessionID)
 
 	tempSession, ok := s.sessions.Load(sessionID)
 	if !ok {

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -42,7 +42,7 @@ func NewSender(accountManager eth.AccountManager) Sender {
 }
 
 func (s *defaultSender) StartSession(recipient ethcommon.Address, ticketParams TicketParams) string {
-	sessionID := hashToHex(ticketParams.RecipientRandHash)
+	sessionID := ticketParams.RecipientRandHash.Hex()
 
 	s.sessions.Store(sessionID, &session{
 		recipient:    recipient,

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -1,0 +1,75 @@
+package pm
+
+import (
+	"math/big"
+	"sync"
+	"sync/atomic"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+)
+
+type Sender interface {
+	StartSession(recipient ethcommon.Address, ticketParams TicketParams) string
+
+	CreateTicket(sessionId string) (*Ticket, *big.Int, []byte, error)
+
+	// Later: support receiving new recipientRandHash values mid-stream
+}
+
+type Session struct {
+	senderNonce uint64
+
+	recipient ethcommon.Address
+
+	ticketParams TicketParams
+}
+
+type DefaultSender struct {
+	address ethcommon.Address
+
+	sessions sync.Map
+}
+
+func NewSender(address ethcommon.Address) Sender {
+	return &DefaultSender{
+		address: address,
+	}
+}
+
+func (s *DefaultSender) StartSession(recipient ethcommon.Address, ticketParams TicketParams) string {
+	sessionId := hashToHex(ticketParams.RecipientRandHash)
+
+	s.sessions.Store(sessionId, &Session{
+		recipient:    recipient,
+		ticketParams: ticketParams,
+		senderNonce:  0,
+	})
+
+	return sessionId
+}
+
+func (s *DefaultSender) CreateTicket(sessionId string) (*Ticket, *big.Int, []byte, error) {
+	recipientRandHash := hexToHash(sessionId)
+
+	tempSession, ok := s.sessions.Load(sessionId)
+	if !ok {
+		return nil, nil, nil, errors.Errorf("cannot create a ticket for an unknown session: %+v", sessionId)
+	}
+	session := tempSession.(*Session)
+
+	senderNonce := atomic.AddUint64(&session.senderNonce, 1)
+
+	ticket := &Ticket{
+		Recipient:         session.recipient,
+		RecipientRandHash: recipientRandHash,
+		Sender:            s.address,
+		SenderNonce:       senderNonce,
+		FaceValue:         session.ticketParams.FaceValue,
+		WinProb:           session.ticketParams.WinProb,
+	}
+
+	// TODO sign!
+
+	return ticket, session.ticketParams.Seed, nil, nil
+}

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -58,7 +58,7 @@ func (s *defaultSender) CreateTicket(sessionID string) (*Ticket, *big.Int, []byt
 
 	tempSession, ok := s.sessions.Load(sessionID)
 	if !ok {
-		return nil, nil, nil, errors.Errorf("cannot create a ticket for an unknown session: %+v", sessionID)
+		return nil, nil, nil, errors.Errorf("cannot create a ticket for an unknown session: %v", sessionID)
 	}
 	session := tempSession.(*session)
 

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -28,7 +28,7 @@ type session struct {
 	ticketParams TicketParams
 }
 
-type defaultSender struct {
+type sender struct {
 	accountManager eth.AccountManager
 
 	sessions sync.Map
@@ -36,12 +36,12 @@ type defaultSender struct {
 
 // NewSender creates a new Sender instance.
 func NewSender(accountManager eth.AccountManager) Sender {
-	return &defaultSender{
+	return &sender{
 		accountManager: accountManager,
 	}
 }
 
-func (s *defaultSender) StartSession(recipient ethcommon.Address, ticketParams TicketParams) string {
+func (s *sender) StartSession(recipient ethcommon.Address, ticketParams TicketParams) string {
 	sessionID := ticketParams.RecipientRandHash.Hex()
 
 	s.sessions.Store(sessionID, &session{
@@ -53,7 +53,7 @@ func (s *defaultSender) StartSession(recipient ethcommon.Address, ticketParams T
 	return sessionID
 }
 
-func (s *defaultSender) CreateTicket(sessionID string) (*Ticket, *big.Int, []byte, error) {
+func (s *sender) CreateTicket(sessionID string) (*Ticket, *big.Int, []byte, error) {
 	recipientRandHash := ethcommon.HexToHash(sessionID)
 
 	tempSession, ok := s.sessions.Load(sessionID)

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestStartSession_GivenSomeRecipientRandHash_UsesItAsSessionId(t *testing.T) {
-	sender := defaultSender(t)
+	sender := defaultNewSender(t)
 	recipient := ethcommon.Address{}
 	ticketParams := defaultTicketParams(t)
 	expectedSessionID := hashToHex(ticketParams.RecipientRandHash)
@@ -32,7 +32,7 @@ func TestStartSession_GivenSomeRecipientRandHash_UsesItAsSessionId(t *testing.T)
 }
 
 func TestStartSession_GivenConcurrentUsage_RecordsAllSessions(t *testing.T) {
-	sender := defaultSender(t)
+	sender := defaultNewSender(t)
 	recipient := ethcommon.Address{}
 
 	var sessions []string
@@ -68,7 +68,7 @@ func TestStartSession_GivenConcurrentUsage_RecordsAllSessions(t *testing.T) {
 }
 
 func TestCreateTicket_GivenNonexistentSession_ReturnsError(t *testing.T) {
-	sender := defaultSender(t)
+	sender := defaultNewSender(t)
 
 	_, _, _, err := sender.CreateTicket("foo")
 
@@ -81,7 +81,7 @@ func TestCreateTicket_GivenNonexistentSession_ReturnsError(t *testing.T) {
 }
 
 func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T) {
-	sender := defaultSender(t)
+	sender := defaultNewSender(t)
 	am := sender.accountManager.(*stubAccountManager)
 	am.signShouldFail = false
 	am.saveSignRequest = true
@@ -132,7 +132,7 @@ func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T
 }
 
 func TestCreateTicket_GivenSigningError_ReturnsError(t *testing.T) {
-	sender := defaultSender(t)
+	sender := defaultNewSender(t)
 	recipient := randAddressOrFatal(t)
 	ticketParams := defaultTicketParams(t)
 	sessionID := sender.StartSession(recipient, ticketParams)
@@ -152,7 +152,7 @@ func TestCreateTicket_GivenSigningError_ReturnsError(t *testing.T) {
 func TestCreateTicket_GivenConcurrentCallsForSameSession_SenderNonceIncrementsCorrectly(t *testing.T) {
 	totalTickets := 100
 	lock := sync.RWMutex{}
-	sender := defaultSender(t)
+	sender := defaultNewSender(t)
 	recipient := randAddressOrFatal(t)
 	ticketParams := defaultTicketParams(t)
 	sessionID := sender.StartSession(recipient, ticketParams)
@@ -182,7 +182,7 @@ func TestCreateTicket_GivenConcurrentCallsForSameSession_SenderNonceIncrementsCo
 	if !ok {
 		t.Fatalf("failed to find session with ID %v", sessionID)
 	}
-	session := sessionUntyped.(*Session)
+	session := sessionUntyped.(*session)
 	if session.senderNonce != uint64(totalTickets) {
 		t.Errorf("expected end state SenderNonce %d to be %d", session.senderNonce, totalTickets)
 	}
@@ -196,7 +196,7 @@ func TestCreateTicket_GivenConcurrentCallsForSameSession_SenderNonceIncrementsCo
 	}
 }
 
-func defaultSender(t *testing.T) *DefaultSender {
+func defaultNewSender(t *testing.T) *defaultSender {
 	account := accounts.Account{
 		Address: randAddressOrFatal(t),
 	}
@@ -204,7 +204,7 @@ func defaultSender(t *testing.T) *DefaultSender {
 		account: account,
 	}
 	sender := NewSender(am)
-	return sender.(*DefaultSender)
+	return sender.(*defaultSender)
 }
 
 func defaultTicketParams(t *testing.T) TicketParams {

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -1,0 +1,160 @@
+package pm
+
+import (
+	"crypto/rand"
+	"math/big"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+func TestStartSession_GivenSomeRecipientRandHash_UsesItAsSessionId(t *testing.T) {
+	sender := NewSender(ethcommon.Address{})
+	recipient := ethcommon.Address{}
+	ticketParams := defaultTicketParams(t)
+	expectedSessionId := hashToHex(ticketParams.RecipientRandHash)
+
+	sessionId := sender.StartSession(recipient, TicketParams{
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		Seed:              big.NewInt(0),
+		RecipientRandHash: ticketParams.RecipientRandHash,
+	})
+
+	if sessionId != expectedSessionId {
+		t.Errorf("expected %v to equal %v", sessionId, expectedSessionId)
+	}
+}
+
+func TestStartSession_GivenConcurrentUsage_RecordsAllSessions(t *testing.T) {
+	sender := NewSender(ethcommon.Address{})
+	recipient := ethcommon.Address{}
+
+	var sessions []string
+	var sessionCount int32
+	ch := make(chan struct{})
+	for i := 0; i < 100; i++ {
+		ticketParams := defaultTicketParams(t)
+		expectedSessionId := hashToHex(ticketParams.RecipientRandHash)
+		sessions = append(sessions, expectedSessionId)
+
+		go func() {
+			sender.StartSession(recipient, TicketParams{
+				FaceValue:         big.NewInt(0),
+				WinProb:           big.NewInt(0),
+				Seed:              big.NewInt(0),
+				RecipientRandHash: ticketParams.RecipientRandHash,
+			})
+			currentCount := atomic.AddInt32(&sessionCount, 1)
+			if currentCount >= 100 {
+				ch <- struct{}{}
+			}
+		}()
+	}
+	// waiting for all session to be created
+	<-ch
+
+	ds := sender.(*DefaultSender)
+	for _, sessionId := range sessions {
+		_, ok := ds.sessions.Load(sessionId)
+		if !ok {
+			t.Errorf("expected to find sessionId in sender. sessionId: %v", sessionId)
+		}
+	}
+}
+
+func TestCreateTicket_GivenNonexistentSession_ReturnsError(t *testing.T) {
+	sender := NewSender(ethcommon.Address{})
+
+	_, _, _, err := sender.CreateTicket("foo")
+
+	if err == nil {
+		t.Errorf("expected an error for nonexistent session")
+	}
+	if !strings.Contains(err.Error(), "unknown session") {
+		t.Errorf("expected error to contain 'unknown session' but instead got: %v", err.Error())
+	}
+}
+
+func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T) {
+	senderAddress := randAddressOrFatal(t)
+	sender := NewSender(senderAddress)
+	recipient := randAddressOrFatal(t)
+	recipientRandHash := randHashOrFatal(t)
+	ticketParams := TicketParams{
+		FaceValue:         big.NewInt(1111),
+		WinProb:           big.NewInt(2222),
+		Seed:              big.NewInt(3333),
+		RecipientRandHash: recipientRandHash,
+	}
+	sessionId := sender.StartSession(recipient, ticketParams)
+
+	ticket, actualSeed, _, err := sender.CreateTicket(sessionId)
+
+	if err != nil {
+		t.Errorf("error tryint to create a ticket: %v", err)
+	}
+	if ticket.Sender != senderAddress {
+		t.Errorf("expected ticket sender %v to be %v", ticket.Sender, senderAddress)
+	}
+	if ticket.Recipient != recipient {
+		t.Errorf("expeceted ticket recipient %v to be %v", ticket.Recipient, recipient)
+	}
+	if ticket.RecipientRandHash != recipientRandHash {
+		t.Errorf("expected ticket recipientRandHash %v to be %v", ticket.RecipientRandHash, recipientRandHash)
+	}
+	if ticket.FaceValue != ticketParams.FaceValue {
+		t.Errorf("expected ticket FaceValue %v to be %v", ticket.FaceValue, ticketParams.FaceValue)
+	}
+	if ticket.WinProb != ticketParams.WinProb {
+		t.Errorf("expected ticket WinProb %v to be %v", ticket.WinProb, ticketParams.WinProb)
+	}
+	if ticket.SenderNonce != 1 {
+		t.Errorf("expected ticket SenderNonce %d to be 1", ticket.SenderNonce)
+	}
+	if actualSeed != ticketParams.Seed {
+		t.Errorf("expected actual seed %d to be %d", actualSeed, ticketParams.Seed)
+	}
+
+	// TODO Sig
+}
+
+func TestCreateTicket_GivenConcurrentCallsForSameSession_SenderNonceIncrementsCorrectly(t *testing.T) {
+	// TODO
+}
+
+func defaultTicketParams(t *testing.T) TicketParams {
+	recipientRandHash := randHashOrFatal(t)
+	return TicketParams{
+		FaceValue:         big.NewInt(0),
+		WinProb:           big.NewInt(0),
+		Seed:              big.NewInt(0),
+		RecipientRandHash: recipientRandHash,
+	}
+}
+
+func randHashOrFatal(t *testing.T) ethcommon.Hash {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+
+	if err != nil {
+		t.Fatalf("failed generating random hash: %v", err)
+		return ethcommon.Hash{}
+	}
+
+	return ethcommon.BytesToHash(key[:])
+}
+
+func randAddressOrFatal(t *testing.T) ethcommon.Address {
+	key := make([]byte, addressSize)
+	_, err := rand.Read(key)
+
+	if err != nil {
+		t.Fatalf("failed generating random address: %v", err)
+		return ethcommon.Address{}
+	}
+
+	return ethcommon.BytesToAddress(key[:])
+}

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -84,6 +84,7 @@ func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T
 	sender := defaultSender(t)
 	am := sender.accountManager.(*stubAccountManager)
 	am.signShouldFail = false
+	am.saveSignRequest = true
 	am.signResponse = randBytesOrFatal(42, t)
 	senderAddress := sender.accountManager.Account().Address
 	recipient := randAddressOrFatal(t)

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestStartSession_GivenSomeRecipientRandHash_UsesItAsSessionId(t *testing.T) {
-	sender := defaultNewSender(t)
+	sender := defaultSender(t)
 	recipient := ethcommon.Address{}
 	ticketParams := defaultTicketParams(t)
 	expectedSessionID := ticketParams.RecipientRandHash.Hex()
@@ -31,7 +31,7 @@ func TestStartSession_GivenSomeRecipientRandHash_UsesItAsSessionId(t *testing.T)
 }
 
 func TestStartSession_GivenConcurrentUsage_RecordsAllSessions(t *testing.T) {
-	sender := defaultNewSender(t)
+	sender := defaultSender(t)
 	recipient := ethcommon.Address{}
 
 	var sessions []string
@@ -63,7 +63,7 @@ func TestStartSession_GivenConcurrentUsage_RecordsAllSessions(t *testing.T) {
 }
 
 func TestCreateTicket_GivenNonexistentSession_ReturnsError(t *testing.T) {
-	sender := defaultNewSender(t)
+	sender := defaultSender(t)
 
 	_, _, _, err := sender.CreateTicket("foo")
 
@@ -76,7 +76,7 @@ func TestCreateTicket_GivenNonexistentSession_ReturnsError(t *testing.T) {
 }
 
 func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T) {
-	sender := defaultNewSender(t)
+	sender := defaultSender(t)
 	am := sender.accountManager.(*stubAccountManager)
 	am.signShouldFail = false
 	am.saveSignRequest = true
@@ -127,7 +127,7 @@ func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T
 }
 
 func TestCreateTicket_GivenSigningError_ReturnsError(t *testing.T) {
-	sender := defaultNewSender(t)
+	sender := defaultSender(t)
 	recipient := randAddressOrFatal(t)
 	ticketParams := defaultTicketParams(t)
 	sessionID := sender.StartSession(recipient, ticketParams)
@@ -147,7 +147,7 @@ func TestCreateTicket_GivenSigningError_ReturnsError(t *testing.T) {
 func TestCreateTicket_GivenConcurrentCallsForSameSession_SenderNonceIncrementsCorrectly(t *testing.T) {
 	totalTickets := 100
 	lock := sync.RWMutex{}
-	sender := defaultNewSender(t)
+	sender := defaultSender(t)
 	recipient := randAddressOrFatal(t)
 	ticketParams := defaultTicketParams(t)
 	sessionID := sender.StartSession(recipient, ticketParams)
@@ -187,15 +187,15 @@ func TestCreateTicket_GivenConcurrentCallsForSameSession_SenderNonceIncrementsCo
 	}
 }
 
-func defaultNewSender(t *testing.T) *defaultSender {
+func defaultSender(t *testing.T) *sender {
 	account := accounts.Account{
 		Address: randAddressOrFatal(t),
 	}
 	am := &stubAccountManager{
 		account: account,
 	}
-	sender := NewSender(am)
-	return sender.(*defaultSender)
+	s := NewSender(am)
+	return s.(*sender)
 }
 
 func defaultTicketParams(t *testing.T) TicketParams {

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -1,9 +1,9 @@
 package pm
 
 import (
+	"bytes"
 	"crypto/rand"
 	"math/big"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -95,7 +95,7 @@ func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T
 	ticket, actualSeed, actualSig, err := sender.CreateTicket(sessionID)
 
 	if err != nil {
-		t.Errorf("error tryint to create a ticket: %v", err)
+		t.Errorf("error trying to create a ticket: %v", err)
 	}
 	if ticket.Sender != senderAddress {
 		t.Errorf("expected ticket sender %v to be %v", ticket.Sender, senderAddress)
@@ -118,10 +118,10 @@ func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T
 	if actualSeed != ticketParams.Seed {
 		t.Errorf("expected actual seed %d to be %d", actualSeed, ticketParams.Seed)
 	}
-	if !reflect.DeepEqual(actualSig, am.signResponse) {
+	if !bytes.Equal(actualSig, am.signResponse) {
 		t.Errorf("expected actual sig %v to be %v", actualSig, am.signResponse)
 	}
-	if !reflect.DeepEqual(am.lastSignRequest, ticket.Hash().Bytes()) {
+	if !bytes.Equal(am.lastSignRequest, ticket.Hash().Bytes()) {
 		t.Errorf("expected sig message bytes %v to be %v", am.lastSignRequest, ticket.Hash().Bytes())
 	}
 }

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -17,7 +17,7 @@ func TestStartSession_GivenSomeRecipientRandHash_UsesItAsSessionId(t *testing.T)
 	sender := defaultNewSender(t)
 	recipient := ethcommon.Address{}
 	ticketParams := defaultTicketParams(t)
-	expectedSessionID := hashToHex(ticketParams.RecipientRandHash)
+	expectedSessionID := ticketParams.RecipientRandHash.Hex()
 
 	sessionID := sender.StartSession(recipient, TicketParams{
 		FaceValue:         big.NewInt(0),
@@ -40,7 +40,7 @@ func TestStartSession_GivenConcurrentUsage_RecordsAllSessions(t *testing.T) {
 	ch := make(chan struct{})
 	for i := 0; i < 100; i++ {
 		ticketParams := defaultTicketParams(t)
-		expectedSessionID := hashToHex(ticketParams.RecipientRandHash)
+		expectedSessionID := ticketParams.RecipientRandHash.Hex()
 		sessions = append(sessions, expectedSessionID)
 
 		go func() {

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -141,6 +141,7 @@ func (v *stubValidator) IsWinningTicket(ticket *Ticket, sig []byte, recipientRan
 
 type stubAccountManager struct {
 	account         accounts.Account
+	saveSignRequest bool
 	lastSignRequest []byte
 	signResponse    []byte
 	signShouldFail  bool
@@ -163,7 +164,9 @@ func (am *stubAccountManager) SignTx(signer types.Signer, tx *types.Transaction)
 }
 
 func (am *stubAccountManager) Sign(msg []byte) ([]byte, error) {
-	am.lastSignRequest = msg
+	if am.saveSignRequest {
+		am.lastSignRequest = msg
+	}
 	if am.signShouldFail {
 		return nil, fmt.Errorf("stub returning error as requested")
 	}

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type stubSigVerifier struct {
@@ -134,4 +137,39 @@ func (v *stubValidator) ValidateTicket(ticket *Ticket, sig []byte, recipientRand
 
 func (v *stubValidator) IsWinningTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) bool {
 	return v.isWinningTicket
+}
+
+type stubAccountManager struct {
+	account         accounts.Account
+	lastSignRequest []byte
+	signResponse    []byte
+	signShouldFail  bool
+}
+
+func (am *stubAccountManager) Unlock(passphrase string) error {
+	return nil
+}
+
+func (am *stubAccountManager) Lock() error {
+	return nil
+}
+
+func (am *stubAccountManager) CreateTransactOpts(gasLimit uint64, gasPrice *big.Int) (*bind.TransactOpts, error) {
+	return nil, nil
+}
+
+func (am *stubAccountManager) SignTx(signer types.Signer, tx *types.Transaction) (*types.Transaction, error) {
+	return nil, nil
+}
+
+func (am *stubAccountManager) Sign(msg []byte) ([]byte, error) {
+	am.lastSignRequest = msg
+	if am.signShouldFail {
+		return nil, fmt.Errorf("stub returning error as requested")
+	}
+	return am.signResponse, nil
+}
+
+func (am *stubAccountManager) Account() accounts.Account {
+	return am.account
 }

--- a/pm/ticket_test.go
+++ b/pm/ticket_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHash(t *testing.T) {
-	exp := hexToHash("24d4264d5ea56ba4362c8f535308005b2df1f9f77c34b4a61f6b5c3bef151b53")
+	exp := ethcommon.HexToHash("24d4264d5ea56ba4362c8f535308005b2df1f9f77c34b4a61f6b5c3bef151b53")
 	ticket := &Ticket{
 		Recipient:         ethcommon.Address{},
 		Sender:            ethcommon.Address{},
@@ -24,7 +24,7 @@ func TestHash(t *testing.T) {
 		t.Errorf("Expected %v got %v", exp, h)
 	}
 
-	exp = hexToHash("ce0918ba94518293e9712effbe5fca4f1f431089833a5b8c257cb1e024595f68")
+	exp = ethcommon.HexToHash("ce0918ba94518293e9712effbe5fca4f1f431089833a5b8c257cb1e024595f68")
 	ticket = &Ticket{
 		Recipient:         ethcommon.Address{},
 		Sender:            ethcommon.Address{},
@@ -39,7 +39,7 @@ func TestHash(t *testing.T) {
 		t.Errorf("Expected %v got %v", exp, h)
 	}
 
-	exp = hexToHash("87ef13f2d37e4d5352a01d3c77b8179d80e0887f1953bfabfd0bfd7b0f689ddd")
+	exp = ethcommon.HexToHash("87ef13f2d37e4d5352a01d3c77b8179d80e0887f1953bfabfd0bfd7b0f689ddd")
 	ticket = &Ticket{
 		Recipient:         ethcommon.Address{},
 		Sender:            ethcommon.Address{},
@@ -54,7 +54,7 @@ func TestHash(t *testing.T) {
 		t.Errorf("Expected %v got %v", exp, h)
 	}
 
-	exp = hexToHash("aa4b35071043587992ac8b9dd1b2cf1d8311130e6458cf0b2342484e21af5f5b")
+	exp = ethcommon.HexToHash("aa4b35071043587992ac8b9dd1b2cf1d8311130e6458cf0b2342484e21af5f5b")
 	ticket = &Ticket{
 		Recipient:         ethcommon.Address{},
 		Sender:            ethcommon.Address{},
@@ -69,7 +69,7 @@ func TestHash(t *testing.T) {
 		t.Errorf("Expected %v got %v", exp, h)
 	}
 
-	exp = hexToHash("81e353ae39046e2b77b9f996abbaeed527fda559b61ef90f299c4499dd508ccc")
+	exp = ethcommon.HexToHash("81e353ae39046e2b77b9f996abbaeed527fda559b61ef90f299c4499dd508ccc")
 	ticket = &Ticket{
 		Recipient:         ethcommon.HexToAddress("73AEd7b5dEb30222fa896f399d46cC99c7BEe57F"),
 		Sender:            ethcommon.Address{},
@@ -87,7 +87,7 @@ func TestHash(t *testing.T) {
 	var recipientRandHash [32]byte
 	copy(recipientRandHash[:], ethcommon.FromHex("41b1a0649752af1b28b3dc29a1556eee781e4a4c3a1f7f53f90fa834de098c4d")[:32])
 
-	exp = hexToHash("be5eaf9a49a39540b9bb02f1a21904f61324a29819e2c032824bfaa10c100b17")
+	exp = ethcommon.HexToHash("be5eaf9a49a39540b9bb02f1a21904f61324a29819e2c032824bfaa10c100b17")
 	ticket = &Ticket{
 		Recipient:         ethcommon.Address{},
 		Sender:            ethcommon.Address{},

--- a/pm/ticket_test.go
+++ b/pm/ticket_test.go
@@ -8,9 +8,6 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
-func hexToHash(in string) ethcommon.Hash {
-	return ethcommon.BytesToHash(ethcommon.FromHex(in))
-}
 func TestHash(t *testing.T) {
 	exp := hexToHash("24d4264d5ea56ba4362c8f535308005b2df1f9f77c34b4a61f6b5c3bef151b53")
 	ticket := &Ticket{

--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,12 @@ go test -logtostderr=true
 t7=$?
 cd ..
 
-if (($t1!=0||$t2!=0||$t3!=0||$t4!=0||$t5!=0||$t6!=0||t7!=0))
+cd pm
+go test -logtostderr=true
+t8=$?
+cd ..
+
+if (($t1!=0||$t2!=0||$t3!=0||$t4!=0||$t5!=0||$t6!=0||t7!=0||t8!=0))
 then
     printf "\n\nSome Tests Failed\n\n"
     exit -1


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds the PM `Sender` interface and implementation, allowing Bs to create PM tickets based on params received from O (B/O PM param exchange has yet to be implemented).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- `pm.Sender` with support for `StartSession` and `CreateTicket`
- `StartSession` begins a PM session with specific params, e.g. `recipientRandHash`, `winProb` and a few more
- `CreateTicket` creates the next valid ticket given a specific session
- Refactored `AccountManager` to be an interface so it can be stubbed out in `sender_test.go`

**How did you test each of these updates (required)**

- Unit tests for `defaultSender`, which is the only `Sender` implementation as of now
- Used `go test -race` and made sure the race condition detector did not find any race conditions

**Does this pull request close any open issues?**

- Fixes #629 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
