### PR TITLE
eth: add context with timeout to eth_getLogs queries

### DIFF
--- a/eth/eventservices/unbondingservice.go
+++ b/eth/eventservices/unbondingservice.go
@@ -43,7 +43,7 @@ func (s *UnbondingService) Start(ctx context.Context) error {
 	}
 
 	if err := s.processHistoricalEvents(); err != nil {
-		return err
+		glog.Errorf("failed to process historical events: %v", err)
 	}
 
 	ctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Added a context with timeout to methods that create an eth_getLogs RPC query. Previously, we did not attach a timeout to these queries. The default timeout is currently 20 seconds.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Added a context with timeout to `client.ProcessHistoricalUnbond`, `client.ProcessHistoricalRebond` and `client.ProcessHistoricalWithdrawStake`.
- Also updated unbondingservice.go to proceed even if processing of
historical events fails.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I built the node in the devenv VM and adjusted the timeout to 2 nanoseconds and observed a log message indicating failure to process historical events and the node continued booting up.


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [X] Node runs in OSX and devenv
- [X] All tests in `./test.sh` pass
