### PR TITLE
Fix ServiceURI Reset Bug

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -380,24 +380,21 @@ func main() {
 		*rtmpAddr = defaultAddr(*rtmpAddr, "127.0.0.1", RtmpPort)
 		*httpAddr = defaultAddr(*httpAddr, "127.0.0.1", RpcPort)
 	} else if n.NodeType == core.OrchestratorNode {
-		n.ServiceURI, err = getServiceURI(n, *serviceAddr)
+		suri, err := getServiceURI(n, *serviceAddr)
 		if err != nil {
 			glog.Error("Error getting service URI: ", err)
 			return
 		}
+		n.SetServiceURI(suri)
 		// if http addr is not provided, listen to all ifaces
 		// take the port to listen to from the service URI
-		*httpAddr = defaultAddr(*httpAddr, "", n.ServiceURI.Port())
+		*httpAddr = defaultAddr(*httpAddr, "", n.GetServiceURI().Port())
 	}
 	*cliAddr = defaultAddr(*cliAddr, "127.0.0.1", CliPort)
 
 	if drivers.NodeStorage == nil {
 		// base URI will be empty for broadcasters; that's OK
-		base := ""
-		if n.ServiceURI != nil {
-			base = n.ServiceURI.String()
-		}
-		drivers.NodeStorage = drivers.NewMemoryDriver(base)
+		drivers.NodeStorage = drivers.NewMemoryDriver(n.GetServiceURI())
 	}
 
 	if n.NodeType == core.BroadcasterNode {

--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -48,7 +48,7 @@ func (w *wizard) registeredOrchestratorStats() map[int]common.Address {
 			eth.FormatPerc(t.PendingRewardCut),
 			eth.FormatPerc(t.PendingFeeShare),
 			eth.FormatUnits(t.PendingPricePerSegment, "ETH"),
-			t.ServiceURI,
+			t.GetServiceURI(),
 		})
 
 		orchestratorIDs[nextId] = t.Address

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -164,7 +164,7 @@ func (w *wizard) orchestratorStats() {
 	data := [][]string{
 		[]string{"Status", t.Status},
 		[]string{"Active", strconv.FormatBool(t.Active)},
-		[]string{"Service URI", t.ServiceURI},
+		[]string{"Service URI", t.GetServiceURI()},
 		[]string{"Delegated Stake", eth.FormatUnits(t.DelegatedStake, "LPT")},
 		[]string{"Reward Cut (%)", eth.FormatPerc(t.RewardCut)},
 		[]string{"Fee Share (%)", eth.FormatPerc(t.FeeShare)},

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -42,7 +42,7 @@ var videoProfiles = []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9, ffmpeg.P240p30f
 
 func TestTranscode(t *testing.T) {
 	//Set up the node
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	db, err := common.InitDB("file:TestTranscode?mode=memory&cache=shared")
 	if err != nil {
 		t.Error("Error initializing DB: ", err)
@@ -87,7 +87,7 @@ func TestTranscode(t *testing.T) {
 
 func TestTranscodeLoop_GivenNoSegmentsPastTimeout_CleansSegmentChan(t *testing.T) {
 	//Set up the node
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	db, _ := common.InitDB("file:TestTranscode?mode=memory&cache=shared")
 	defer db.Close()
 	seth := &eth.StubClient{}
@@ -117,7 +117,7 @@ func TestTranscodeLoop_GivenNoSegmentsPastTimeout_CleansSegmentChan(t *testing.T
 func TestTranscodeLoop_GivenOnePMSessionAtVideoSessionTimeout_RedeemsOneSession(t *testing.T) {
 	recipient := new(pm.MockRecipient)
 	//Set up the node
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	db, _ := common.InitDB("file:TestTranscode?mode=memory&cache=shared")
 	defer db.Close()
 	seth := &eth.StubClient{}
@@ -151,7 +151,7 @@ func TestTranscodeLoop_GivenOnePMSessionAtVideoSessionTimeout_RedeemsOneSession(
 func TestTranscodeLoop_GivenMultiplePMSessionAtVideoSessionTimeout_RedeemsAllSessions(t *testing.T) {
 	recipient := new(pm.MockRecipient)
 	//Set up the node
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	db, _ := common.InitDB("file:TestTranscode?mode=memory&cache=shared")
 	defer db.Close()
 	seth := &eth.StubClient{}
@@ -195,7 +195,7 @@ func TestTranscodeLoop_GivenMultiplePMSessionAtVideoSessionTimeout_RedeemsAllSes
 func TestTranscodeLoop_GivenMultiplePMSessionsAtVideoSessionTimeout_CleansSessionIDMemoryCache(t *testing.T) {
 	recipient := new(pm.MockRecipient)
 	//Set up the node
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	db, _ := common.InitDB("file:TestTranscode?mode=memory&cache=shared")
 	defer db.Close()
 	seth := &eth.StubClient{}
@@ -231,7 +231,7 @@ func TestTranscodeLoop_GivenMultiplePMSessionsAtVideoSessionTimeout_CleansSessio
 func TestTranscodeLoop_GivenNoPMSessionAtVideoSessionTimeout_DoesntTryToRedeem(t *testing.T) {
 	recipient := new(pm.MockRecipient)
 	//Set up the node
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	db, _ := common.InitDB("file:TestTranscode?mode=memory&cache=shared")
 	defer db.Close()
 	seth := &eth.StubClient{}
@@ -257,7 +257,7 @@ func TestTranscodeLoop_GivenNoPMSessionAtVideoSessionTimeout_DoesntTryToRedeem(t
 func TestTranscodeLoop_GivenRedeemErrorAtVideoSessionTimeout_ErrorLogIsWritten(t *testing.T) {
 	recipient := new(pm.MockRecipient)
 	//Set up the node
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	db, _ := common.InitDB("file:TestTranscode?mode=memory&cache=shared")
 	defer db.Close()
 	seth := &eth.StubClient{}
@@ -291,7 +291,7 @@ func TestTranscodeLoop_GivenRedeemErrorAtVideoSessionTimeout_ErrorLogIsWritten(t
 func TestTranscodeLoop_GivenRedeemErrorAtVideoSessionTimeout_StillCleanspmSessionsCache(t *testing.T) {
 	recipient := new(pm.MockRecipient)
 	//Set up the node
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	db, _ := common.InitDB("file:TestTranscode?mode=memory&cache=shared")
 	defer db.Close()
 	seth := &eth.StubClient{}

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -54,7 +54,6 @@ type LivepeerNode struct {
 	Recipient        pm.Recipient
 	OrchestratorPool net.OrchestratorPool
 	Ipfs             ipfs.IpfsApi
-	ServiceURI       *url.URL
 	OrchSecret       string
 	Transcoder       Transcoder
 
@@ -62,6 +61,7 @@ type LivepeerNode struct {
 	Sender pm.Sender
 
 	// Transcoder private fields
+	serviceURI      *url.URL
 	pmSessions      map[ManifestID]map[string]bool
 	pmSessionsMutex *sync.Mutex
 	segmentMutex    *sync.RWMutex
@@ -124,4 +124,15 @@ func (n *LivepeerNode) StopEthServices() error {
 	}
 
 	return nil
+}
+
+func (n *LivepeerNode) GetServiceURI() *url.URL {
+	return n.serviceURI
+}
+
+func (n *LivepeerNode) SetServiceURI(newUrl *url.URL) {
+	if newUrl != nil && n.serviceURI != nil {
+		*n.serviceURI = *newUrl
+	}
+	n.serviceURI = newUrl //for nil cases
 }

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -61,7 +61,7 @@ type LivepeerNode struct {
 	Sender pm.Sender
 
 	// Transcoder private fields
-	serviceURI      *url.URL
+	serviceURI      url.URL
 	pmSessions      map[ManifestID]map[string]bool
 	pmSessionsMutex *sync.Mutex
 	segmentMutex    *sync.RWMutex
@@ -127,12 +127,9 @@ func (n *LivepeerNode) StopEthServices() error {
 }
 
 func (n *LivepeerNode) GetServiceURI() *url.URL {
-	return n.serviceURI
+	return &n.serviceURI
 }
 
 func (n *LivepeerNode) SetServiceURI(newUrl *url.URL) {
-	if newUrl != nil && n.serviceURI != nil {
-		*n.serviceURI = *newUrl
-	}
-	n.serviceURI = newUrl //for nil cases
+	n.serviceURI = *newUrl
 }

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -117,7 +117,15 @@ func TestServiceURIChange(t *testing.T) {
 	newUrl, err := url.Parse("test://newurl.com")
 	n.SetServiceURI(newUrl)
 	require.Nil(err)
-	url, err := sesh.SaveData("testdata2", []byte{0, 0, 0})
+	furl, err := sesh.SaveData("testdata2", []byte{0, 0, 0})
 	require.Nil(err)
-	assert.Equal("test://newurl.com/stream/testpath/testdata2", url)
+	assert.Equal("test://newurl.com/stream/testpath/testdata2", furl)
+
+	glog.Infof("Setting service URL to secondurl")
+	secondUrl, err := url.Parse("test://secondurl.com")
+	n.SetServiceURI(secondUrl)
+	require.Nil(err)
+	surl, err := sesh.SaveData("testdata3", []byte{0, 0, 0})
+	require.Nil(err)
+	assert.Equal("test://secondurl.com/stream/testpath/testdata3", surl)
 }

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -251,7 +251,7 @@ func TestGetSegmentChan(t *testing.T) {
 	n, _ := NewLivepeerNode(nil, "", nil)
 	segData := StubSegTranscodingMetadata()
 
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	sc, err := n.getSegmentChan(segData)
 	if err != nil {
 		t.Error("error with getSegmentChan", err)

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -301,7 +301,8 @@ func TestGetSegmentChan(t *testing.T) {
 }
 
 func TestOrchCheckCapacity(t *testing.T) {
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	n, _ := NewLivepeerNode(nil, "", nil)
 	o := NewOrchestrator(n)
 	md := StubSegTranscodingMetadata()

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -38,7 +38,7 @@ type orchestrator struct {
 }
 
 func (orch *orchestrator) ServiceURI() *url.URL {
-	return orch.node.ServiceURI
+	return orch.node.GetServiceURI()
 }
 
 func (orch *orchestrator) CurrentBlock() *big.Int {

--- a/core/playlistmanager_test.go
+++ b/core/playlistmanager_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bytes"
+	"net/url"
 	"testing"
 
 	"github.com/ericxtang/m3u8"
@@ -145,7 +146,8 @@ func TestCleanup(t *testing.T) {
 	vProfile := ffmpeg.P144p30fps16x9
 	hlsStrmID := MakeStreamID(RandomManifestID(), &vProfile)
 	mid := hlsStrmID.ManifestID
-	osd := drivers.NewMemoryDriver("test://some.host")
+	url, _ := url.ParseRequestURI("test://some.host")
+	osd := drivers.NewMemoryDriver(url)
 	osSession := osd.NewSession("testPath")
 	memoryOS := osSession.(*drivers.MemorySession)
 	testData := []byte{1, 2, 3, 4}

--- a/drivers/local.go
+++ b/drivers/local.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"fmt"
+	"net/url"
 	"path"
 	"sync"
 
@@ -11,7 +12,7 @@ import (
 var dataCacheLen = 12
 
 type MemoryOS struct {
-	baseURI  string
+	baseURI  *url.URL
 	sessions map[string]*MemorySession
 	lock     sync.RWMutex
 }
@@ -24,7 +25,7 @@ type MemorySession struct {
 	dLock  sync.RWMutex
 }
 
-func NewMemoryDriver(baseURI string) *MemoryOS {
+func NewMemoryDriver(baseURI *url.URL) *MemoryOS {
 	return &MemoryOS{
 		baseURI:  baseURI,
 		sessions: make(map[string]*MemorySession),
@@ -93,7 +94,6 @@ func (ostore *MemorySession) GetInfo() *net.OSInfo {
 }
 
 func (ostore *MemorySession) SaveData(name string, data []byte) (string, error) {
-
 	path, file := path.Split(ostore.getAbsolutePath(name))
 
 	ostore.dLock.Lock()
@@ -124,8 +124,8 @@ func (ostore *MemorySession) getAbsolutePath(name string) string {
 
 func (ostore *MemorySession) getAbsoluteURI(name string) string {
 	name = "/stream/" + ostore.getAbsolutePath(name)
-	if ostore.os.baseURI != "" {
-		return ostore.os.baseURI + name
+	if ostore.os.baseURI != nil {
+		return ostore.os.baseURI.String() + name
 	}
 	return name
 }

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"flag"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -31,7 +32,7 @@ import (
 var S *LivepeerServer
 
 func setupServer() *LivepeerServer {
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	if S == nil {
 		n, _ := core.NewLivepeerNode(nil, "./tmp", nil)
 		S = NewLivepeerServer("127.0.0.1:1938", "127.0.0.1:8080", n)
@@ -338,6 +339,13 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 }
 
 func TestMultiStream(t *testing.T) {
+	//Turning off logging to stderr because this test prints ALOT of logs.
+	//Ideally we would record the flag value and set it back instead of hardcoding the value,
+	// but the `flag` doesn't allow easy access to existing flag value.
+	flag.Set("logtostderr", "false")
+	defer func() {
+		flag.Set("logtostderr", "true")
+	}()
 	s := setupServer()
 	s.RTMPSegmenter = &StubSegmenter{skip: true}
 	handler := gotRTMPStreamHandler(s)
@@ -472,7 +480,7 @@ func TestRegisterConnection(t *testing.T) {
 	// Should return an error if missing node storage
 	_, err = s.registerConnection(strm)
 	assert.Equal(err, ErrStorage)
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 
 	// normal success case
 	rand.Seed(123)

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -373,7 +373,7 @@ func TestGetPaymentSender_GivenValidPaymentTicket(t *testing.T) {
 
 func TestGetOrchestrator_GivenValidSig_ReturnsTranscoderURI(t *testing.T) {
 	orch := &mockOrchestrator{}
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	uri := "http://someuri.com"
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 	orch.On("ServiceURI").Return(url.Parse(uri))
@@ -388,7 +388,7 @@ func TestGetOrchestrator_GivenValidSig_ReturnsTranscoderURI(t *testing.T) {
 
 func TestGetOrchestrator_GivenInvalidSig_ReturnsError(t *testing.T) {
 	orch := &mockOrchestrator{}
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(false)
 
 	oInfo, err := getOrchestrator(orch, &net.OrchestratorRequest{})
@@ -400,7 +400,7 @@ func TestGetOrchestrator_GivenInvalidSig_ReturnsError(t *testing.T) {
 
 func TestGetOrchestrator_GivenValidSig_ReturnsOrchTicketParams(t *testing.T) {
 	orch := &mockOrchestrator{}
-	drivers.NodeStorage = drivers.NewMemoryDriver("")
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	uri := "http://someuri.com"
 	expectedParams := defaultTicketParams()
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -47,7 +47,7 @@ func (s *LivepeerServer) setServiceURI(serviceURI string) error {
 
 	// Avoids a restart if only the host has been changed.
 	// If the port has been changed, a restart is still needed.
-	s.LivepeerNode.ServiceURI = parsedURI
+	s.LivepeerNode.SetServiceURI(parsedURI)
 
 	return nil
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
`baseURI` is not updated in the memory driver because it's set at startup time.  So we now change it to a pointer, so it'll always load the latest ServiceURI value.  Thanks to @angyangie for pairing with me on this.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Update `baseURI` to a pointer
- Create getters and setters to `ServiceURI` so when it's updated, we set the value instead of the pointer value
- Add a test

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
With `TestServiceURIChange`

**Does this pull request close any open issues?**
<!-- Fixes # -->
Closes https://github.com/livepeer/go-livepeer/issues/691

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
