### PR TITLE
Add unit tests for ServeSegment and SubmitSegment

### DIFF
--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -45,7 +45,7 @@ func dummyHandler() http.Handler {
 func TestMustHaveFormParams_NoParamsRequired(t *testing.T) {
 	handler := mustHaveFormParams(dummyHandler())
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -56,7 +56,7 @@ func TestMustHaveFormParams_NoParamsRequired(t *testing.T) {
 func TestMustHaveFormParams_SingleParamRequiredNotProvided(t *testing.T) {
 	handler := mustHaveFormParams(dummyHandler(), "a")
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -70,7 +70,7 @@ func TestMustHaveFormParams_SingleParamRequiredAndProvided(t *testing.T) {
 	form := url.Values{
 		"a": {"foo"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -84,7 +84,7 @@ func TestMustHaveFormParams_MultipleParamsRequiredOneNotProvided(t *testing.T) {
 	form := url.Values{
 		"a": {"foo"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -98,7 +98,7 @@ func TestMustHaveFormParams_MultipleParamsRequiredAllProvided(t *testing.T) {
 		"a": {"foo"},
 		"b": {"foo"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -109,7 +109,7 @@ func TestMustHaveFormParams_MultipleParamsRequiredAllProvided(t *testing.T) {
 func TestCurrentBlockHandler_MissingBlockGetter(t *testing.T) {
 	handler := currentBlockHandler(nil)
 
-	resp := httpResp(handler, "GET", nil)
+	resp := httpGetResp(handler)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -123,7 +123,7 @@ func TestCurrentBlockHandler_LastSeenBlockError(t *testing.T) {
 
 	getter.On("LastSeenBlock").Return(nil, errors.New("LastSeenBlock error"))
 
-	resp := httpResp(handler, "GET", nil)
+	resp := httpGetResp(handler)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -137,7 +137,7 @@ func TestCurrentBlockHandler_Success(t *testing.T) {
 
 	getter.On("LastSeenBlock").Return(big.NewInt(50), nil)
 
-	resp := httpResp(handler, "GET", nil)
+	resp := httpGetResp(handler)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -148,7 +148,7 @@ func TestCurrentBlockHandler_Success(t *testing.T) {
 func TestFundAndApproveSignersHandler_MissingClient(t *testing.T) {
 	handler := fundAndApproveSignersHandler(nil)
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -163,7 +163,7 @@ func TestFundAndApproveSignersHandler_InvalidDepositAmount(t *testing.T) {
 	form := url.Values{
 		"depositAmount": {"foo"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -179,7 +179,7 @@ func TestFundAndApproveSignersHandler_InvalidPenaltyEscrowAmount(t *testing.T) {
 		"depositAmount":       {"100"},
 		"penaltyEscrowAmount": {"foo"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -197,7 +197,7 @@ func TestFundAndApproveSignersHandler_TransactionSubmissionError(t *testing.T) {
 		"depositAmount":       {"50"},
 		"penaltyEscrowAmount": {"50"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -216,7 +216,7 @@ func TestFundAndApproveSignersHandler_TransactionWaitError(t *testing.T) {
 		"depositAmount":       {"50"},
 		"penaltyEscrowAmount": {"50"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -235,7 +235,7 @@ func TestFundAndApproveSignersHandler_Success(t *testing.T) {
 		"depositAmount":       {"50"},
 		"penaltyEscrowAmount": {"50"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -246,7 +246,7 @@ func TestFundAndApproveSignersHandler_Success(t *testing.T) {
 func TestFundDepositHandler_MissingClient(t *testing.T) {
 	handler := fundDepositHandler(nil)
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -261,7 +261,7 @@ func TestFundDepositHandler_InvalidAmount(t *testing.T) {
 	form := url.Values{
 		"amount": {"foo"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -278,7 +278,7 @@ func TestFundDepositHandler_TransactionSubmissionError(t *testing.T) {
 	form := url.Values{
 		"amount": {"100"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -296,7 +296,7 @@ func TestFundDepositHandler_TransactionWaitError(t *testing.T) {
 	form := url.Values{
 		"amount": {"100"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -314,7 +314,7 @@ func TestFundDepositHandler_Success(t *testing.T) {
 	form := url.Values{
 		"amount": {"100"},
 	}
-	resp := httpResp(handler, "POST", strings.NewReader(form.Encode()))
+	resp := httpPostFormResp(handler, strings.NewReader(form.Encode()))
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -325,7 +325,7 @@ func TestFundDepositHandler_Success(t *testing.T) {
 func TestUnlockHandler_MissingClient(t *testing.T) {
 	handler := unlockHandler(nil)
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -339,7 +339,7 @@ func TestUnlockHandler_TransactionSubmissionError(t *testing.T) {
 
 	client.On("Unlock").Return(nil, errors.New("Unlock error"))
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -354,7 +354,7 @@ func TestUnlockHandler_TransactionWaitError(t *testing.T) {
 	client.On("Unlock").Return(nil, nil)
 	client.On("CheckTx", mock.Anything).Return(errors.New("CheckTx error"))
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -369,7 +369,7 @@ func TestUnlockHandler_Success(t *testing.T) {
 	client.On("Unlock").Return(nil, nil)
 	client.On("CheckTx", mock.Anything).Return(nil)
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -380,7 +380,7 @@ func TestUnlockHandler_Success(t *testing.T) {
 func TestCancelUnlockHandler_MissingClient(t *testing.T) {
 	handler := cancelUnlockHandler(nil)
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -394,7 +394,7 @@ func TestCancelUnlockHandler_TransactionSubmissionError(t *testing.T) {
 
 	client.On("CancelUnlock").Return(nil, errors.New("CancelUnlock error"))
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -409,7 +409,7 @@ func TestCancelUnlockHandler_TransactionWaitError(t *testing.T) {
 	client.On("CancelUnlock").Return(nil, nil)
 	client.On("CheckTx", mock.Anything).Return(errors.New("CheckTx error"))
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -424,7 +424,7 @@ func TestCancelUnlockHandler_Success(t *testing.T) {
 	client.On("CancelUnlock").Return(nil, nil)
 	client.On("CheckTx", mock.Anything).Return(nil)
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -435,7 +435,7 @@ func TestCancelUnlockHandler_Success(t *testing.T) {
 func TestWithdrawHandler_MissingClient(t *testing.T) {
 	handler := withdrawHandler(nil)
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -449,7 +449,7 @@ func TestWithdrawHandler_TransactionSubmissionError(t *testing.T) {
 
 	client.On("Withdraw").Return(nil, errors.New("Withdraw error"))
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -463,7 +463,7 @@ func TestWithdrawHandler_TransactionWaitError(t *testing.T) {
 	client.On("Withdraw").Return(nil, nil)
 	client.On("CheckTx", mock.Anything).Return(errors.New("CheckTx error"))
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -478,7 +478,7 @@ func TestWithdrawHandler_Success(t *testing.T) {
 	client.On("Withdraw").Return(nil, nil)
 	client.On("CheckTx", mock.Anything).Return(nil)
 
-	resp := httpResp(handler, "POST", nil)
+	resp := httpPostFormResp(handler, nil)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -489,7 +489,7 @@ func TestWithdrawHandler_Success(t *testing.T) {
 func TestSenderInfoHandler_MissingClient(t *testing.T) {
 	handler := senderInfoHandler(nil)
 
-	resp := httpResp(handler, "GET", nil)
+	resp := httpGetResp(handler)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -505,7 +505,7 @@ func TestSenderInfoHandler_SendersError(t *testing.T) {
 	client.On("Account").Return(accounts.Account{Address: addr})
 	client.On("Senders", addr).Return(nil, nil, nil, errors.New("Senders error"))
 
-	resp := httpResp(handler, "GET", nil)
+	resp := httpGetResp(handler)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -525,7 +525,7 @@ func TestSenderInfoHandler_Success(t *testing.T) {
 	client.On("Account").Return(accounts.Account{Address: addr})
 	client.On("Senders", addr).Return(deposit, penaltyEscrow, withdrawBlock, nil)
 
-	resp := httpResp(handler, "GET", nil)
+	resp := httpGetResp(handler)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	var sender struct {
@@ -546,7 +546,7 @@ func TestSenderInfoHandler_Success(t *testing.T) {
 func TestTicketBrokerParamsHandler_MissingClient(t *testing.T) {
 	handler := ticketBrokerParamsHandler(nil)
 
-	resp := httpResp(handler, "GET", nil)
+	resp := httpGetResp(handler)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -560,7 +560,7 @@ func TestTicketBrokerParamsHandler_MinPenaltyEscrowError(t *testing.T) {
 
 	client.On("MinPenaltyEscrow").Return(nil, errors.New("MinPenaltyEscrow error"))
 
-	resp := httpResp(handler, "GET", nil)
+	resp := httpGetResp(handler)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -575,7 +575,7 @@ func TestTicketBrokerParamsHandler_UnlockPeriodError(t *testing.T) {
 	client.On("MinPenaltyEscrow").Return(big.NewInt(50), nil)
 	client.On("UnlockPeriod").Return(nil, errors.New("UnlockPeriod error"))
 
-	resp := httpResp(handler, "GET", nil)
+	resp := httpGetResp(handler)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	assert := assert.New(t)
@@ -592,7 +592,7 @@ func TestTicketBrokerParamsHandler_Success(t *testing.T) {
 	client.On("MinPenaltyEscrow").Return(minPenaltyEscrow, nil)
 	client.On("UnlockPeriod").Return(unlockPeriod, nil)
 
-	resp := httpResp(handler, "GET", nil)
+	resp := httpGetResp(handler)
 	body, _ := ioutil.ReadAll(resp.Body)
 
 	var params struct {
@@ -608,9 +608,30 @@ func TestTicketBrokerParamsHandler_Success(t *testing.T) {
 	assert.Equal(unlockPeriod, params.UnlockPeriod)
 }
 
-func httpResp(handler http.Handler, method string, body io.Reader) *http.Response {
+func httpPostFormResp(handler http.Handler, body io.Reader) *http.Response {
+	headers := map[string]string{
+		"Content-Type": "application/x-www-form-urlencoded",
+	}
+
+	return httpPostResp(handler, body, headers)
+}
+
+func httpPostResp(handler http.Handler, body io.Reader, headers map[string]string) *http.Response {
+	return httpResp(handler, "POST", body, headers)
+}
+
+func httpGetResp(handler http.Handler) *http.Response {
+	return httpResp(handler, "GET", nil, nil)
+}
+
+func httpResp(handler http.Handler, method string, body io.Reader, headers map[string]string) *http.Response {
 	req := httptest.NewRequest(method, "http://example.com", body)
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	if headers != nil {
+		for k, v := range headers {
+			req.Header.Add(k, v)
+		}
+	}
 
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -27,6 +27,7 @@ import (
 )
 
 const PaymentHeader = "Livepeer-Payment"
+const SegmentHeader = "Livepeer-Segment"
 
 var ErrSegEncoding = errors.New("ErrorSegEncoding")
 var ErrSegSig = errors.New("ErrSegSig")
@@ -48,7 +49,7 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// check the segment sig from the broadcaster
-	seg := r.Header.Get("Livepeer-Segment")
+	seg := r.Header.Get(SegmentHeader)
 
 	segData, err := verifySegCreds(orch, seg, getPaymentSender(payment))
 	if err != nil {
@@ -252,8 +253,8 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 		return nil, err
 	}
 
-	req.Header.Set("Livepeer-Segment", segCreds)
-	req.Header.Set("Livepeer-Payment", payment)
+	req.Header.Set(SegmentHeader, segCreds)
+	req.Header.Set(PaymentHeader, payment)
 	if uploaded {
 		req.Header.Set("Content-Type", "application/vnd+livepeer.uri")
 	} else {

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -1,0 +1,525 @@
+package server
+
+import (
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/golang/protobuf/proto"
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/drivers"
+	"github.com/livepeer/go-livepeer/net"
+	ffmpeg "github.com/livepeer/lpms/ffmpeg"
+	"github.com/livepeer/lpms/stream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+)
+
+func serveSegmentHandler(orch Orchestrator) http.Handler {
+	lp := lphttp{
+		orchestrator: orch,
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lp.ServeSegment(w, r)
+	})
+}
+func TestServeSegment_GetPaymentError(t *testing.T) {
+	orch := &mockOrchestrator{}
+	handler := serveSegmentHandler(orch)
+
+	headers := map[string]string{
+		PaymentHeader: "foo",
+	}
+	resp := httpPostResp(handler, nil, headers)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusPaymentRequired, resp.StatusCode)
+	assert.Contains(strings.TrimSpace(string(body)), "base64")
+}
+
+func TestServeSegment_VerifySegCredsError(t *testing.T) {
+	orch := &mockOrchestrator{}
+	handler := serveSegmentHandler(orch)
+
+	headers := map[string]string{
+		PaymentHeader: "",
+		SegmentHeader: "foo",
+	}
+	resp := httpPostResp(handler, nil, headers)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusForbidden, resp.StatusCode)
+	assert.Equal(ErrSegEncoding.Error(), strings.TrimSpace(string(body)))
+}
+
+func TestServeSegment_ProcessPaymentError(t *testing.T) {
+	orch := &mockOrchestrator{}
+	handler := serveSegmentHandler(orch)
+
+	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
+
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+	}
+	creds, err := genSegCreds(s, &stream.HLSSegment{})
+	require.Nil(t, err)
+
+	orch.On("ProcessPayment", mock.Anything, mock.Anything).Return(errors.New("ProcessPayment error"))
+
+	headers := map[string]string{
+		PaymentHeader: "",
+		SegmentHeader: creds,
+	}
+	resp := httpPostResp(handler, nil, headers)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusPaymentRequired, resp.StatusCode)
+	assert.Equal("ProcessPayment error", strings.TrimSpace(string(body)))
+}
+
+func TestServeSegment_MismatchHashError(t *testing.T) {
+	orch := &mockOrchestrator{}
+	handler := serveSegmentHandler(orch)
+
+	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
+
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+	}
+	creds, err := genSegCreds(s, &stream.HLSSegment{})
+	require.Nil(t, err)
+
+	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
+
+	headers := map[string]string{
+		PaymentHeader: "",
+		SegmentHeader: creds,
+	}
+	resp := httpPostResp(handler, bytes.NewReader([]byte("foo")), headers)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusForbidden, resp.StatusCode)
+	assert.Equal("Forbidden", strings.TrimSpace(string(body)))
+}
+
+func TestServeSegment_TranscodeSegError(t *testing.T) {
+	orch := &mockOrchestrator{}
+	handler := serveSegmentHandler(orch)
+
+	require := require.New(t)
+
+	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
+
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+	}
+	seg := &stream.HLSSegment{Data: []byte("foo")}
+	creds, err := genSegCreds(s, seg)
+	require.Nil(err)
+
+	md, err := verifySegCreds(orch, creds, ethcommon.Address{})
+	require.Nil(err)
+
+	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
+	orch.On("TranscodeSeg", md, seg).Return(nil, errors.New("TranscodeSeg error"))
+
+	headers := map[string]string{
+		PaymentHeader: "",
+		SegmentHeader: creds,
+	}
+	resp := httpPostResp(handler, bytes.NewReader(seg.Data), headers)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(err)
+
+	var tr net.TranscodeResult
+	err = proto.Unmarshal(body, &tr)
+	require.Nil(err)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+
+	res, ok := tr.Result.(*net.TranscodeResult_Error)
+	assert.True(ok)
+	assert.Equal("TranscodeSeg error", res.Error)
+}
+
+func TestServeSegment_OSSaveDataError(t *testing.T) {
+	orch := &mockOrchestrator{}
+	handler := serveSegmentHandler(orch)
+
+	require := require.New(t)
+
+	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
+
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+		Profiles: []ffmpeg.VideoProfile{
+			ffmpeg.P720p60fps16x9,
+		},
+	}
+	seg := &stream.HLSSegment{Data: []byte("foo")}
+	creds, err := genSegCreds(s, seg)
+	require.Nil(err)
+
+	md, err := verifySegCreds(orch, creds, ethcommon.Address{})
+	require.Nil(err)
+
+	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
+
+	mos := &mockOSSession{}
+
+	mos.On("SaveData", mock.Anything, mock.Anything).Return("", errors.New("SaveData error"))
+
+	tRes := &core.TranscodeResult{
+		Data: [][]byte{
+			[]byte("foo"),
+		},
+		Sig: []byte("foo"),
+		OS:  mos,
+	}
+	orch.On("TranscodeSeg", md, seg).Return(tRes, nil)
+
+	headers := map[string]string{
+		PaymentHeader: "",
+		SegmentHeader: creds,
+	}
+	resp := httpPostResp(handler, bytes.NewReader(seg.Data), headers)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(err)
+
+	var tr net.TranscodeResult
+	err = proto.Unmarshal(body, &tr)
+	require.Nil(err)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+
+	res, ok := tr.Result.(*net.TranscodeResult_Data)
+	assert.True(ok)
+	assert.Equal([]byte("foo"), res.Data.Sig)
+	assert.Equal(0, len(res.Data.Segments))
+}
+
+func TestServeSegment_ReturnSingleTranscodedSegmentData(t *testing.T) {
+	orch := &mockOrchestrator{}
+	handler := serveSegmentHandler(orch)
+
+	require := require.New(t)
+
+	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
+
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+		Profiles: []ffmpeg.VideoProfile{
+			ffmpeg.P720p60fps16x9,
+		},
+	}
+	seg := &stream.HLSSegment{Data: []byte("foo")}
+	creds, err := genSegCreds(s, seg)
+	require.Nil(err)
+
+	md, err := verifySegCreds(orch, creds, ethcommon.Address{})
+	require.Nil(err)
+
+	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
+
+	tRes := &core.TranscodeResult{
+		Data: [][]byte{
+			[]byte("foo"),
+		},
+		Sig: []byte("foo"),
+		OS:  drivers.NewMemoryDriver(nil).NewSession(""),
+	}
+	orch.On("TranscodeSeg", md, seg).Return(tRes, nil)
+
+	headers := map[string]string{
+		PaymentHeader: "",
+		SegmentHeader: creds,
+	}
+	resp := httpPostResp(handler, bytes.NewReader(seg.Data), headers)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(err)
+
+	var tr net.TranscodeResult
+	err = proto.Unmarshal(body, &tr)
+	require.Nil(err)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+
+	res, ok := tr.Result.(*net.TranscodeResult_Data)
+	assert.True(ok)
+	assert.Equal([]byte("foo"), res.Data.Sig)
+	assert.Equal(1, len(res.Data.Segments))
+}
+
+func TestServeSegment_ReturnMultipleTranscodedSegmentData(t *testing.T) {
+	orch := &mockOrchestrator{}
+	handler := serveSegmentHandler(orch)
+
+	require := require.New(t)
+
+	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
+
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+		Profiles: []ffmpeg.VideoProfile{
+			ffmpeg.P720p60fps16x9,
+			ffmpeg.P240p30fps16x9,
+		},
+	}
+	seg := &stream.HLSSegment{Data: []byte("foo")}
+	creds, err := genSegCreds(s, seg)
+	require.Nil(err)
+
+	md, err := verifySegCreds(orch, creds, ethcommon.Address{})
+	require.Nil(err)
+
+	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
+
+	tRes := &core.TranscodeResult{
+		Data: [][]byte{
+			[]byte("foo"),
+			[]byte("foo"),
+		},
+		Sig: []byte("foo"),
+		OS:  drivers.NewMemoryDriver(nil).NewSession(""),
+	}
+	orch.On("TranscodeSeg", md, seg).Return(tRes, nil)
+
+	headers := map[string]string{
+		PaymentHeader: "",
+		SegmentHeader: creds,
+	}
+	resp := httpPostResp(handler, bytes.NewReader(seg.Data), headers)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(err)
+
+	var tr net.TranscodeResult
+	err = proto.Unmarshal(body, &tr)
+	require.Nil(err)
+
+	assert := assert.New(t)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+
+	res, ok := tr.Result.(*net.TranscodeResult_Data)
+	assert.True(ok)
+	assert.Equal([]byte("foo"), res.Data.Sig)
+	assert.Equal(2, len(res.Data.Segments))
+}
+
+func TestSubmitSegment_GenSegCredsError(t *testing.T) {
+	b := StubBroadcaster2()
+	b.signErr = errors.New("Sign error")
+
+	s := &BroadcastSession{
+		Broadcaster: b,
+		ManifestID:  core.RandomManifestID(),
+	}
+
+	_, err := SubmitSegment(s, &stream.HLSSegment{}, 0)
+
+	assert.Equal(t, "Sign error", err.Error())
+}
+
+func TestSubmitSegment_HttpPostError(t *testing.T) {
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+		OrchestratorInfo: &net.OrchestratorInfo{
+			Transcoder: "https://foo.com",
+		},
+	}
+
+	_, err := SubmitSegment(s, &stream.HLSSegment{}, 0)
+
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestSubmitSegment_Non200StatusCode(t *testing.T) {
+	ts, mux := stubTLSServer()
+	defer ts.Close()
+	mux.HandleFunc("/segment", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Server error", http.StatusInternalServerError)
+	})
+
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+		OrchestratorInfo: &net.OrchestratorInfo{
+			Transcoder: ts.URL,
+		},
+	}
+
+	_, err := SubmitSegment(s, &stream.HLSSegment{}, 0)
+
+	assert.Equal(t, "Server error", err.Error())
+}
+
+func TestSubmitSegment_ProtoUnmarshalError(t *testing.T) {
+	ts, mux := stubTLSServer()
+	defer ts.Close()
+	mux.HandleFunc("/segment", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("foo"))
+	})
+
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+		OrchestratorInfo: &net.OrchestratorInfo{
+			Transcoder: ts.URL,
+		},
+	}
+
+	_, err := SubmitSegment(s, &stream.HLSSegment{}, 0)
+
+	assert.Contains(t, err.Error(), "proto")
+}
+
+func TestSubmitSegment_TranscodeResultError(t *testing.T) {
+	tr := &net.TranscodeResult{
+		Result: &net.TranscodeResult_Error{Error: "TranscodeResult error"},
+	}
+	buf, err := proto.Marshal(tr)
+	require.Nil(t, err)
+
+	ts, mux := stubTLSServer()
+	defer ts.Close()
+	mux.HandleFunc("/segment", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(buf)
+	})
+
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+		OrchestratorInfo: &net.OrchestratorInfo{
+			Transcoder: ts.URL,
+		},
+	}
+
+	_, err = SubmitSegment(s, &stream.HLSSegment{}, 0)
+
+	assert.Equal(t, "TranscodeResult error", err.Error())
+}
+
+func TestSubmitSegment_Success(t *testing.T) {
+	require := require.New(t)
+
+	tr := &net.TranscodeResult{
+		Result: &net.TranscodeResult_Data{
+			Data: &net.TranscodeData{
+				Segments: []*net.TranscodedSegmentData{
+					&net.TranscodedSegmentData{Url: "foo"},
+				},
+				Sig: []byte("bar"),
+			},
+		},
+	}
+	buf, err := proto.Marshal(tr)
+	require.Nil(err)
+
+	var runChecks func(r *http.Request)
+
+	ts, mux := stubTLSServer()
+	defer ts.Close()
+	mux.HandleFunc("/segment", func(w http.ResponseWriter, r *http.Request) {
+		if runChecks != nil {
+			runChecks(r)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(buf)
+	})
+
+	s := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+		OrchestratorInfo: &net.OrchestratorInfo{
+			Transcoder: ts.URL,
+		},
+	}
+
+	assert := assert.New(t)
+
+	runChecks = func(r *http.Request) {
+		assert.Equal("video/MP2T", r.Header.Get("Content-Type"))
+
+		data, err := ioutil.ReadAll(r.Body)
+		require.Nil(err)
+
+		assert.Equal([]byte("dummy"), data)
+	}
+
+	tdata, err := SubmitSegment(s, &stream.HLSSegment{Data: []byte("dummy")}, 0)
+
+	assert.Nil(err)
+	assert.Equal(1, len(tdata.Segments))
+	assert.Equal("foo", tdata.Segments[0].Url)
+	assert.Equal([]byte("bar"), tdata.Sig)
+
+	// Test when input data is uploaded
+	runChecks = func(r *http.Request) {
+		assert.Equal("application/vnd+livepeer.uri", r.Header.Get("Content-Type"))
+
+		data, err := ioutil.ReadAll(r.Body)
+		require.Nil(err)
+
+		assert.Equal([]byte("foo"), data)
+	}
+
+	SubmitSegment(s, &stream.HLSSegment{Name: "foo", Data: []byte("dummy")}, 0)
+}
+
+func stubTLSServer() (*httptest.Server, *http.ServeMux) {
+	mux := http.NewServeMux()
+
+	ts := httptest.NewUnstartedServer(mux)
+	ts.TLS = &tls.Config{
+		// This config option fixes the "unexpected ALPN protocol ""; want h2" error
+		NextProtos: []string{http2.NextProtoTLS},
+	}
+	ts.StartTLS()
+
+	return ts, mux
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Add unit tests for the ServeSegment and SubmitSegment.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Refactored ServeSegment to return http.Handler to make it easier to test
- Added unit tests for ServeSegment and SubmitSegment - used the [httptest](https://golang.org/pkg/net/http/httptest/) package

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I ran the additional unit tests introduced by this PR.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #675 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [X] Node runs in OSX and devenv
- [X] All tests in `./test.sh` pass
