### PR TITLE
Misc TranscoderManager Changes

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -73,9 +73,6 @@ type LivepeerNode struct {
 	pmSessions      map[ManifestID]map[string]bool
 	pmSessionsMutex *sync.Mutex
 	segmentMutex    *sync.RWMutex
-	taskMutex       *sync.RWMutex
-	taskChans       map[int64]TranscoderChan
-	taskCount       int64
 }
 
 //NewLivepeerNode creates a new Livepeer Node. Eth can be nil.
@@ -90,8 +87,6 @@ func NewLivepeerNode(e eth.LivepeerEthClient, wd string, dbh *common.DB) (*Livep
 		pmSessions:      make(map[ManifestID]map[string]bool),
 		pmSessionsMutex: &sync.Mutex{},
 		segmentMutex:    &sync.RWMutex{},
-		taskMutex:       &sync.RWMutex{},
-		taskChans:       make(map[int64]TranscoderChan),
 	}, nil
 
 }

--- a/server/cliserver_test.go
+++ b/server/cliserver_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
@@ -19,7 +20,8 @@ func TestGetStatus(t *testing.T) {
 	n.TranscoderManager = core.NewRemoteTranscoderManager()
 	strm := &common.StubServerStream{}
 	transcoder := core.NewRemoteTranscoder(n, strm, 5)
-	n.TranscoderManager.Register(transcoder)
+	go func() { n.TranscoderManager.Manage(transcoder) }()
+	time.Sleep(1 * time.Millisecond)
 	n.Transcoder = n.TranscoderManager
 	s := NewLivepeerServer("127.0.0.1:1938", "127.0.0.1:8080", n)
 	mux := s.cliWebServerHandlers("addr")

--- a/server/cliserver_test.go
+++ b/server/cliserver_test.go
@@ -19,8 +19,7 @@ func TestGetStatus(t *testing.T) {
 	n.NodeType = core.TranscoderNode
 	n.TranscoderManager = core.NewRemoteTranscoderManager()
 	strm := &common.StubServerStream{}
-	transcoder := core.NewRemoteTranscoder(n, strm, 5)
-	go func() { n.TranscoderManager.Manage(transcoder) }()
+	go func() { n.TranscoderManager.Manage(strm, 5) }()
 	time.Sleep(1 * time.Millisecond)
 	n.Transcoder = n.TranscoderManager
 	s := NewLivepeerServer("127.0.0.1:1938", "127.0.0.1:8080", n)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
A few changes on top of the multi-T branch. The most important functional change is adding the notion of "fatal" errors (description in the following commit message), T retries, and API shrinkage.

Initially made the changes for fatal errors because that area of the code was making me nervous, and the feeling turns out to have been warranted: we had a bug where *any* error, including errors within the segment itself, would cause a T to not be added back on the `remoteTranscoders` list, eventually leading to dangling entries in the `liveTranscoders` table.

Following this, the fatal / non-fatal distinction offered a good opportunity to retry transcoding under certain conditions. We now retry the transcoding for fatal, non-timeout errors. Non-fatal errors are likely to mean an issue with the segment or something external to the transcoder, so we don't retry those.

Unit tests were also missing in this area so added some. Notably, the API felt a bit clunky when writing these tests, since a bit of the responsibility for dealing with remote transcoders was shared between the TranscoderManager and the LivepeerNode.  The notes in the [test code](https://github.com/livepeer/go-livepeer/commit/dc7eabc8d2f105d5a6791211d6cb113585488230#diff-4eb362572b306b3d740814ad1eeb41f5R260) should give an idea of the clunkiness. Fatal errors would lead to permanent removal from the `remoteTranscoders` list as expected, but Unregister would not be automatically called to clean up the `liveTranscoders` table unless we also listen for the EOF within `LivepeerNode.serveTranscoder`. This also exposed a latent blocking bug similar to https://github.com/livepeer/go-livepeer/pull/852 ...

All that being said, we fix a couple things, get a tighter TranscoderManager API, and have an overall reduced footprint for the LivepeerNode.

If all this looks good then I can fix up the rest of the tests that are commented out.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
https://github.com/livepeer/go-livepeer/commit/dc7eabc8d2f105d5a6791211d6cb113585488230 tmanager: Distinguish between fatal and non-fatal errors.
    
    Fatal errors likely indicate something wrong with the transcoder
    itself and will lead to a disconnect. Non-fatal errors are more
    likely to indicate an issue with the source stream or something
    other than the transcoder, so maintain the transcoder within the
    manager.
    
    This also enables safer retries of failed transcodes; only fatal
    errors are retries.

https://github.com/livepeer/go-livepeer/commit/ebd9a2241270912abdc075a1386f8d4f0085a6c2 tmanager: Retry on most fatal errors.

https://github.com/livepeer/go-livepeer/commit/082da834ef4600cb61b214158d57e7ad8d016e77 
tmanager: Collapse Register/Unregister into Manage.  …
This shrinks the API surface area and takes some of the logic
out of the LivepeerNode, which (hopefully) makes the manager
workflow more straightforward.

https://github.com/livepeer/go-livepeer/commit/d8b00a8f9cc44f45355d653667e2b4013abb77a3 tmanager: Move task tracking into manager.  …
Further reduces the footprint of the LivepeerNode.

**How did you test each of these updates (required)**
Unit testing, manual testing


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
