### PR TITLE
Clean up flag values in livepeer.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can also build the executables from scratch.
 ### Quick start
 - Make sure you have successfully gone through the steps in 'Installing Livepeer' and 'Additional Dependencies'.
 
-- Run `./livepeer -rinkeby -currentManifest`.
+- Run `./livepeer -network rinkeby -currentManifest`.
 
 - Run `./livepeer_cli`.
   * You should see a wizard launch in the command line.
@@ -91,7 +91,7 @@ Livepeer node doesn't do any storage management, it only saves data and never de
 
 We'll walk through the steps of becoming a transcoder on the test network.  To learn more about the transcoder, refer to the [Livepeer whitepaper](https://github.com/livepeer/wiki/blob/master/WHITEPAPER.md) and the [Transcoding guide](http://livepeer.readthedocs.io/en/latest/transcoding.html).
 
-- `livepeer --rinkeby --transcoder` to start the node as an orchestrator with an attached local transcoder .
+- `livepeer --network rinkeby --transcoder=true` to start the node as an orchestrator with an attached local transcoder .
 
 - `livepeer_cli` - make sure you have test ether and test Livepeer token.  Refer to the Quick Start section for getting test ether and test tokens.
 
@@ -107,7 +107,7 @@ We'll walk through the steps of becoming a transcoder on the test network.  To l
 
 Orchestrators can be run in standalone mode without an attached transcoder. Standalone transcoders will need to connect to this orchestrator in order for the orchestrator to process jobs.
 
-- `livepeer --rinkeby --orchestrator -orchSecret asdf`
+- `livepeer --network rinkeby --orchestrator=true -orchSecret asdf`
 
 The orchSecret is a shared secret used to authenticate remote transcoders. It can be any arbitrary string.
 
@@ -115,7 +115,7 @@ The orchSecret is a shared secret used to authenticate remote transcoders. It ca
 
 A standalone transcoder can be run which connects to a remote orchestrator. The orchestrator will send transcoding tasks to this transcoder as segments come in.
 
-- `livepeer -standaloneTranscoder -orchAddr 127.0.0.1:8935 -orchSecret asdf`
+- `livepeer -transcoder=true -orchAddr 127.0.0.1:8935 -orchSecret asdf`
 
 ## Contribution
 Thank you for your interest in contributing to the core software of Livepeer.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can also build the executables from scratch.
 ### Quick start
 - Make sure you have successfully gone through the steps in 'Installing Livepeer' and 'Additional Dependencies'.
 
-- Run `./livepeer -network rinkeby -currentManifest`.
+- Run `./livepeer -broadcaster -network rinkeby -currentManifest`.
 
 - Run `./livepeer_cli`.
   * You should see a wizard launch in the command line.
@@ -91,7 +91,7 @@ Livepeer node doesn't do any storage management, it only saves data and never de
 
 We'll walk through the steps of becoming a transcoder on the test network.  To learn more about the transcoder, refer to the [Livepeer whitepaper](https://github.com/livepeer/wiki/blob/master/WHITEPAPER.md) and the [Transcoding guide](http://livepeer.readthedocs.io/en/latest/transcoding.html).
 
-- `livepeer --network rinkeby --transcoder=true` to start the node as an orchestrator with an attached local transcoder .
+- `livepeer -orchestrator -transcoder -network rinkeby` to start the node as an orchestrator with an attached local transcoder .
 
 - `livepeer_cli` - make sure you have test ether and test Livepeer token.  Refer to the Quick Start section for getting test ether and test tokens.
 
@@ -107,7 +107,7 @@ We'll walk through the steps of becoming a transcoder on the test network.  To l
 
 Orchestrators can be run in standalone mode without an attached transcoder. Standalone transcoders will need to connect to this orchestrator in order for the orchestrator to process jobs.
 
-- `livepeer --network rinkeby --orchestrator=true -orchSecret asdf`
+- `livepeer -network rinkeby -orchestrator -orchSecret asdf`
 
 The orchSecret is a shared secret used to authenticate remote transcoders. It can be any arbitrary string.
 
