### PR TITLE
cmd, discovery, server: allow B to set MaxBroadcastPrice to filter acceptable O's stored in cache

### DIFF
--- a/cmd/livepeer_cli/wizard_broadcast.go
+++ b/cmd/livepeer_cli/wizard_broadcast.go
@@ -51,8 +51,14 @@ func (w *wizard) allTranscodingOptions() map[int]string {
 }
 
 func (w *wizard) setBroadcastConfig() {
-	fmt.Printf("Enter broadcast max price per segment in Wei - ")
-	maxPricePerSegment := w.readBigInt()
+	fmt.Printf("Enter a maximum transcoding price per pixel, in wei per pixels (pricePerUnit / pixelsPerUnit).\n")
+	fmt.Printf("eg. 1 wei / 10 pixels = 0,1 wei per pixel \n")
+	fmt.Printf("\n")
+	fmt.Printf("Enter amount of pixels that make up a single unit (default: 1 pixel) - ")
+	pixelsPerUnit := w.readDefaultInt(1)
+	fmt.Printf("\n")
+	fmt.Printf("Enter the maximum price to pay for %d pixels in Wei (required) - ", pixelsPerUnit)
+	maxPricePerUnit := w.readDefaultInt(0)
 
 	opts := w.allTranscodingOptions()
 	if opts == nil {
@@ -69,7 +75,8 @@ func (w *wizard) setBroadcastConfig() {
 	}
 
 	val := url.Values{
-		"maxPricePerSegment": {fmt.Sprintf("%v", maxPricePerSegment.String())},
+		"pixelsPerUnit":      {fmt.Sprintf("%v", strconv.Itoa(pixelsPerUnit))},
+		"maxPricePerUnit":    {fmt.Sprintf("%v", strconv.Itoa(maxPricePerUnit))},
 		"transcodingOptions": {fmt.Sprintf("%v", transOpts)},
 	}
 

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -360,7 +360,7 @@ func (w *wizard) getEthBalance() string {
 	return e
 }
 
-func (w *wizard) getBroadcastConfig() (*big.Int, string) {
+func (w *wizard) getBroadcastConfig() (*big.Rat, string) {
 	resp, err := http.Get(fmt.Sprintf("http://%v:%v/getBroadcastConfig", w.host, w.httpPort))
 	if err != nil {
 		glog.Errorf("Error getting broadcast config: %v", err)
@@ -375,7 +375,7 @@ func (w *wizard) getBroadcastConfig() (*big.Int, string) {
 	}
 
 	var config struct {
-		MaxPricePerSegment *big.Int
+		MaxPrice           *big.Rat
 		TranscodingOptions string
 	}
 	err = json.Unmarshal(result, &config)
@@ -384,7 +384,7 @@ func (w *wizard) getBroadcastConfig() (*big.Int, string) {
 		return nil, ""
 	}
 
-	return config.MaxPricePerSegment, config.TranscodingOptions
+	return config.MaxPrice, config.TranscodingOptions
 }
 
 func (w *wizard) getOrchestratorInfo() (lpTypes.Transcoder, error) {

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -23,6 +23,25 @@ import (
 	"github.com/livepeer/lpms/stream"
 )
 
+var BroadcastCfg = &BroadcastConfig{}
+
+type BroadcastConfig struct {
+	maxPrice *big.Rat
+	mu       sync.RWMutex
+}
+
+func (cfg *BroadcastConfig) MaxPrice() *big.Rat {
+	cfg.mu.RLock()
+	defer cfg.mu.RUnlock()
+	return cfg.maxPrice
+}
+
+func (cfg *BroadcastConfig) SetMaxPrice(price *big.Rat) {
+	cfg.mu.RLock()
+	defer cfg.mu.RUnlock()
+	cfg.maxPrice = price
+}
+
 type BroadcastSessionsManager struct {
 	// Accessing or changing any of the below requires ownership of this mutex
 	sessLock *sync.Mutex

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -55,7 +55,6 @@ const StreamKeyBytes = 6
 const SegLen = 2 * time.Second
 const BroadcastRetry = 15 * time.Second
 
-var BroadcastPrice = big.NewInt(1)
 var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmpeg.P360p30fps16x9}
 
 var AuthWebhookURL string

--- a/test_args.sh
+++ b/test_args.sh
@@ -45,6 +45,11 @@ run_lp -broadcaster -network rinkeby $ETH_ARGS
 [ -d "$DEFAULT_DATADIR"/rinkeby ]
 kill $pid
 
+# Error if flags to set MaxBroadcastPrice aren't provided correctly
+res=0
+./livepeer -broadcaster -network rinkeby $ETH_ARGS -maxPricePerUnit 0 -pixelsPerUnit -5 || res=$?
+[ $res -ne 0 ]
+
 run_lp -broadcaster -network mainnet $ETH_ARGS
 [ -d "$DEFAULT_DATADIR"/mainnet ]
 kill $pid


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Allows a broadcaster to set a maximum price preference `BroadcastPrice *MaxBroadcastPrice` (not required) in the same format as #916 either by specifying the flags `maxPricePerUnit` and `pixelsPerUnit` on node startup, or through the CLI. 

When `orchestratorPool.getOrchestrators` is called on the orchestrators cached in the DBcache, it will filter orchestrators based on this max price setting (if set). 

**Specific updates (required)**
- Added `maxPricePerUnit` flag to `cmd/livepeer.go`
- Added setting `maxPricePerUnit` and `pixelsPerUnit` through broadcaster CLI config 
- Added a predicate function to `orchestratorPool` struct
- Added a new constructor to create an `orchestratorPool` with a predicate function `NewOrchestratorPoolWithPred`
- Adjusted `DBOrchestratorPoolCache.getOrchestrators` to initiate `orchestratorPool` with a predicate function through the new constructor `NewOrchestratorPoolWithPred`. The predicate function returns true when B's `MaxBroadcastPrice` isn't set, or is greater than Orchestrators `PriceInfo`
- Adjusted exported variable in `server` package `BroadcastPrice` to be a struct of type `MaxBroadcastPrice` consisting out of a `*big.Rat` and `sync.RWMutex` 

**How did you test each of these updates (required)**
Added unit tests (80.3 % coverage for `discovery` package)
Added test to `./test_args.sh` for when flags are set , but incorrectly provided 

**Does this pull request close any open issues?**
Fixes #906 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
