### PR TITLE
adding cacheRegisteredTranscoders method

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -14,7 +14,7 @@ import (
 	"github.com/golang/glog"
 )
 
-const GetOrchestratorsTimeoutLoop = 3 * time.Second
+const GetOrchestratorsTimeoutLoop = 1 * time.Hour
 
 type orchestratorPool struct {
 	uris  []*url.URL

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -46,6 +46,24 @@ func StubOrchestrators(addresses []string) []*lpTypes.Transcoder {
 	return orchestrators
 }
 
+func TestCacheRegisteredTranscoders_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *testing.T) {
+	dbh, dbraw, err := common.TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	require := require.New(t)
+	require.Nil(err)
+
+	addresses := []string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"}
+	orchestrators := StubOrchestrators(addresses)
+
+	node, _ := core.NewLivepeerNode(nil, "", nil)
+	node.Database = dbh
+	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
+
+	err = cacheRegisteredTranscoders(node)
+	require.Nil(err)
+}
+
 func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *testing.T) {
 	dbh, dbraw, err := common.TempDB(t)
 	defer dbh.Close()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Description here: https://github.com/livepeer/go-livepeer/issues/676

**Specific updates (required)**
- Adds `cacheRegisteredTranscoders`
- `orchestrators, err := node.Eth.RegisteredTranscoders()` runs on first tick.

**How did you test each of these updates (required)**
- Running node in Docker environment, making certain registered transcoders are indeed cached

**Does this pull request close any open issues?**
Fixes this issue: https://github.com/livepeer/go-livepeer/issues/676


**Checklist:**
- [ ] README and other documentation updated
- [X] Node runs in OSX and devenv
- [X] All tests in `./test.sh` pass
