### PR TITLE
Option to forward all logs to Grafana’s Loki log aggregator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ jobs:
       - run: go get -u -v go.opencensus.io/stats
       - run: go get -u -v go.opencensus.io/tag
       - run: go get -u -v go.opencensus.io/exporter/prometheus
+      - run: go get -u -v github.com/gogo/protobuf/proto
+      - run: go get -u -v github.com/golang/snappy
+      - run: go get -u -v github.com/livepeer/loki-client/client
 
       - run:
           name: Lint

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/livepeer/go-livepeer/common/log"
 	"github.com/livepeer/go-livepeer/pm"
 
 	ipfslogging "gx/ipfs/QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52/go-log"
@@ -97,6 +98,7 @@ func main() {
 	version := flag.Bool("version", false, "Print out the version")
 	verbosity := flag.String("v", "", "Log verbosity.  {4|5|6}")
 	logIPFS := flag.Bool("logIPFS", false, "Set to true if log files should not be generated") // unused until we re-enable IPFS
+	lokiURL := flag.String("lokiUrl", "", "Grafana's Loki URL to forward logs to")
 
 	// Storage:
 	datadir := flag.String("datadir", "", "data directory")
@@ -111,6 +113,11 @@ func main() {
 
 	flag.Parse()
 	vFlag.Value.Set(*verbosity)
+
+	if *lokiURL != "" {
+		hn, _ := os.Hostname()
+		log.ForwardLogsToLoki(*lokiURL, hn)
+	}
 
 	if *version {
 		fmt.Println("Livepeer Node Version: " + core.LivepeerVersion)

--- a/common/log/loki_forwarder.go
+++ b/common/log/loki_forwarder.go
@@ -1,0 +1,133 @@
+// Package log contains logging utilites.
+// Right now contains only Loki forwarder.
+package log
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	lokiclient "github.com/livepeer/loki-client/client"
+	"github.com/livepeer/loki-client/model"
+)
+
+const glogTimeFormat = "20060102 15:04:05.999999"
+
+var (
+	levels       = []string{"info", "warning", "error", "fatal"}
+	errShortLine = errors.New("Too short line")
+	year         string
+)
+
+// ForwardLogsToLoki forwards data written to `os.Stderr` into `Loki` instance
+func ForwardLogsToLoki(lokiURL, instanceName string) {
+	glog.Infof("Forwarding logs from stderr to Loki instance %s with label instance=%s", lokiURL, instanceName)
+	year = strconv.FormatInt(int64(time.Now().Year()), 10)
+	started := make(chan interface{})
+	go forwardLogsToLoki(started, lokiURL, instanceName)
+	<-started
+}
+
+func logger(v ...interface{}) {
+	fmt.Println(v...)
+}
+
+func forwardLogsToLoki(started chan interface{}, lokiURL, instanceName string) {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		glog.Fatal(err)
+	}
+	baseLabels := model.LabelSet{"instance": instanceName}
+	client, err := lokiclient.NewWithDefaults(lokiURL, baseLabels, logger)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	realStderr := os.Stderr
+	os.Stderr = pw
+	tr := io.TeeReader(pr, realStderr)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	defer func() {
+		pw.Close()
+		os.Stderr = realStderr
+		glog.Warning("Loki forwarding stopped")
+	}()
+	go func() {
+		br := bufio.NewReader(tr)
+		lastLineTime := time.Now()
+		for {
+			line, err := br.ReadString('\n')
+			line = strings.TrimSpace(line)
+			if len(line) > 0 {
+				ts, level, file, caller, message, err := parseLine(line)
+				if err != nil {
+					client.Handle(nil, lastLineTime, line)
+				} else if len(message) > 0 {
+					lastLineTime = ts
+					labels := model.LabelSet{"level": level, "file": file}
+					f := "level=" + level + " caller=" + caller + ` msg="` + strings.Replace(message, `"`, `\"`, -1) + `"`
+					client.Handle(labels, ts, f)
+				}
+			}
+			if err != nil {
+				break
+			}
+		}
+		wg.Done()
+	}()
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt)
+	go waitExit(client, c)
+	close(started)
+	wg.Wait()
+}
+
+func waitExit(client *lokiclient.Client, c chan os.Signal) {
+	<-c
+	client.Stop()
+}
+
+func parseLine(line string) (time.Time, string, string, string, string, error) {
+	var t time.Time
+	var level = "unknown"
+	var file, caller, message string
+	if len(line) < 31 {
+		return t, level, file, caller, message, errShortLine
+	}
+	switch line[0] {
+	case 'I':
+		level = levels[0]
+	case 'W':
+		level = levels[1]
+	case 'E':
+		level = levels[2]
+	case 'F':
+		level = levels[3]
+	}
+	t, err := time.ParseInLocation(glogTimeFormat, year+line[1:21], time.Local)
+	if err != nil {
+		return t, level, file, caller, message, err
+	}
+	ll := line[30:]
+	file = ll[:strings.IndexByte(ll, ':')]
+	bi := strings.IndexByte(ll, ']')
+	if bi+3 >= len(ll) {
+		return t, level, file, caller, message, errShortLine
+	}
+	caller = ll[:bi]
+	message = ll[bi+2:]
+	if message[len(message)-1] == '\n' {
+		message = message[:len(message)-1]
+	}
+
+	return t, level, file, caller, message, nil
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,9 @@ RUN go get github.com/stretchr/testify/mock
 RUN go get -u -v go.opencensus.io/stats
 RUN go get -u -v go.opencensus.io/tag
 RUN go get -u -v go.opencensus.io/exporter/prometheus
+RUN go get -u -v github.com/gogo/protobuf/proto
+RUN go get -u -v github.com/golang/snappy
+RUN go get -u -v github.com/livepeer/loki-client/client
 
 COPY install_ffmpeg.sh install_ffmpeg.sh
 RUN ./install_ffmpeg.sh

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -23,6 +23,9 @@ RUN go get github.com/stretchr/testify/mock
 RUN go get -u -v go.opencensus.io/stats
 RUN go get -u -v go.opencensus.io/tag
 RUN go get -u -v go.opencensus.io/exporter/prometheus
+RUN go get -u -v github.com/gogo/protobuf/proto
+RUN go get -u -v github.com/golang/snappy
+RUN go get -u -v github.com/livepeer/loki-client/client
 
 COPY vendor vendor
 # .dockerbuild.deps contains list of packages used by go-client

--- a/docker/Dockerfile.debian.auto
+++ b/docker/Dockerfile.debian.auto
@@ -21,6 +21,9 @@ RUN go get github.com/stretchr/testify/mock
 RUN go get -u -v go.opencensus.io/stats
 RUN go get -u -v go.opencensus.io/tag
 RUN go get -u -v go.opencensus.io/exporter/prometheus
+RUN go get -u -v github.com/gogo/protobuf/proto
+RUN go get -u -v github.com/golang/snappy
+RUN go get -u -v github.com/livepeer/loki-client/client
 
 COPY . .
 RUN git describe --always --long --dirty > .git.describe


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds forwarding of logs to [Loki](https://github.com/grafana/loki).

**Specific updates (required)**
Currently our logs gets sent to stderr. This update takes intercepts data flow into stderr and send it to [Loki](https://github.com/grafana/loki) server, while also sending it to original stderr. There is no official separate client to Loki, only one that is in main Loki repository itself, but it can't be used as lib - it panics in runtime, so I've cut out minimal client implementation and put it to separate [repo](https://github.com/livepeer/loki-client).

**How did you test each of these updates (required)**
Manually

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass