### PR TITLE
server: fix O sig check

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -101,6 +101,7 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 	}
 
 	if won {
+		glog.V(common.DEBUG).Info("Received winning ticket")
 		cachePMSessionID(orch.node, manifestID, sessionID)
 	}
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -260,19 +260,6 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		var sess *BroadcastSession
 
 		if s.LivepeerNode.Eth != nil {
-
-			//Check if round is initialized
-			initialized, err := s.LivepeerNode.Eth.CurrentRoundInitialized()
-			if err != nil {
-				glog.Errorf("Could not check whether round was initialized: %v", err)
-				return err
-			}
-			if !initialized {
-				glog.Infof("Round was uninitialized. Please try again in a few blocks.")
-				// todo send to metrics ?
-				return ErrRoundInit
-			}
-
 			// TODO: Check broadcaster's deposit with TicketBroker
 		}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Use the sender ETH address in PM tickets for verification of a
signature over seg creds.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Create a separate helper `getPayment()` for parsing the payment header
- Create a separate helper `getPaymentSender()` for parsing the payment sender (handles cases where the payment header is an empty string, the ticket is missing from the payment or the ticket sender is missing - the helper will make sure to return the null address)
- Within `ServeSegment`, parse the payment header first and try getting the broadcaster address to be used in `verifySegCreds()`. When running in off-chain mode, the null address would be used as the broadcaster address
- Remove initialized round check in the mediaserver when starting a stream

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Unit tests
- Manual tests: transcoding with B & O in off-chain mode, transcoding with B & O in on-chain mode

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #666 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
