### PR TITLE
Orchestrator capacity cap

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -101,6 +101,7 @@ func main() {
 	verbosity := flag.String("v", "", "Log verbosity.  {4|5|6}")
 	faceValue := flag.Float64("faceValue", 0, "The faceValue to expect in PM tickets, denominated in ETH (e.g. 0.3)")
 	winProb := flag.Float64("winProb", 0, "The win probability to expect in PM tickets, as a percent float between 0 and 100 (e.g. 5.3)")
+	maxSessions := flag.Int("maxSessions", 10, "Orchestrator only. Maximum number of concurrent transcoding sessions")
 
 	flag.Parse()
 	vFlag.Value.Set(*verbosity)
@@ -370,6 +371,8 @@ func main() {
 			return
 		}
 	}
+
+	core.MaxTranscodeSessions = *maxSessions
 
 	if n.NodeType == core.BroadcasterNode {
 		// default lpms listener for broadcaster; same as default rpc port

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -63,8 +63,8 @@ type LivepeerNode struct {
 
 	// Transcoder private fields
 	pmSessions      map[ManifestID]map[string]bool
-	segmentMutex    *sync.Mutex
 	pmSessionsMutex *sync.Mutex
+	segmentMutex    *sync.RWMutex
 	tcoderMutex     *sync.RWMutex
 	taskMutex       *sync.RWMutex
 	taskChans       map[int64]TranscoderChan
@@ -81,8 +81,8 @@ func NewLivepeerNode(e eth.LivepeerEthClient, wd string, dbh *common.DB) (*Livep
 		EthServices:     make(map[string]eth.EventService),
 		SegmentChans:    make(map[ManifestID]SegmentChan),
 		pmSessions:      make(map[ManifestID]map[string]bool),
-		segmentMutex:    &sync.Mutex{},
 		pmSessionsMutex: &sync.Mutex{},
+		segmentMutex:    &sync.RWMutex{},
 		tcoderMutex:     &sync.RWMutex{},
 		taskMutex:       &sync.RWMutex{},
 		taskChans:       make(map[int64]TranscoderChan),

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -261,7 +261,8 @@ func TestGetSegmentChan(t *testing.T) {
 		t.Error("SegmentChans mapping did not include channel")
 	}
 
-	drivers.NodeStorage = nil
+	// Test what happens when invoking the transcode loop fails
+	drivers.NodeStorage = nil // will make the transcode loop fail
 	node, _ := NewLivepeerNode(nil, "", nil)
 
 	sc, storageError := node.getSegmentChan(segData)
@@ -269,16 +270,19 @@ func TestGetSegmentChan(t *testing.T) {
 		t.Error("transcodingLoop did not fail when expected to", storageError)
 	}
 
-	if sc == n.SegmentChans[segData.ManifestID] {
+	if _, ok := node.SegmentChans[segData.ManifestID]; ok {
 		t.Error("SegmentChans mapping included new channel when expected to return an err/nil")
 	}
 
+	// The following tests may seem identical to the two cases above
+	// however, calling `getSegmentChan` used to hang on the invocation after an
+	// error. Reproducing the scenario here but should not hang.
 	sc, storageErr := node.getSegmentChan(segData)
 	if storageErr.Error() != "Missing local storage" {
 		t.Error("transcodingLoop did not fail when expected to", storageErr)
 	}
 
-	if sc == n.SegmentChans[segData.ManifestID] {
+	if _, ok := node.SegmentChans[segData.ManifestID]; ok {
 		t.Error("SegmentChans mapping included new channel when expected to return an err/nil")
 	}
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -226,7 +226,7 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) {
 	}()
 }
 
-var sessionErrStrings = []string{"dial tcp", "unexpected EOF", core.ErrOrchBusy.Error()}
+var sessionErrStrings = []string{"dial tcp", "unexpected EOF", core.ErrOrchBusy.Error(), core.ErrOrchCap.Error()}
 
 func generateSessionErrors() *regexp.Regexp {
 	// Given a list [err1, err2, err3] generates a regexp `(err1)|(err2)|(err3)`

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -14,6 +14,7 @@ func TestStopSessionErrors(t *testing.T) {
 		"Unable to read response body for segment 4 : unexpected EOF",
 		"Unable to submit segment 5 Post https://127.0.0.1:8936/segment: dial tcp 127.0.0.1:8936: getsockopt: connection refused",
 		core.ErrOrchBusy.Error(),
+		core.ErrOrchCap.Error(),
 	}
 
 	// Sanity check that we're checking each failure case


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Implements an orchestrator capacity cap. Most of the interesting changes are here: https://github.com/livepeer/go-livepeer/commit/70342afc9cdd8599241271aa2b0066c23577ddd7

**Specific updates (required)**
- Adds a `-maxSession` CLI parameter
- Checks the capacity during GetOrchInfo (so B doesn't send segments over unnecessarily), during seg creds checking (prior to download) and prior to actually transcoding (also atomic to creating a new transcode loop).
- Reduces transcode loop timeout from 10 minutes to 1 minute. The previous value of 10 minutes was set in order to give plenty of time for retries before submitting an on-chain transaction to claim payment. Here, there is no such concern, and we want to release resources as soon as possible if a transcode session shows signs of being idle.
- Add tests around the capacity cap
- Fixes an older, separate test case that wasn't really checking the right thing.

**How did you test each of these updates (required)**
Unit testing, manual testing.

**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/go-livepeer/issues/603


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
