### PR TITLE
`m3u8` dependency move to Livepeer's repo

### DIFF
--- a/.dockerbuild.deps
+++ b/.dockerbuild.deps
@@ -84,7 +84,7 @@ github.com/aws/aws-sdk-go/service/s3
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/vendor/github.com/jmespath/go-jmespath
 github.com/beorn7/perks/quantile
-github.com/ericxtang/m3u8
+github.com/livepeer/m3u8
 github.com/golang/glog
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/ptypes

--- a/core/playlistmanager.go
+++ b/core/playlistmanager.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/drivers"
 	ffmpeg "github.com/livepeer/lpms/ffmpeg"
+	"github.com/livepeer/m3u8"
 )
 
 const LIVE_LIST_LENGTH uint = 6

--- a/core/playlistmanager_test.go
+++ b/core/playlistmanager_test.go
@@ -5,9 +5,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/livepeer/go-livepeer/drivers"
 	ffmpeg "github.com/livepeer/lpms/ffmpeg"
+	"github.com/livepeer/m3u8"
 )
 
 func TestGetMasterPlaylist(t *testing.T) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/livepeer/go-livepeer
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get update && apt-get -y install build-essential pkg-config autoconf nodejs gnutls-dev
 RUN go get github.com/golang/glog
-RUN go get -u -v github.com/ericxtang/m3u8
+RUN go get -u -v github.com/livepeer/m3u8
 RUN go get github.com/aws/aws-sdk-go/aws
 RUN go get -u google.golang.org/grpc
 RUN go get github.com/pkg/errors

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -25,7 +25,7 @@ ENV PKG_CONFIG_PATH /root/compiled/lib/pkgconfig
 WORKDIR /go/src/github.com/livepeer/go-livepeer
 
 RUN go get github.com/golang/glog
-RUN go get github.com/ericxtang/m3u8
+RUN go get github.com/livepeer/m3u8
 RUN go get github.com/aws/aws-sdk-go/aws
 RUN go get -u google.golang.org/grpc
 RUN go get github.com/pkg/errors

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -15,7 +15,7 @@ ENV PKG_CONFIG_PATH /root/compiled/lib/pkgconfig
 WORKDIR /go/src/github.com/livepeer/go-livepeer
 
 RUN go get github.com/golang/glog
-RUN go get -u -v github.com/ericxtang/m3u8
+RUN go get -u -v github.com/livepeer/m3u8
 RUN go get github.com/aws/aws-sdk-go/aws
 RUN go get -u google.golang.org/grpc
 RUN go get github.com/pkg/errors

--- a/docker/Dockerfile.debian.auto
+++ b/docker/Dockerfile.debian.auto
@@ -13,7 +13,7 @@ ENV PKG_CONFIG_PATH /root/compiled/lib/pkgconfig
 WORKDIR /go/src/github.com/livepeer/go-livepeer
 
 RUN go get github.com/golang/glog
-RUN go get -u -v github.com/ericxtang/m3u8
+RUN go get -u -v github.com/livepeer/m3u8
 RUN go get github.com/aws/aws-sdk-go/aws
 RUN go get -u google.golang.org/grpc
 RUN go get github.com/pkg/errors

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -3,7 +3,7 @@
 set -e
 
 go get -u -v contrib.go.opencensus.io/exporter/prometheus
-go get -u -v github.com/ericxtang/m3u8
+go get -u -v github.com/livepeer/m3u8
 go get -u -v go.opencensus.io/stats
 go get -u -v go.opencensus.io/tag
 go get -u google.golang.org/grpc

--- a/net/interface.go
+++ b/net/interface.go
@@ -3,7 +3,7 @@ package net
 import (
 	"net/url"
 
-	"github.com/ericxtang/m3u8"
+	"github.com/livepeer/m3u8"
 )
 
 type OrchestratorPool interface {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -25,7 +25,6 @@ import (
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/net"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
@@ -34,6 +33,7 @@ import (
 	"github.com/livepeer/lpms/segmenter"
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/lpms/vidplayer"
+	"github.com/livepeer/m3u8"
 )
 
 var errAlreadyExists = errors.New("StreamAlreadyExists")

--- a/vendor/github.com/livepeer/lpms/cmd/example/main.go
+++ b/vendor/github.com/livepeer/lpms/cmd/example/main.go
@@ -17,12 +17,12 @@ import (
 
 	"github.com/livepeer/lpms/transcoder"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
 	"github.com/livepeer/lpms/core"
 	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/livepeer/lpms/segmenter"
 	"github.com/livepeer/lpms/stream"
+	"github.com/livepeer/m3u8"
 )
 
 var HLSWaitTime = time.Second * 10

--- a/vendor/github.com/livepeer/lpms/core/lpms.go
+++ b/vendor/github.com/livepeer/lpms/core/lpms.go
@@ -10,13 +10,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
 	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/livepeer/lpms/segmenter"
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/lpms/vidlistener"
 	"github.com/livepeer/lpms/vidplayer"
+	"github.com/livepeer/m3u8"
 
 	joy4rtmp "github.com/nareix/joy4/format/rtmp"
 )

--- a/vendor/github.com/livepeer/lpms/ffmpeg/videoprofile.go
+++ b/vendor/github.com/livepeer/lpms/ffmpeg/videoprofile.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
+	"github.com/livepeer/m3u8"
 )
 
 //Standard Profiles:

