### PR TITLE
Watch for `SIGTERM` signal for graceful shutdown of transcoder

### DIFF
--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -18,6 +18,7 @@ import (
 	"os/signal"
 	"strconv"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -95,7 +96,7 @@ func runTranscoder(n *core.LivepeerNode, orchAddr string, capacity int) error {
 
 	// Catch interrupt signal to shut down transcoder
 	exitc := make(chan os.Signal)
-	signal.Notify(exitc, os.Interrupt)
+	signal.Notify(exitc, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(exitc)
 	go func() {
 		select {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds `SIGTERM` in addition to `SIGINT` to signals being watched for graceful shutdown of transcoder.



**How did you test each of these updates (required)**
Manually

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass