### PR TITLE
Graceful shutdown of transcoder (second try)

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -460,7 +460,7 @@ func main() {
 		orch := core.NewOrchestrator(s.LivepeerNode)
 
 		go func() {
-			server.StartTranscodeServer(orch, *httpAddr, s.HttpMux, n.WorkDir, n.TranscoderManager != nil)
+			server.StartTranscodeServer(orch, *httpAddr, s.HTTPMux, n.WorkDir, n.TranscoderManager != nil)
 			tc <- struct{}{}
 		}()
 

--- a/common/util.go
+++ b/common/util.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -12,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/golang/glog"
 	ffmpeg "github.com/livepeer/lpms/ffmpeg"
+	"google.golang.org/grpc/peer"
 )
 
 var (
@@ -138,4 +140,12 @@ func ProfilesNames(profiles []ffmpeg.VideoProfile) string {
 	}
 	names.Sort()
 	return strings.Join(names, ",")
+}
+
+func GetConnectionAddr(ctx context.Context) string {
+	from := "unknown"
+	if p, ok := peer.FromContext(ctx); ok {
+		from = p.Addr.String()
+	}
+	return from
 }

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -16,7 +16,7 @@ import (
 
 func StubBroadcastSession(transcoder string) *BroadcastSession {
 	return &BroadcastSession{
-		Broadcaster:      StubBroadcaster2(),
+		Broadcaster:      stubBroadcaster2(),
 		ManifestID:       core.RandomManifestID(),
 		OrchestratorInfo: &net.OrchestratorInfo{Transcoder: transcoder},
 	}

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -116,14 +116,14 @@ func TestSelectOrchestrator(t *testing.T) {
 	mid := core.RandomManifestID()
 	storage := drivers.NodeStorage.NewSession(string(mid))
 	pl := core.NewBasicPlaylistManager(mid, storage)
-	if _, err := selectOrchestrator(s.LivepeerNode, pl, 4); err != ErrDiscovery {
+	if _, err := selectOrchestrator(s.LivepeerNode, pl, 4); err != errDiscovery {
 		t.Error("Expected error with discovery")
 	}
 
 	sd := &stubDiscovery{}
 	// Discovery returned no orchestrators
 	s.LivepeerNode.OrchestratorPool = sd
-	if sess, err := selectOrchestrator(s.LivepeerNode, pl, 4); sess != nil || err != ErrNoOrchs {
+	if sess, err := selectOrchestrator(s.LivepeerNode, pl, 4); sess != nil || err != errNoOrchs {
 		t.Error("Expected nil session")
 	}
 
@@ -248,7 +248,7 @@ func TestCreateRTMPStreamHandlerCap(t *testing.T) {
 }
 
 type authWebhookReq struct {
-	url string `json:"url"`
+	URL string `json:"url"`
 }
 
 func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
@@ -407,7 +407,7 @@ func TestEndRTMPStreamHandler(t *testing.T) {
 	st := stream.NewBasicRTMPVideoStream(sid)
 
 	// Nonexistent stream
-	if err := endHandler(u, st); err != ErrUnknownStream {
+	if err := endHandler(u, st); err != errUnknownStream {
 		t.Error("Expected unknown stream ", err)
 	}
 	// Normal case: clean up existing stream
@@ -418,7 +418,7 @@ func TestEndRTMPStreamHandler(t *testing.T) {
 		t.Error("Did  not end stream ", err)
 	}
 	// Check behavior on calling `endHandler` twice
-	if err := endHandler(u, st); err != ErrUnknownStream {
+	if err := endHandler(u, st); err != errUnknownStream {
 		t.Error("Stream was not cleaned up properly ", err)
 	}
 }
@@ -438,7 +438,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 	// Check for invalid node storage
 	oldStorage := drivers.NodeStorage
 	drivers.NodeStorage = nil
-	if err := handler(u, strm); err != ErrStorage {
+	if err := handler(u, strm); err != errStorage {
 		t.Error("Expected storage error ", err)
 	}
 	drivers.NodeStorage = oldStorage
@@ -458,7 +458,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 	}
 
 	//Stream already exists
-	if err := handler(u, strm); err != ErrAlreadyExists {
+	if err := handler(u, strm); err != errAlreadyExists {
 		t.Errorf("Expecting publish error because stream already exists, but got: %v", err)
 	}
 
@@ -618,7 +618,7 @@ func TestRegisterConnection(t *testing.T) {
 	c.On("Senders", addr).Return(big.NewInt(0), nil, nil, nil).Once()
 
 	_, err = s.registerConnection(strm)
-	assert.Equal(ErrLowDeposit, err)
+	assert.Equal(errLowDeposit, err)
 
 	// Remove node storage
 	drivers.NodeStorage = nil
@@ -627,14 +627,14 @@ func TestRegisterConnection(t *testing.T) {
 	c.On("Senders", addr).Return(big.NewInt(1), nil, nil, nil).Once()
 
 	_, err = s.registerConnection(strm)
-	assert.NotEqual(ErrLowDeposit, err)
+	assert.NotEqual(errLowDeposit, err)
 
 	// Switch to off-chain mode
 	s.LivepeerNode.Eth = nil
 
 	// Should return an error if missing node storage
 	_, err = s.registerConnection(strm)
-	assert.Equal(err, ErrStorage)
+	assert.Equal(err, errStorage)
 	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 
 	// normal success case
@@ -653,7 +653,7 @@ func TestRegisterConnection(t *testing.T) {
 
 	// Should return an error if creating another cxn with the same mid
 	_, err = s.registerConnection(strm)
-	assert.Equal(err, ErrAlreadyExists)
+	assert.Equal(err, errAlreadyExists)
 
 	// Ensure thread-safety under -race
 	var wg sync.WaitGroup

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -37,7 +37,7 @@ func TestServeSegment_GetPaymentError(t *testing.T) {
 	handler := serveSegmentHandler(orch)
 
 	headers := map[string]string{
-		PaymentHeader: "foo",
+		paymentHeader: "foo",
 	}
 	resp := httpPostResp(handler, nil, headers)
 	defer resp.Body.Close()
@@ -55,8 +55,8 @@ func TestServeSegment_VerifySegCredsError(t *testing.T) {
 	handler := serveSegmentHandler(orch)
 
 	headers := map[string]string{
-		PaymentHeader: "",
-		SegmentHeader: "foo",
+		paymentHeader: "",
+		segmentHeader: "foo",
 	}
 	resp := httpPostResp(handler, nil, headers)
 	defer resp.Body.Close()
@@ -66,7 +66,7 @@ func TestServeSegment_VerifySegCredsError(t *testing.T) {
 
 	assert := assert.New(t)
 	assert.Equal(http.StatusForbidden, resp.StatusCode)
-	assert.Equal(ErrSegEncoding.Error(), strings.TrimSpace(string(body)))
+	assert.Equal(errSegEncoding.Error(), strings.TrimSpace(string(body)))
 }
 
 func TestServeSegment_ProcessPaymentError(t *testing.T) {
@@ -76,7 +76,7 @@ func TestServeSegment_ProcessPaymentError(t *testing.T) {
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 	}
 	creds, err := genSegCreds(s, &stream.HLSSegment{})
@@ -85,8 +85,8 @@ func TestServeSegment_ProcessPaymentError(t *testing.T) {
 	orch.On("ProcessPayment", mock.Anything, mock.Anything).Return(errors.New("ProcessPayment error"))
 
 	headers := map[string]string{
-		PaymentHeader: "",
-		SegmentHeader: creds,
+		paymentHeader: "",
+		segmentHeader: creds,
 	}
 	resp := httpPostResp(handler, nil, headers)
 	defer resp.Body.Close()
@@ -106,7 +106,7 @@ func TestServeSegment_MismatchHashError(t *testing.T) {
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 	}
 	creds, err := genSegCreds(s, &stream.HLSSegment{})
@@ -115,8 +115,8 @@ func TestServeSegment_MismatchHashError(t *testing.T) {
 	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
 
 	headers := map[string]string{
-		PaymentHeader: "",
-		SegmentHeader: creds,
+		paymentHeader: "",
+		segmentHeader: creds,
 	}
 	resp := httpPostResp(handler, bytes.NewReader([]byte("foo")), headers)
 	defer resp.Body.Close()
@@ -138,7 +138,7 @@ func TestServeSegment_TranscodeSegError(t *testing.T) {
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 	}
 	seg := &stream.HLSSegment{Data: []byte("foo")}
@@ -152,8 +152,8 @@ func TestServeSegment_TranscodeSegError(t *testing.T) {
 	orch.On("TranscodeSeg", md, seg).Return(nil, errors.New("TranscodeSeg error"))
 
 	headers := map[string]string{
-		PaymentHeader: "",
-		SegmentHeader: creds,
+		paymentHeader: "",
+		segmentHeader: creds,
 	}
 	resp := httpPostResp(handler, bytes.NewReader(seg.Data), headers)
 	defer resp.Body.Close()
@@ -182,7 +182,7 @@ func TestServeSegment_OSSaveDataError(t *testing.T) {
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 		Profiles: []ffmpeg.VideoProfile{
 			ffmpeg.P720p60fps16x9,
@@ -211,8 +211,8 @@ func TestServeSegment_OSSaveDataError(t *testing.T) {
 	orch.On("TranscodeSeg", md, seg).Return(tRes, nil)
 
 	headers := map[string]string{
-		PaymentHeader: "",
-		SegmentHeader: creds,
+		paymentHeader: "",
+		segmentHeader: creds,
 	}
 	resp := httpPostResp(handler, bytes.NewReader(seg.Data), headers)
 	defer resp.Body.Close()
@@ -242,7 +242,7 @@ func TestServeSegment_ReturnSingleTranscodedSegmentData(t *testing.T) {
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 		Profiles: []ffmpeg.VideoProfile{
 			ffmpeg.P720p60fps16x9,
@@ -267,8 +267,8 @@ func TestServeSegment_ReturnSingleTranscodedSegmentData(t *testing.T) {
 	orch.On("TranscodeSeg", md, seg).Return(tRes, nil)
 
 	headers := map[string]string{
-		PaymentHeader: "",
-		SegmentHeader: creds,
+		paymentHeader: "",
+		segmentHeader: creds,
 	}
 	resp := httpPostResp(handler, bytes.NewReader(seg.Data), headers)
 	defer resp.Body.Close()
@@ -298,7 +298,7 @@ func TestServeSegment_ReturnMultipleTranscodedSegmentData(t *testing.T) {
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 		Profiles: []ffmpeg.VideoProfile{
 			ffmpeg.P720p60fps16x9,
@@ -325,8 +325,8 @@ func TestServeSegment_ReturnMultipleTranscodedSegmentData(t *testing.T) {
 	orch.On("TranscodeSeg", md, seg).Return(tRes, nil)
 
 	headers := map[string]string{
-		PaymentHeader: "",
-		SegmentHeader: creds,
+		paymentHeader: "",
+		segmentHeader: creds,
 	}
 	resp := httpPostResp(handler, bytes.NewReader(seg.Data), headers)
 	defer resp.Body.Close()
@@ -348,7 +348,7 @@ func TestServeSegment_ReturnMultipleTranscodedSegmentData(t *testing.T) {
 }
 
 func TestSubmitSegment_GenSegCredsError(t *testing.T) {
-	b := StubBroadcaster2()
+	b := stubBroadcaster2()
 	b.signErr = errors.New("Sign error")
 
 	s := &BroadcastSession{
@@ -363,7 +363,7 @@ func TestSubmitSegment_GenSegCredsError(t *testing.T) {
 
 func TestSubmitSegment_HttpPostError(t *testing.T) {
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 		OrchestratorInfo: &net.OrchestratorInfo{
 			Transcoder: "https://foo.com",
@@ -383,7 +383,7 @@ func TestSubmitSegment_Non200StatusCode(t *testing.T) {
 	})
 
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 		OrchestratorInfo: &net.OrchestratorInfo{
 			Transcoder: ts.URL,
@@ -404,7 +404,7 @@ func TestSubmitSegment_ProtoUnmarshalError(t *testing.T) {
 	})
 
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 		OrchestratorInfo: &net.OrchestratorInfo{
 			Transcoder: ts.URL,
@@ -431,7 +431,7 @@ func TestSubmitSegment_TranscodeResultError(t *testing.T) {
 	})
 
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 		OrchestratorInfo: &net.OrchestratorInfo{
 			Transcoder: ts.URL,
@@ -473,7 +473,7 @@ func TestSubmitSegment_Success(t *testing.T) {
 	})
 
 	s := &BroadcastSession{
-		Broadcaster: StubBroadcaster2(),
+		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 		OrchestratorInfo: &net.OrchestratorInfo{
 			Transcoder: ts.URL,

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -53,6 +53,8 @@ func (s *LivepeerServer) setServiceURI(serviceURI string) error {
 	return nil
 }
 
+// StartCliWebserver starts web server for CLI
+// blocks until exit
 func (s *LivepeerServer) StartCliWebserver(bindAddr string) {
 	mux := s.cliWebServerHandlers(bindAddr)
 	srv := &http.Server{


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
On transcoder's shutdown, wait for currently transcoded segments to finish transcoding.
Notify orchestrator about shutdown, so it doesn't send any more tasks.


**How did you test each of these updates (required)**
Manually

**Does this pull request close any open issues?**
Fixes #847


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass