### PR TITLE
server: set transcoding options in offchain mode

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -102,18 +102,16 @@ func NewLivepeerServer(rtmpAddr string, httpAddr string, lpNode *core.LivepeerNo
 
 //StartServer starts the LPMS server
 func (s *LivepeerServer) StartMediaServer(ctx context.Context, maxPricePerSegment *big.Int, transcodingOptions string) error {
-	if s.LivepeerNode.Eth != nil {
-		BroadcastPrice = maxPricePerSegment
-		bProfiles := make([]ffmpeg.VideoProfile, 0)
-		for _, opt := range strings.Split(transcodingOptions, ",") {
-			p, ok := ffmpeg.VideoProfileLookup[strings.TrimSpace(opt)]
-			if ok {
-				bProfiles = append(bProfiles, p)
-			}
+	bProfiles := make([]ffmpeg.VideoProfile, 0)
+	for _, opt := range strings.Split(transcodingOptions, ",") {
+		p, ok := ffmpeg.VideoProfileLookup[strings.TrimSpace(opt)]
+		if ok {
+			bProfiles = append(bProfiles, p)
 		}
-		BroadcastJobVideoProfiles = bProfiles
-		glog.V(common.SHORT).Infof("Transcode Job Price: %v, Transcode Job Type: %v", BroadcastPrice, BroadcastJobVideoProfiles)
 	}
+	BroadcastJobVideoProfiles = bProfiles
+
+	glog.V(common.SHORT).Infof("Transcode Job Price: %v, Transcode Job Type: %v", BroadcastPrice, BroadcastJobVideoProfiles)
 
 	//LPMS handlers for handling RTMP video
 	s.LPMS.HandleRTMPPublish(createRTMPStreamIDHandler(s), gotRTMPStreamHandler(s), endRTMPStreamHandler(s))


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Allow a broadcaster to use the `-transcodingOptions` flag to set requested video profiles for transcoding even when in off-chain mode.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Set `BroadcastJobVideoProfiles` in `mediaserver.go` even when in off-chain mode

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Ran the node in devenv with the `-offchain` and `-transcodingOptions` flags.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #681 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
