### PR TITLE
Webhook URL

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -6,8 +6,10 @@ package server
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"net/http"
@@ -53,6 +55,8 @@ const BroadcastRetry = 15 * time.Second
 var BroadcastPrice = big.NewInt(1)
 var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmpeg.P360p30fps16x9}
 
+var AuthWebhookURL string
+
 type rtmpConnection struct {
 	mid     core.ManifestID
 	nonce   uint64
@@ -83,6 +87,10 @@ type LivepeerServer struct {
 	lastHLSStreamID core.StreamID
 	lastManifestID  core.ManifestID
 	connectionLock  *sync.RWMutex
+}
+
+type authWebhookResponse struct {
+	ManifestID string `json:"manifestID"`
 }
 
 func NewLivepeerServer(rtmpAddr string, httpAddr string, lpNode *core.LivepeerNode) *LivepeerServer {
@@ -146,33 +154,71 @@ func (s *LivepeerServer) StartMediaServer(ctx context.Context, transcodingOption
 //RTMP Publish Handlers
 func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID string) {
 	return func(url *url.URL) (strmID string) {
-		//Create a ManifestID
-		//If manifestID is passed in, use that one
+		//Check webhook for ManifestID
+		//If ManifestID is returned from webhook, use it
+		//Else check URL for ManifestID
+		//If ManifestID is passed in URL, use that one
 		//Else create one
-		mid := parseManifestID(url.Query().Get("manifestID"))
+		var mid core.ManifestID
+		var err error
+		if mid, err = authenticateStream(url.String()); err != nil {
+			glog.Error("Authentication denied for ", err)
+			return ""
+		}
+
+		if mid == "" {
+			mid = parseManifestID(url.Query().Get("manifestID"))
+		}
 		if mid == "" {
 			mid = core.RandomManifestID()
 		}
 
 		// Ensure there's no concurrent StreamID with the same name
 		s.connectionLock.RLock()
+		defer s.connectionLock.RUnlock()
 		if core.MaxSessions > 0 && len(s.rtmpConnections) >= core.MaxSessions {
 			glog.Error("Too many connections")
-			s.connectionLock.RUnlock()
 			return ""
 		}
 		if _, exists := s.rtmpConnections[mid]; exists {
 			glog.Error("Manifest already exists ", mid)
-			s.connectionLock.RUnlock()
 			return ""
 		}
-		s.connectionLock.RUnlock()
 
 		// Generate RTMP part of StreamID
 		key := hex.EncodeToString(core.RandomIdGenerator(StreamKeyBytes))
 		return core.MakeStreamIDFromString(string(mid), key).String()
 	}
+}
 
+func authenticateStream(url string) (core.ManifestID, error) {
+	if AuthWebhookURL == "" {
+		return "", nil
+	}
+	payload := fmt.Sprintf(`{"url":"%s"}"`, url)
+	body := strings.NewReader(payload)
+
+	resp, err := http.Post(AuthWebhookURL, "application/json", body)
+	if err != nil {
+		return "", err
+	}
+	rbody, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return "", errors.New(resp.Status)
+	}
+	if len(rbody) == 0 {
+		return "", nil
+	}
+	var authResp authWebhookResponse
+	err = json.Unmarshal(rbody, &authResp)
+	if err != nil {
+		return "", err
+	}
+	if authResp.ManifestID == "" {
+		return "", errors.New("Empty manifest id not allowed")
+	}
+	return core.ManifestID(authResp.ManifestID), nil
 }
 
 func rtmpManifestID(rtmpStrm stream.RTMPVideoStream) core.ManifestID {

--- a/test_args.sh
+++ b/test_args.sh
@@ -94,4 +94,14 @@ res=0
 ./livepeer -transcoder || res=$?
 [ $res -ne 0 ]
 
+# exit early if webhhok url is not http
+res=0
+./livepeer -broadcaster -authWebhookUrl tcp://host/ || res=$?
+[ $res -ne 0 ]
+
+# exit early if webhook url is not properly formatted
+res=0
+./livepeer -broadcaster -authWebhookUrl http\\://host/ || res=$?
+[ $res -ne 0 ]
+
 rm -rf "$TMPDIR"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Webhook URL option - allows authenticate incoming streams through call to webhook

**Specific updates (required)**
Adds `webhookUrl` option to Livepeer node - this URL get called upon receiving RTMP connection and manifest id being passed to it. If this request returns non 200 response, then RTMP connection being denied.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
Fixes #703


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
