### PR TITLE
cmd: reject invalid values for -faceValue & -winProb

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -307,6 +307,16 @@ func main() {
 				return
 			}
 
+			if *faceValue < float64(0) {
+				glog.Errorf("-faceValue must be greater than 0, but %v provided. Restart the node with a different valid value for -faceValue", *faceValue)
+				return
+			}
+
+			if *winProb < float64(0) || *winProb > float64(100) {
+				glog.Errorf("-winProb must be between 0 and 100, but %v provided. Restart the node with a different valid value for -winProb", *winProb)
+				return
+			}
+
 			sigVerifier := &pm.DefaultSigVerifier{}
 			validator := pm.NewValidator(sigVerifier)
 			faceValueInWei := eth.ToBaseUnit(big.NewFloat(*faceValue))


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Checks the -faceValue and -winProb flags when starting a node - if invalid values are passed in, we log an error message and stop the node.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add error message when -faceValue or -winProb are given invalid values (values > 100 are also treated as invalid for -winProb)
- If one of the values for these flags is invalid, the node stops.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Confirmed in devenv that passing in invalid values for the flags will result in logged error messages and the node stopping.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #678 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
