### PR TITLE
BroadcastSessionManager struct + methods

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"math"
 	"math/rand"
 	"net/url"
 	"strings"
@@ -75,6 +76,9 @@ func NewOnchainOrchestratorPool(node *core.LivepeerNode) *orchestratorPool {
 }
 
 func (o *orchestratorPool) GetOrchestrators(numOrchestrators int) ([]*net.OrchestratorInfo, error) {
+	numAvailableOrchs := len(o.uris)
+	numOrchestrators = int(math.Min(float64(numAvailableOrchs), float64(numOrchestrators)))
+
 	ctx, cancel := context.WithTimeout(context.Background(), GetOrchestratorsTimeoutLoop)
 	orchInfos := []*net.OrchestratorInfo{}
 	orchChan := make(chan struct{})

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -30,7 +30,8 @@ func selectOrchestrator(n *core.LivepeerNode, cpl core.PlaylistManager) (*Broadc
 
 	rpcBcast := core.NewBroadcaster(n)
 
-	tinfos, err := n.OrchestratorPool.GetOrchestrators(1)
+	defaultNumOrchs := HTTPTimeout / SegLen
+	tinfos, err := n.OrchestratorPool.GetOrchestrators(int(defaultNumOrchs))
 	if len(tinfos) <= 0 {
 		glog.Info("No orchestrators found; not transcoding. Error: ", err)
 		return nil, ErrNoOrchs

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -59,11 +59,12 @@ var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmp
 var AuthWebhookURL string
 
 type rtmpConnection struct {
-	mid     core.ManifestID
-	nonce   uint64
-	stream  stream.RTMPVideoStream
-	pl      core.PlaylistManager
-	profile *ffmpeg.VideoProfile
+	mid         core.ManifestID
+	nonce       uint64
+	stream      stream.RTMPVideoStream
+	pl          core.PlaylistManager
+	profile     *ffmpeg.VideoProfile
+	sessManager *BroadcastSessionsManager
 
 	needOrch chan struct{}
 	eof      chan struct{}
@@ -353,15 +354,15 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 		return nil, ErrAlreadyExists
 	}
 	cxn := &rtmpConnection{
-		mid:     mid,
-		nonce:   nonce,
-		stream:  rtmpStrm,
-		pl:      core.NewBasicPlaylistManager(mid, storage),
-		profile: &vProfile,
-		lock:    &sync.RWMutex{},
-
-		needOrch: make(chan struct{}),
-		eof:      make(chan struct{}),
+		mid:         mid,
+		nonce:       nonce,
+		stream:      rtmpStrm,
+		pl:          core.NewBasicPlaylistManager(mid, storage),
+		profile:     &vProfile,
+		lock:        &sync.RWMutex{},
+		sessManager: &BroadcastSessionsManager{broadcastSessions: []*BroadcastSession{}, sessLock: &sync.Mutex{}},
+		needOrch:    make(chan struct{}),
+		eof:         make(chan struct{}),
 	}
 	s.rtmpConnections[mid] = cxn
 	s.lastManifestID = mid

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 
 	"github.com/livepeer/go-livepeer/common"
@@ -531,4 +533,60 @@ func defaultTicket(t *testing.T) *net.Ticket {
 		SenderNonce:       456,
 		RecipientRandHash: pm.RandBytes(123),
 	}
+}
+
+func StubBroadcastSessionsManager() *BroadcastSessionsManager {
+	sess1 := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+	}
+	sess2 := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+	}
+	return &BroadcastSessionsManager{broadcastSessions: []*BroadcastSession{sess1, sess2}, sessLock: &sync.Mutex{}}
+}
+
+func TestSelectFromList_Successt(t *testing.T) {
+	bsm := StubBroadcastSessionsManager()
+	expectedSess := bsm.broadcastSessions[0]
+	sess := bsm.selectFromList()
+
+	assert := assert.New(t)
+	assert.Equal(expectedSess, sess)
+	assert.Len(bsm.broadcastSessions, 1)
+}
+
+func TestRemoveFromList_Successt(t *testing.T) {
+	bsm := StubBroadcastSessionsManager()
+	expectedSess := bsm.broadcastSessions[0]
+	remove := bsm.broadcastSessions[1]
+	bsm.removeFromList(remove)
+	glog.Error(remove)
+
+	assert := assert.New(t)
+	assert.Equal(expectedSess, bsm.broadcastSessions[0])
+	assert.Len(bsm.broadcastSessions, 1)
+}
+
+func TestAddToList_Success(t *testing.T) {
+	bsm := StubBroadcastSessionsManager()
+	sess := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+	}
+
+	bsm.addToList(sess)
+	assert := assert.New(t)
+	assert.Equal(sess, bsm.broadcastSessions[2])
+	assert.Len(bsm.broadcastSessions, 3)
+}
+
+// note: once selectOrchestrator is integrated into statusOfList(), must beef up this test
+func TestStatusOfList_Success(t *testing.T) {
+	bsm := StubBroadcastSessionsManager()
+	bsm.checkStatusOfList()
+
+	assert := assert.New(t)
+	assert.Len(bsm.broadcastSessions, 2)
 }

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -19,7 +19,6 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 
 	"github.com/livepeer/go-livepeer/common"
