### PR TITLE
cmd, core, pm, server: O creates Price info for B based on txCost for payment redemption

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -13,6 +13,7 @@ package core
 import (
 	"context"
 	"errors"
+	"math/big"
 	"math/rand"
 	"net/url"
 	"sync"
@@ -64,6 +65,7 @@ type LivepeerNode struct {
 	OrchSecret        string
 	Transcoder        Transcoder
 	TranscoderManager *RemoteTranscoderManager
+	PriceInfo         *big.Rat
 
 	// Broadcaster public fields
 	Sender pm.Sender
@@ -88,7 +90,6 @@ func NewLivepeerNode(e eth.LivepeerEthClient, wd string, dbh *common.DB) (*Livep
 		pmSessionsMutex: &sync.Mutex{},
 		segmentMutex:    &sync.RWMutex{},
 	}, nil
-
 }
 
 func (n *LivepeerNode) StartEthServices() error {

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -160,6 +160,20 @@ func (orch *orchestrator) TicketParams(sender ethcommon.Address) (*net.TicketPar
 	}, nil
 }
 
+func (orch *orchestrator) PriceInfo(sender ethcommon.Address) (*big.Rat, error) {
+	if orch.node == nil || orch.node.Recipient == nil {
+		return nil, nil
+	}
+
+	txCostMultiplier, err := orch.node.Recipient.TxCostMultiplier(sender)
+	if err != nil {
+		return nil, err
+	}
+	// pricePerPixel = basePrice * (1 + 1/ txCostMultiplier)
+	overhead := new(big.Rat).Add(big.NewRat(1, 1), new(big.Rat).Inv(txCostMultiplier))
+	return new(big.Rat).Mul(orch.node.PriceInfo, overhead), nil
+}
+
 func NewOrchestrator(n *LivepeerNode) *orchestrator {
 	var addr ethcommon.Address
 	if n.Eth != nil {

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -310,6 +310,16 @@ func (m *MockRecipient) TicketParams(sender ethcommon.Address) (*TicketParams, e
 	return params, args.Error(1)
 }
 
+// TxCostMultiplier returns the transaction cost multiplier for a sender based on sender's MaxFloat
+func (m *MockRecipient) TxCostMultiplier(sender ethcommon.Address) (*big.Rat, error) {
+	args := m.Called(sender)
+	var multiplier *big.Rat
+	if args.Get(0) != nil {
+		multiplier = args.Get(0).(*big.Rat)
+	}
+	return multiplier, args.Error(1)
+}
+
 // MockSender is useful for testing components that depend on pm.Sender
 type MockSender struct {
 	mock.Mock

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -43,6 +43,7 @@ type Orchestrator interface {
 	TranscoderResults(job int64, res *core.RemoteTranscoderResult)
 	ProcessPayment(payment net.Payment, manifestID core.ManifestID) error
 	TicketParams(sender ethcommon.Address) (*net.TicketParams, error)
+	PriceInfo(sender ethcommon.Address) (*big.Rat, error)
 }
 
 type Broadcaster interface {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -75,6 +75,10 @@ func (r *stubOrchestrator) TicketParams(sender ethcommon.Address) (*net.TicketPa
 	return nil, nil
 }
 
+func (r *stubOrchestrator) PriceInfo(sender ethcommon.Address) (*big.Rat, error) {
+	return nil, nil
+}
+
 func newStubOrchestrator() *stubOrchestrator {
 	pk, err := ethcrypto.GenerateKey()
 	if err != nil {
@@ -525,6 +529,14 @@ func (o *mockOrchestrator) TicketParams(sender ethcommon.Address) (*net.TicketPa
 	args := o.Called(sender)
 	if args.Get(0) != nil {
 		return args.Get(0).(*net.TicketParams), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (o *mockOrchestrator) PriceInfo(sender ethcommon.Address) (*big.Rat, error) {
+	args := o.Called(sender)
+	if args.Get(0) != nil {
+		return args.Get(0).(*big.Rat), args.Error(1)
 	}
 	return nil, args.Error(1)
 }

--- a/test_args.sh
+++ b/test_args.sh
@@ -89,12 +89,31 @@ res=0
 ./livepeer -orchestrator -serviceAddr 127.0.0.1:8935 || res=$?
 [ $res -ne 0 ]
 
+# Orchestrator needs to explicitly set PricePerUnit otherwise it will default to 0 resulting in a fatal error
+res=0
+./livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -network rinkeby $ETH_ARGS || res=$?
+[ $res -ne 0 ]
+# Orchestrator needs PricePerUnit > 0 
+res=0
+./livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pricePerUnit 0 -network rinkeby $ETH_ARGS || res=$?
+[ $res -ne 0 ]
+res=0
+./livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pricePerUnit -5 -network rinkeby $ETH_ARGS || res=$?
+[ $res -ne 0 ]
+# Orchestrator needs PixelsPerUnit > 0
+res=0
+./livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pixelsPerUnit 0 -pricePerUnit 5 -network rinkeby $ETH_ARGS || res=$?
+[ $res -ne 0 ]
+res=0
+./livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pixelsPerUnit -5 -pricePerUnit 5 -network rinkeby $ETH_ARGS || res=$?
+[ $res -ne 0 ]
+
 # transcoder needs -orchSecret
 res=0
 ./livepeer -transcoder || res=$?
 [ $res -ne 0 ]
 
-# exit early if webhhok url is not http
+# exit early if webhook url is not http
 res=0
 ./livepeer -broadcaster -authWebhookUrl tcp://host/ || res=$?
 [ $res -ne 0 ]


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Allows an `Orchestator` to define a `pixelsPerUnit` and `pricePerUnit` flag which results as an O's base `Price Per Pixel`, represented as a `big.Rat`. Defining both the amount of pixels in a unit and the price for it allows smaller price granularity than `1 wei / pixel`. This baseInfo is then used to create `PriceInfo` for a `BroadCaster` based on the transaction cost to redeem a payment on-chain (see #904). This PriceInfo changes depending on how the `MaxFloat` from a B to an O affects the transaction cost for payment redemption. 

When a B has adequate `MaxFloat` to an O to cover for its `faceValue` the overhead will always be 1% 
-> `basePricePerPixel * 1,01`

When a B has only half of the `MaxFloat` to cover for an O's `faceValue` the overhead becomes double of that , or 2%. 
-> `basePricePerPixel * 1,02`


**Specific updates (required)**
- Added Flags in `cmd` allowing an O to set `pixelsPerUnit` and `pricePerUnit`. Added error handling if either is set to 0. (Defaults : `PricePerUnit = 0` , `PixelsPerUnit = 1`. This means an Orchestrator will have to explicitly set a price, as it defaults to 0 to prevent the node starting up with 1 wei/pixel unknowingly.
- Added a `priceInfo` field to the `LivepeerNode` struct to set `PriceInfo` for an `Orchestrator` after calling `NewOrchestrator(node)`
- Created a new method in `recipient.go` , `r.txCost()`, which calculates the transaction cost based on the current `gasPrice` (through `gasPriceMonitor`) and `r.cfg.RedeemGas`. This method is introduced to keep the code DRY and is now used in both `r.faceValue()` and `r.TxCostMultiplier`
- Created a new method in `recipient.go` , `r.TxMultiplier(sender)` which dynamically calculates and returns the `TxCostMultiplier` based upon the sender's `MaxFloat`
- added `r.TxMultiplier(sender)` to the `Recipient` interface
- Created a new method in `orchestrator.go`, `orch.PriceInfo(sender)` which returns an orchestrator's priceInfo depending on the sender based on the `PriceInfo` set by an orchestrator, scaled by multiplying `1+ 1/TxCostMultiplier`.
- Added `orch.PriceInfo` to the `Orchestrator` interface in `rpc.go`
- Added unit tests for `orch.PriceInfo` and `r.TxCostMultiplier()`
- Added tests in `test_args.sh` for testing the new flags and its fatal errors. 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Ran unit tests 
- Ran argument tests 
- Manually started a rinkeby node setting `PricePerUnit` 
_Ubuntu 18.04 LTS Bionic Beaver
go1.12.2 linux/amd64_

**Does this pull request close any open issues?**
Fixes #894 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in ~~OSX~~ _Ubuntu_ and devenv
- [x] All tests in `./test.sh` pass
