### PR TITLE
Randomizing orch selection

### DIFF
--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"math/rand"
 	"net/url"
 	"testing"
 
@@ -99,30 +100,27 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 func TestNewOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *testing.T) {
 	node, _ := core.NewLivepeerNode(nil, "", nil)
 	addresses := []string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"}
-	expectedOffchainOrch := StubOrchestratorPool(addresses)
+	expected := []string{"https://127.0.0.1:8938", "https://127.0.0.1:8937", "https://127.0.0.1:8936"}
 	assert := assert.New(t)
-	require := require.New(t)
 
 	// creating NewOrchestratorPool with orch addresses
-	offchainOrch := NewOrchestratorPool(node, addresses)
-	for i, uri := range offchainOrch.uris {
-		assert.Equal(uri.String(), expectedOffchainOrch.uris[i].String())
-	}
+	rand.Seed(321)
+	perm = func(len int) []int { return rand.Perm(3) }
 
-	// creating new OrchestratorPool with different first value
-	addresses[0] = "https://127.0.0.1:89"
-	expectedOffchainOrch = StubOrchestratorPool(addresses)
-	assert.NotEqual(offchainOrch.uris[0].String(), expectedOffchainOrch.uris[0].String())
+	offchainOrch := NewOrchestratorPool(node, addresses)
+
+	for i, uri := range offchainOrch.uris {
+		assert.Equal(uri.String(), expected[i])
+	}
 
 	orchestrators := StubOrchestrators(addresses)
 	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
 
-	expectedRegisteredTranscoders, err := node.Eth.RegisteredTranscoders()
-	require.Nil(err)
-
 	// testing NewOnchainOrchestratorPool
+	rand.Seed(321)
+	perm = func(len int) []int { return rand.Perm(3) }
 	offchainOrchFromOnchainList := NewOnchainOrchestratorPool(node)
 	for i, uri := range offchainOrchFromOnchainList.uris {
-		assert.Equal(uri.String(), expectedRegisteredTranscoders[i].ServiceURI)
+		assert.Equal(uri.String(), expected[i])
 	}
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
We are running into some issues with the orchestrator selection algorithm when testing. For example, in a situation with 15 Os and 15Bs, if each B gets a stream at the same time, based on our simple round-robin selection algorithm, they will all likely pick the same O. 

The onchain DB orch list is populated when in `StartMediaServer`, then `gotRTMPStreamHandler`, which ends up calling `selectOrchestrator` and `n.OrchestratorPool.GetOrchestrators(1)`, which grabs orch info asynchronously (`server.GetOrchestratorInfo(ctx, o.bcast, uri)`) and returns  it in the order it was received: https://github.com/livepeer/go-livepeer/blob/master/discovery/discovery.go#L76-L88. Though the first one on that list could more often than not be the same, that's not necessarily the case every time (which is why you might be seeing some variability in test results).

**Specific updates (required)**

This PR randomizes which orch gets selected, for testing purposes, until we come up with a more complex way of selecting orchs. We have hard-coded the number of orchestrators that get selected (1), and this solution is ONLY works when that hard-code is kept in place: https://github.com/livepeer/go-livepeer/blob/master/server/broadcast.go#L33, and is meant to be a TEMPORARY solution.

**Checklist:**
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [X] All tests in `./test.sh` pass
