### PR TITLE
Fix reciprocal S3 uploads

### DIFF
--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -97,12 +97,13 @@ func (os *s3OS) NewSession(path string) OSSession {
 	policy, signature, credential, xAmzDate := createPolicy(os.awsAccessKeyID,
 		os.bucket, os.region, os.awsSecretAccessKey, path)
 	sess := &s3Session{
-		host:       s3Host(os.bucket),
-		key:        path,
-		policy:     policy,
-		signature:  signature,
-		credential: credential,
-		xAmzDate:   xAmzDate,
+		host:        s3Host(os.bucket),
+		key:         path,
+		policy:      policy,
+		signature:   signature,
+		credential:  credential,
+		xAmzDate:    xAmzDate,
+		storageType: net.OSInfo_S3,
 	}
 	sess.fields = s3GetFields(sess)
 	return sess

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -308,13 +308,11 @@ func endRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 			return ErrUnknownStream
 		}
 		cxn.pl.Cleanup()
-		if monitor.Enabled {
-			monitor.LogStreamEndedEvent(cxn.nonce)
-		}
 		glog.Infof("Ended stream with id=%s", mid)
 		cxn.eof <- struct{}{}
 		delete(s.rtmpConnections, mid)
 		if monitor.Enabled {
+			monitor.LogStreamEndedEvent(cxn.nonce)
 			monitor.CurrentSessions(len(s.rtmpConnections))
 		}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The S3 session is missing the storage type specifier. This breaks reciprocal uploads (O uploading into B's S3 and vice versa).

**Specific updates (required)**
- https://github.com/livepeer/go-livepeer/commit/9a2fb4810fe06d4af07b4d90f0e54bb0e43c84e7 Add storage type specifier to S3 session
- https://github.com/livepeer/go-livepeer/commit/9f101b33d53bc3567b548bfb235f51b6c58c9209 Merge RTMP stream end metrics

**How did you test each of these updates (required)**
Manually.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
