### PR TITLE
add missing shebang lines to .sh files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 os=$([ $(uname | grep 'Darwin') ] && echo 'darwin' || echo 'linux');
 curl -s https://api.github.com/repos/livepeer/go-livepeer/releases/latest \
   | grep browser_download_url \

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 set -ex
 
 export PATH="$HOME/compiled/bin":$PATH

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #Test script to run all the tests for continuous integration
 
 cd core

--- a/test_docker.sh
+++ b/test_docker.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/env bash
+
 docker build -t go-livepeer-test . && docker run --rm --name go-livepeer-test-run go-livepeer-test

--- a/transcode_demo.sh
+++ b/transcode_demo.sh
@@ -1,8 +1,10 @@
+#!/usr/bin/env bash
+
 url='localhost:8935'
 manifestID='current'
 
 print_usage() {
-  printf "Usage: use -u to specify the url (default localhost:8935), use -m to specify manifestID (default current.m3u8)" 
+  printf "Usage: use -u to specify the url (default localhost:8935), use -m to specify manifestID (default current.m3u8)"
 }
 
 while getopts ":u:m:h" opt; do


### PR DESCRIPTION
Tiny change to add shebang lines to a few .sh files that were missing them. These wouldn't execute automatically in my fish-shell.