### PR TITLE
Persist Winning Tickets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
       - run: go get -u google.golang.org/grpc
       - run: go get github.com/jstemmer/go-junit-report
       - run: go get github.com/pkg/errors
+      - run: go get github.com/stretchr/testify
 
       - run:
           name: Run unit tests

--- a/common/db.go
+++ b/common/db.go
@@ -165,7 +165,8 @@ var schema = `
 		winProb BLOB,
 		senderNonce INTEGER,
 		recipientRand BLOB,
-		sig BLOB
+		sig BLOB,
+		sessionID STRING
 	);
 `
 
@@ -409,7 +410,7 @@ func InitDB(dbPath string) (*DB, error) {
 	d.withdrawableUnbondingLocks = stmt
 
 	// Winning tickets prepared statements
-	stmt, err = db.Prepare("INSERT INTO winningTickets(sender, recipient, faceValue, winProb, senderNonce, recipientRand, sig) VALUES(?, ?, ?, ?, ?, ?, ?)")
+	stmt, err = db.Prepare("INSERT INTO winningTickets(sender, recipient, faceValue, winProb, senderNonce, recipientRand, sig, sessionID) VALUES(?, ?, ?, ?, ?, ?, ?, ?)")
 	if err != nil {
 		glog.Error("Unable to prepare insertWinningTicket ", err)
 		d.Close()
@@ -899,10 +900,10 @@ func (db *DB) UnbondingLocks(currentRound *big.Int) ([]*DBUnbondingLock, error) 
 	return unbondingLocks, nil
 }
 
-func (db *DB) InsertWinningTicket(sender ethcommon.Address, recipient ethcommon.Address, faceValue *big.Int, winProb *big.Int, senderNonce uint64, recipientRand *big.Int, sig []byte) error {
+func (db *DB) InsertWinningTicket(sender ethcommon.Address, recipient ethcommon.Address, faceValue *big.Int, winProb *big.Int, senderNonce uint64, recipientRand *big.Int, sig []byte, sessionID string) error {
 	glog.V(DEBUG).Infof("db: Inserting winning ticket from %v, recipientRand %d, senderNonce %d", sender.Hex(), recipientRand, senderNonce)
 
-	_, err := db.insertWinningTicket.Exec(sender.Hex(), recipient.Hex(), faceValue.Bytes(), winProb.Bytes(), senderNonce, recipientRand.Bytes(), sig)
+	_, err := db.insertWinningTicket.Exec(sender.Hex(), recipient.Hex(), faceValue.Bytes(), winProb.Bytes(), senderNonce, recipientRand.Bytes(), sig, sessionID)
 
 	if err != nil {
 		// TODO wrap with custom error

--- a/common/db.go
+++ b/common/db.go
@@ -163,7 +163,7 @@ var schema = `
 		recipient STRING,
 		faceValue BLOB,
 		winProb BLOB,
-		senderNonce UNSIGNED BIG INT,
+		senderNonce INTEGER,
 		recipientRand BLOB,
 		sig BLOB
 	);

--- a/common/db.go
+++ b/common/db.go
@@ -929,7 +929,7 @@ func (db *DB) StoreWinningTicket(sessionID string, ticket *pm.Ticket, sig []byte
 	_, err := db.insertWinningTicket.Exec(ticket.Sender.Hex(), ticket.Recipient.Hex(), ticket.FaceValue.Bytes(), ticket.WinProb.Bytes(), ticket.SenderNonce, recipientRand.Bytes(), ticket.RecipientRandHash.Hex(), sig, sessionID)
 
 	if err != nil {
-		return errors.Wrapf(err, "failed inserting winning ticket. sessionID: %v, ticket: %v", sessionID, ticket)
+		return errors.Wrapf(err, "failed inserting winning ticket for sessionID: %v, ticket: %v", sessionID, ticket)
 	}
 	return nil
 }

--- a/common/db.go
+++ b/common/db.go
@@ -937,7 +937,7 @@ func (db *DB) LoadWinningTickets(sessionID string) (tickets []*pm.Ticket, sigs [
 	for rows.Next() {
 		var sender, recipient, sessionID string
 		var faceValue, winProb, recipientRandBytes, sig []byte
-		var senderNonce uint64
+		var senderNonce uint32
 
 		err = rows.Scan(&sender, &recipient, &faceValue, &winProb, &senderNonce, &recipientRandBytes, &sig, &sessionID)
 		if err != nil {

--- a/common/db.go
+++ b/common/db.go
@@ -915,6 +915,15 @@ func (db *DB) UnbondingLocks(currentRound *big.Int) ([]*DBUnbondingLock, error) 
 }
 
 func (db *DB) StoreWinningTicket(sessionID string, ticket *pm.Ticket, sig []byte, recipientRand *big.Int) error {
+	if ticket == nil {
+		return errors.New("cannot store nil ticket")
+	}
+	if sig == nil {
+		return errors.New("cannot store nil sig")
+	}
+	if recipientRand == nil {
+		return errors.New("cannot store nil recipientRand")
+	}
 	glog.V(DEBUG).Infof("db: Inserting winning ticket from %v, recipientRand %d, senderNonce %d", ticket.Sender.Hex(), recipientRand, ticket.SenderNonce)
 
 	_, err := db.insertWinningTicket.Exec(ticket.Sender.Hex(), ticket.Recipient.Hex(), ticket.FaceValue.Bytes(), ticket.WinProb.Bytes(), ticket.SenderNonce, recipientRand.Bytes(), ticket.RecipientRandHash.Hex(), sig, sessionID)

--- a/common/db.go
+++ b/common/db.go
@@ -11,6 +11,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang/glog"
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
+	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/lpms/ffmpeg"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -900,10 +901,10 @@ func (db *DB) UnbondingLocks(currentRound *big.Int) ([]*DBUnbondingLock, error) 
 	return unbondingLocks, nil
 }
 
-func (db *DB) InsertWinningTicket(sender ethcommon.Address, recipient ethcommon.Address, faceValue *big.Int, winProb *big.Int, senderNonce uint64, recipientRand *big.Int, sig []byte, sessionID string) error {
-	glog.V(DEBUG).Infof("db: Inserting winning ticket from %v, recipientRand %d, senderNonce %d", sender.Hex(), recipientRand, senderNonce)
+func (db *DB) StoreWinningTicket(sessionID string, ticket *pm.Ticket, sig []byte, recipientRand *big.Int) error {
+	glog.V(DEBUG).Infof("db: Inserting winning ticket from %v, recipientRand %d, senderNonce %d", ticket.Sender.Hex(), recipientRand, ticket.SenderNonce)
 
-	_, err := db.insertWinningTicket.Exec(sender.Hex(), recipient.Hex(), faceValue.Bytes(), winProb.Bytes(), senderNonce, recipientRand.Bytes(), sig, sessionID)
+	_, err := db.insertWinningTicket.Exec(ticket.Sender.Hex(), ticket.Recipient.Hex(), ticket.FaceValue.Bytes(), ticket.WinProb.Bytes(), ticket.SenderNonce, recipientRand.Bytes(), sig, sessionID)
 
 	if err != nil {
 		// TODO wrap with custom error

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -616,18 +616,18 @@ func TestInsertWinningTicket_GivenValidInputs_InsertsOneRowCorrectly(t *testing.
 	if actualRecipient != recipient.Hex() {
 		t.Errorf("expected recipient %v to equal %v", actualRecipient, recipient.Hex())
 	}
-	actualFaceValue := bytesToBigInt(actualFaceValueBytes)
+	actualFaceValue := new(big.Int).SetBytes(actualFaceValueBytes)
 	if actualFaceValue.Cmp(faceValue) != 0 {
 		t.Errorf("expected faceValue %d to equal %d", actualFaceValue, faceValue)
 	}
-	actualWinProb := bytesToBigInt(actualWinProbBytes)
+	actualWinProb := new(big.Int).SetBytes(actualWinProbBytes)
 	if actualWinProb.Cmp(winProb) != 0 {
 		t.Errorf("expected winProb %d to equal %d", actualWinProb, winProb)
 	}
 	if actualSenderNonce != senderNonce {
 		t.Errorf("expected senderNonce %d to equal %d", actualSenderNonce, senderNonce)
 	}
-	actualRecipientRand := bytesToBigInt(actualRecipientRandBytes)
+	actualRecipientRand := new(big.Int).SetBytes(actualRecipientRandBytes)
 	if actualRecipientRand.Cmp(recipientRand) != 0 {
 		t.Errorf("expected recipientRand %d to equal %d", actualRecipientRand, recipientRand)
 	}
@@ -683,10 +683,4 @@ func randBytes(size int) ([]byte, error) {
 	_, err := rand.Read(key)
 
 	return key, err
-}
-
-func bytesToBigInt(buf []byte) *big.Int {
-	res := big.NewInt(0)
-	res.SetBytes(buf)
-	return res
 }

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -597,18 +597,19 @@ func TestInsertWinningTicket_GivenValidInputs_InsertsOneRowCorrectly(t *testing.
 	senderNonce := uint64(123)
 	recipientRand := big.NewInt(4567)
 	sig := randBytesOrFatal(42, t)
+	sessionID := "foo bar"
 
-	err = dbh.InsertWinningTicket(sender, recipient, faceValue, winProb, senderNonce, recipientRand, sig)
+	err = dbh.InsertWinningTicket(sender, recipient, faceValue, winProb, senderNonce, recipientRand, sig, sessionID)
 
 	if err != nil {
 		t.Errorf("Failed to insert winning ticket with error: %v", err)
 	}
 
-	row := dbraw.QueryRow("SELECT sender, recipient, faceValue, winProb, senderNonce, recipientRand, sig FROM winningTickets")
-	var actualSender, actualRecipient string
+	row := dbraw.QueryRow("SELECT sender, recipient, faceValue, winProb, senderNonce, recipientRand, sig, sessionID FROM winningTickets")
+	var actualSender, actualRecipient, actualSessionID string
 	var actualFaceValueBytes, actualWinProbBytes, actualRecipientRandBytes, actualSig []byte
 	var actualSenderNonce uint64
-	err = row.Scan(&actualSender, &actualRecipient, &actualFaceValueBytes, &actualWinProbBytes, &actualSenderNonce, &actualRecipientRandBytes, &actualSig)
+	err = row.Scan(&actualSender, &actualRecipient, &actualFaceValueBytes, &actualWinProbBytes, &actualSenderNonce, &actualRecipientRandBytes, &actualSig, &actualSessionID)
 
 	if actualSender != sender.Hex() {
 		t.Errorf("expected sender %v to equal %v", actualSender, sender.Hex())
@@ -633,6 +634,9 @@ func TestInsertWinningTicket_GivenValidInputs_InsertsOneRowCorrectly(t *testing.
 	}
 	if !bytes.Equal(actualSig, sig) {
 		t.Errorf("expected sig %v to equal %v", actualSig, sig)
+	}
+	if actualSessionID != sessionID {
+		t.Errorf("expeceted sessionID %v to equal %v", actualSessionID, sessionID)
 	}
 
 	ticketsCount := getRowCountOrFatal("SELECT count(*) FROM winningTickets", dbraw, t)

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -1,13 +1,11 @@
 package common
 
 import (
-	"bytes"
 	"crypto/rand"
 	"database/sql"
 	"fmt"
 	"math"
 	"math/big"
-	"reflect"
 	"testing"
 	"time"
 
@@ -15,6 +13,7 @@ import (
 	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/lpms/ffmpeg"
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDBLastSeenBlock(t *testing.T) {
@@ -606,42 +605,21 @@ func TestInsertWinningTicket_GivenValidInputs_InsertsOneRowCorrectly(t *testing.
 	var actualSenderNonce uint32
 	err = row.Scan(&actualSender, &actualRecipient, &actualFaceValueBytes, &actualWinProbBytes, &actualSenderNonce, &actualRecipientRandBytes, &actualRecipientRandHash, &actualSig, &actualSessionID)
 
-	if actualSender != ticket.Sender.Hex() {
-		t.Errorf("expected sender %v to equal %v", actualSender, ticket.Sender.Hex())
-	}
-	if actualRecipient != ticket.Recipient.Hex() {
-		t.Errorf("expected recipient %v to equal %v", actualRecipient, ticket.Recipient.Hex())
-	}
-	actualFaceValue := new(big.Int).SetBytes(actualFaceValueBytes)
-	if actualFaceValue.Cmp(ticket.FaceValue) != 0 {
-		t.Errorf("expected faceValue %d to equal %d", actualFaceValue, ticket.FaceValue)
-	}
-	actualWinProb := new(big.Int).SetBytes(actualWinProbBytes)
-	if actualWinProb.Cmp(ticket.WinProb) != 0 {
-		t.Errorf("expected winProb %d to equal %d", actualWinProb, ticket.WinProb)
-	}
-	if actualSenderNonce != ticket.SenderNonce {
-		t.Errorf("expected senderNonce %d to equal %d", actualSenderNonce, ticket.SenderNonce)
-	}
-	actualRecipientRand := new(big.Int).SetBytes(actualRecipientRandBytes)
-	if actualRecipientRand.Cmp(recipientRand) != 0 {
-		t.Errorf("expected recipientRand %d to equal %d", actualRecipientRand, recipientRand)
-	}
-	if ethcommon.HexToHash(actualRecipientRandHash) != ticket.RecipientRandHash {
-		t.Errorf("expected recipientRandHash %v to equal %v", ethcommon.HexToHash(actualRecipientRandHash), ticket.RecipientRandHash)
-	}
-	if !bytes.Equal(actualSig, sig) {
-		t.Errorf("expected sig %v to equal %v", actualSig, sig)
-	}
-	if actualSessionID != sessionID {
-		t.Errorf("expeceted sessionID %v to equal %v", actualSessionID, sessionID)
-	}
+	assert := assert.New(t)
+	assert.Equal(ticket.Sender.Hex(), actualSender)
+	assert.Equal(ticket.Recipient.Hex(), actualRecipient)
+	assert.Equal(ticket.FaceValue, new(big.Int).SetBytes(actualFaceValueBytes))
+	assert.Equal(ticket.WinProb, new(big.Int).SetBytes(actualWinProbBytes))
+	assert.Equal(ticket.SenderNonce, actualSenderNonce)
+	assert.Equal(recipientRand, new(big.Int).SetBytes(actualRecipientRandBytes))
+	assert.Equal(ticket.RecipientRandHash, ethcommon.HexToHash(actualRecipientRandHash))
+	assert.Equal(sig, actualSig)
+	assert.Equal(sessionID, actualSessionID)
 
 	ticketsCount := getRowCountOrFatal("SELECT count(*) FROM winningTickets", dbraw, t)
-	if ticketsCount != 1 {
-		t.Errorf("expected db ticket count %d to be 1", ticketsCount)
-	}
+	assert.Equal(1, ticketsCount)
 }
+
 func TestInsertWinningTicket_GivenMaxValueInputs_InsertsOneRowCorrectly(t *testing.T) {
 	dbh, dbraw, err := TempDB(t)
 	defer dbh.Close()
@@ -668,45 +646,22 @@ func TestInsertWinningTicket_GivenMaxValueInputs_InsertsOneRowCorrectly(t *testi
 	var actualSenderNonce uint32
 	err = row.Scan(&actualSender, &actualRecipient, &actualFaceValueBytes, &actualWinProbBytes, &actualSenderNonce, &actualRecipientRandBytes, &actualRecipientRandHash, &actualSig, &actualSessionID)
 
-	if actualSender != ticket.Sender.Hex() {
-		t.Errorf("expected sender %v to equal %v", actualSender, ticket.Sender.Hex())
-	}
-	if actualRecipient != ticket.Recipient.Hex() {
-		t.Errorf("expected recipient %v to equal %v", actualRecipient, ticket.Recipient.Hex())
-	}
-	actualFaceValue := new(big.Int).SetBytes(actualFaceValueBytes)
-	if actualFaceValue.Cmp(ticket.FaceValue) != 0 {
-		t.Errorf("expected faceValue %d to equal %d", actualFaceValue, ticket.FaceValue)
-	}
-	actualWinProb := new(big.Int).SetBytes(actualWinProbBytes)
-	if actualWinProb.Cmp(ticket.WinProb) != 0 {
-		t.Errorf("expected winProb %d to equal %d", actualWinProb, ticket.WinProb)
-	}
-	if actualSenderNonce != ticket.SenderNonce {
-		t.Errorf("expected senderNonce %d to equal %d", actualSenderNonce, ticket.SenderNonce)
-	}
-	actualRecipientRand := new(big.Int).SetBytes(actualRecipientRandBytes)
-	if actualRecipientRand.Cmp(recipientRand) != 0 {
-		t.Errorf("expected recipientRand %d to equal %d", actualRecipientRand, recipientRand)
-	}
-	if ethcommon.HexToHash(actualRecipientRandHash) != ticket.RecipientRandHash {
-		t.Errorf("expected recipientRandHash %v to equal %v", ethcommon.HexToHash(actualRecipientRandHash), ticket.RecipientRandHash)
-	}
-	if !bytes.Equal(actualSig, sig) {
-		t.Errorf("expected sig %v to equal %v", actualSig, sig)
-	}
-	if actualSessionID != sessionID {
-		t.Errorf("expeceted sessionID %v to equal %v", actualSessionID, sessionID)
-	}
+	assert := assert.New(t)
+	assert.Equal(ticket.Sender.Hex(), actualSender)
+	assert.Equal(ticket.Recipient.Hex(), actualRecipient)
+	assert.Equal(ticket.FaceValue, new(big.Int).SetBytes(actualFaceValueBytes))
+	assert.Equal(ticket.WinProb, new(big.Int).SetBytes(actualWinProbBytes))
+	assert.Equal(ticket.SenderNonce, actualSenderNonce)
+	assert.Equal(recipientRand, new(big.Int).SetBytes(actualRecipientRandBytes))
+	assert.Equal(ticket.RecipientRandHash, ethcommon.HexToHash(actualRecipientRandHash))
+	assert.Equal(sig, actualSig)
+	assert.Equal(sessionID, actualSessionID)
 
 	ticketsCount := getRowCountOrFatal("SELECT count(*) FROM winningTickets", dbraw, t)
-	if ticketsCount != 1 {
-		t.Errorf("expected db ticket count %d to be 1", ticketsCount)
-	}
+	assert.Equal(1, ticketsCount)
 }
 
 // TODO
-// same test but with max values
 // tests with errors
 
 func TestLoadtWinningTicket_GivenStoredTicket_LoadsItCorrectly(t *testing.T) {
@@ -734,15 +689,10 @@ func TestLoadtWinningTicket_GivenStoredTicket_LoadsItCorrectly(t *testing.T) {
 	actualSig := sigs[0]
 	actualRecipientRand := recipientRands[0]
 
-	if !reflect.DeepEqual(actualTicket, ticket) {
-		t.Errorf("expected ticket %v to equal %v", actualTicket, ticket)
-	}
-	if !bytes.Equal(actualSig, sig) {
-		t.Errorf("expected sig %v to equal %v", actualSig, sig)
-	}
-	if actualRecipientRand.Cmp(recipientRand) != 0 {
-		t.Errorf("expected recipientRand %d to equal %d", actualRecipientRand, recipientRand)
-	}
+	assert := assert.New(t)
+	assert.Equal(ticket, actualTicket)
+	assert.Equal(sig, actualSig)
+	assert.Equal(recipientRand, actualRecipientRand)
 }
 
 func TestLoadtWinningTicket_GivenStoredTicketsFromDifferentSessions_OnlyLoadsFromSpecificSessionID(t *testing.T) {
@@ -777,31 +727,18 @@ func TestLoadtWinningTicket_GivenStoredTicketsFromDifferentSessions_OnlyLoadsFro
 	}
 
 	tickets, sigs, recipientRands, err := dbh.LoadWinningTickets(firstSessionID)
-	if err != nil {
-		t.Fatalf("unexpected error loading tickets: %v", err)
-	}
-	if len(tickets) != 2 || len(sigs) != 2 || len(recipientRands) != 2 {
-		t.Errorf("expected one item per slice but got unexpected number of results. tickets: %d, sigs: %d, recipientRands: %d", len(tickets), len(sigs), len(recipientRands))
-	}
 
-	if !reflect.DeepEqual(tickets[0], ticket0) {
-		t.Errorf("expected ticket %v to equal %v", tickets[0], ticket0)
-	}
-	if !bytes.Equal(sigs[0], sig0) {
-		t.Errorf("expected sig %v to equal %v", sigs[0], sig0)
-	}
-	if recipientRands[0].Cmp(recipientRand0) != 0 {
-		t.Errorf("expected recipientRand %d to equal %d", recipientRands[0], recipientRand0)
-	}
-	if !reflect.DeepEqual(tickets[1], ticket1) {
-		t.Errorf("expected ticket %v to equal %v", tickets[1], ticket1)
-	}
-	if !bytes.Equal(sigs[1], sig1) {
-		t.Errorf("expected sig %v to equal %v", sigs[1], sig1)
-	}
-	if recipientRands[1].Cmp(recipientRand1) != 0 {
-		t.Errorf("expected recipientRand %d to equal %d", recipientRands[1], recipientRand1)
-	}
+	assert := assert.New(t)
+	assert.Nil(err)
+	assert.Len(tickets, 2)
+	assert.Len(sigs, 2)
+	assert.Len(recipientRands, 2)
+	assert.Equal(ticket0, tickets[0])
+	assert.Equal(sig0, sigs[0])
+	assert.Equal(recipientRand0, recipientRands[0])
+	assert.Equal(ticket1, tickets[1])
+	assert.Equal(sig1, sigs[1])
+	assert.Equal(recipientRand1, recipientRands[1])
 }
 
 func TestLoadtWinningTicket_GivenNonexistentSessionID_ReturnsEmptySlicesNoError(t *testing.T) {
@@ -814,12 +751,12 @@ func TestLoadtWinningTicket_GivenNonexistentSessionID_ReturnsEmptySlicesNoError(
 	}
 
 	tickets, sigs, recipientRands, err := dbh.LoadWinningTickets("some sessionID")
-	if err != nil {
-		t.Errorf("unexpected error loading nonexistent session: %v", err)
-	}
-	if len(tickets) != 0 || len(sigs) != 0 || len(recipientRands) != 0 {
-		t.Errorf("expected zero items per slice but got unexpected number of results. tickets: %d, sigs: %d, recipientRands: %d", len(tickets), len(sigs), len(recipientRands))
-	}
+
+	assert := assert.New(t)
+	assert.Nil(err)
+	assert.Len(tickets, 0)
+	assert.Len(sigs, 0)
+	assert.Len(recipientRands, 0)
 }
 
 func TestLoadtWinningTicket_GivenEmptySessionID_ReturnsEmptySlicesNoError(t *testing.T) {
@@ -832,12 +769,12 @@ func TestLoadtWinningTicket_GivenEmptySessionID_ReturnsEmptySlicesNoError(t *tes
 	}
 
 	tickets, sigs, recipientRands, err := dbh.LoadWinningTickets("")
-	if err != nil {
-		t.Errorf("unexpected error loading nonexistent session: %v", err)
-	}
-	if len(tickets) != 0 || len(sigs) != 0 || len(recipientRands) != 0 {
-		t.Errorf("expected zero items per slice but got unexpected number of results. tickets: %d, sigs: %d, recipientRands: %d", len(tickets), len(sigs), len(recipientRands))
-	}
+
+	assert := assert.New(t)
+	assert.Nil(err)
+	assert.Len(tickets, 0)
+	assert.Len(sigs, 0)
+	assert.Len(recipientRands, 0)
 }
 
 func defaultWinningTicket(t *testing.T) (sessionID string, ticket *pm.Ticket, sig []byte, recipientRand *big.Int) {

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -661,8 +661,57 @@ func TestInsertWinningTicket_GivenMaxValueInputs_InsertsOneRowCorrectly(t *testi
 	assert.Equal(1, ticketsCount)
 }
 
-// TODO
-// tests with errors
+func TestStoreWinningTicket_GivenNilTicket_ReturnsError(t *testing.T) {
+	dbh, dbraw, err := TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	sig := randBytesOrFatal(42, t)
+	recipientRand := new(big.Int).SetInt64(1234)
+
+	err = dbh.StoreWinningTicket("sessionID", nil, sig, recipientRand)
+
+	assert := assert.New(t)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "nil ticket")
+}
+
+func TestStoreWinningTicket_GivenNilSig_ReturnsError(t *testing.T) {
+	dbh, dbraw, err := TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	sessionID, ticket, _, recipientRand := defaultWinningTicket(t)
+
+	err = dbh.StoreWinningTicket(sessionID, ticket, nil, recipientRand)
+
+	assert := assert.New(t)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "nil sig")
+}
+
+func TestStoreWinningTicket_GivenNilRecipientRand_ReturnsError(t *testing.T) {
+	dbh, dbraw, err := TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	sessionID, ticket, sig, _ := defaultWinningTicket(t)
+
+	err = dbh.StoreWinningTicket(sessionID, ticket, sig, nil)
+
+	assert := assert.New(t)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "nil recipientRand")
+}
 
 func TestLoadtWinningTicket_GivenStoredTicket_LoadsItCorrectly(t *testing.T) {
 	dbh, dbraw, err := TempDB(t)

--- a/pm/helpers.go
+++ b/pm/helpers.go
@@ -7,7 +7,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
-func randHashOrFatal(t *testing.T) ethcommon.Hash {
+func RandHashOrFatal(t *testing.T) ethcommon.Hash {
 	key, err := randBytes(32)
 
 	if err != nil {

--- a/pm/helpers.go
+++ b/pm/helpers.go
@@ -18,7 +18,7 @@ func RandHashOrFatal(t *testing.T) ethcommon.Hash {
 	return ethcommon.BytesToHash(key[:])
 }
 
-func randAddressOrFatal(t *testing.T) ethcommon.Address {
+func RandAddressOrFatal(t *testing.T) ethcommon.Address {
 	key, err := randBytes(addressSize)
 
 	if err != nil {
@@ -29,7 +29,7 @@ func randAddressOrFatal(t *testing.T) ethcommon.Address {
 	return ethcommon.BytesToAddress(key[:])
 }
 
-func randBytesOrFatal(size int, t *testing.T) []byte {
+func RandBytesOrFatal(size int, t *testing.T) []byte {
 	res, err := randBytes(size)
 
 	if err != nil {

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -38,7 +38,7 @@ type recipient struct {
 
 	invalidRands sync.Map
 
-	senderNonces     map[string]uint64
+	senderNonces     map[string]uint32
 	senderNoncesLock sync.Mutex
 
 	faceValue *big.Int
@@ -69,7 +69,7 @@ func NewRecipientWithSecret(broker Broker, val Validator, store TicketStore, sec
 		store:        store,
 		secret:       secret,
 		faceValue:    faceValue,
-		senderNonces: make(map[string]uint64),
+		senderNonces: make(map[string]uint32),
 		winProb:      winProb,
 	}
 }
@@ -200,7 +200,7 @@ func (r *recipient) updateInvalidRands(rand *big.Int) {
 	r.invalidRands.Store(rand.String(), true)
 }
 
-func (r *recipient) updateSenderNonce(rand *big.Int, senderNonce uint64) error {
+func (r *recipient) updateSenderNonce(rand *big.Int, senderNonce uint32) error {
 	r.senderNoncesLock.Lock()
 	defer r.senderNoncesLock.Unlock()
 

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -103,7 +103,7 @@ func (r *recipient) ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (bo
 	}
 
 	if r.val.IsWinningTicket(ticket, sig, recipientRand) {
-		if err := r.store.Store(ticket.RecipientRandHash.Hex(), ticket, sig, recipientRand); err != nil {
+		if err := r.store.StoreWinningTicket(ticket.RecipientRandHash.Hex(), ticket, sig, recipientRand); err != nil {
 			return true, err
 		}
 
@@ -116,7 +116,7 @@ func (r *recipient) ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (bo
 // RedeemWinningTicket redeems all winning tickets with the broker
 // for a session ID
 func (r *recipient) RedeemWinningTickets(sessionID string) error {
-	tickets, sigs, recipientRands, err := r.store.Load(sessionID)
+	tickets, sigs, recipientRands, err := r.store.LoadWinningTickets(sessionID)
 	if err != nil {
 		return err
 	}

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -111,7 +111,7 @@ func TestReceiveTicket_InvalidRecipientRand_InvalidRecipientRandHash(t *testing.
 
 	// Test invalid recipientRand from seed (invalid recipientRandHash)
 	ticket := newTicket(sender, params, 0)
-	ticket.RecipientRandHash = randHashOrFatal(t) // Using invalid recipientRandHash
+	ticket.RecipientRandHash = RandHashOrFatal(t) // Using invalid recipientRandHash
 
 	_, err = r.ReceiveTicket(ticket, sig, params.Seed)
 	if err == nil {

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func newRecipientFixtureOrFatal(t *testing.T) (ethcommon.Address, *stubBroker, *stubValidator, *stubTicketStore, *big.Int, *big.Int, []byte) {
-	sender := randAddressOrFatal(t)
+	sender := RandAddressOrFatal(t)
 
 	b := newStubBroker()
 	b.SetDeposit(sender, big.NewInt(500))

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -267,7 +267,7 @@ func TestReceiveTicket_ValidWinningTicket_StoreError(t *testing.T) {
 	params := ticketParamsOrFatal(t, r, sender)
 
 	// Test valid winning ticket
-	newSenderNonce := uint64(3)
+	newSenderNonce := uint32(3)
 	ticket := newTicket(sender, params, newSenderNonce)
 
 	// Config stub validator with valid winning tickets

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -18,7 +18,7 @@ func newRecipientFixture(t *testing.T) (ethcommon.Address, *stubBroker, *stubVal
 	return randAddressOrFatal(t), newStubBroker(), &stubValidator{}, newStubTicketStore(), big.NewInt(100), big.NewInt(100), []byte("foo")
 }
 
-func newTicket(sender ethcommon.Address, params *TicketParams, senderNonce uint64) *Ticket {
+func newTicket(sender ethcommon.Address, params *TicketParams, senderNonce uint32) *Ticket {
 	return &Ticket{
 		Recipient:         ethcommon.Address{},
 		Sender:            sender,
@@ -219,7 +219,7 @@ func TestReceiveTicket_ValidNonWinningTicket(t *testing.T) {
 	}
 
 	// Test valid non-winning ticket
-	newSenderNonce := uint64(3)
+	newSenderNonce := uint32(3)
 	ticket := newTicket(sender, params, newSenderNonce)
 
 	won, err := r.ReceiveTicket(ticket, sig, params.Seed)
@@ -254,7 +254,7 @@ func TestReceiveTicket_ValidWinningTicket(t *testing.T) {
 	}
 
 	// Test valid winning ticket
-	newSenderNonce := uint64(3)
+	newSenderNonce := uint32(3)
 	ticket := newTicket(sender, params, newSenderNonce)
 
 	won, err := r.ReceiveTicket(ticket, sig, params.Seed)
@@ -318,7 +318,7 @@ func TestReceiveTicket_ValidWinningTicket_StoreError(t *testing.T) {
 	}
 
 	// Test valid winning ticket
-	newSenderNonce := uint64(3)
+	newSenderNonce := uint32(3)
 	ticket := newTicket(sender, params, newSenderNonce)
 
 	_, err = r.ReceiveTicket(ticket, sig, params.Seed)
@@ -468,7 +468,7 @@ func TestReceiveTicket_ValidNonWinningTicket_Concurrent(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
 
-		go func(senderNonce uint64) {
+		go func(senderNonce uint32) {
 			defer wg.Done()
 
 			ticket := newTicket(sender, params, senderNonce)
@@ -477,7 +477,7 @@ func TestReceiveTicket_ValidNonWinningTicket_Concurrent(t *testing.T) {
 			if err != nil {
 				atomic.AddUint64(&errCount, 1)
 			}
-		}(uint64(i))
+		}(uint32(i))
 	}
 
 	wg.Wait()

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -272,7 +272,7 @@ func TestReceiveTicket_ValidWinningTicket(t *testing.T) {
 		t.Errorf("expected senderNonce to be %d, got %d", newSenderNonce, senderNonce)
 	}
 
-	storeTickets, storeSigs, storeRecipientRands, err := ts.Load(ticket.RecipientRandHash.Hex())
+	storeTickets, storeSigs, storeRecipientRands, err := ts.LoadWinningTickets(ticket.RecipientRandHash.Hex())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -333,7 +333,7 @@ func TestReceiveTicket_ValidWinningTicket_StoreError(t *testing.T) {
 		t.Errorf("expected senderNonce to be %d, got %d", newSenderNonce, senderNonce)
 	}
 
-	storeTickets, storeSigs, storeRecipientRands, err := ts.Load(ticket.RecipientRandHash.Hex())
+	storeTickets, storeSigs, storeRecipientRands, err := ts.LoadWinningTickets(ticket.RecipientRandHash.Hex())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -6,7 +6,6 @@ import (
 	"sync/atomic"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/livepeer/go-livepeer/eth"
 	"github.com/pkg/errors"
 )
 
@@ -29,15 +28,15 @@ type session struct {
 }
 
 type sender struct {
-	accountManager eth.AccountManager
+	signer Signer
 
 	sessions sync.Map
 }
 
 // NewSender creates a new Sender instance.
-func NewSender(accountManager eth.AccountManager) Sender {
+func NewSender(signer Signer) Sender {
 	return &sender{
-		accountManager: accountManager,
+		signer: signer,
 	}
 }
 
@@ -67,13 +66,13 @@ func (s *sender) CreateTicket(sessionID string) (*Ticket, *big.Int, []byte, erro
 	ticket := &Ticket{
 		Recipient:         session.recipient,
 		RecipientRandHash: recipientRandHash,
-		Sender:            s.accountManager.Account().Address,
+		Sender:            s.signer.Account().Address,
 		SenderNonce:       senderNonce,
 		FaceValue:         session.ticketParams.FaceValue,
 		WinProb:           session.ticketParams.WinProb,
 	}
 
-	sig, err := s.accountManager.Sign(ticket.Hash().Bytes())
+	sig, err := s.signer.Sign(ticket.Hash().Bytes())
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "error signing ticket for session: %v", sessionID)
 	}

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -20,7 +20,7 @@ type Sender interface {
 }
 
 type session struct {
-	senderNonce uint64
+	senderNonce uint32
 
 	recipient ethcommon.Address
 
@@ -61,7 +61,7 @@ func (s *sender) CreateTicket(sessionID string) (*Ticket, *big.Int, []byte, erro
 	}
 	session := tempSession.(*session)
 
-	senderNonce := atomic.AddUint64(&session.senderNonce, 1)
+	senderNonce := atomic.AddUint32(&session.senderNonce, 1)
 
 	ticket := &Ticket{
 		Recipient:         session.recipient,

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -173,11 +173,11 @@ func TestCreateTicket_GivenConcurrentCallsForSameSession_SenderNonceIncrementsCo
 		t.Fatalf("failed to find session with ID %v", sessionID)
 	}
 	session := sessionUntyped.(*session)
-	if session.senderNonce != uint64(totalTickets) {
+	if session.senderNonce != uint32(totalTickets) {
 		t.Errorf("expected end state SenderNonce %d to be %d", session.senderNonce, totalTickets)
 	}
 
-	uniqueNonces := make(map[uint64]bool)
+	uniqueNonces := make(map[uint32]bool)
 	for _, ticket := range tickets {
 		uniqueNonces[ticket.SenderNonce] = true
 	}

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -82,7 +82,7 @@ func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T
 	am.signResponse = randBytesOrFatal(42, t)
 	senderAddress := sender.signer.Account().Address
 	recipient := randAddressOrFatal(t)
-	recipientRandHash := randHashOrFatal(t)
+	recipientRandHash := RandHashOrFatal(t)
 	ticketParams := TicketParams{
 		FaceValue:         big.NewInt(1111),
 		WinProb:           big.NewInt(2222),
@@ -198,7 +198,7 @@ func defaultSender(t *testing.T) *sender {
 }
 
 func defaultTicketParams(t *testing.T) TicketParams {
-	recipientRandHash := randHashOrFatal(t)
+	recipientRandHash := RandHashOrFatal(t)
 	return TicketParams{
 		FaceValue:         big.NewInt(0),
 		WinProb:           big.NewInt(0),

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -79,9 +79,9 @@ func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T
 	am := sender.signer.(*stubSigner)
 	am.signShouldFail = false
 	am.saveSignRequest = true
-	am.signResponse = randBytesOrFatal(42, t)
+	am.signResponse = RandBytesOrFatal(42, t)
 	senderAddress := sender.signer.Account().Address
-	recipient := randAddressOrFatal(t)
+	recipient := RandAddressOrFatal(t)
 	recipientRandHash := RandHashOrFatal(t)
 	ticketParams := TicketParams{
 		FaceValue:         big.NewInt(1111),
@@ -127,7 +127,7 @@ func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T
 
 func TestCreateTicket_GivenSigningError_ReturnsError(t *testing.T) {
 	sender := defaultSender(t)
-	recipient := randAddressOrFatal(t)
+	recipient := RandAddressOrFatal(t)
 	ticketParams := defaultTicketParams(t)
 	sessionID := sender.StartSession(recipient, ticketParams)
 	am := sender.signer.(*stubSigner)
@@ -147,7 +147,7 @@ func TestCreateTicket_GivenConcurrentCallsForSameSession_SenderNonceIncrementsCo
 	totalTickets := 100
 	lock := sync.RWMutex{}
 	sender := defaultSender(t)
-	recipient := randAddressOrFatal(t)
+	recipient := RandAddressOrFatal(t)
 	ticketParams := defaultTicketParams(t)
 	sessionID := sender.StartSession(recipient, ticketParams)
 
@@ -188,7 +188,7 @@ func TestCreateTicket_GivenConcurrentCallsForSameSession_SenderNonceIncrementsCo
 
 func defaultSender(t *testing.T) *sender {
 	account := accounts.Account{
-		Address: randAddressOrFatal(t),
+		Address: RandAddressOrFatal(t),
 	}
 	am := &stubSigner{
 		account: account,

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -76,11 +76,11 @@ func TestCreateTicket_GivenNonexistentSession_ReturnsError(t *testing.T) {
 
 func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T) {
 	sender := defaultSender(t)
-	am := sender.accountManager.(*stubAccountManager)
+	am := sender.signer.(*stubSigner)
 	am.signShouldFail = false
 	am.saveSignRequest = true
 	am.signResponse = randBytesOrFatal(42, t)
-	senderAddress := sender.accountManager.Account().Address
+	senderAddress := sender.signer.Account().Address
 	recipient := randAddressOrFatal(t)
 	recipientRandHash := randHashOrFatal(t)
 	ticketParams := TicketParams{
@@ -130,7 +130,7 @@ func TestCreateTicket_GivenSigningError_ReturnsError(t *testing.T) {
 	recipient := randAddressOrFatal(t)
 	ticketParams := defaultTicketParams(t)
 	sessionID := sender.StartSession(recipient, ticketParams)
-	am := sender.accountManager.(*stubAccountManager)
+	am := sender.signer.(*stubSigner)
 	am.signShouldFail = true
 
 	_, _, _, err := sender.CreateTicket(sessionID)
@@ -190,7 +190,7 @@ func defaultSender(t *testing.T) *sender {
 	account := accounts.Account{
 		Address: randAddressOrFatal(t),
 	}
-	am := &stubAccountManager{
+	am := &stubSigner{
 		account: account,
 	}
 	s := NewSender(am)

--- a/pm/signer.go
+++ b/pm/signer.go
@@ -1,0 +1,10 @@
+package pm
+
+import "github.com/ethereum/go-ethereum/accounts"
+
+// Signer supports identifying as an Ethereum account owner, by providing the
+// Account and enabling message signing.
+type Signer interface {
+	Sign(msg []byte) ([]byte, error)
+	Account() accounts.Account
+}

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -27,7 +27,7 @@ func newStubTicketStore() *stubTicketStore {
 	}
 }
 
-func (ts *stubTicketStore) Store(sessionID string, ticket *Ticket, sig []byte, recipientRand *big.Int) error {
+func (ts *stubTicketStore) StoreWinningTicket(sessionID string, ticket *Ticket, sig []byte, recipientRand *big.Int) error {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 
@@ -42,7 +42,7 @@ func (ts *stubTicketStore) Store(sessionID string, ticket *Ticket, sig []byte, r
 	return nil
 }
 
-func (ts *stubTicketStore) Load(sessionID string) ([]*Ticket, [][]byte, []*big.Int, error) {
+func (ts *stubTicketStore) LoadWinningTickets(sessionID string) ([]*Ticket, [][]byte, []*big.Int, error) {
 	ts.lock.RLock()
 	defer ts.lock.RUnlock()
 

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 )
 
 type stubTicketStore struct {
@@ -188,7 +187,7 @@ func (v *stubValidator) IsWinningTicket(ticket *Ticket, sig []byte, recipientRan
 	return v.isWinningTicket
 }
 
-type stubAccountManager struct {
+type stubSigner struct {
 	account         accounts.Account
 	saveSignRequest bool
 	lastSignRequest []byte
@@ -196,32 +195,23 @@ type stubAccountManager struct {
 	signShouldFail  bool
 }
 
-func (am *stubAccountManager) Unlock(passphrase string) error {
-	return nil
-}
-
-func (am *stubAccountManager) Lock() error {
-	return nil
-}
-
-func (am *stubAccountManager) CreateTransactOpts(gasLimit uint64, gasPrice *big.Int) (*bind.TransactOpts, error) {
+// TODO remove this function
+// NOTE: Keeping this function for now because removing it causes the tests to fail when run with the
+// logtostderr flag.
+func (s *stubSigner) CreateTransactOpts(gasLimit uint64, gasPrice *big.Int) (*bind.TransactOpts, error) {
 	return nil, nil
 }
 
-func (am *stubAccountManager) SignTx(signer types.Signer, tx *types.Transaction) (*types.Transaction, error) {
-	return nil, nil
-}
-
-func (am *stubAccountManager) Sign(msg []byte) ([]byte, error) {
-	if am.saveSignRequest {
-		am.lastSignRequest = msg
+func (s *stubSigner) Sign(msg []byte) ([]byte, error) {
+	if s.saveSignRequest {
+		s.lastSignRequest = msg
 	}
-	if am.signShouldFail {
+	if s.signShouldFail {
 		return nil, fmt.Errorf("stub returning error as requested")
 	}
-	return am.signResponse, nil
+	return s.signResponse, nil
 }
 
-func (am *stubAccountManager) Account() accounts.Account {
-	return am.account
+func (s *stubSigner) Account() accounts.Account {
+	return s.account
 }

--- a/pm/ticket.go
+++ b/pm/ticket.go
@@ -45,7 +45,7 @@ type Ticket struct {
 
 	// SenderNonce is the monotonically increasing counter that makes
 	// each ticket unique given a particular recipientRand value
-	SenderNonce uint64
+	SenderNonce uint32
 
 	// RecipientRandHash is the 32 byte keccak-256 hash commitment to a random number
 	// provided by the recipient. In order for the recipient to redeem
@@ -66,7 +66,7 @@ func (t *Ticket) flatten() []byte {
 	i += copy(buf[i:], t.Sender.Bytes())
 	i += copy(buf[i:], ethcommon.LeftPadBytes(t.FaceValue.Bytes(), uint256Size))
 	i += copy(buf[i:], ethcommon.LeftPadBytes(t.WinProb.Bytes(), uint256Size))
-	i += copy(buf[i:], ethcommon.LeftPadBytes(new(big.Int).SetUint64(t.SenderNonce).Bytes(), uint256Size))
+	i += copy(buf[i:], ethcommon.LeftPadBytes(new(big.Int).SetUint64(uint64(t.SenderNonce)).Bytes(), uint256Size))
 	i += copy(buf[i:], t.RecipientRandHash.Bytes())
 
 	return buf

--- a/pm/ticket_test.go
+++ b/pm/ticket_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestHash(t *testing.T) {
-	exp := ethcommon.HexToHash("24d4264d5ea56ba4362c8f535308005b2df1f9f77c34b4a61f6b5c3bef151b53")
+	exp := ethcommon.HexToHash("e1393fc7f6de093780674022f96cb8e3872235167d037c04d554e58c0e63d280")
 	ticket := &Ticket{
 		Recipient:         ethcommon.Address{},
 		Sender:            ethcommon.Address{},
 		FaceValue:         big.NewInt(0),
 		WinProb:           big.NewInt(0),
-		SenderNonce:       math.MaxUint64,
+		SenderNonce:       math.MaxUint32,
 		RecipientRandHash: ethcommon.Hash{},
 	}
 	h := ticket.Hash()

--- a/pm/ticketstore.go
+++ b/pm/ticketstore.go
@@ -9,9 +9,9 @@ import (
 type TicketStore interface {
 	// Store persists a ticket with its signature and recipientRand
 	// for a session ID
-	Store(sessionID string, ticket *Ticket, sig []byte, recipientRand *big.Int) error
+	StoreWinningTicket(sessionID string, ticket *Ticket, sig []byte, recipientRand *big.Int) error
 
 	// Load fetches all persisted tickets in the store with their signatures and recipientRands
 	// for a session ID
-	Load(sessionID string) (tickets []*Ticket, sigs [][]byte, recipientRands []*big.Int, err error)
+	LoadWinningTickets(sessionID string) (tickets []*Ticket, sigs [][]byte, recipientRands []*big.Int, err error)
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Supports the storage of winning PM tickets into the node's local database.


**Specific updates (required)**

- A new `winningTickets` table in the local database
- `db.go` implements the `TicketStore` interface
- A new testing dependency for succinct assertions (and more!)
- Had to change `SenderNonce` to `uint32` since the SQL library doesn't support very high values of `uint64`
- Refactor to abstract away the `AccountManager` dependency such that the `pm` package no longer imports anything from the `eth` package - this was critical to resolve a cyclical dependency issue (since `common` now imports `pm` for the `pm.Ticket` type in the new function signatures)

**How did you test each of these updates (required)**

- Unit tests that interact with an actual test DB instance


**Does this pull request close any open issues?**

- Fixes https://github.com/livepeer/go-livepeer/issues/621


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
