### PR TITLE
Structured Ingest URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can also build the executables from scratch.
 ### Quick start
 - Make sure you have successfully gone through the steps in 'Installing Livepeer' and 'Additional Dependencies'.
 
-- Run `./livepeer -broadcaster -network rinkeby -currentManifest`.
+- Run `./livepeer -broadcaster -network rinkeby`.
 
 - Run `./livepeer_cli`.
   * You should see a wizard launch in the command line.
@@ -67,9 +67,11 @@ By default, the RTMP port is 1935.  For example, if you are using OSX with ffmpe
 
 Similarly, you can use OBS, and change the Settings->Stream->URL to `rtmp://localhost:1935/movie` , along with the keyframe interval to 4 seconds, via `Settings -> Output -> Output Mode (Advanced) -> Streaming tab -> Keyframe Interval 4`.
 
-If the broadcast is successful, you should be able to get a streamID by querying the local node's CLI API:
+If the broadcast is successful, you should be able to access the stream at:
 
-`curl http://localhost:7935/manifestID`
+`http://localhost:8935/stream/movie.m3u8`
+
+where the "movie" stream name is taken from the path in the RTMP URL.
 
 #### Authentication of incoming RTMP streams
 
@@ -80,9 +82,9 @@ Incoming RTMP streams can be authenicating using RTMP Authentication Webhook fun
 
 You can use tools like `ffplay` or `VLC` to view the stream.
 
-For example, after you get the streamID, you can view the stream by running:
+For example, after you start streaming to `rtmp://localhost/movie`, you can view the stream by running:
 
-`ffplay http://localhost:8935/stream/current.m3u8`
+`ffplay http://localhost:8935/stream/movie.m3u8`
 
 Note that the default HTTP port or playback (8935) is different from the CLI API port (7935) that is used for node management and diagnostics!
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ If the broadcast is successful, you should be able to access the stream at:
 
 where the "movie" stream name is taken from the path in the RTMP URL.
 
+See the documentation on [RTMP ingest](doc/ingest.md) for more details.
+
 #### Authentication of incoming RTMP streams
 
 Incoming RTMP streams can be authenicating using RTMP Authentication Webhook functionality, details is [here](doc/rtmpwebhookauth.md).

--- a/doc/ingest.md
+++ b/doc/ingest.md
@@ -1,0 +1,86 @@
+# RTMP Ingest
+
+Livepeer starts a RTMP server on the default port of 1935 as the ingest point
+into the Livepeer network. Upon ingest, the segmenter pulls the RTMP stream
+prior to transcoding.
+
+### Ingest Configuration
+
+By default, the RTMP server listens to localhost on the default RTMP port of 1935.
+
+This can be set at node start-up time with the `-rtmpAddr` flag, which takes an
+`interface:port` pair, such as `-rtmpAddr 0.0.0.0:1936` which would make the
+Livepeer node listen to all interfaces on port 1936.
+
+The node has a default maximum of 10 concurrent RTMP sessions. To change this, run the node with the `-maxSessions` flag indicating the limit, for example `-maxSessions 100` to raise the limit to 100 concurrent sessions.
+
+### Stream Naming and Addressing
+
+The stream name is taken to be the first part of the RTMP URL path. The stream name may optionally be prefixed with `/stream/` to match the HLS output address.
+
+```
+# Canonical Form
+rtmp://localhost/movie1
+rtmp://localhost/movie2
+
+# Alternate Form
+rtmp://localhost/stream/movie1
+rtmp://localhost/stream/movie2
+
+# Output URL
+http://localhost:8935/stream/movie1.m3u8
+http://localhost:8935/stream/movie2.m3u8
+```
+
+If no name is provided, then a stream name is randomly generated. For example:
+
+```
+# Ingest URL
+rtmp://localhost
+rtmp://localhost/stream # alternate form; /stream gets stripped
+
+# RTMP Playback URL
+rtmp://localhost/<randomStreamName>/<randomStreamKey>
+
+# HLS Playback URL
+http://localhost:8935/stream/<randomStreamName>.m3u8
+```
+
+There are two options for using randomly generated stream names.
+
+If the node is started with the `-currentManifest` flag, then the latest stream can be
+accessed via the HLS `current.m3u8` endpoint, regardless of its name, eg
+
+`curl http://localhost:8935/stream/current.m3u8`
+
+Alternatively, a list of active streams can be found by querying the CLI API:
+
+`curl http://localhost:7935/status`
+
+
+### Stream Authentication
+
+Streams can be authenticated through a webhook. See the documentation on the
+[RTMP Authentication Webhook](rtmpauthwebhook.md) for more details.
+
+### RTMP Playback Protection
+
+The RTMP stream can be played back, or pulled from Livepeer by another part of
+the ingest infrastructure. To prevent unauthorized RTMP playback of streams
+whose name is known, a stream key is randomly appended to the playback URL at
+ingest itme. However, the broadcaster can control the stream key by
+appending the key to the RTMP URL.
+
+
+```
+# Ingest and Playback URL: protected by stream key
+rtmp://localhost/movie/Secret/Stream/Key
+
+# HLS Output URL: publicly known
+http://localhost:8935/stream/movie.m3u8
+```
+
+Here, the stream name is `movie` and the stream key is `Secret/Stream/Key`.
+The RTMP stream can then be played back with this complete RTMP URL. The key is
+optional; if one is not supplied, then a random key will be generated. The key
+may also be specified via webhook.

