### PR TITLE
eth: use NonceManager to manage transaction nonces

### DIFF
--- a/eth/client.go
+++ b/eth/client.go
@@ -190,6 +190,8 @@ func (c *client) SetGasInfo(gasLimit uint64, gasPrice *big.Int) error {
 		return err
 	}
 
+	opts.NonceManager = NewNonceManager(c.backend)
+
 	if err := c.setContracts(opts); err != nil {
 		return err
 	} else {

--- a/eth/client.go
+++ b/eth/client.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -156,11 +155,8 @@ type client struct {
 	*contracts.LivepeerVerifierSession
 	*contracts.LivepeerTokenFaucetSession
 
-	nonceInitialized bool
-	nextNonce        uint64
-	nonceLock        sync.Mutex
-	gasLimit         uint64
-	gasPrice         *big.Int
+	gasLimit uint64
+	gasPrice *big.Int
 
 	txTimeout time.Duration
 }
@@ -192,10 +188,6 @@ func (c *client) SetGasInfo(gasLimit uint64, gasPrice *big.Int) error {
 	opts, err := c.accountManager.CreateTransactOpts(gasLimit, gasPrice)
 	if err != nil {
 		return err
-	}
-
-	opts.NonceFetcher = func() (uint64, error) {
-		return c.getNonce()
 	}
 
 	if err := c.setContracts(opts); err != nil {
@@ -860,36 +852,6 @@ func (c *client) ReplaceTransaction(tx *types.Transaction, method string, gasPri
 	}
 
 	return newSignedTx, err
-}
-
-func (c *client) getNonce() (uint64, error) {
-	c.nonceLock.Lock()
-	defer c.nonceLock.Unlock()
-
-	if !c.nonceInitialized {
-		nextNonce, err := c.backend.PendingNonceAt(context.Background(), c.Account().Address)
-		if err != nil {
-			return 0, err
-		}
-
-		c.nonceInitialized = true
-		c.nextNonce = nextNonce
-
-		return c.nextNonce, nil
-	} else {
-		c.nextNonce++
-
-		nextNonce, err := c.backend.PendingNonceAt(context.Background(), c.Account().Address)
-		if err != nil {
-			return 0, err
-		}
-
-		if nextNonce > c.nextNonce {
-			c.nextNonce = nextNonce
-		}
-
-		return c.nextNonce, nil
-	}
 }
 
 func (c *client) LatestBlockNum() (*big.Int, error) {

--- a/eth/noncemanager.go
+++ b/eth/noncemanager.go
@@ -1,0 +1,91 @@
+package eth
+
+import (
+	"context"
+	"sync"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+// RemoteNonceReader is an interface that describes an object
+// capable of reading transaction nonces for ETH address from a remote source
+type RemoteNonceReader interface {
+	PendingNonceAt(ctx context.Context, addr ethcommon.Address) (uint64, error)
+}
+
+type nonceLock struct {
+	nonce uint64
+	mu    sync.Mutex
+}
+
+// NonceManager manages transaction nonces for multiple ETH addresses
+type NonceManager struct {
+	nonces map[ethcommon.Address]*nonceLock
+	mu     sync.Mutex
+
+	remoteReader RemoteNonceReader
+}
+
+// NewNonceManager creates an instance of a NonceManager
+func NewNonceManager(remoteReader RemoteNonceReader) *NonceManager {
+	return &NonceManager{
+		nonces:       make(map[ethcommon.Address]*nonceLock),
+		remoteReader: remoteReader,
+	}
+}
+
+// Lock locks the provided address. The caller should always call Lock before
+// calling Next or Update
+func (m *NonceManager) Lock(addr ethcommon.Address) {
+	m.getNonceLock(addr).mu.Lock()
+}
+
+// Unlock unlocks the provided address. The caller should always call Unlock
+// after finishing calls to Next or Update
+func (m *NonceManager) Unlock(addr ethcommon.Address) {
+	m.getNonceLock(addr).mu.Unlock()
+}
+
+// Next returns the next transaction nonce to be used for the provided address
+func (m *NonceManager) Next(addr ethcommon.Address) (uint64, error) {
+	nonceLock := m.getNonceLock(addr)
+	localNonce := nonceLock.nonce
+
+	remoteNonce, err := m.remoteReader.PendingNonceAt(context.Background(), addr)
+	if err != nil {
+		return 0, err
+	}
+
+	// If remote nonce > local nonce, another client was likely used
+	// to submit transactions such that the local nonce does not capture
+	// transactions submitted by other clients
+	if remoteNonce > localNonce {
+		return remoteNonce, nil
+	}
+
+	return localNonce, nil
+}
+
+// Update uses the last nonce for the provided address to update the next transaction nonce
+func (m *NonceManager) Update(addr ethcommon.Address, lastNonce uint64) {
+	nonceLock := m.getNonceLock(addr)
+	localNonce := nonceLock.nonce
+
+	if lastNonce == localNonce {
+		nonceLock.nonce = localNonce + 1
+		return
+	}
+
+	nonceLock.nonce = lastNonce + 1
+}
+
+func (m *NonceManager) getNonceLock(addr ethcommon.Address) *nonceLock {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.nonces[addr]; !ok {
+		m.nonces[addr] = new(nonceLock)
+	}
+
+	return m.nonces[addr]
+}

--- a/eth/noncemanager_test.go
+++ b/eth/noncemanager_test.go
@@ -1,0 +1,215 @@
+package eth
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/livepeer/go-livepeer/pm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRemoteNonceReader struct {
+	mock.Mock
+}
+
+func (m *mockRemoteNonceReader) PendingNonceAt(ctx context.Context, addr ethcommon.Address) (uint64, error) {
+	args := m.Called(ctx, addr)
+
+	return args.Get(0).(uint64), args.Error(1)
+}
+
+func TestNext_PendingNonceAtError(t *testing.T) {
+	r := &mockRemoteNonceReader{}
+	nm := NewNonceManager(r)
+	addr := pm.RandAddress()
+
+	r.On("PendingNonceAt", mock.Anything, addr).Return(uint64(0), errors.New("PendingNonceAt error"))
+
+	assert := assert.New(t)
+
+	_, err := nm.Next(addr)
+	assert.NotNil(err)
+	assert.Equal("PendingNonceAt error", err.Error())
+}
+
+func TestNext_ZeroNonce(t *testing.T) {
+	r := &mockRemoteNonceReader{}
+	nm := NewNonceManager(r)
+	addr := pm.RandAddress()
+
+	r.On("PendingNonceAt", mock.Anything, addr).Return(uint64(0), nil)
+
+	assert := assert.New(t)
+
+	nonce, err := nm.Next(addr)
+	assert.Nil(err)
+	assert.Equal(uint64(0), nonce)
+}
+
+func TestNext_IncrementLocal(t *testing.T) {
+	r := &mockRemoteNonceReader{}
+	nm := NewNonceManager(r)
+	addr := pm.RandAddress()
+
+	r.On("PendingNonceAt", mock.Anything, addr).Return(uint64(0), nil)
+
+	assert := assert.New(t)
+	require := require.New(t)
+
+	nonce, err := nm.Next(addr)
+	require.Nil(err)
+	require.Equal(uint64(0), nonce)
+
+	nm.Update(addr, nonce)
+
+	nonce, err = nm.Next(addr)
+	assert.Nil(err)
+	assert.Equal(uint64(1), nonce)
+}
+
+func TestNext_LocalLowerThanRemote(t *testing.T) {
+	r := &mockRemoteNonceReader{}
+	nm := NewNonceManager(r)
+	addr := pm.RandAddress()
+
+	r.On("PendingNonceAt", mock.Anything, addr).Return(uint64(10), nil)
+
+	assert := assert.New(t)
+
+	nonce, err := nm.Next(addr)
+	assert.Nil(err)
+	assert.Equal(uint64(10), nonce)
+}
+
+func TestUpdate_LastNonceEqualsLocalNonce(t *testing.T) {
+	r := &mockRemoteNonceReader{}
+	nm := NewNonceManager(r)
+	addr := pm.RandAddress()
+
+	r.On("PendingNonceAt", mock.Anything, addr).Return(uint64(0), nil)
+
+	nm.Update(addr, uint64(0))
+
+	nonce, err := nm.Next(addr)
+	require.Nil(t, err)
+
+	assert.Equal(t, uint64(1), nonce)
+}
+
+func TestUpdate_LastNonceNotEqualsLocalNonce(t *testing.T) {
+	r := &mockRemoteNonceReader{}
+	nm := NewNonceManager(r)
+	addr := pm.RandAddress()
+
+	r.On("PendingNonceAt", mock.Anything, addr).Return(uint64(0), nil)
+
+	nm.Update(addr, uint64(10))
+
+	nonce, err := nm.Next(addr)
+	require.Nil(t, err)
+
+	assert.Equal(t, uint64(11), nonce)
+}
+
+func TestNextAndUpdate_ConcurrentMultipleAddrs(t *testing.T) {
+	r := &mockRemoteNonceReader{}
+	nm := NewNonceManager(r)
+
+	r.On("PendingNonceAt", mock.Anything, mock.Anything).Return(uint64(0), nil)
+
+	var wg sync.WaitGroup
+	var errCount uint64
+	var addrs [50]ethcommon.Address
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+
+		addrs[i] = pm.RandAddress()
+
+		go func(addr ethcommon.Address) {
+			defer wg.Done()
+
+			nm.Lock(addr)
+			defer nm.Unlock(addr)
+
+			nonce, err := nm.Next(addr)
+			if err != nil {
+				atomic.AddUint64(&errCount, 1)
+			}
+
+			if err == nil {
+				nm.Update(addr, nonce)
+			}
+		}(addrs[i])
+	}
+
+	wg.Wait()
+
+	assert := assert.New(t)
+
+	assert.Equal(uint64(0), errCount)
+
+	for _, addr := range addrs {
+		nonce, err := nm.Next(addr)
+		assert.Nil(err)
+		assert.Equal(uint64(1), nonce)
+	}
+}
+
+func TestNextAndUpdate_ConcurrentSingleAddr(t *testing.T) {
+	r := &mockRemoteNonceReader{}
+	nm := NewNonceManager(r)
+	addr := pm.RandAddress()
+
+	r.On("PendingNonceAt", mock.Anything, addr).Return(uint64(0), nil)
+
+	var wg sync.WaitGroup
+	var errCount uint64
+
+	var usedNoncesLock sync.Mutex
+	usedNonces := make(map[uint64]bool)
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			nm.Lock(addr)
+			defer nm.Unlock(addr)
+
+			nonce, err := nm.Next(addr)
+			if err != nil {
+				atomic.AddUint64(&errCount, 1)
+			}
+
+			usedNoncesLock.Lock()
+			usedNonces[nonce] = true
+			usedNoncesLock.Unlock()
+
+			if err == nil {
+				nm.Update(addr, nonce)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	assert := assert.New(t)
+
+	assert.Equal(uint64(0), errCount)
+
+	nonce, err := nm.Next(addr)
+	assert.Nil(err)
+	assert.Equal(uint64(50), nonce)
+
+	for i := 0; i < 50; i++ {
+		assert.True(usedNonces[uint64(i)])
+	}
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Add a global NonceManager to assign ETH transaction nonces. The included implementation also supports multiple ETH addresses - this feature isn't used at the moment, but might be useful in the future if a node submits transactions with multiple ETH addresses.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Introduce the NonceManager interface in the vendored go-ethereum
package. The interface is used to get and update the next nonce
- Added a NonceManager implementation in the eth package

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Wrote unit tests for the NonceManager implementation. Confirmed that transaction submission works in devenv and that a failed transaction submission would not disrupt subsequent transactions.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #684 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