@@ -115,7 +115,7 @@ The orchSecret is a shared secret used to authenticate remote transcoders. It ca
 
 A standalone transcoder can be run which connects to a remote orchestrator. The orchestrator will send transcoding tasks to this transcoder as segments come in.
 
-- `livepeer -transcoder=true -orchAddr 127.0.0.1:8935 -orchSecret asdf`
+- `livepeer -transcoder -orchAddr 127.0.0.1:8935 -orchSecret asdf`
 
 ## Contribution
 Thank you for your interest in contributing to the core software of Livepeer.

--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -87,13 +87,12 @@ func main() {
 	acc := createKey(tempKeystoreDir)
 	glog.Infof("Using account %s", acc)
 	dataDir := filepath.Join(*baseDataDir, t+"_"+acc)
-	dataDirToCreate := filepath.Join(dataDir, "devenv")
-	err = os.MkdirAll(dataDirToCreate, 0755)
+	err = os.MkdirAll(dataDir, 0755)
 	if err != nil {
 		glog.Fatalf("Can't create directory %v", err)
 	}
 
-	keystoreDir := filepath.Join(dataDirToCreate, "keystore")
+	keystoreDir := filepath.Join(dataDir, "keystore")
 	err = os.Rename(tempKeystoreDir, keystoreDir)
 	if err != nil {
 		glog.Fatal(err)
@@ -263,9 +262,13 @@ func createRunScript(ethAcctAddr, dataDir string, isBroadcaster bool) {
 
 	if !isBroadcaster {
 		script += fmt.Sprintf(` -initializeRound=true \
-    -serviceAddr 127.0.0.1:8936 -httpAddr 127.0.0.1:8936  -transcoder \
+    -serviceAddr 127.0.0.1:8936 -httpAddr 127.0.0.1:8936  -transcoder=true -orchestrator=true \
     -cliAddr 127.0.0.1:7936 -ipfsPath ./%s/trans
     `, dataDir)
+	}
+
+	if isBroadcaster {
+		script += fmt.Sprint(` -broadcaster=true`)
 	}
 
 	glog.Info(script)
@@ -333,7 +336,7 @@ func remoteConsole(destAccountAddr string) error {
 
 	if !ethControllerOverride {
 		// f9a6cf519167d81bc5cb3d26c60c0c9a19704aa908c148e82a861b570f4cd2d7 - SetContractInfo event
-		getethControllerScript := `
+		getEthControllerScript := `
 		var logs = [];
 		var filter = web3.eth.filter({ fromBlock: 0, toBlock: "latest",
 			topics: ["0xf9a6cf519167d81bc5cb3d26c60c0c9a19704aa908c148e82a861b570f4cd2d7"]});
@@ -342,8 +345,8 @@ func remoteConsole(destAccountAddr string) error {
 		});
 		console.log(logs[0][0].address);''
 	`
-		glog.Infof("Running eth script: %s", getethControllerScript)
-		err = console.Evaluate(getethControllerScript)
+		glog.Infof("Running eth script: %s", getEthControllerScript)
+		err = console.Evaluate(getEthControllerScript)
 		if err != nil {
 			glog.Error(err)
 		}

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -202,6 +202,8 @@ func main() {
 		n.NodeType = core.TranscoderNode
 	} else if *broadcaster {
 		n.NodeType = core.BroadcasterNode
+	} else {
+		glog.Fatalf("Node type not set; must be one of -broadcaster, -transcoder or -orchestrator")
 	}
 
 	if *monitor {

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -372,6 +372,18 @@ func main() {
 		// TODO provide an option to disable this?
 		*rtmpAddr = defaultAddr(*rtmpAddr, "127.0.0.1", RtmpPort)
 		*httpAddr = defaultAddr(*httpAddr, "127.0.0.1", RpcPort)
+
+		// Set up orchestrator discovery
+		if len(orchAddresses) > 0 {
+			n.OrchestratorPool = discovery.NewOrchestratorPool(n, orchAddresses)
+		} else if *network != "offchain" {
+			n.OrchestratorPool = discovery.NewDBOrchestratorPoolCache(n)
+		}
+		if n.OrchestratorPool == nil {
+			// Not a fatal error; may continue operating in segment-only mode
+			glog.Error("No orchestrator specified; transcoding will not happen")
+		}
+
 	} else if n.NodeType == core.OrchestratorNode {
 		suri, err := getServiceURI(n, *serviceAddr)
 		if err != nil {
@@ -391,17 +403,6 @@ func main() {
 	if drivers.NodeStorage == nil {
 		// base URI will be empty for broadcasters; that's OK
 		drivers.NodeStorage = drivers.NewMemoryDriver(n.GetServiceURI())
-	}
-
-	if n.NodeType == core.BroadcasterNode {
-		if len(orchAddresses) > 0 {
-			n.OrchestratorPool = discovery.NewOrchestratorPool(n, orchAddresses)
-		} else if *network != "offchain" {
-			n.OrchestratorPool = discovery.NewDBOrchestratorPoolCache(n)
-		}
-		if n.OrchestratorPool == nil {
-			glog.Errorf("No orchestrator specified; transcoding will not happen")
-		}
 	}
 
 	//Create Livepeer Node

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -99,7 +99,7 @@ func main() {
 	logIPFS := flag.Bool("logIPFS", false, "Set to true if log files should not be generated") // unused until we re-enable IPFS
 
 	// Storage:
-	datadir := flag.String("datadir", fmt.Sprintf("%v/.lpData", usr.HomeDir), "data directory")
+	datadir := flag.String("datadir", "", "data directory")
 	ipfsPath := flag.String("ipfsPath", fmt.Sprintf("%v/.ipfs", usr.HomeDir), "IPFS path") // unused until we re-enable IPFS
 	s3bucket := flag.String("s3bucket", "", "S3 region/bucket (e.g. eu-central-1/testbucket)")
 	s3creds := flag.String("s3creds", "", "S3 credentials (in form ACCESSKEYID/ACCESSKEY)")
@@ -165,13 +165,17 @@ func main() {
 	}
 
 	if *datadir == "" {
-		*datadir = filepath.Join(usr.HomeDir, ".lpData", *network)
+		homedir := os.Getenv("HOME")
+		if homedir == "" {
+			homedir = usr.HomeDir
+		}
+		*datadir = filepath.Join(homedir, ".lpData", *network)
 	}
 
 	//Make sure datadir is present
 	if _, err := os.Stat(*datadir); os.IsNotExist(err) {
 		glog.Infof("Creating data dir: %v", *datadir)
-		if err = os.Mkdir(*datadir, 0755); err != nil {
+		if err = os.MkdirAll(*datadir, 0755); err != nil {
 			glog.Errorf("Error creating datadir: %v", err)
 		}
 	}

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -218,7 +218,8 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) {
 		cond.L.Unlock()
 
 		ticketParams := sess.OrchestratorInfo.GetTicketParams()
-		if !pm.VerifySig(ethcommon.BytesToAddress(ticketParams.Recipient), crypto.Keccak256(segHashes...), res.Sig) {
+		if ticketParams != nil && // may be nil in offchain mode
+			!pm.VerifySig(ethcommon.BytesToAddress(ticketParams.Recipient), crypto.Keccak256(segHashes...), res.Sig) {
 			glog.Error("Sig check failed for segment ", seg.SeqNo)
 			return
 		}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/livepeer/go-livepeer/drivers"
-	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/net"
 
@@ -103,12 +102,7 @@ func NewLivepeerServer(rtmpAddr string, httpAddr string, lpNode *core.LivepeerNo
 }
 
 //StartServer starts the LPMS server
-func (s *LivepeerServer) StartMediaServer(ctx context.Context, maxPricePerSegment *big.Int, transcodingOptions string) error {
-	if s.LivepeerNode.Eth != nil {
-		BroadcastPrice = maxPricePerSegment
-		glog.V(common.SHORT).Infof("Transcode Job Price: %v", eth.FormatUnits(BroadcastPrice, "ETH"))
-	}
-
+func (s *LivepeerServer) StartMediaServer(ctx context.Context, transcodingOptions string) error {
 	bProfiles := make([]ffmpeg.VideoProfile, 0)
 	for _, opt := range strings.Split(transcodingOptions, ",") {
 		p, ok := ffmpeg.VideoProfileLookup[strings.TrimSpace(opt)]

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -36,7 +36,7 @@ func setupServer() *LivepeerServer {
 	if S == nil {
 		n, _ := core.NewLivepeerNode(nil, "./tmp", nil)
 		S = NewLivepeerServer("127.0.0.1:1938", "127.0.0.1:8080", n)
-		go S.StartMediaServer(context.Background(), big.NewInt(0), "")
+		go S.StartMediaServer(context.Background(), "")
 		go S.StartWebserver("127.0.0.1:8938")
 	}
 	return S

--- a/test.sh
+++ b/test.sh
@@ -40,7 +40,10 @@ go test -logtostderr=true
 t8=$?
 cd ..
 
-if (($t1!=0||$t2!=0||$t3!=0||$t4!=0||$t5!=0||$t6!=0||t7!=0||t8!=0))
+./test_args.sh
+t_args=$?
+
+if (($t1!=0||$t2!=0||$t3!=0||$t4!=0||$t5!=0||$t6!=0||$t7!=0||$t8!=0||$t_args!=0))
 then
     printf "\n\nSome Tests Failed\n\n"
     exit -1

--- a/test_args.sh
+++ b/test_args.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# build the binary
+go build cmd/livepeer/livepeer.go
+
+# set a clean slate "home dir" for testing
+TMPDIR=/tmp/livepeer-test-"$RANDOM"
+DEFAULT_DATADIR="$TMPDIR"/.lpData
+CUSTOM_DATADIR="$TMPDIR"/customDatadir
+export HOME=$TMPDIR
+rm -rf "$DEFAULT_DATADIR"
+mkdir -p $TMPDIR  # goclient should make the lpData datadir
+
+# Set up ethereum key
+cat > $TMPDIR/key <<ETH_KEY
+{"address":"089d8ab6752bac616a1f17246294eb068ee23d3e","crypto":{"cipher":"aes-128-ctr","ciphertext":"e868446e99842291b4991ae2c8e6c6834296c81937c4182e45af2edf0af61968","cipherparams":{"iv":"62205b25b7c4b2c35717128d9702f3c8"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"dfa46628fec666ebd46d21d59cd3cbad0039d13f3c09dd5304128e32edfdec57"},"mac":"a5d4cde1863803a2b17718eb6b0770c0e7fcdfcf3659c9bd24f033d4529a5af3"},"id":"b84a7400-5fbd-4397-894e-c59403663b88","version":3}
+ETH_KEY
+
+ETH_ARGS="-ethKeystorePath $TMPDIR/key"
+SLEEP=0.25
+
+
+run_lp () {
+    ./livepeer "$@" &
+    pid=$!
+    sleep $SLEEP
+}
+
+# sanity check that default datadir does not exist
+[ ! -d "$DEFAULT_DATADIR" ]
+
+# check that we exit early if node type is not set
+res=0
+./livepeer || res=$?
+[ $res -ne 0 ]
+
+
+run_lp -broadcaster
+[ -d "$DEFAULT_DATADIR"/offchain ]
+kill $pid
+
+run_lp -broadcaster -network rinkeby $ETH_ARGS
+[ -d "$DEFAULT_DATADIR"/rinkeby ]
+kill $pid
+
+run_lp -broadcaster -network mainnet $ETH_ARGS
+[ -d "$DEFAULT_DATADIR"/mainnet ]
+kill $pid
+
+run_lp -broadcaster -network anyNetwork $ETH_ARGS -ethUrl "wss://rinkeby.infura.io/ws" -v 99
+[ -d "$DEFAULT_DATADIR"/anyNetwork ]
+kill $pid
+
+# sanity check that custom datadir does not exist
+[ ! -d "$CUSTOM_DATADIR" ]
+
+# check custom datadir without a network (offchain)
+run_lp -broadcaster -datadir "$CUSTOM_DATADIR"
+[ -d "$CUSTOM_DATADIR" ]
+[ ! -d  "$CUSTOM_DATADIR"/offchain ] # sanity check that network isn't included
+kill $pid
+
+# check custom datadir with a network
+run_lp -broadcaster -datadir "$CUSTOM_DATADIR" -network rinkeby $ETH_ARGS
+[ ! -d  "$CUSTOM_DATADIR"/rinkeby ] # sanity check that network isn't included
+kill $pid
+
+# check invalid service address via inserting control character
+./livepeer -orchestrator -orchSecret asdf -serviceAddr "hibye" 2>&1 | grep "Error getting service URI"
+[ ${PIPESTATUS[0]} -ne 0 ]
+
+# check missing service address via failed availability check
+# Testing these isn't quite reliable enough (slow)
+# XXX currently returns zero; should be nonzero
+#./livepeer -orchestrator -orchSecret asdf 2>&1 | grep "Orchestrator not available"
+#./livepeer -orchestrator -orchSecret asdf -serviceAddr livepeer.org 2>&1 | grep "Orchestrator not available"
+
+# check that orchestrators require -orchSecret or -transcoder
+# sanity check with -transcoder
+run_lp -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder
+kill $pid
+# sanity check with -orchSecret
+run_lp -orchestrator -serviceAddr 127.0.0.1:8935 -orchSecret asdf
+kill $pid
+# XXX need a better way of confirming the error type. specialized exit code?
+res=0
+./livepeer -orchestrator -serviceAddr 127.0.0.1:8935 || res=$?
+[ $res -ne 0 ]
+
+# transcoder needs -orchSecret
+res=0
+./livepeer -transcoder || res=$?
+[ $res -ne 0 ]
+
+rm -rf "$TMPDIR"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is the first step in this issue: https://github.com/livepeer/go-livepeer/issues/710. It is a halfway step to adding a config file and different flag parsing code to `livepeer.go`.

Generally, how we handle flags needs a lot of cleanup. Rather than flag parsing or the number of flags itself, this issue is more around how we check and use those flags in `cmd/livepeer` to initialize the node. The code interleaves between initialization for orchestrators, broadcasters and both, often switching back-and-forth.

Discussion on flag clean-up is here:
https://github.com/livepeer/go-livepeer/issues/709
https://github.com/livepeer/go-livepeer/issues/580

**Specific updates (required)**
- Grouped flags together based on general function (makes the file more readable)
- Added a `NetworkConfig` struct to hold network config options like `ethUrl`, `ethController`, and `monHost`. If more network specific options are added in the future, we could add them here.
- Removed `maxPricePerSegment` (unused flag)
- Combined `ethIpcPath` and `ethUrl`
- Renamed `noipfsLogFiles` to `logIpfs`
- Renamed `monhost` to `monHost`
- Made `transcoder` var into a flag,  removed `standaloneTranscoder`
- Removed `orchAndTrans`. Temporarily setting orchs and transc to be both, here: 
```golang
if *transcoder || *orchestrator {
		*transcoder = true
		*orchestrator = true
	}
```
- Added `-network` flag. Removed `-rinkeby`, `devenv`, `offchain` flags. If network isn't set, `-network offchain` is assumed, regardless of what other options might have been specified. If network is set, but not `rinkeby` or `mainnet`, network remains as was specified. (REVIEW)
- Edited devtool script to work with all changes


**To do:**
- [x] (TBD) Add a `-broadcaster` flag for consistency 
- [x] (Must review) No way for user to operate in `offchain` mode and to name their own network
- [x] (TBD) Allow users to set their own `datadir` name, without network subfolder?
- [ ] More testing on different networks

**Will not do:**
Remove `ipfsPath`, `noipfsLogFiles`, unused flags - a lot of code was already written in anticipation of these flags. Since it seems like these flags will be used in the near future, I vote for keeping them commented out. 

**How did you test each of these updates (required)**
I can successfully transcode using devtool. All tests passed. 

**Does this pull request close any open issues?**
https://github.com/livepeer/go-livepeer/issues/709
https://github.com/livepeer/go-livepeer/issues/580

**Checklist:**
- [X] README and other documentation updated
- [X] Node runs in OSX and devenv
- [X] All tests in `./test.sh` pass