--- a/vendor/github.com/livepeer/lpms/segmenter/video_segmenter.go
+++ b/vendor/github.com/livepeer/lpms/segmenter/video_segmenter.go
@@ -13,10 +13,10 @@ import (
 
 	"path"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
 	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/livepeer/lpms/stream"
+	"github.com/livepeer/m3u8"
 	"github.com/nareix/joy4/av"
 )
 

--- a/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
+++ b/vendor/github.com/livepeer/lpms/segmenter/video_segmenter_test.go
@@ -19,11 +19,11 @@ import (
 
 	"strings"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
 	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/lpms/vidplayer"
+	"github.com/livepeer/m3u8"
 	"github.com/nareix/joy4/av"
 	"github.com/nareix/joy4/av/avutil"
 	"github.com/nareix/joy4/format"

--- a/vendor/github.com/livepeer/lpms/stream/basic_hls_video_manifest.go
+++ b/vendor/github.com/livepeer/lpms/stream/basic_hls_video_manifest.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
+	"github.com/livepeer/m3u8"
 )
 
 var ErrVideoManifest = errors.New("ErrVideoManifest")

--- a/vendor/github.com/livepeer/lpms/stream/basic_hls_video_test.go
+++ b/vendor/github.com/livepeer/lpms/stream/basic_hls_video_test.go
@@ -3,7 +3,7 @@ package stream
 import (
 	"testing"
 
-	"github.com/ericxtang/m3u8"
+	"github.com/livepeer/m3u8"
 )
 
 func TestAddAndRemove(t *testing.T) {

--- a/vendor/github.com/livepeer/lpms/stream/basic_hls_videostream.go
+++ b/vendor/github.com/livepeer/lpms/stream/basic_hls_videostream.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ericxtang/m3u8"
+	"github.com/livepeer/m3u8"
 )
 
 const DefaultHLSStreamCap = uint(500)

--- a/vendor/github.com/livepeer/lpms/stream/hls.go
+++ b/vendor/github.com/livepeer/lpms/stream/hls.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/ericxtang/m3u8"
+	"github.com/livepeer/m3u8"
 )
 
 var ErrNotFound = errors.New("Not Found")

--- a/vendor/github.com/livepeer/lpms/stream/interface.go
+++ b/vendor/github.com/livepeer/lpms/stream/interface.go
@@ -3,7 +3,7 @@ package stream
 import (
 	"context"
 
-	"github.com/ericxtang/m3u8"
+	"github.com/livepeer/m3u8"
 	"github.com/nareix/joy4/av"
 )
 

--- a/vendor/github.com/livepeer/lpms/stream/stream.go
+++ b/vendor/github.com/livepeer/lpms/stream/stream.go
@@ -7,7 +7,7 @@ import (
 
 	"time"
 
-	"github.com/ericxtang/m3u8"
+	"github.com/livepeer/m3u8"
 )
 
 var ErrBufferFull = errors.New("Stream Buffer Full")

--- a/vendor/github.com/livepeer/lpms/vidplayer/player.go
+++ b/vendor/github.com/livepeer/lpms/vidplayer/player.go
@@ -16,9 +16,9 @@ import (
 
 	"time"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/golang/glog"
 	"github.com/livepeer/lpms/stream"
+	"github.com/livepeer/m3u8"
 	joy4rtmp "github.com/nareix/joy4/format/rtmp"
 )
 

--- a/vendor/github.com/livepeer/lpms/vidplayer/player_test.go
+++ b/vendor/github.com/livepeer/lpms/vidplayer/player_test.go
@@ -10,8 +10,8 @@ import (
 
 	"net/url"
 
-	"github.com/ericxtang/m3u8"
 	"github.com/livepeer/lpms/stream"
+	"github.com/livepeer/m3u8"
 	joy4rtmp "github.com/nareix/joy4/format/rtmp"
 )
 


### PR DESCRIPTION

**What does this pull request do? Explain your changes. (required)**
All links changed from
`github.com/ericxtang/m3u8` to
`github.com/livepeer/m3u8`


**Specific updates (required)**
Only links changes


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
