### PR TITLE
Ar/select orchestrator returns broadcast sessions

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"math"
 	"math/rand"
 	"net/url"
 	"strings"
@@ -75,6 +76,9 @@ func NewOnchainOrchestratorPool(node *core.LivepeerNode) *orchestratorPool {
 }
 
 func (o *orchestratorPool) GetOrchestrators(numOrchestrators int) ([]*net.OrchestratorInfo, error) {
+	numAvailableOrchs := len(o.uris)
+	numOrchestrators = int(math.Min(float64(numAvailableOrchs), float64(numOrchestrators)))
+
 	ctx, cancel := context.WithTimeout(context.Background(), GetOrchestratorsTimeoutLoop)
 	orchInfos := []*net.OrchestratorInfo{}
 	orchChan := make(chan struct{})

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -31,7 +31,8 @@ func selectOrchestrator(n *core.LivepeerNode, cpl core.PlaylistManager) (*Broadc
 
 	rpcBcast := core.NewBroadcaster(n)
 
-	tinfos, err := n.OrchestratorPool.GetOrchestrators(1)
+	defaultNumOrchs := HTTPTimeout / SegLen
+	tinfos, err := n.OrchestratorPool.GetOrchestrators(int(defaultNumOrchs))
 	if len(tinfos) <= 0 {
 		glog.Info("No orchestrators found; not transcoding. Error: ", err)
 		return nil, ErrNoOrchs

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -22,8 +22,7 @@ import (
 	"github.com/livepeer/lpms/stream"
 )
 
-func selectOrchestrator(n *core.LivepeerNode, cpl core.PlaylistManager) (*BroadcastSession, error) {
-
+func selectOrchestrator(n *core.LivepeerNode, cpl core.PlaylistManager) ([]*BroadcastSession, error) {
 	if n.OrchestratorPool == nil {
 		glog.Info("No orchestrators specified; not transcoding")
 		return nil, ErrDiscovery
@@ -40,39 +39,45 @@ func selectOrchestrator(n *core.LivepeerNode, cpl core.PlaylistManager) (*Broadc
 	if err != nil {
 		return nil, err
 	}
-	tinfo := tinfos[0]
 
-	var sessionID string
+	var sessions []*BroadcastSession
 
-	if n.Sender != nil {
-		protoParams := tinfo.TicketParams
-		params := pm.TicketParams{
-			Recipient:         ethcommon.BytesToAddress(protoParams.Recipient),
-			FaceValue:         new(big.Int).SetBytes(protoParams.FaceValue),
-			WinProb:           new(big.Int).SetBytes(protoParams.WinProb),
-			RecipientRandHash: ethcommon.BytesToHash(protoParams.RecipientRandHash),
-			Seed:              new(big.Int).SetBytes(protoParams.Seed),
+	for _, tinfo := range tinfos {
+		var sessionID string
+
+		if n.Sender != nil {
+			protoParams := tinfo.TicketParams
+			params := pm.TicketParams{
+				Recipient:         ethcommon.BytesToAddress(protoParams.Recipient),
+				FaceValue:         new(big.Int).SetBytes(protoParams.FaceValue),
+				WinProb:           new(big.Int).SetBytes(protoParams.WinProb),
+				RecipientRandHash: ethcommon.BytesToHash(protoParams.RecipientRandHash),
+				Seed:              new(big.Int).SetBytes(protoParams.Seed),
+			}
+
+			sessionID = n.Sender.StartSession(params)
 		}
 
-		sessionID = n.Sender.StartSession(params)
+		var orchOS drivers.OSSession
+		if len(tinfo.Storage) > 0 {
+			orchOS = drivers.NewSession(tinfo.Storage[0])
+		}
+
+		session := &BroadcastSession{
+			Broadcaster:      rpcBcast,
+			ManifestID:       cpl.ManifestID(),
+			Profiles:         BroadcastJobVideoProfiles,
+			OrchestratorInfo: tinfo,
+			OrchestratorOS:   orchOS,
+			BroadcasterOS:    cpl.GetOSSession(),
+			Sender:           n.Sender,
+			PMSessionID:      sessionID,
+		}
+
+		sessions = append(sessions, session)
 	}
 
-	// set OSes
-	var orchOS drivers.OSSession
-	if len(tinfo.Storage) > 0 {
-		orchOS = drivers.NewSession(tinfo.Storage[0])
-	}
-
-	return &BroadcastSession{
-		Broadcaster:      rpcBcast,
-		ManifestID:       cpl.ManifestID(),
-		Profiles:         BroadcastJobVideoProfiles,
-		OrchestratorInfo: tinfo,
-		OrchestratorOS:   orchOS,
-		BroadcasterOS:    cpl.GetOSSession(),
-		Sender:           n.Sender,
-		PMSessionID:      sessionID,
-	}, nil
+	return sessions, nil
 }
 
 func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -59,11 +59,12 @@ var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmp
 var AuthWebhookURL string
 
 type rtmpConnection struct {
-	mid     core.ManifestID
-	nonce   uint64
-	stream  stream.RTMPVideoStream
-	pl      core.PlaylistManager
-	profile *ffmpeg.VideoProfile
+	mid         core.ManifestID
+	nonce       uint64
+	stream      stream.RTMPVideoStream
+	pl          core.PlaylistManager
+	profile     *ffmpeg.VideoProfile
+	sessManager *BroadcastSessionsManager
 
 	needOrch chan struct{}
 	eof      chan struct{}
@@ -365,15 +366,15 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 		return nil, ErrAlreadyExists
 	}
 	cxn := &rtmpConnection{
-		mid:     mid,
-		nonce:   nonce,
-		stream:  rtmpStrm,
-		pl:      core.NewBasicPlaylistManager(mid, storage),
-		profile: &vProfile,
-		lock:    &sync.RWMutex{},
-
-		needOrch: make(chan struct{}),
-		eof:      make(chan struct{}),
+		mid:         mid,
+		nonce:       nonce,
+		stream:      rtmpStrm,
+		pl:          core.NewBasicPlaylistManager(mid, storage),
+		profile:     &vProfile,
+		lock:        &sync.RWMutex{},
+		sessManager: &BroadcastSessionsManager{broadcastSessions: []*BroadcastSession{}, sessLock: &sync.Mutex{}},
+		needOrch:    make(chan struct{}),
+		eof:         make(chan struct{}),
 	}
 	s.rtmpConnections[mid] = cxn
 	s.lastManifestID = mid

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -390,7 +390,7 @@ func (s *LivepeerServer) startSession(cxn *rtmpConnection) *BroadcastSession {
 
 	mid := cxn.mid
 	cpl := cxn.pl
-	var sess *BroadcastSession
+	var sess []*BroadcastSession
 
 	// Connect to the orchestrator. If it fails, retry for as long
 	// as the RTMP stream is alive
@@ -414,7 +414,10 @@ func (s *LivepeerServer) startSession(cxn *rtmpConnection) *BroadcastSession {
 	expb.MaxInterval = BroadcastRetry
 	expb.MaxElapsedTime = 0
 	backoff.Retry(broadcastFunc, expb)
-	return sess
+	if len(sess) > 0 {
+		return sess[0]
+	}
+	return nil
 }
 
 func (s *LivepeerServer) startSessionListener(cxn *rtmpConnection) {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 
 	"github.com/livepeer/go-livepeer/common"
@@ -531,4 +533,60 @@ func defaultTicket(t *testing.T) *net.Ticket {
 		SenderNonce:       456,
 		RecipientRandHash: pm.RandBytes(123),
 	}
+}
+
+func StubBroadcastSessionsManager() *BroadcastSessionsManager {
+	sess1 := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+	}
+	sess2 := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+	}
+	return &BroadcastSessionsManager{broadcastSessions: []*BroadcastSession{sess1, sess2}, sessLock: &sync.Mutex{}}
+}
+
+func TestSelectFromList_Successt(t *testing.T) {
+	bsm := StubBroadcastSessionsManager()
+	expectedSess := bsm.broadcastSessions[0]
+	sess := bsm.selectFromList()
+
+	assert := assert.New(t)
+	assert.Equal(expectedSess, sess)
+	assert.Len(bsm.broadcastSessions, 1)
+}
+
+func TestRemoveFromList_Successt(t *testing.T) {
+	bsm := StubBroadcastSessionsManager()
+	expectedSess := bsm.broadcastSessions[0]
+	remove := bsm.broadcastSessions[1]
+	bsm.removeFromList(remove)
+	glog.Error(remove)
+
+	assert := assert.New(t)
+	assert.Equal(expectedSess, bsm.broadcastSessions[0])
+	assert.Len(bsm.broadcastSessions, 1)
+}
+
+func TestAddToList_Success(t *testing.T) {
+	bsm := StubBroadcastSessionsManager()
+	sess := &BroadcastSession{
+		Broadcaster: StubBroadcaster2(),
+		ManifestID:  core.RandomManifestID(),
+	}
+
+	bsm.addToList(sess)
+	assert := assert.New(t)
+	assert.Equal(sess, bsm.broadcastSessions[2])
+	assert.Len(bsm.broadcastSessions, 3)
+}
+
+// note: once selectOrchestrator is integrated into statusOfList(), must beef up this test
+func TestStatusOfList_Success(t *testing.T) {
+	bsm := StubBroadcastSessionsManager()
+	bsm.checkStatusOfList()
+
+	assert := assert.New(t)
+	assert.Len(bsm.broadcastSessions, 2)
 }

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -19,7 +19,6 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 
 	"github.com/livepeer/go-livepeer/common"
@@ -547,29 +546,26 @@ func StubBroadcastSessionsManager() *BroadcastSessionsManager {
 	return &BroadcastSessionsManager{broadcastSessions: []*BroadcastSession{sess1, sess2}, sessLock: &sync.Mutex{}}
 }
 
-func TestSelectFromList_Successt(t *testing.T) {
+func TestSelectFromList(t *testing.T) {
 	bsm := StubBroadcastSessionsManager()
-	expectedSess := bsm.broadcastSessions[0]
-	sess := bsm.selectFromList()
+	expectedSess := bsm.broadcastSessions[1]
 
 	assert := assert.New(t)
+	assert.Len(bsm.broadcastSessions, 2)
+
+	sess := bsm.selectFromList()
 	assert.Equal(expectedSess, sess)
 	assert.Len(bsm.broadcastSessions, 1)
+
+	bsm = &BroadcastSessionsManager{broadcastSessions: []*BroadcastSession{}, sessLock: &sync.Mutex{}}
+	assert.Len(bsm.broadcastSessions, 0)
+
+	sess = bsm.selectFromList()
+	assert.Nil(sess)
+	assert.Len(bsm.broadcastSessions, 0)
 }
 
-func TestRemoveFromList_Successt(t *testing.T) {
-	bsm := StubBroadcastSessionsManager()
-	expectedSess := bsm.broadcastSessions[0]
-	remove := bsm.broadcastSessions[1]
-	bsm.removeFromList(remove)
-	glog.Error(remove)
-
-	assert := assert.New(t)
-	assert.Equal(expectedSess, bsm.broadcastSessions[0])
-	assert.Len(bsm.broadcastSessions, 1)
-}
-
-func TestAddToList_Success(t *testing.T) {
+func TestAddToList(t *testing.T) {
 	bsm := StubBroadcastSessionsManager()
 	sess := &BroadcastSession{
 		Broadcaster: StubBroadcaster2(),
@@ -583,7 +579,7 @@ func TestAddToList_Success(t *testing.T) {
 }
 
 // note: once selectOrchestrator is integrated into statusOfList(), must beef up this test
-func TestStatusOfList_Success(t *testing.T) {
+func TestStatusOfList(t *testing.T) {
 	bsm := StubBroadcastSessionsManager()
 	bsm.checkStatusOfList()
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

** **NOTE** : includes these changes: https://github.com/livepeer/go-livepeer/pull/799. Will rebase once #799 is merged. **

Edit `selectOrchestrator` to build and return []*BroadcastSessions, not just a BroadcastSession. This will also involve changing how a single BroadcastSession will be stored/created in startSession and in rtmpConnection struct (BroadcastSessionManager will be stored instead of a single BroadcastSession . 

**How did you test each of these updates (required)**
Unit tests

**Does this pull request close any open issues?**
See here for more info: https://docs.google.com/document/d/1KfEWm0z3svw10TrFH9hiMImkXocl3ba_S-8vmX94HNc/edit#


**Checklist:**
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
