### PR TITLE
ci: build binaries with Ubuntu 16.04

### DIFF
--- a/docker/Dockerfile.build-linux
+++ b/docker/Dockerfile.build-linux
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-devel-ubuntu18.04
+FROM nvidia/cuda:10.1-devel-ubuntu16.04
 
 ENV PATH "/usr/lib/go-1.12/bin:/go/bin:${PATH}"
 ENV PKG_CONFIG_PATH "/root/compiled/lib/pkgconfig"


### PR DESCRIPTION
Some of our GPU testing servers have Ubuntu 16.04 installed, which was incompatible with the binaries we were using. There are more sophisticated ways to fix this but tweaking the Docker base fixes it for the CI builds at least.