### PR TITLE
Misc threading fixes

### DIFF
--- a/core/broadcaster.go
+++ b/core/broadcaster.go
@@ -1,13 +1,9 @@
 package core
 
 import (
-	"errors"
-
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
-
-var ErrNotFound = errors.New("ErrNotFound")
 
 // Broadcaster RPC interface implementation
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -27,9 +27,7 @@ import (
 )
 
 var ErrTranscoderAvail = errors.New("ErrTranscoderUnavailable")
-var ErrLivepeerNode = errors.New("ErrLivepeerNode")
 var ErrTranscode = errors.New("ErrTranscode")
-var DefaultJobLength = int64(5760) //Avg 1 day in 15 sec blocks
 var LivepeerVersion = "0.3.1-unstable"
 
 type NodeType int

--- a/core/playlistmanager.go
+++ b/core/playlistmanager.go
@@ -70,27 +70,30 @@ func (mgr *BasicPlaylistManager) getPL(rendition string) *m3u8.MediaPlaylist {
 	return mpl
 }
 
-func (mgr *BasicPlaylistManager) createPL(profile *ffmpeg.VideoProfile) *m3u8.MediaPlaylist {
+func (mgr *BasicPlaylistManager) getOrCreatePL(profile *ffmpeg.VideoProfile) (*m3u8.MediaPlaylist, error) {
+	mgr.mapSync.Lock()
+	defer mgr.mapSync.Unlock()
+	if pl, ok := mgr.mediaLists[profile.Name]; ok {
+		return pl, nil
+	}
 	mpl, err := m3u8.NewMediaPlaylist(LIVE_LIST_LENGTH, LIVE_LIST_LENGTH)
 	if err != nil {
 		glog.Error(err)
-		return nil
+		return nil, err
 	}
-	mgr.mapSync.Lock()
 	mgr.mediaLists[profile.Name] = mpl
-	mgr.mapSync.Unlock()
 	vParams := ffmpeg.VideoProfileToVariantParams(*profile)
 	url := fmt.Sprintf("%v/%v.m3u8", mgr.manifestID, profile.Name)
 	mgr.masterPList.Append(url, mpl, vParams)
-	return mpl
+	return mpl, nil
 }
 
 func (mgr *BasicPlaylistManager) InsertHLSSegment(profile *ffmpeg.VideoProfile, seqNo uint64, uri string,
 	duration float64) error {
 
-	mpl := mgr.getPL(profile.Name)
-	if mpl == nil {
-		mpl = mgr.createPL(profile)
+	mpl, err := mgr.getOrCreatePL(profile)
+	if err != nil {
+		return err
 	}
 	return mgr.addToMediaPlaylist(uri, seqNo, duration, mpl)
 }

--- a/core/playlistmanager_test.go
+++ b/core/playlistmanager_test.go
@@ -37,20 +37,108 @@ func TestGetMasterPlaylist(t *testing.T) {
 	}
 }
 
-func TestForWrongStream(t *testing.T) {
-	/* Mismatched streams don't really happen anymore
-	vProfile := ffmpeg.P144p30fps16x9
-	hlsStrmID := MakeStreamID(RandomManifestID(), &vProfile)
-	mid := hlsStrmID.ManifestID
-	c := NewBasicPlaylistManager(mid, nil)
-	err := c.InsertHLSSegment(&vProfile, 1, "test_uri", 12)
-	if err == nil {
-		t.Fatalf("Should fail here")
+func TestGetOrCreatePL(t *testing.T) {
+
+	c := NewBasicPlaylistManager(RandomManifestID(), nil)
+	vProfile := &ffmpeg.P144p30fps16x9
+
+	// Sanity check some properties of an empty master playlist
+	masterPL := c.GetHLSMasterPlaylist()
+	if len(masterPL.Variants) != 0 {
+		t.Error("Master PL had some unexpected variants")
 	}
-	if !strings.Contains(err.Error(), "Wrong manifest id") {
-		t.Fatalf("Wrong error, should contain 'Wrong stream id', but has %s", err.Error())
+
+	// insert one
+	pl, err := c.getOrCreatePL(vProfile)
+	if err != nil {
+		t.Error("Unexpected error ", err)
 	}
-	*/
+
+	// Sanity check some master PL properties
+	expectedRes := vProfile.Resolution
+	if len(masterPL.Variants) != 1 || masterPL.Variants[0].Resolution != expectedRes {
+		t.Error("Master PL had some unexpected variants or properties")
+	}
+
+	// using the same profile name should return the original profile
+	orig := pl
+	vProfile = &ffmpeg.VideoProfile{Name: vProfile.Name}
+	pl, err = c.getOrCreatePL(vProfile)
+	if err != nil || orig != pl {
+		t.Error("Mismatched profile or error ", err)
+	}
+	// Further sanity check some master PL properties
+	if len(masterPL.Variants) != 1 || masterPL.Variants[0].Resolution != expectedRes {
+		t.Error("Master PL had some unexpected variants or properties")
+	}
+
+	// using a different profile name should return a different profile
+	vProfile = &ffmpeg.P240p30fps16x9
+	pl, err = c.getOrCreatePL(vProfile)
+	if err != nil || orig == pl {
+		t.Error("Matched profile or error ", err)
+	}
+	// Further sanity check some master PL properties
+	if len(masterPL.Variants) != 2 || masterPL.Variants[1].Resolution != vProfile.Resolution {
+		t.Error("Master PL had some unexpected variants or properties")
+	}
+}
+
+func TestPlaylists(t *testing.T) {
+
+	c := NewBasicPlaylistManager(RandomManifestID(), nil)
+	vProfile := &ffmpeg.P144p30fps16x9
+
+	// Check getting a nonexistent media PL
+	if pl := c.GetHLSMediaPlaylist("nonexistent"); pl != nil {
+		t.Error("Recevied a nonexistent playlist ", pl)
+	}
+
+	// Insert one segment
+	compareSeg := func(a, b *m3u8.MediaSegment) bool {
+		return a.SeqId == b.SeqId && a.URI == b.URI && a.Duration == b.Duration
+	}
+	seg := &m3u8.MediaSegment{SeqId: 9, URI: "abc", Duration: -11.1}
+	if err := c.InsertHLSSegment(vProfile, seg.SeqId, seg.URI, seg.Duration); err != nil {
+		t.Error("HLS insertion")
+	}
+	// Sanity check some PL properties
+	pl := c.GetHLSMediaPlaylist(vProfile.Name)
+	if pl == nil {
+		t.Error("No playlist")
+	}
+	if len(pl.Segments) != int(LIVE_LIST_LENGTH) || !compareSeg(seg, pl.Segments[0]) || pl.Segments[1] != nil {
+		t.Error("Unexpected playlist/segment properties")
+	}
+
+	// insert a "duplicate" seqno. Should not work but does. Fix.
+	if err := c.InsertHLSSegment(vProfile, seg.SeqId, seg.URI, seg.Duration); err != nil {
+		t.Error("HLS insertion")
+	}
+	if len(pl.Segments) != int(LIVE_LIST_LENGTH) || !compareSeg(seg, pl.Segments[0]) || !compareSeg(pl.Segments[0], pl.Segments[1]) {
+		t.Error("Unexpected playlist/segment properties")
+	}
+
+	// Insert out of order. Playlist should accommodate this. Fix.
+	seg = &m3u8.MediaSegment{SeqId: 3, URI: "abc", Duration: -11.1}
+	if err := c.InsertHLSSegment(vProfile, seg.SeqId, seg.URI, seg.Duration); err != nil {
+		t.Error("HLS insertion")
+	}
+	if !compareSeg(seg, pl.Segments[2]) {
+		t.Error("Unexpected seg properties")
+	}
+
+	// Ensure we have different segments between two playlists
+	newSeg := &m3u8.MediaSegment{SeqId: 3, URI: "abc", Duration: -11.1}
+	newProfile := &ffmpeg.P240p30fps16x9
+	if err := c.InsertHLSSegment(newProfile, newSeg.SeqId, newSeg.URI, newSeg.Duration); err != nil {
+		t.Error("HLS insertion")
+	}
+	newPL := c.GetHLSMediaPlaylist(newProfile.Name)
+	if !compareSeg(seg, newPL.Segments[0]) || compareSeg(pl.Segments[0], newPL.Segments[0]) {
+		t.Error("Unexpected seg properties in new playlist")
+	}
+
 }
 
 func TestCleanup(t *testing.T) {

--- a/core/streamdata.go
+++ b/core/streamdata.go
@@ -16,7 +16,6 @@ import (
 	"github.com/livepeer/lpms/ffmpeg"
 )
 
-var ErrStreamID = errors.New("ErrStreamID")
 var ErrManifestID = errors.New("ErrManifestID")
 
 const (

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -78,7 +78,7 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) {
 	nonce := cxn.nonce
 	rtmpStrm := cxn.stream
 	cpl := cxn.pl
-	mid := rtmpManifestID(rtmpStrm)
+	mid := cxn.mid
 	vProfile := cxn.profile
 
 	cxn.lock.RLock()

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -35,11 +35,7 @@ import (
 )
 
 var ErrAlreadyExists = errors.New("StreamAlreadyExists")
-var ErrRTMPPublish = errors.New("ErrRTMPPublish")
 var ErrBroadcast = errors.New("ErrBroadcast")
-var ErrHLSPlay = errors.New("ErrHLSPlay")
-var ErrRTMPPlay = errors.New("ErrRTMPPlay")
-var ErrRoundInit = errors.New("ErrRoundInit")
 var ErrStorage = errors.New("ErrStorage")
 var ErrDiscovery = errors.New("ErrDiscovery")
 var ErrNoOrchs = errors.New("ErrNoOrchs")
@@ -51,12 +47,10 @@ const HLSBufferWindow = uint(5)
 const StreamKeyBytes = 6
 
 const SegLen = 2 * time.Second
-const HLSUnsubWorkerFreq = time.Second * 5
 const BroadcastRetry = 15 * time.Second
 
 var BroadcastPrice = big.NewInt(1)
 var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmpeg.P360p30fps16x9}
-var MinDepositSegmentCount = int64(75) // 5 mins assuming 4s segments
 
 type rtmpConnection struct {
 	mid     core.ManifestID

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -301,7 +301,7 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 
 func (s *LivepeerServer) startSession(cxn *rtmpConnection) *BroadcastSession {
 
-	mid := rtmpManifestID(cxn.stream)
+	mid := cxn.mid
 	cpl := cxn.pl
 	var sess *BroadcastSession
 
@@ -345,14 +345,14 @@ func (s *LivepeerServer) startSessionListener(cxn *rtmpConnection) {
 		// we don't terminate the stream *then* assign the session to the cxn
 		s.connectionLock.RLock()
 		defer s.connectionLock.RUnlock()
-		if _, active := s.rtmpConnections[cxn.pl.ManifestID()]; !active {
+		if _, active := s.rtmpConnections[cxn.mid]; !active {
 			sess = nil // don't assign if stream terminated
 		}
 		mut.Lock()
 		defer mut.Unlock()
 		cxn.sess = sess
 	}
-	glog.V(common.DEBUG).Info("Starting broadcast listener for ", cxn.pl.ManifestID())
+	glog.V(common.DEBUG).Info("Starting broadcast listener for ", cxn.mid)
 	finished := false
 	for {
 		if finished {
@@ -376,7 +376,7 @@ func (s *LivepeerServer) startSessionListener(cxn *rtmpConnection) {
 			break
 		}
 	}
-	glog.V(common.DEBUG).Info("Stopping broadcast listener for ", cxn.pl.ManifestID())
+	glog.V(common.DEBUG).Info("Stopping broadcast listener for ", cxn.mid)
 }
 
 //End RTMP Publish Handlers

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -194,6 +194,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 			Resolution: resolution,
 			Bitrate:    "4000k", // Fix this
 		}
+		hlsStrmID := core.MakeStreamID(mid, &vProfile)
 		s.connectionLock.Lock()
 		_, exists := s.rtmpConnections[mid]
 		if exists {
@@ -213,18 +214,15 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 			eof:      make(chan struct{}),
 		}
 		s.rtmpConnections[mid] = cxn
-		s.connectionLock.Unlock()
 		LastManifestID = mid
+		LastHLSStreamID = hlsStrmID
+		s.connectionLock.Unlock()
 
 		startSeq := 0
 
 		if s.LivepeerNode.Eth != nil {
 			// TODO: Check broadcaster's deposit with TicketBroker
 		}
-
-		hlsStrmID := core.MakeStreamID(mid, &vProfile)
-
-		LastHLSStreamID = hlsStrmID
 
 		streamStarted := false
 		//Segment the stream, insert the segments into the broadcaster

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -59,6 +59,7 @@ var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmp
 var MinDepositSegmentCount = int64(75) // 5 mins assuming 4s segments
 
 type rtmpConnection struct {
+	mid     core.ManifestID
 	nonce   uint64
 	stream  stream.RTMPVideoStream
 	pl      core.PlaylistManager
@@ -182,48 +183,18 @@ func rtmpManifestID(rtmpStrm stream.RTMPVideoStream) core.ManifestID {
 func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error) {
 	return func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error) {
 
-		// Set up the connection tracking
-		mid := rtmpManifestID(rtmpStrm)
-		if drivers.NodeStorage == nil {
-			glog.Error("Missing node storage")
-			return ErrStorage
+		cxn, err := s.registerConnection(rtmpStrm)
+		if err != nil {
+			return err
 		}
-		storage := drivers.NodeStorage.NewSession(string(mid))
-		// Build the source video profile from the RTMP stream.
-		resolution := fmt.Sprintf("%vx%v", rtmpStrm.Width(), rtmpStrm.Height())
-		vProfile := ffmpeg.VideoProfile{
-			Name:       "source",
-			Resolution: resolution,
-			Bitrate:    "4000k", // Fix this
-		}
-		hlsStrmID := core.MakeStreamID(mid, &vProfile)
-		s.connectionLock.Lock()
-		_, exists := s.rtmpConnections[mid]
-		if exists {
-			// We can only have one concurrent stream per ManifestID
-			s.connectionLock.Unlock()
-			return ErrAlreadyExists
-		}
-		nonce := rand.Uint64()
-		cxn := &rtmpConnection{
-			nonce:   nonce,
-			stream:  rtmpStrm,
-			pl:      core.NewBasicPlaylistManager(mid, storage),
-			profile: &vProfile,
-			lock:    &sync.RWMutex{},
 
-			needOrch: make(chan struct{}),
-			eof:      make(chan struct{}),
-		}
-		s.rtmpConnections[mid] = cxn
-		s.lastManifestID = mid
-		s.lastHLSStreamID = hlsStrmID
-		s.connectionLock.Unlock()
-
+		mid := cxn.mid
+		nonce := cxn.nonce
 		startSeq := 0
 
 		if s.LivepeerNode.Eth != nil {
 			// TODO: Check broadcaster's deposit with TicketBroker
+			//       (perhaps within registerConnection?)
 		}
 
 		streamStarted := false
@@ -263,7 +234,6 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		}
 
 		glog.Infof("\n\nVideo Created With ManifestID: %v\n\n", mid)
-		glog.V(common.SHORT).Infof("\n\nhlsStrmID: %v\n\n", hlsStrmID)
 
 		//Create Transcode Job Onchain
 		go s.startSessionListener(cxn)
@@ -292,6 +262,47 @@ func endRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 
 		return nil
 	}
+}
+
+func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*rtmpConnection, error) {
+	// Set up the connection tracking
+	mid := rtmpManifestID(rtmpStrm)
+	if drivers.NodeStorage == nil {
+		glog.Error("Missing node storage")
+		return nil, ErrStorage
+	}
+	storage := drivers.NodeStorage.NewSession(string(mid))
+	// Build the source video profile from the RTMP stream.
+	resolution := fmt.Sprintf("%vx%v", rtmpStrm.Width(), rtmpStrm.Height())
+	vProfile := ffmpeg.VideoProfile{
+		Name:       "source",
+		Resolution: resolution,
+		Bitrate:    "4000k", // Fix this
+	}
+	hlsStrmID := core.MakeStreamID(mid, &vProfile)
+	s.connectionLock.Lock()
+	defer s.connectionLock.Unlock()
+	_, exists := s.rtmpConnections[mid]
+	if exists {
+		// We can only have one concurrent stream per ManifestID
+		return nil, ErrAlreadyExists
+	}
+	cxn := &rtmpConnection{
+		mid:     mid,
+		nonce:   rand.Uint64(),
+		stream:  rtmpStrm,
+		pl:      core.NewBasicPlaylistManager(mid, storage),
+		profile: &vProfile,
+		lock:    &sync.RWMutex{},
+
+		needOrch: make(chan struct{}),
+		eof:      make(chan struct{}),
+	}
+	s.rtmpConnections[mid] = cxn
+	s.lastManifestID = mid
+	s.lastHLSStreamID = hlsStrmID
+
+	return cxn, nil
 }
 
 func (s *LivepeerServer) startSession(cxn *rtmpConnection) *BroadcastSession {

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -291,11 +291,11 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 
 	// Check assigned IDs
 	mid := rtmpManifestID(strm)
-	if s.LatestPlaylist().ManifestID() != mid || LastManifestID != mid {
+	if s.LatestPlaylist().ManifestID() != mid {
 		t.Error("Unexpected Manifest ID")
 	}
-	if LastHLSStreamID != expectedSid {
-		t.Error("Unexpected Stream ID ", LastHLSStreamID, expectedSid)
+	if s.LastHLSStreamID() != expectedSid {
+		t.Error("Unexpected Stream ID ", s.LastHLSStreamID(), expectedSid)
 	}
 
 	//Stream already exists
@@ -323,6 +323,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 	}
 
 	for i := 0; i < 4; i++ {
+		// XXX we shouldn't do this. Need threadsafe accessors for playlist
 		seg := pl.Segments[i]
 		shouldSegName := fmt.Sprintf("/stream/%s/%s/%d.ts", mid, expectedSid.Rendition, i)
 		if seg.URI != shouldSegName {

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -712,11 +712,11 @@ func (s *LivepeerServer) StartWebserver(bindAddr string) {
 
 	//Print the current broadcast HLS streamID
 	mux.HandleFunc("/streamID", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(LastHLSStreamID.String()))
+		w.Write([]byte(s.LastHLSStreamID().String()))
 	})
 
 	mux.HandleFunc("/manifestID", func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(LastManifestID))
+		w.Write([]byte(s.LastManifestID()))
 	})
 
 	mux.HandleFunc("/localStreams", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Prompted by [this comment](https://github.com/livepeer/go-livepeer/pull/643#discussion_r245076349) -- fixes up some other threading issues as identified by the golang race detector.

**Specific updates (required)**
- Atomically  getAndSet media playlists
- Add tests for the above and generally improved playlist manager test coverage. This exposed a few problems with playlist handling; captured [here](https://github.com/livepeer/go-livepeer/issues/667)
- Un-globalify LastManifestID / LastHLSStreamID and provide threadsafe accessors
- Fix detected unsafe conditions with multistream tests

**How did you test each of these updates (required)**
Ran these tests under `-race`


**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/go-livepeer/pull/643#discussion_r245076349 and https://github.com/livepeer/go-livepeer/pull/643#discussion_r245077232


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
