### PR TITLE
Update LPMS API and webhook presets

### DIFF
--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -23,7 +23,8 @@ Webhook can respond with zero body - in that case `ManifestID` for the stream wi
 ```json
 {
     "manifestID": "ManifestIDString",
-    "streamKey":  "SecretKey"
+    "streamKey":  "SecretKey",
+    "presets":    ["Preset", "Names"]
 }
 ```
 and Livepeer node will use returned `ManifestID` for the stream.
@@ -32,5 +33,7 @@ and Livepeer node will use returned `ManifestID` for the stream.
 
 An optional streamKey can be passed in to protect the RTMP from playback. If the
 streamKey is omitted, then a random key is generated.
+
+Presets can be specified to override the default transcoding options. The available presets are listed [here](https://github.com/livepeer/go-livepeer/blob/master/common/videoprofile_ids.go).
 
 There is simple webhook authentication server [example](https://github.com/livepeer/go-livepeer/blob/master/cmd/simple_auth_server/simple_auth_server.go).

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -137,7 +137,7 @@ func (bsm *BroadcastSessionsManager) cleanup() {
 	bsm.sessMap = make(map[string]*BroadcastSession) // prevent segfaults
 }
 
-func NewSessionManager(node *core.LivepeerNode, pl core.PlaylistManager) *BroadcastSessionsManager {
+func NewSessionManager(node *core.LivepeerNode, params *streamParameters, pl core.PlaylistManager) *BroadcastSessionsManager {
 	var poolSize float64
 	if node.OrchestratorPool != nil {
 		poolSize = float64(node.OrchestratorPool.Size())
@@ -146,7 +146,7 @@ func NewSessionManager(node *core.LivepeerNode, pl core.PlaylistManager) *Broadc
 	numOrchs := int(math.Min(poolSize, maxInflight*2))
 	bsm := &BroadcastSessionsManager{
 		sessMap:        make(map[string]*BroadcastSession),
-		createSessions: func() ([]*BroadcastSession, error) { return selectOrchestrator(node, pl, numOrchs) },
+		createSessions: func() ([]*BroadcastSession, error) { return selectOrchestrator(node, params, pl, numOrchs) },
 		sessLock:       &sync.Mutex{},
 		numOrchs:       numOrchs,
 	}
@@ -154,7 +154,7 @@ func NewSessionManager(node *core.LivepeerNode, pl core.PlaylistManager) *Broadc
 	return bsm
 }
 
-func selectOrchestrator(n *core.LivepeerNode, cpl core.PlaylistManager, count int) ([]*BroadcastSession, error) {
+func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core.PlaylistManager, count int) ([]*BroadcastSession, error) {
 	if n.OrchestratorPool == nil {
 		glog.Info("No orchestrators specified; not transcoding")
 		return nil, errDiscovery
@@ -203,8 +203,8 @@ func selectOrchestrator(n *core.LivepeerNode, cpl core.PlaylistManager, count in
 
 		session := &BroadcastSession{
 			Broadcaster:      rpcBcast,
-			ManifestID:       cpl.ManifestID(),
-			Profiles:         BroadcastJobVideoProfiles,
+			ManifestID:       params.mid,
+			Profiles:         params.profiles,
 			OrchestratorInfo: tinfo,
 			OrchestratorOS:   orchOS,
 			BroadcasterOS:    bcastOS,

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -77,11 +77,12 @@ func TestNewSessionManager(t *testing.T) {
 	assert := assert.New(t)
 
 	mid := core.RandomManifestID()
+	params := &streamParameters{}
 	storage := drivers.NewMemoryDriver(nil).NewSession(string(mid))
 	pl := core.NewBasicPlaylistManager(mid, storage)
 
 	// Check empty pool produces expected numOrchs
-	sess := NewSessionManager(n, pl)
+	sess := NewSessionManager(n, params, pl)
 	assert.Equal(0, sess.numOrchs)
 
 	// Check numOrchs up to maximum and a bit beyond
@@ -89,7 +90,7 @@ func TestNewSessionManager(t *testing.T) {
 	n.OrchestratorPool = sd
 	max := int(HTTPTimeout.Seconds()/SegLen.Seconds()) * 2
 	for i := 0; i < 10; i++ {
-		sess = NewSessionManager(n, pl)
+		sess = NewSessionManager(n, params, pl)
 		if i < max {
 			assert.Equal(i, sess.numOrchs)
 		} else {

--- a/vendor/github.com/livepeer/lpms/cmd/example/main.go
+++ b/vendor/github.com/livepeer/lpms/cmd/example/main.go
@@ -27,6 +27,12 @@ import (
 
 var HLSWaitTime = time.Second * 10
 
+type exampleStream string
+
+func (t *exampleStream) StreamID() string {
+	return string(*t)
+}
+
 func randString(n int) string {
 	rand.Seed(time.Now().UnixNano())
 	x := make([]byte, n, n)
@@ -75,8 +81,9 @@ func main() {
 
 	lpms.HandleRTMPPublish(
 		//makeStreamID (give the stream an ID)
-		func(url *url.URL) (strmID string) {
-			return randString(10)
+		func(url *url.URL) stream.AppData {
+			s := exampleStream(randString(10))
+			return &s
 		},
 
 		//gotStream

--- a/vendor/github.com/livepeer/lpms/core/lpms.go
+++ b/vendor/github.com/livepeer/lpms/core/lpms.go
@@ -116,7 +116,7 @@ func (l *LPMS) Start(ctx context.Context) error {
 
 //HandleRTMPPublish offload to the video listener.  To understand how it works, look at videoListener.HandleRTMPPublish.
 func (l *LPMS) HandleRTMPPublish(
-	makeStreamID func(url *url.URL) (strmID string),
+	makeStreamID func(url *url.URL) (strmID stream.AppData),
 	gotStream func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error),
 	endStream func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error) {
 

--- a/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
+++ b/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
@@ -32,6 +32,7 @@ import (
 
 type TestStream struct{}
 
+func (s TestStream) AppData() stream.AppData              { return nil }
 func (s TestStream) String() string                       { return "" }
 func (s *TestStream) GetStreamFormat() stream.VideoFormat { return stream.RTMP }
 func (s *TestStream) GetStreamID() string                 { return "test" }

--- a/vendor/github.com/livepeer/lpms/stream/basic_hls_videostream.go
+++ b/vendor/github.com/livepeer/lpms/stream/basic_hls_videostream.go
@@ -53,6 +53,8 @@ func (s *BasicHLSVideoStream) SetSubscriber(f func(seg *HLSSegment, eof bool)) {
 //GetStreamID returns the streamID
 func (s *BasicHLSVideoStream) GetStreamID() string { return s.strmID }
 
+func (s *BasicHLSVideoStream) AppData() AppData { return nil }
+
 //GetStreamFormat always returns HLS
 func (s *BasicHLSVideoStream) GetStreamFormat() VideoFormat { return HLS }
 

--- a/vendor/github.com/livepeer/lpms/stream/interface.go
+++ b/vendor/github.com/livepeer/lpms/stream/interface.go
@@ -7,7 +7,12 @@ import (
 	"github.com/nareix/joy4/av"
 )
 
+type AppData interface {
+	StreamID() string
+}
+
 type VideoStream interface {
+	AppData() AppData
 	GetStreamID() string
 	GetStreamFormat() VideoFormat
 	String() string

--- a/vendor/github.com/livepeer/lpms/vidlistener/listener.go
+++ b/vendor/github.com/livepeer/lpms/vidlistener/listener.go
@@ -27,7 +27,7 @@ type VidListener struct {
 //gotStream is called when the stream starts.  It gives you access to the stream.
 //endStream is called when the stream ends.  It gives you access to the stream.
 func (self *VidListener) HandleRTMPPublish(
-	makeStreamID func(url *url.URL) (strmID string),
+	makeStreamID func(url *url.URL) (strmID stream.AppData),
 	gotStream func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error,
 	endStream func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error) {
 
@@ -36,7 +36,7 @@ func (self *VidListener) HandleRTMPPublish(
 			glog.V(2).Infof("RTMP server got upstream: %v", conn.URL)
 
 			strmID := makeStreamID(conn.URL)
-			if strmID == "" {
+			if strmID == nil || strmID.StreamID() == "" {
 				conn.Close()
 				return
 			}

--- a/vendor/github.com/livepeer/lpms/vidlistener/listener_test.go
+++ b/vendor/github.com/livepeer/lpms/vidlistener/listener_test.go
@@ -14,6 +14,16 @@ import (
 	joy4rtmp "github.com/nareix/joy4/format/rtmp"
 )
 
+type testStream string
+
+func (t *testStream) StreamID() string {
+	return string(*t)
+}
+func newTestStream() *testStream {
+	t := testStream("testID")
+	return &t
+}
+
 func TestListener(t *testing.T) {
 	server := &joy4rtmp.Server{Addr: ":1937"}
 	listener := &VidListener{RtmpServer: server}
@@ -21,8 +31,8 @@ func TestListener(t *testing.T) {
 
 	listener.HandleRTMPPublish(
 		//makeStreamID
-		func(url *url.URL) string {
-			return "testID"
+		func(url *url.URL) stream.AppData {
+			return newTestStream()
 		},
 		//gotStream
 		func(url *url.URL, rtmpStrm stream.RTMPVideoStream) (err error) {
@@ -72,8 +82,8 @@ func TestListenerError(t *testing.T) {
 	failures := 0
 	badListener.HandleRTMPPublish(
 		//makeStreamID
-		func(url *url.URL) string {
-			return "testID"
+		func(url *url.URL) stream.AppData {
+			return newTestStream()
 		},
 		//gotStream
 		func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error {
@@ -113,9 +123,9 @@ func TestListenerEmptyStreamID(t *testing.T) {
 
 	badListener.HandleRTMPPublish(
 		//makeStreamID
-		func(url *url.URL) string {
+		func(url *url.URL) stream.AppData {
 			// On returning empty stream id connection should be closed
-			return ""
+			return newTestStream()
 		},
 		//gotStream
 		func(url *url.URL, rtmpStrm stream.RTMPVideoStream) error {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Two primary changes here:

1. Changes the `createRTMPStreamIDHandler` to return structured data via the new `streamParameters` struct. This allows us to propagate additional information from the auth webhook. See https://github.com/livepeer/go-livepeer/issues/793 for more details.

This also has the effect of laying groundwork to more cleanly support additional ingest methods beyond RTMP (eg, API-initiated HLS). We can continue to refactor things into the `streamParameters` struct as necessary without being tied to RTMP (eg, populated via API call).

2. To make this change more immediately useful by way of example, added support for presets to the webhook callback. Hopefully this makes extending the webhook to support other features more straightforward (eg, storage).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Refactors the `createRTMPStreamID` to match the updated LPMS API.
- Introduces a `streamParameters` struct that is returned via the handler and used downstream.
- Adds preset support to the webhook callback.
- Cleans up some webhook tests (and adds more tests in support of presets)

**How did you test each of these updates (required)**
* Unit testing
* Manual testing via modifying the `simple_auth_server` sample code

**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/go-livepeer/issues/793

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