@@ -547,29 +546,26 @@ func StubBroadcastSessionsManager() *BroadcastSessionsManager {
 	return &BroadcastSessionsManager{broadcastSessions: []*BroadcastSession{sess1, sess2}, sessLock: &sync.Mutex{}}
 }
 
-func TestSelectFromList_Successt(t *testing.T) {
+func TestSelectFromList(t *testing.T) {
 	bsm := StubBroadcastSessionsManager()
-	expectedSess := bsm.broadcastSessions[0]
-	sess := bsm.selectFromList()
+	expectedSess := bsm.broadcastSessions[1]
 
 	assert := assert.New(t)
+	assert.Len(bsm.broadcastSessions, 2)
+
+	sess := bsm.selectFromList()
 	assert.Equal(expectedSess, sess)
 	assert.Len(bsm.broadcastSessions, 1)
+
+	bsm = &BroadcastSessionsManager{broadcastSessions: []*BroadcastSession{}, sessLock: &sync.Mutex{}}
+	assert.Len(bsm.broadcastSessions, 0)
+
+	sess = bsm.selectFromList()
+	assert.Nil(sess)
+	assert.Len(bsm.broadcastSessions, 0)
 }
 
-func TestRemoveFromList_Successt(t *testing.T) {
-	bsm := StubBroadcastSessionsManager()
-	expectedSess := bsm.broadcastSessions[0]
-	remove := bsm.broadcastSessions[1]
-	bsm.removeFromList(remove)
-	glog.Error(remove)
-
-	assert := assert.New(t)
-	assert.Equal(expectedSess, bsm.broadcastSessions[0])
-	assert.Len(bsm.broadcastSessions, 1)
-}
-
-func TestAddToList_Success(t *testing.T) {
+func TestAddToList(t *testing.T) {
 	bsm := StubBroadcastSessionsManager()
 	sess := &BroadcastSession{
 		Broadcaster: StubBroadcaster2(),
@@ -583,7 +579,7 @@ func TestAddToList_Success(t *testing.T) {
 }
 
 // note: once selectOrchestrator is integrated into statusOfList(), must beef up this test
-func TestStatusOfList_Success(t *testing.T) {
+func TestStatusOfList(t *testing.T) {
 	bsm := StubBroadcastSessionsManager()
 	bsm.checkStatusOfList()
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This PR builds the `BroadcastSessionManager` struct and associated methods. The struct manages the list of BroadcastSessions, and handles BroadcastSession selection/additions/list refreshes. 

For background, we've chosen the round-robin strategy as the most optimal method at this point in time, and get us to 99%+ reliability. A B will “take turns” assigning segments to be transcoded to different Os. eg. send seg1 to O1, seg2 to O2, seg3 to O3, seg4 to O1, seg5 to O2, etc. (in the case of three O's). Alternating sending segments to a selection of Os gives individual Os more time to process segments - the more O’s involved, the more time for segment processing. Os will not have more than one segment per stream in flight, which mitigates back logging.

**Specific updates (required)**
- BroadcastSessionManager {}
- addToList()
- selectFromList()
- checkStatusOfList()

**Does this pull request close any open issues?**
For more info, see here: https://docs.google.com/document/d/1KfEWm0z3svw10TrFH9hiMImkXocl3ba_S-8vmX94HNc/edit#

**Checklist:**
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
