### PR TITLE
ci: use gometalinter for linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,12 @@ jobs:
       - run: go get github.com/jstemmer/go-junit-report
       - run: go get github.com/pkg/errors
       - run: go get github.com/stretchr/testify
+      - run: go get github.com/alecthomas/gometalinter && gometalinter --install
+
+      - run:
+          name: Lint
+          command: |
+            gometalinter --disable-all --enable=gofmt --enable=vet --enable=golint --deadline=4m pm
 
       - run:
           name: Run unit tests

--- a/pm/helpers.go
+++ b/pm/helpers.go
@@ -8,6 +8,9 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
+// VerifySig verifies that a ETH ECDSA signature over a given message
+// is produced by a given ETH address
+//
 // TODO refactor to a package that both eth and pm can import
 func VerifySig(addr ethcommon.Address, msg, sig []byte) bool {
 	personalMsg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", 32, msg)
@@ -21,14 +24,17 @@ func VerifySig(addr ethcommon.Address, msg, sig []byte) bool {
 	return crypto.PubkeyToAddress(*pubkey) == addr
 }
 
+// RandHash returns a random keccak256 hash
 func RandHash() ethcommon.Hash {
 	return ethcommon.BytesToHash(RandBytes(32))
 }
 
+// RandAddress returns a random ETH address
 func RandAddress() ethcommon.Address {
 	return ethcommon.BytesToAddress(RandBytes(addressSize))
 }
 
+// RandBytes returns a slice of random bytes with the size specified by the caller
 func RandBytes(size uint) []byte {
 	x := make([]byte, size, size)
 	for i := 0; i < len(x); i++ {

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -18,7 +18,7 @@ type Recipient interface {
 	// ReceiveTicket validates and processes a received ticket
 	ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (sessionID string, won bool, err error)
 
-	// RedeemWinningTicket redeems all winning tickets with the broker
+	// RedeemWinningTickets redeems all winning tickets with the broker
 	// for a all sessionIDs
 	RedeemWinningTickets(sessionIDs []string) error
 

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -12,8 +12,12 @@ import (
 // Sender enables starting multiple probabilistic micropayment sessions with multiple recipients
 // and create tickets that adhere to each session's params and unique nonce requirements.
 type Sender interface {
+	// StartSession creates a session for a given set of ticket params which tracks information
+	// for creating new tickets
 	StartSession(ticketParams TicketParams) string
 
+	// CreateTicket returns a new ticket, seed (which the recipient can use to derive its random number),
+	// and signature over the new ticket for a given session ID
 	CreateTicket(sessionID string) (*Ticket, *big.Int, []byte, error)
 
 	// Later: support receiving new recipientRandHash values mid-stream

--- a/pm/sigverifier.go
+++ b/pm/sigverifier.go
@@ -20,6 +20,8 @@ type SigVerifier interface {
 type DefaultSigVerifier struct {
 }
 
+// Verify checks if a provided signature over a message
+// is valid for a given ETH address
 func (sv *DefaultSigVerifier) Verify(addr ethcommon.Address, msg, sig []byte) bool {
 	return VerifySig(addr, msg, sig)
 }

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -237,22 +237,26 @@ func (s *stubSigner) Account() accounts.Account {
 	return s.account
 }
 
-// MockRecipient is useful for testing components that depend on pm.Recipient, such as
-// LivepeerNode
+// MockRecipient is useful for testing components that depend on pm.Recipient
 type MockRecipient struct {
 	mock.Mock
 }
 
+// ReceiveTicket validates and processes a received ticket
 func (m *MockRecipient) ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (sessionID string, won bool, err error) {
 	args := m.Called(ticket, sig, seed)
 	return args.String(0), args.Bool(1), args.Error(2)
 }
 
+// RedeemWinningTickets redeems all winning tickets with the broker
+// for a all sessionIDs
 func (m *MockRecipient) RedeemWinningTickets(sessionIDs []string) error {
 	args := m.Called(sessionIDs)
 	return args.Error(0)
 }
 
+// TicketParams returns the recipient's currently accepted ticket parameters
+// for a provided sender ETH adddress
 func (m *MockRecipient) TicketParams(sender ethcommon.Address) *TicketParams {
 	args := m.Called(sender)
 
@@ -269,11 +273,15 @@ type MockSender struct {
 	mock.Mock
 }
 
+// StartSession creates a session for a given set of ticket params which tracks information
+// for creating new tickets
 func (m *MockSender) StartSession(ticketParams TicketParams) string {
 	args := m.Called(ticketParams)
 	return args.String(0)
 }
 
+// CreateTicket returns a new ticket, seed (which the recipient can use to derive its random number),
+// and signature over the new ticket for a given session ID
 func (m *MockSender) CreateTicket(sessionID string) (*Ticket, *big.Int, []byte, error) {
 	args := m.Called(sessionID)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Adds [gometalinter](https://github.com/alecthomas/gometalinter) to the CI.

Rather than lint all packages and fix all the linting warnings in a single swoop (I expect there to be many), I thought that we could gradually introduce linting into packages since some stuff is probably going to move around as we complete the tech debt eng retro issues.

Eventually, when we want to lint all packages, we can update the CI lint command to something like this: 

```
gometalinter --disable-all --enable=gofmt --enable=vet --enable=golint --deadline=4m $(go list -f '{{.Dir}}' ./...)
```

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Only lint the pm package for now - fixed all linting warnings
- Enable the vet (for potential errors that would otherwise compile) and
golint/gofmt for style

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I only made updates to comments in order to fix linting warnings.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #650 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [X] Node runs in OSX and devenv
- [X] All tests in `./test.sh` pass