--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -12,7 +12,7 @@ For example, if incoming RTMP request was made to `rtmp://livepeer.node:1935/som
 
 ```json
 {
-    "url": "rtmp://livepeer.node:1935/something?manifestID=manifest"
+    "url": "rtmp://livepeer.node:1935/manifest"
 }
 ```
 
@@ -29,5 +29,8 @@ Webhook can respond with zero body - in that case `ManifestID` for the stream wi
 and Livepeer node will use returned `ManifestID` for the stream.
 
 `ManifestID`, returned from webhook or provided in url shouldn't have backslahes in it, any other alpha-numeric characters allowed in url will do.
+
+An optional streamKey can be passed in to protect the RTMP from playback. If the
+streamKey is omitted, then a random key is generated.
 
 There is simple webhook authentication server [example](https://github.com/livepeer/go-livepeer/blob/master/cmd/simple_auth_server/simple_auth_server.go).

--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -22,7 +22,8 @@ Webhook can respond with zero body - in that case `ManifestID` for the stream wi
 
 ```json
 {
-    "manifestID": "StrigThatIsIDofManifest"
+    "manifestID": "ManifestIDString",
+    "streamKey":  "SecretKey"
 }
 ```
 and Livepeer node will use returned `ManifestID` for the stream.

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -168,7 +168,7 @@ func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID str
 		}
 
 		if mid == "" {
-			mid = parseManifestID(url.Query().Get("manifestID"))
+			mid = parseStreamID(url.Path).ManifestID
 		}
 		if mid == "" {
 			mid = core.RandomManifestID()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Uses RTMP URL by default to construct manifest ID and stream key.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- https://github.com/livepeer/go-livepeer/commit/bcd4202eb34912f4527ad66ccf444cad600b64f9 Extract ManifestID from URL path. Note that this follows the scheme outlined in https://github.com/livepeer/go-livepeer/issues/791#issuecomment-472572559 where the user can incorporate an optional `/stream/` prefix into the path.

- https://github.com/livepeer/go-livepeer/commit/4bd3167d2f1d11a1ff34dd794540c907ee6d58e9 Extract stream key from URL path. Also return stream keys from the auth webhook. If no key is provided, then a random key is generated (following the old behavior).

- Removed the support for looking up the manifestID via the query parameter. This is technically a breaking change; the test harness and any client scripts that use the query parameter will have to change. cc @ya7ya @darkdarkdragon This does *not* affect webhooks, which are still free to use any URL structure they please, including query parameters, as shown in our [simple auth server](https://github.com/livepeer/go-livepeer/blob/master/cmd/simple_auth_server/simple_auth_server.go) example.

**How did you test each of these updates (required)**
Added unit testing, performed manual testing.

**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/go-livepeer/issues/791
Fixes https://github.com/livepeer/go-livepeer/issues/764

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass