### PR TITLE
Factor out connection registration

### DIFF
--- a/core/broadcaster.go
+++ b/core/broadcaster.go
@@ -1,13 +1,9 @@
 package core
 
 import (
-	"errors"
-
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
-
-var ErrNotFound = errors.New("ErrNotFound")
 
 // Broadcaster RPC interface implementation
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -27,9 +27,7 @@ import (
 )
 
 var ErrTranscoderAvail = errors.New("ErrTranscoderUnavailable")
-var ErrLivepeerNode = errors.New("ErrLivepeerNode")
 var ErrTranscode = errors.New("ErrTranscode")
-var DefaultJobLength = int64(5760) //Avg 1 day in 15 sec blocks
 var LivepeerVersion = "0.3.1-unstable"
 
 type NodeType int

--- a/core/streamdata.go
+++ b/core/streamdata.go
@@ -16,7 +16,6 @@ import (
 	"github.com/livepeer/lpms/ffmpeg"
 )
 
-var ErrStreamID = errors.New("ErrStreamID")
 var ErrManifestID = errors.New("ErrManifestID")
 
 const (

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -78,7 +78,7 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) {
 	nonce := cxn.nonce
 	rtmpStrm := cxn.stream
 	cpl := cxn.pl
-	mid := rtmpManifestID(rtmpStrm)
+	mid := cxn.mid
 	vProfile := cxn.profile
 
 	cxn.lock.RLock()

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -35,11 +35,7 @@ import (
 )
 
 var ErrAlreadyExists = errors.New("StreamAlreadyExists")
-var ErrRTMPPublish = errors.New("ErrRTMPPublish")
 var ErrBroadcast = errors.New("ErrBroadcast")
-var ErrHLSPlay = errors.New("ErrHLSPlay")
-var ErrRTMPPlay = errors.New("ErrRTMPPlay")
-var ErrRoundInit = errors.New("ErrRoundInit")
 var ErrStorage = errors.New("ErrStorage")
 var ErrDiscovery = errors.New("ErrDiscovery")
 var ErrNoOrchs = errors.New("ErrNoOrchs")
@@ -51,12 +47,10 @@ const HLSBufferWindow = uint(5)
 const StreamKeyBytes = 6
 
 const SegLen = 2 * time.Second
-const HLSUnsubWorkerFreq = time.Second * 5
 const BroadcastRetry = 15 * time.Second
 
 var BroadcastPrice = big.NewInt(1)
 var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmpeg.P360p30fps16x9}
-var MinDepositSegmentCount = int64(75) // 5 mins assuming 4s segments
 
 type rtmpConnection struct {
 	mid     core.ManifestID

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -301,7 +301,7 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 
 func (s *LivepeerServer) startSession(cxn *rtmpConnection) *BroadcastSession {
 
-	mid := rtmpManifestID(cxn.stream)
+	mid := cxn.mid
 	cpl := cxn.pl
 	var sess *BroadcastSession
 
@@ -345,14 +345,14 @@ func (s *LivepeerServer) startSessionListener(cxn *rtmpConnection) {
 		// we don't terminate the stream *then* assign the session to the cxn
 		s.connectionLock.RLock()
 		defer s.connectionLock.RUnlock()
-		if _, active := s.rtmpConnections[cxn.pl.ManifestID()]; !active {
+		if _, active := s.rtmpConnections[cxn.mid]; !active {
 			sess = nil // don't assign if stream terminated
 		}
 		mut.Lock()
 		defer mut.Unlock()
 		cxn.sess = sess
 	}
-	glog.V(common.DEBUG).Info("Starting broadcast listener for ", cxn.pl.ManifestID())
+	glog.V(common.DEBUG).Info("Starting broadcast listener for ", cxn.mid)
 	finished := false
 	for {
 		if finished {
@@ -376,7 +376,7 @@ func (s *LivepeerServer) startSessionListener(cxn *rtmpConnection) {
 			break
 		}
 	}
-	glog.V(common.DEBUG).Info("Stopping broadcast listener for ", cxn.pl.ManifestID())
+	glog.V(common.DEBUG).Info("Stopping broadcast listener for ", cxn.mid)
 }
 
 //End RTMP Publish Handlers

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -59,6 +59,7 @@ var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmp
 var MinDepositSegmentCount = int64(75) // 5 mins assuming 4s segments
 
 type rtmpConnection struct {
+	mid     core.ManifestID
 	nonce   uint64
 	stream  stream.RTMPVideoStream
 	pl      core.PlaylistManager
@@ -182,48 +183,18 @@ func rtmpManifestID(rtmpStrm stream.RTMPVideoStream) core.ManifestID {
 func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error) {
 	return func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error) {
 
-		// Set up the connection tracking
-		mid := rtmpManifestID(rtmpStrm)
-		if drivers.NodeStorage == nil {
-			glog.Error("Missing node storage")
-			return ErrStorage
+		cxn, err := s.registerConnection(rtmpStrm)
+		if err != nil {
+			return err
 		}
-		storage := drivers.NodeStorage.NewSession(string(mid))
-		// Build the source video profile from the RTMP stream.
-		resolution := fmt.Sprintf("%vx%v", rtmpStrm.Width(), rtmpStrm.Height())
-		vProfile := ffmpeg.VideoProfile{
-			Name:       "source",
-			Resolution: resolution,
-			Bitrate:    "4000k", // Fix this
-		}
-		hlsStrmID := core.MakeStreamID(mid, &vProfile)
-		s.connectionLock.Lock()
-		_, exists := s.rtmpConnections[mid]
-		if exists {
-			// We can only have one concurrent stream per ManifestID
-			s.connectionLock.Unlock()
-			return ErrAlreadyExists
-		}
-		nonce := rand.Uint64()
-		cxn := &rtmpConnection{
-			nonce:   nonce,
-			stream:  rtmpStrm,
-			pl:      core.NewBasicPlaylistManager(mid, storage),
-			profile: &vProfile,
-			lock:    &sync.RWMutex{},
 
-			needOrch: make(chan struct{}),
-			eof:      make(chan struct{}),
-		}
-		s.rtmpConnections[mid] = cxn
-		s.lastManifestID = mid
-		s.lastHLSStreamID = hlsStrmID
-		s.connectionLock.Unlock()
-
+		mid := cxn.mid
+		nonce := cxn.nonce
 		startSeq := 0
 
 		if s.LivepeerNode.Eth != nil {
 			// TODO: Check broadcaster's deposit with TicketBroker
+			//       (perhaps within registerConnection?)
 		}
 
 		streamStarted := false
@@ -263,7 +234,6 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		}
 
 		glog.Infof("\n\nVideo Created With ManifestID: %v\n\n", mid)
-		glog.V(common.SHORT).Infof("\n\nhlsStrmID: %v\n\n", hlsStrmID)
 
 		//Create Transcode Job Onchain
 		go s.startSessionListener(cxn)
@@ -292,6 +262,47 @@ func endRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 
 		return nil
 	}
+}
+
+func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*rtmpConnection, error) {
+	// Set up the connection tracking
+	mid := rtmpManifestID(rtmpStrm)
+	if drivers.NodeStorage == nil {
+		glog.Error("Missing node storage")
+		return nil, ErrStorage
+	}
+	storage := drivers.NodeStorage.NewSession(string(mid))
+	// Build the source video profile from the RTMP stream.
+	resolution := fmt.Sprintf("%vx%v", rtmpStrm.Width(), rtmpStrm.Height())
+	vProfile := ffmpeg.VideoProfile{
+		Name:       "source",
+		Resolution: resolution,
+		Bitrate:    "4000k", // Fix this
+	}
+	hlsStrmID := core.MakeStreamID(mid, &vProfile)
+	s.connectionLock.Lock()
+	defer s.connectionLock.Unlock()
+	_, exists := s.rtmpConnections[mid]
+	if exists {
+		// We can only have one concurrent stream per ManifestID
+		return nil, ErrAlreadyExists
+	}
+	cxn := &rtmpConnection{
+		mid:     mid,
+		nonce:   rand.Uint64(),
+		stream:  rtmpStrm,
+		pl:      core.NewBasicPlaylistManager(mid, storage),
+		profile: &vProfile,
+		lock:    &sync.RWMutex{},
+
+		needOrch: make(chan struct{}),
+		eof:      make(chan struct{}),
+	}
+	s.rtmpConnections[mid] = cxn
+	s.lastManifestID = mid
+	s.lastHLSStreamID = hlsStrmID
+
+	return cxn, nil
 }
 
 func (s *LivepeerServer) startSession(cxn *rtmpConnection) *BroadcastSession {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Small code-cleanup refactoring on top of the changes for [failover](https://github.com/livepeer/go-livepeer/pull/646) and [threading](https://github.com/livepeer/go-livepeer/pull/668). No functional changes.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Move the process of creating a `rtmpConnection` and registering the cxn with the LivepeerServer into a `registerConnection` function
- Add tests for the above
- Clean up unused errors

**How did you test each of these updates (required)**
Unit tests, manual tests.


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
