### PR TITLE
In `Dockerfile.debian` explicitly set version of go to 1.11

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -11,7 +11,7 @@ COPY install_ffmpeg.sh install_ffmpeg.sh
 RUN ./install_ffmpeg.sh
 
 
-FROM golang:1-stretch as builder2
+FROM golang:1.11-stretch as builder2
 ENV PKG_CONFIG_PATH /root/compiled/lib/pkgconfig
 WORKDIR /root
 RUN apt update \


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
In `Dockerfile.debian` explicitly set version of go to 1.11, so new releases doesn't broke build
Recent go 1.12 release changed something in standard libraries, and that made .dockerfile.deps obsolete. Just stick with go 1.11 for now.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass