### PR TITLE
PM sender RPC handling

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -318,6 +318,10 @@ func main() {
 			}
 		}
 
+		if n.NodeType == core.BroadcasterNode {
+			n.Sender = pm.NewSender(n.Eth)
+		}
+
 		// Start services
 		err = n.StartEthServices()
 		if err != nil {

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -308,10 +308,10 @@ func main() {
 			}
 
 			sigVerifier := &pm.DefaultSigVerifier{}
-			validator := pm.NewValidator(n.Eth.Account().Address, sigVerifier)
+			validator := pm.NewValidator(sigVerifier)
 			faceValueInWei := eth.ToBaseUnit(big.NewFloat(*faceValue))
 			winProbBigInt := eth.FromPercOfUint256(*winProb)
-			n.Recipient, err = pm.NewRecipient(n.Eth, validator, n.Database, faceValueInWei, winProbBigInt)
+			n.Recipient, err = pm.NewRecipient(n.Eth.Account().Address, n.Eth, validator, n.Database, faceValueInWei, winProbBigInt)
 			if err != nil {
 				glog.Errorf("Error setting up PM recipient: %v", err)
 				return

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -60,6 +60,9 @@ type LivepeerNode struct {
 	OrchSecret       string
 	Transcoder       Transcoder
 
+	// Broadcaster public fields
+	Sender pm.Sender
+
 	// Transcoder private fields
 	pmSessions      map[ManifestID]map[string]bool
 	segmentMutex    *sync.Mutex

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -426,6 +426,7 @@ func TestTicketParams(t *testing.T) {
 	recipient := new(pm.MockRecipient)
 	n.Recipient = recipient
 	expectedParams := &pm.TicketParams{
+		Recipient:         pm.RandAddress(),
 		FaceValue:         big.NewInt(1234),
 		WinProb:           big.NewInt(2345),
 		Seed:              big.NewInt(3456),
@@ -433,12 +434,11 @@ func TestTicketParams(t *testing.T) {
 	}
 	recipient.On("TicketParams", mock.Anything).Return(expectedParams)
 	orch := NewOrchestrator(n)
-	orch.address = pm.RandAddress()
 
 	actualParams := orch.TicketParams(pm.RandAddress())
 
 	assert := assert.New(t)
-	assert.Equal(orch.address.Bytes(), actualParams.Recipient)
+	assert.Equal(expectedParams.Recipient.Bytes(), actualParams.Recipient)
 	assert.Equal(expectedParams.FaceValue.Bytes(), actualParams.FaceValue)
 	assert.Equal(expectedParams.WinProb.Bytes(), actualParams.WinProb)
 	assert.Equal(expectedParams.RecipientRandHash.Bytes(), actualParams.RecipientRandHash)

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -114,7 +114,7 @@ func (orch *orchestrator) TicketParams(sender ethcommon.Address) *net.TicketPara
 
 	params := orch.node.Recipient.TicketParams(sender)
 	return &net.TicketParams{
-		Recipient:         orch.address.Bytes(),
+		Recipient:         params.Recipient.Bytes(),
 		FaceValue:         params.FaceValue.Bytes(),
 		WinProb:           params.WinProb.Bytes(),
 		RecipientRandHash: params.RecipientRandHash.Bytes(),

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -30,8 +30,8 @@ func newRecipientFixtureOrFatal(t *testing.T) (ethcommon.Address, *stubBroker, *
 	return sender, b, v, newStubTicketStore(), big.NewInt(100), big.NewInt(100), []byte("foo")
 }
 
-func newRecipientOrFatal(t *testing.T, b Broker, v Validator, ts TicketStore, faceValue *big.Int, winProb *big.Int) Recipient {
-	r, err := NewRecipient(b, v, ts, faceValue, winProb)
+func newRecipientOrFatal(t *testing.T, addr ethcommon.Address, b Broker, v Validator, ts TicketStore, faceValue *big.Int, winProb *big.Int) Recipient {
+	r, err := NewRecipient(addr, b, v, ts, faceValue, winProb)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func genRecipientRand(sender ethcommon.Address, secret [32]byte, seed *big.Int) 
 
 func TestReceiveTicket_InvalidRecipientRand_InvalidSeed(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test invalid recipientRand from seed (invalid seed)
@@ -83,7 +83,7 @@ func TestReceiveTicket_InvalidRecipientRand_InvalidSeed(t *testing.T) {
 
 func TestReceiveTicket_InvalidRecipientRand_InvalidSender(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test invalid recipientRand from seed (invalid sender)
@@ -100,7 +100,7 @@ func TestReceiveTicket_InvalidRecipientRand_InvalidSender(t *testing.T) {
 
 func TestReceiveTicket_InvalidRecipientRand_InvalidRecipientRandHash(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test invalid recipientRand from seed (invalid recipientRandHash)
@@ -118,7 +118,7 @@ func TestReceiveTicket_InvalidRecipientRand_InvalidRecipientRandHash(t *testing.
 
 func TestReceiveTicket_InvalidFaceValue(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test invalid faceValue
@@ -136,7 +136,7 @@ func TestReceiveTicket_InvalidFaceValue(t *testing.T) {
 
 func TestReceiveTicket_InvalidWinProb(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test invalid winProb
@@ -154,7 +154,7 @@ func TestReceiveTicket_InvalidWinProb(t *testing.T) {
 
 func TestReceiveTicket_InvalidTicket(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test invalid ticket
@@ -175,7 +175,7 @@ func TestReceiveTicket_InvalidTicket(t *testing.T) {
 func TestReceiveTicket_ValidNonWinningTicket(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(b, v, ts, secret, faceValue, winProb)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, secret, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test valid non-winning ticket
@@ -204,7 +204,7 @@ func TestReceiveTicket_ValidNonWinningTicket(t *testing.T) {
 func TestReceiveTicket_ValidWinningTicket(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(b, v, ts, secret, faceValue, winProb)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, secret, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test valid winning ticket
@@ -263,7 +263,7 @@ func TestReceiveTicket_ValidWinningTicket(t *testing.T) {
 func TestReceiveTicket_ValidWinningTicket_StoreError(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(b, v, ts, secret, faceValue, winProb)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, secret, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test valid winning ticket
@@ -309,7 +309,7 @@ func TestReceiveTicket_ValidWinningTicket_StoreError(t *testing.T) {
 
 func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test invalid recipientRand revealed
@@ -342,7 +342,7 @@ func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed(t *testing.T) {
 
 func TestReceiveTicket_InvalidSenderNonce(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Test invalid senderNonce
@@ -383,7 +383,7 @@ func TestReceiveTicket_InvalidSenderNonce(t *testing.T) {
 
 func TestReceiveTicket_ValidNonWinningTicket_Concurrent(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	var wg sync.WaitGroup
@@ -413,7 +413,7 @@ func TestReceiveTicket_ValidNonWinningTicket_Concurrent(t *testing.T) {
 
 func TestRedeemWinningTickets_InvalidSessionID(t *testing.T) {
 	_, b, v, ts, faceValue, winProb, _ := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 
 	// Config stub ticket store to fail load
 	ts.loadShouldFail = true
@@ -429,7 +429,7 @@ func TestRedeemWinningTickets_InvalidSessionID(t *testing.T) {
 
 func TestRedeemWinningTickets_SingleTicket_SendersError(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Config stub validator with valid winning tickets
@@ -460,7 +460,7 @@ func TestRedeemWinningTickets_SingleTicket_SendersError(t *testing.T) {
 
 func TestRedeemWinningTickets_SingleTicket_ZeroDepositAndPenaltyEscrow(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, b, v, ts, faceValue, winProb)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Config stub validator with valid winning tickets
@@ -493,7 +493,7 @@ func TestRedeemWinningTickets_SingleTicket_ZeroDepositAndPenaltyEscrow(t *testin
 func TestRedeemWinningTickets_SingleTicket_RedeemError(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(b, v, ts, secret, faceValue, winProb)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, secret, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Config stub validator with valid winning tickets
@@ -543,7 +543,7 @@ func TestRedeemWinningTickets_SingleTicket_RedeemError(t *testing.T) {
 func TestRedeemWinningTickets_SingleTicket(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(b, v, ts, secret, faceValue, winProb)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, secret, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Config stub validator with valid winning tickets
@@ -587,7 +587,7 @@ func TestRedeemWinningTickets_SingleTicket(t *testing.T) {
 func TestRedeemWinningTickets_MultipleTickets(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(b, v, ts, secret, faceValue, winProb)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, secret, faceValue, winProb)
 	params := r.TicketParams(sender)
 
 	// Config stub validator with valid winning tickets
@@ -651,7 +651,7 @@ func TestRedeemWinningTickets_MultipleTickets(t *testing.T) {
 func TestRedeemWinningTickets_MultipleTicketsFromMultipleSessions(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(b, v, ts, secret, faceValue, winProb)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, secret, faceValue, winProb)
 	// Config stub validator with valid winning tickets
 	v.SetIsWinningTicket(true)
 	require := require.New(t)
@@ -697,11 +697,16 @@ func TestRedeemWinningTickets_MultipleTicketsFromMultipleSessions(t *testing.T) 
 
 func TestTicketParams(t *testing.T) {
 	sender, b, v, ts, faceValue, winProb, _ := newRecipientFixtureOrFatal(t)
+	recipient := RandAddress()
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(b, v, ts, secret, faceValue, winProb)
+	r := NewRecipientWithSecret(recipient, b, v, ts, secret, faceValue, winProb)
 
 	// Test correct params returned
 	params1 := r.TicketParams(sender)
+
+	if params1.Recipient != recipient {
+		t.Errorf("expected recipient %x got %x", recipient, params1.Recipient)
+	}
 
 	if params1.FaceValue.Cmp(faceValue) != 0 {
 		t.Errorf("expected faceValue %d got %d", faceValue, params1.FaceValue)
@@ -719,6 +724,10 @@ func TestTicketParams(t *testing.T) {
 
 	// Test correct params returned and different seed + recipientRandHash
 	params2 := r.TicketParams(sender)
+
+	if params2.Recipient != recipient {
+		t.Errorf("expected recipient %x got %x", recipient, params2.Recipient)
+	}
 
 	if params2.FaceValue.Cmp(faceValue) != 0 {
 		t.Errorf("expected faceValue %d got %d", faceValue, params2.FaceValue)

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -14,10 +14,11 @@ import (
 func TestStartSession_GivenSomeRecipientRandHash_UsesItAsSessionId(t *testing.T) {
 	sender := defaultSender(t)
 	recipient := ethcommon.Address{}
-	ticketParams := defaultTicketParams(t)
+	ticketParams := defaultTicketParams(t, recipient)
 	expectedSessionID := ticketParams.RecipientRandHash.Hex()
 
-	sessionID := sender.StartSession(recipient, TicketParams{
+	sessionID := sender.StartSession(TicketParams{
+		Recipient:         recipient,
 		FaceValue:         big.NewInt(0),
 		WinProb:           big.NewInt(0),
 		Seed:              big.NewInt(0),
@@ -37,12 +38,13 @@ func TestStartSession_GivenConcurrentUsage_RecordsAllSessions(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(100)
 	for i := 0; i < 100; i++ {
-		ticketParams := defaultTicketParams(t)
+		ticketParams := defaultTicketParams(t, recipient)
 		expectedSessionID := ticketParams.RecipientRandHash.Hex()
 		sessions = append(sessions, expectedSessionID)
 
 		go func() {
-			sender.StartSession(recipient, TicketParams{
+			sender.StartSession(TicketParams{
+				Recipient:         recipient,
 				FaceValue:         big.NewInt(0),
 				WinProb:           big.NewInt(0),
 				Seed:              big.NewInt(0),
@@ -84,12 +86,13 @@ func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T
 	recipient := RandAddress()
 	recipientRandHash := RandHash()
 	ticketParams := TicketParams{
+		Recipient:         recipient,
 		FaceValue:         big.NewInt(1111),
 		WinProb:           big.NewInt(2222),
 		Seed:              big.NewInt(3333),
 		RecipientRandHash: recipientRandHash,
 	}
-	sessionID := sender.StartSession(recipient, ticketParams)
+	sessionID := sender.StartSession(ticketParams)
 
 	ticket, actualSeed, actualSig, err := sender.CreateTicket(sessionID)
 
@@ -128,8 +131,8 @@ func TestCreateTicket_GivenValidSessionId_UsesSessionParamsInTicket(t *testing.T
 func TestCreateTicket_GivenSigningError_ReturnsError(t *testing.T) {
 	sender := defaultSender(t)
 	recipient := RandAddress()
-	ticketParams := defaultTicketParams(t)
-	sessionID := sender.StartSession(recipient, ticketParams)
+	ticketParams := defaultTicketParams(t, recipient)
+	sessionID := sender.StartSession(ticketParams)
 	am := sender.signer.(*stubSigner)
 	am.signShouldFail = true
 
@@ -148,8 +151,8 @@ func TestCreateTicket_GivenConcurrentCallsForSameSession_SenderNonceIncrementsCo
 	lock := sync.RWMutex{}
 	sender := defaultSender(t)
 	recipient := RandAddress()
-	ticketParams := defaultTicketParams(t)
-	sessionID := sender.StartSession(recipient, ticketParams)
+	ticketParams := defaultTicketParams(t, recipient)
+	sessionID := sender.StartSession(ticketParams)
 
 	var wg sync.WaitGroup
 	wg.Add(totalTickets)
@@ -197,9 +200,10 @@ func defaultSender(t *testing.T) *sender {
 	return s.(*sender)
 }
 
-func defaultTicketParams(t *testing.T) TicketParams {
+func defaultTicketParams(t *testing.T, recipient ethcommon.Address) TicketParams {
 	recipientRandHash := RandHash()
 	return TicketParams{
+		Recipient:         recipient,
 		FaceValue:         big.NewInt(0),
 		WinProb:           big.NewInt(0),
 		Seed:              big.NewInt(0),

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -263,3 +263,35 @@ func (m *MockRecipient) TicketParams(sender ethcommon.Address) *TicketParams {
 
 	return params
 }
+
+// MockSender is useful for testing components that depend on pm.Sender
+type MockSender struct {
+	mock.Mock
+}
+
+func (m *MockSender) StartSession(recipient ethcommon.Address, ticketParams TicketParams) string {
+	args := m.Called(recipient, ticketParams)
+	return args.String(0)
+}
+
+func (m *MockSender) CreateTicket(sessionID string) (*Ticket, *big.Int, []byte, error) {
+	args := m.Called(sessionID)
+
+	var ticket *Ticket
+	var seed *big.Int
+	var sig []byte
+
+	if args.Get(0) != nil {
+		ticket = args.Get(0).(*Ticket)
+	}
+
+	if args.Get(1) != nil {
+		seed = args.Get(1).(*big.Int)
+	}
+
+	if args.Get(2) != nil {
+		sig = args.Get(2).([]byte)
+	}
+
+	return ticket, seed, sig, args.Error(3)
+}

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -196,7 +196,7 @@ func (v *stubValidator) SetIsWinningTicket(isWinningTicket bool) {
 	v.isWinningTicket = isWinningTicket
 }
 
-func (v *stubValidator) ValidateTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) error {
+func (v *stubValidator) ValidateTicket(recipient ethcommon.Address, ticket *Ticket, sig []byte, recipientRand *big.Int) error {
 	if !v.isValidTicket {
 		return fmt.Errorf("stub validator invalid ticket error")
 	}
@@ -269,8 +269,8 @@ type MockSender struct {
 	mock.Mock
 }
 
-func (m *MockSender) StartSession(recipient ethcommon.Address, ticketParams TicketParams) string {
-	args := m.Called(recipient, ticketParams)
+func (m *MockSender) StartSession(ticketParams TicketParams) string {
+	args := m.Called(ticketParams)
 	return args.String(0)
 }
 

--- a/pm/ticket.go
+++ b/pm/ticket.go
@@ -17,6 +17,8 @@ const (
 // TicketParams represents the parameters defined by a receiver that a sender must adhere to when
 // sending tickets to receiver.
 type TicketParams struct {
+	Recipient ethcommon.Address
+
 	FaceValue *big.Int
 
 	WinProb *big.Int

--- a/pm/validator.go
+++ b/pm/validator.go
@@ -19,7 +19,7 @@ var (
 // of validating tickets
 type Validator interface {
 	// ValidateTicket checks if a ticket is valid
-	ValidateTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) error
+	ValidateTicket(recipient ethcommon.Address, ticket *Ticket, sig []byte, recipientRand *big.Int) error
 
 	// IsWinningTicket checks if a ticket won
 	// Note: This method does not check if a ticket is valid which is done using ValidateTicket
@@ -28,21 +28,19 @@ type Validator interface {
 
 // validator is an implementation of the Validator interface
 type validator struct {
-	addr        ethcommon.Address
 	sigVerifier SigVerifier
 }
 
 // NewValidator returns an instance of a validator
-func NewValidator(addr ethcommon.Address, sigVerifier SigVerifier) Validator {
+func NewValidator(sigVerifier SigVerifier) Validator {
 	return &validator{
-		addr:        addr,
 		sigVerifier: sigVerifier,
 	}
 }
 
 // ValidateTicket checks if a ticket is valid
-func (v *validator) ValidateTicket(ticket *Ticket, sig []byte, recipientRand *big.Int) error {
-	if ticket.Recipient != v.addr {
+func (v *validator) ValidateTicket(recipient ethcommon.Address, ticket *Ticket, sig []byte, recipientRand *big.Int) error {
+	if ticket.Recipient != recipient {
 		return errInvalidTicketRecipient
 	}
 

--- a/pm/validator_test.go
+++ b/pm/validator_test.go
@@ -18,7 +18,7 @@ func TestValidateTicket(t *testing.T) {
 	sv := &stubSigVerifier{}
 	sv.SetVerifyResult(true)
 
-	v := NewValidator(recipient, sv)
+	v := NewValidator(sv)
 
 	// Test invalid recipient (null address)
 	ticket := &Ticket{
@@ -30,7 +30,7 @@ func TestValidateTicket(t *testing.T) {
 		RecipientRandHash: recipientRandHash,
 	}
 
-	err := v.ValidateTicket(ticket, sig, recipientRand)
+	err := v.ValidateTicket(recipient, ticket, sig, recipientRand)
 	if err == nil {
 		t.Error("expected invalid recipient (null address) error")
 	}
@@ -48,7 +48,7 @@ func TestValidateTicket(t *testing.T) {
 		RecipientRandHash: recipientRandHash,
 	}
 
-	err = v.ValidateTicket(ticket, sig, recipientRand)
+	err = v.ValidateTicket(recipient, ticket, sig, recipientRand)
 	if err == nil {
 		t.Error("expected invalid recipient (non-null address) error")
 	}
@@ -66,7 +66,7 @@ func TestValidateTicket(t *testing.T) {
 		RecipientRandHash: recipientRandHash,
 	}
 
-	err = v.ValidateTicket(ticket, sig, recipientRand)
+	err = v.ValidateTicket(recipient, ticket, sig, recipientRand)
 	if err == nil {
 		t.Error("expected invalid sender error")
 	}
@@ -84,7 +84,7 @@ func TestValidateTicket(t *testing.T) {
 		RecipientRandHash: ethcommon.Hash{},
 	}
 
-	err = v.ValidateTicket(ticket, sig, recipientRand)
+	err = v.ValidateTicket(recipient, ticket, sig, recipientRand)
 	if err == nil {
 		t.Error("expected invalid recipientRand for recipientRandHash error")
 	}
@@ -105,7 +105,7 @@ func TestValidateTicket(t *testing.T) {
 		RecipientRandHash: recipientRandHash,
 	}
 
-	err = v.ValidateTicket(ticket, sig, recipientRand)
+	err = v.ValidateTicket(recipient, ticket, sig, recipientRand)
 	if err == nil {
 		t.Error("expected invalid signature error")
 	}
@@ -117,7 +117,7 @@ func TestValidateTicket(t *testing.T) {
 	// Set signature verification to return true
 	sv.SetVerifyResult(true)
 
-	if err := v.ValidateTicket(ticket, sig, recipientRand); err != nil {
+	if err := v.ValidateTicket(recipient, ticket, sig, recipientRand); err != nil {
 		t.Errorf("expected valid ticket, got error %v", err)
 	}
 }
@@ -132,7 +132,7 @@ func TestIsWinningTicket(t *testing.T) {
 	sv := &stubSigVerifier{}
 	sv.SetVerifyResult(true)
 
-	v := NewValidator(recipient, sv)
+	v := NewValidator(sv)
 
 	// Test non-winning ticket
 	ticket := &Ticket{

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -202,13 +202,14 @@ func (s *LivepeerServer) startBroadcast(cpl core.PlaylistManager) (*BroadcastSes
 	if s.LivepeerNode.Sender != nil {
 		protoParams := tinfo.TicketParams
 		params := pm.TicketParams{
+			Recipient:         ethcommon.BytesToAddress(protoParams.Recipient),
 			FaceValue:         new(big.Int).SetBytes(protoParams.FaceValue),
 			WinProb:           new(big.Int).SetBytes(protoParams.WinProb),
 			RecipientRandHash: ethcommon.BytesToHash(protoParams.RecipientRandHash),
 			Seed:              new(big.Int).SetBytes(protoParams.Seed),
 		}
 
-		sessionID = s.LivepeerNode.Sender.StartSession(ethcommon.BytesToAddress(protoParams.Recipient), params)
+		sessionID = s.LivepeerNode.Sender.StartSession(params)
 	}
 
 	// set OSes

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -123,15 +123,15 @@ func TestStartBroadcast(t *testing.T) {
 	sender := &pm.MockSender{}
 	s.LivepeerNode.Sender = sender
 
-	recipient := pm.RandAddressOrFatal(t)
 	params := pm.TicketParams{
+		Recipient:         pm.RandAddress(),
 		FaceValue:         big.NewInt(1234),
 		WinProb:           big.NewInt(5678),
-		RecipientRandHash: pm.RandHashOrFatal(t),
+		RecipientRandHash: pm.RandHash(),
 		Seed:              big.NewInt(7777),
 	}
 	protoParams := &net.TicketParams{
-		Recipient:         recipient.Bytes(),
+		Recipient:         params.Recipient.Bytes(),
 		FaceValue:         params.FaceValue.Bytes(),
 		WinProb:           params.WinProb.Bytes(),
 		RecipientRandHash: params.RecipientRandHash.Bytes(),
@@ -145,7 +145,7 @@ func TestStartBroadcast(t *testing.T) {
 	}
 
 	expSessionID := "foo"
-	sender.On("StartSession", recipient, params).Return(expSessionID)
+	sender.On("StartSession", params).Return(expSessionID)
 
 	sess, err := s.startBroadcast(pl)
 	require.Nil(t, err)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -11,6 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/livepeer/go-livepeer/pm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/drivers"
@@ -70,6 +74,10 @@ func (s *StubSegmenter) SegmentRTMPToHLS(ctx context.Context, rs stream.RTMPVide
 func TestStartBroadcast(t *testing.T) {
 	s := setupServer()
 
+	defer func() {
+		s.LivepeerNode.Sender = nil
+	}()
+
 	// Empty discovery
 	mid := core.ManifestID(core.RandomVideoID())
 	storage := drivers.NodeStorage.NewSession(string(mid))
@@ -104,6 +112,47 @@ func TestStartBroadcast(t *testing.T) {
 	if sess.OrchestratorInfo != sd.infos[0] || sd.infos[0] == sd.infos[1] {
 		t.Error("Unexpected orchestrator info")
 	}
+	if sess.Sender != nil {
+		t.Error("Unexpected sender")
+	}
+	if sess.PMSessionID != "" {
+		t.Error("Unexpected PM sessionID")
+	}
+
+	// Test start PM session
+	sender := &pm.MockSender{}
+	s.LivepeerNode.Sender = sender
+
+	recipient := pm.RandAddressOrFatal(t)
+	params := pm.TicketParams{
+		FaceValue:         big.NewInt(1234),
+		WinProb:           big.NewInt(5678),
+		RecipientRandHash: pm.RandHashOrFatal(t),
+		Seed:              big.NewInt(7777),
+	}
+	protoParams := &net.TicketParams{
+		Recipient:         recipient.Bytes(),
+		FaceValue:         params.FaceValue.Bytes(),
+		WinProb:           params.WinProb.Bytes(),
+		RecipientRandHash: params.RecipientRandHash.Bytes(),
+		Seed:              params.Seed.Bytes(),
+	}
+
+	sd.infos = []*net.OrchestratorInfo{
+		&net.OrchestratorInfo{
+			TicketParams: protoParams,
+		},
+	}
+
+	expSessionID := "foo"
+	sender.On("StartSession", recipient, params).Return(expSessionID)
+
+	sess, err := s.startBroadcast(pl)
+	require.Nil(t, err)
+
+	assert := assert.New(t)
+	assert.Equal(sender, sess.Sender)
+	assert.Equal(expSessionID, sess.PMSessionID)
 }
 
 func TestCreateRTMPStreamHandler(t *testing.T) {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -248,7 +248,6 @@ func genPayment(sess *BroadcastSession) (string, error) {
 
 	data, err := proto.Marshal(protoPayment)
 	if err != nil {
-		glog.Error("Unable to marshal ", err)
 		return "", err
 	}
 

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -18,9 +18,6 @@ import (
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 
 	"github.com/golang/protobuf/proto"
 
@@ -245,15 +242,15 @@ func TestGenPayment(t *testing.T) {
 
 	// Test payment creation
 	ticket := &pm.Ticket{
-		Recipient:         pm.RandAddressOrFatal(t),
-		Sender:            pm.RandAddressOrFatal(t),
+		Recipient:         pm.RandAddress(),
+		Sender:            pm.RandAddress(),
 		FaceValue:         big.NewInt(1234),
 		WinProb:           big.NewInt(5678),
 		SenderNonce:       777,
-		RecipientRandHash: pm.RandHashOrFatal(t),
+		RecipientRandHash: pm.RandHash(),
 	}
 	seed := big.NewInt(7777)
-	sig := pm.RandBytesOrFatal(42, t)
+	sig := pm.RandBytes(42)
 
 	sender.On("CreateTicket", mock.Anything).Return(ticket, seed, sig, nil).Once()
 

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -18,6 +18,9 @@ import (
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/golang/protobuf/proto"
 
@@ -202,6 +205,71 @@ func TestRPCSeg(t *testing.T) {
 	corruptSegData(sd, ErrSegSig) // missing sig
 	sd.Sig = []byte("abc")
 	corruptSegData(sd, ErrSegSig) // invalid sig
+}
+
+func TestGenPayment(t *testing.T) {
+	mid, _ := core.MakeManifestID(core.RandomVideoID())
+	b := StubBroadcaster2()
+	s := &BroadcastSession{
+		Broadcaster: b,
+		ManifestID:  mid,
+	}
+
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Test missing sender
+	payment, err := genPayment(s)
+	assert.Equal("", payment)
+	assert.Nil(err)
+
+	sender := &pm.MockSender{}
+	s.Sender = sender
+
+	// Test CreateTicket error
+	sender.On("CreateTicket", mock.Anything).Return(nil, nil, nil, errors.New("CreateTicket error")).Once()
+
+	_, err = genPayment(s)
+	assert.Equal("CreateTicket error", err.Error())
+
+	decodePayment := func(payment string) net.Payment {
+		buf, err := base64.StdEncoding.DecodeString(payment)
+		assert.Nil(err)
+
+		var protoPayment net.Payment
+		err = proto.Unmarshal(buf, &protoPayment)
+		assert.Nil(err)
+
+		return protoPayment
+	}
+
+	// Test payment creation
+	ticket := &pm.Ticket{
+		Recipient:         pm.RandAddressOrFatal(t),
+		Sender:            pm.RandAddressOrFatal(t),
+		FaceValue:         big.NewInt(1234),
+		WinProb:           big.NewInt(5678),
+		SenderNonce:       777,
+		RecipientRandHash: pm.RandHashOrFatal(t),
+	}
+	seed := big.NewInt(7777)
+	sig := pm.RandBytesOrFatal(42, t)
+
+	sender.On("CreateTicket", mock.Anything).Return(ticket, seed, sig, nil).Once()
+
+	payment, err = genPayment(s)
+	require.Nil(err)
+
+	protoPayment := decodePayment(payment)
+	protoTicket := protoPayment.Ticket
+	assert.Equal(ticket.Recipient, ethcommon.BytesToAddress(protoTicket.Recipient))
+	assert.Equal(ticket.Sender, ethcommon.BytesToAddress(protoTicket.Sender))
+	assert.Equal(ticket.FaceValue, new(big.Int).SetBytes(protoTicket.FaceValue))
+	assert.Equal(ticket.WinProb, new(big.Int).SetBytes(protoTicket.WinProb))
+	assert.Equal(ticket.SenderNonce, protoTicket.SenderNonce)
+	assert.Equal(ticket.RecipientRandHash, ethcommon.BytesToHash(protoTicket.RecipientRandHash))
+	assert.Equal(sig, protoPayment.Sig)
+	assert.Equal(seed, new(big.Int).SetBytes(protoPayment.Seed))
 }
 
 func TestPing(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Implements PM sender RPC message handling for a broadcaster.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add a PM sender to the LivepeerNode
- Use TicketParams included in OrchestratorInfo messages to start local PM sessions
- Create Ticket payments which are attached to the header of segment messages sent to orchestrators

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I wrote additional unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #633 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
