### PR TITLE
Capacity Cap for B

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -101,7 +101,7 @@ func main() {
 	verbosity := flag.String("v", "", "Log verbosity.  {4|5|6}")
 	faceValue := flag.Float64("faceValue", 0, "The faceValue to expect in PM tickets, denominated in ETH (e.g. 0.3)")
 	winProb := flag.Float64("winProb", 0, "The win probability to expect in PM tickets, as a percent float between 0 and 100 (e.g. 5.3)")
-	maxSessions := flag.Int("maxSessions", 10, "Orchestrator only. Maximum number of concurrent transcoding sessions")
+	maxSessions := flag.Int("maxSessions", 10, "Maximum number of concurrent transcoding sessions for Orchestrator or maximum number or RTMP streams for Broadcaster")
 	webhookURL := flag.String("webhookUrl", "", "Authentication webhook URL")
 
 	flag.Parse()
@@ -373,7 +373,7 @@ func main() {
 		}
 	}
 
-	core.MaxTranscodeSessions = *maxSessions
+	core.MaxSessions = *maxSessions
 
 	if n.NodeType == core.BroadcasterNode {
 		// default lpms listener for broadcaster; same as default rpc port

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -35,6 +35,8 @@ var ErrTranscode = errors.New("ErrTranscode")
 // output of the `git describe` command.
 var LivepeerVersion = "undefined"
 
+var MaxSessions = 10
+
 type NodeType int
 
 const (

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -262,8 +262,8 @@ func TestGetSegmentChan(t *testing.T) {
 	}
 
 	// Test max sessions
-	oldTranscodeSessions := MaxTranscodeSessions
-	MaxTranscodeSessions = 0
+	oldTranscodeSessions := MaxSessions
+	MaxSessions = 0
 	if _, err := n.getSegmentChan(segData); err != nil {
 		t.Error("Existing mid should continue processing even when O is at capacity: ", err)
 	}
@@ -271,7 +271,7 @@ func TestGetSegmentChan(t *testing.T) {
 	if _, err := n.getSegmentChan(segData); err != ErrOrchCap {
 		t.Error("Didn't fail when orch cap hit: ", err)
 	}
-	MaxTranscodeSessions = oldTranscodeSessions
+	MaxSessions = oldTranscodeSessions
 
 	// Test what happens when invoking the transcode loop fails
 	drivers.NodeStorage = nil // will make the transcode loop fail
@@ -306,21 +306,21 @@ func TestOrchCheckCapacity(t *testing.T) {
 	n, _ := NewLivepeerNode(nil, "", nil)
 	o := NewOrchestrator(n)
 	md := StubSegTranscodingMetadata()
-	cap := MaxTranscodeSessions
+	cap := MaxSessions
 	assert := assert.New(t)
 
 	// happy case
 	assert.Nil(o.CheckCapacity(md.ManifestID))
 
 	// capped case
-	MaxTranscodeSessions = 0
+	MaxSessions = 0
 	assert.Equal(ErrOrchCap, o.CheckCapacity(md.ManifestID))
 
 	// ensure existing segment chans pass while cap is active
-	MaxTranscodeSessions = cap
+	MaxSessions = cap
 	_, err := n.getSegmentChan(md) // store md into segment chans
 	assert.Nil(err)
-	MaxTranscodeSessions = 0
+	MaxSessions = 0
 	assert.Nil(o.CheckCapacity(md.ManifestID))
 }
 

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -27,8 +27,6 @@ import (
 	"github.com/livepeer/lpms/stream"
 )
 
-var MaxTranscodeSessions = 10
-
 var transcodeLoopTimeout = 1 * time.Minute
 
 // Transcoder / orchestrator RPC interface implementation
@@ -77,7 +75,7 @@ func (orch *orchestrator) CheckCapacity(mid ManifestID) error {
 	if _, ok := orch.node.SegmentChans[mid]; ok {
 		return nil
 	}
-	if len(orch.node.SegmentChans) >= MaxTranscodeSessions {
+	if len(orch.node.SegmentChans) >= MaxSessions {
 		return ErrOrchCap
 	}
 	return nil
@@ -218,7 +216,7 @@ func (n *LivepeerNode) getSegmentChan(md *SegTranscodingMetadata) (SegmentChan, 
 	if sc, ok := n.SegmentChans[md.ManifestID]; ok {
 		return sc, nil
 	}
-	if len(n.SegmentChans) >= MaxTranscodeSessions {
+	if len(n.SegmentChans) >= MaxSessions {
 		return nil, ErrOrchCap
 	}
 	sc := make(SegmentChan, 1)

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -164,6 +164,11 @@ func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID str
 
 		// Ensure there's no concurrent StreamID with the same name
 		s.connectionLock.RLock()
+		if core.MaxSessions > 0 && len(s.rtmpConnections) >= core.MaxSessions {
+			glog.Error("Too many connections")
+			s.connectionLock.RUnlock()
+			return ""
+		}
 		if _, exists := s.rtmpConnections[mid]; exists {
 			glog.Error("Manifest already exists ", mid)
 			s.connectionLock.RUnlock()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Add capacity cap for Broadcaster

**Specific updates (required)**
Reuse `-maxSessions` option for Broadcaster, on new RTMP connection check if number of current connections (`rtmpConnections`) is less than `-maxSessions`. By default it is not specified and not checked.

**How did you test each of these updates (required)**
Added unit tests

**Does this pull request close any open issues?**
Fixes #706 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass