### PR TITLE
Orchestrator acceptable PM ticket error handling

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -55,6 +55,8 @@ var (
 	smCleanupInterval = 1 * time.Minute
 	// The time to live for cached max float values for PM senders (else they will be cleaned up)
 	smTTL = 3600 // 1 minute
+	// smMaxErrCount is the maximum number of acceptable errors tolerated by a PM recipient for a sender
+	smMaxErrCount = 3
 )
 
 const RtmpPort = "1935"
@@ -364,7 +366,7 @@ func main() {
 			}
 			defer gpm.Stop()
 
-			sm := pm.NewSenderMonitor(n.Eth.Account().Address, n.Eth, smCleanupInterval, smTTL)
+			sm := pm.NewSenderMonitor(n.Eth.Account().Address, n.Eth, smCleanupInterval, smTTL, smMaxErrCount)
 			// Start sender monitor
 			sm.Start()
 			defer sm.Stop()

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -360,7 +360,7 @@ func main() {
 			validator := pm.NewValidator(sigVerifier, n.Eth)
 			gpm := eth.NewGasPriceMonitor(backend, gpmPollingInterval)
 			// Start gas price monitor
-			if err := gpm.Start(context.Background()); err != nil {
+			if _, err := gpm.Start(context.Background()); err != nil {
 				glog.Errorf("error starting gas price monitor: %v", err)
 				return
 			}

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -360,13 +360,14 @@ func main() {
 			validator := pm.NewValidator(sigVerifier, n.Eth)
 			gpm := eth.NewGasPriceMonitor(backend, gpmPollingInterval)
 			// Start gas price monitor
-			if _, err := gpm.Start(context.Background()); err != nil {
+			gasPriceUpdate, err := gpm.Start(context.Background())
+			if err != nil {
 				glog.Errorf("error starting gas price monitor: %v", err)
 				return
 			}
 			defer gpm.Stop()
 
-			sm := pm.NewSenderMonitor(n.Eth.Account().Address, n.Eth, smCleanupInterval, smTTL, smMaxErrCount)
+			sm := pm.NewSenderMonitor(n.Eth.Account().Address, n.Eth, gasPriceUpdate, smCleanupInterval, smTTL, smMaxErrCount)
 			// Start sender monitor
 			sm.Start()
 			defer sm.Stop()

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -662,14 +662,13 @@ func TestProcessPayment_GivenConcurrentWinningTickets_RedeemsAll(t *testing.T) {
 	recipient.AssertNumberOfCalls(t, "RedeemWinningTicket", numTickets)
 }
 
-func TestProcessPayment_GivenReceiveTicketError_ReturnsFirstError(t *testing.T) {
+func TestProcessPayment_GivenReceiveTicketError_ReturnsError(t *testing.T) {
 	n, _ := NewLivepeerNode(nil, "", nil)
 	recipient := new(pm.MockRecipient)
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	manifestID := ManifestID("some manifest")
-	expErr := errors.New("ReceiveTicket error")
-	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", false, expErr).Once()
+	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", false, errors.New("ReceiveTicket error")).Once()
 	// This should trigger a redemption even though it returns an error because it still returns won = true
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", true, errors.New("not first error")).Once()
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", true, nil).Once()
@@ -689,7 +688,7 @@ func TestProcessPayment_GivenReceiveTicketError_ReturnsFirstError(t *testing.T) 
 
 	time.Sleep(time.Millisecond * 20)
 	assert := assert.New(t)
-	assert.EqualError(err, expErr.Error())
+	assert.EqualError(err, "error receiving tickets with payment")
 	recipient.AssertNumberOfCalls(t, "RedeemWinningTicket", 2)
 }
 

--- a/pm/errors.go
+++ b/pm/errors.go
@@ -1,0 +1,32 @@
+package pm
+
+// Error is an interface that describes methods for a PM related error that
+// may be acceptable depending on the type of underlying error
+type Error interface {
+	error
+
+	// Acceptable returns whether the error is acceptable
+	Acceptable() bool
+}
+
+type receiveError struct {
+	err        error
+	acceptable bool
+}
+
+func newReceiveError(err error, acceptable bool) *receiveError {
+	return &receiveError{
+		err:        err,
+		acceptable: acceptable,
+	}
+}
+
+// Error returns the underlying error as a string
+func (re *receiveError) Error() string {
+	return re.err.Error()
+}
+
+// Acceptable returns whether the error is acceptable
+func (re *receiveError) Acceptable() bool {
+	return re.acceptable
+}

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -274,10 +274,10 @@ func (r *recipient) acceptTicket(ticket *Ticket, sig []byte, recipientRand *big.
 		// When a winning ticket is redeemed, the ticket's recipientRand is invalidated
 		// and the sender must send tickets with a new seed, but there could be a delay
 		// before the sender is notified of the new seed.
-		//
-		// TODO(yondonfu): Track the number of these types of errors to determine
-		// whether we should accept more of these types of errors
-		return errors.Errorf("invalid already revealed recipientRand %v", recipientRand)
+		return newReceiveError(
+			errors.Errorf("invalid already revealed recipientRand %v", recipientRand),
+			r.sm.AcceptErr(ticket.Sender),
+		)
 	}
 
 	if err := r.updateSenderNonce(recipientRand, ticket.SenderNonce); err != nil {
@@ -294,10 +294,10 @@ func (r *recipient) acceptTicket(ticket *Ticket, sig []byte, recipientRand *big.
 		// When the gas price changes or the sender's max float changes, the required faceValue
 		// also changes and the sender must send tickets with the new faceValue, but there could
 		// be a delay before the sender is notified of the new faceValue.
-		//
-		// TODO(yondonfu): Track the number of these types of errors to determine
-		// whether we should accept more of these types of errors
-		return errors.Errorf("invalid ticket faceValue %v", ticket.FaceValue)
+		return newReceiveError(
+			errors.Errorf("invalid ticket faceValue %v", ticket.FaceValue),
+			r.sm.AcceptErr(ticket.Sender),
+		)
 	}
 
 	if ticket.WinProb.Cmp(r.winProb(faceValue)) != 0 {
@@ -305,10 +305,10 @@ func (r *recipient) acceptTicket(ticket *Ticket, sig []byte, recipientRand *big.
 		// When the gas price changes or the sender's max float changes, the required winProb
 		// also changes and the sender must send tickets with the new winProb, but there could
 		// be a delay before the sender is notified of the new winProb.
-		//
-		// TODO(yondonfu): Track the number of these types of errors to determine
-		// whether we should accept more of these types of errors
-		return errors.Errorf("invalid ticket winProb %v", ticket.WinProb)
+		return newReceiveError(
+			errors.Errorf("invalid ticket winProb %v", ticket.WinProb),
+			r.sm.AcceptErr(ticket.Sender),
+		)
 	}
 
 	return nil

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -130,6 +130,11 @@ func (sm *senderMonitor) AddFloat(addr ethcommon.Address, amount *big.Int) error
 
 	sm.senders[addr].pendingAmount.Sub(pendingAmount, amount)
 
+	// Reset errCount for sender
+	// An updated max float results in updated ticket params
+	// The sender could plausibly send tickets that trigger acceptable errors
+	sm.senders[addr].errCount = 0
+
 	// Whenever a sender's max float increases, signal the updated max float to the
 	// sender's associated ticket queue in case there are queued tickets that
 	// can be redeemed
@@ -150,6 +155,11 @@ func (sm *senderMonitor) SubFloat(addr ethcommon.Address, amount *big.Int) error
 	// Adding to pendingAmount = subtracting from max float
 	pendingAmount := sm.senders[addr].pendingAmount
 	sm.senders[addr].pendingAmount.Add(pendingAmount, amount)
+
+	// Reset errCount for sender
+	// An updated max float results in updated ticket params
+	// The sender could plausibly send tickets that trigger acceptable errors
+	sm.senders[addr].errCount = 0
 
 	return nil
 }

--- a/pm/sendermonitor_test.go
+++ b/pm/sendermonitor_test.go
@@ -25,7 +25,7 @@ var increaseTime = func(sec int64) {
 func TestMaxFloat(t *testing.T) {
 	claimant := RandAddress()
 	b := newStubBroker()
-	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600)
+	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600, 3)
 	sm.Start()
 	defer sm.Stop()
 
@@ -62,7 +62,7 @@ func TestMaxFloat(t *testing.T) {
 func TestSubFloat(t *testing.T) {
 	claimant := RandAddress()
 	b := newStubBroker()
-	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600)
+	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600, 3)
 	sm.Start()
 	defer sm.Stop()
 
@@ -111,7 +111,7 @@ func TestSubFloat(t *testing.T) {
 func TestAddFloat(t *testing.T) {
 	claimant := RandAddress()
 	b := newStubBroker()
-	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600)
+	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600, 3)
 	sm.Start()
 	defer sm.Stop()
 
@@ -169,7 +169,7 @@ func TestAddFloat(t *testing.T) {
 func TestQueueTicketAndSignalMaxFloat(t *testing.T) {
 	claimant := RandAddress()
 	b := newStubBroker()
-	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600)
+	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600, 3)
 	sm.Start()
 	defer sm.Stop()
 
@@ -242,7 +242,7 @@ func TestQueueTicketAndSignalMaxFloat(t *testing.T) {
 func TestCleanup(t *testing.T) {
 	claimant := RandAddress()
 	b := newStubBroker()
-	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 2)
+	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 2, 3)
 	sm.Start()
 	defer sm.Stop()
 
@@ -369,4 +369,30 @@ func TestCleanup(t *testing.T) {
 
 	assert.Equal(reserve4, mf1)
 	assert.Equal(reserve5, mf2)
+}
+
+func TestAcceptErr(t *testing.T) {
+	claimant := RandAddress()
+	addr := RandAddress()
+	b := newStubBroker()
+	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 2, 1)
+
+	assert := assert.New(t)
+
+	// Cache remote sender
+	reserve := big.NewInt(10)
+	b.SetReserve(addr, reserve)
+	sm.MaxFloat(addr)
+
+	// Test errCount for addr below maxErrCount
+	ok := sm.AcceptErr(addr)
+	assert.True(ok)
+
+	// Test errCount for addr equal to maxErrCount
+	ok = sm.AcceptErr(addr)
+	assert.False(ok)
+
+	// Test errCount did not increase when errCount = maxErrCount
+	ok = sm.AcceptErr(addr)
+	assert.False(ok)
 }

--- a/pm/sendermonitor_test.go
+++ b/pm/sendermonitor_test.go
@@ -62,7 +62,7 @@ func TestMaxFloat(t *testing.T) {
 func TestSubFloat(t *testing.T) {
 	claimant := RandAddress()
 	b := newStubBroker()
-	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600, 3)
+	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600, 1)
 	sm.Start()
 	defer sm.Stop()
 
@@ -93,6 +93,12 @@ func TestSubFloat(t *testing.T) {
 
 	// Test value cached
 
+	// Set errCount to be non-zero
+	ok := sm.AcceptErr(addr)
+	assert.True(ok)
+	ok = sm.AcceptErr(addr)
+	assert.False(ok)
+
 	// Change stub broker value
 	// SenderMonitor should still use cached value which
 	// is different
@@ -107,11 +113,15 @@ func TestSubFloat(t *testing.T) {
 		new(big.Int).Sub(reserve, new(big.Int).Mul(amount, big.NewInt(2))),
 		mf,
 	)
+
+	// Test resetting errCount
+	ok = sm.AcceptErr(addr)
+	assert.True(ok)
 }
 func TestAddFloat(t *testing.T) {
 	claimant := RandAddress()
 	b := newStubBroker()
-	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600, 3)
+	sm := NewSenderMonitor(claimant, b, 5*time.Minute, 3600, 1)
 	sm.Start()
 	defer sm.Stop()
 
@@ -158,12 +168,22 @@ func TestAddFloat(t *testing.T) {
 	err = sm.SubFloat(addr, amount)
 	require.Nil(err)
 
+	// Set errCount to be non-zero
+	ok := sm.AcceptErr(addr)
+	assert.True(ok)
+	ok = sm.AcceptErr(addr)
+	assert.False(ok)
+
 	err = sm.AddFloat(addr, amount)
 	assert.Nil(err)
 
 	mf, err = sm.MaxFloat(addr)
 	require.Nil(err)
 	assert.Equal(reserve, mf)
+
+	// Test resetting errCount
+	ok = sm.AcceptErr(addr)
+	assert.True(ok)
 }
 
 func TestQueueTicketAndSignalMaxFloat(t *testing.T) {

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -323,6 +323,8 @@ func (s *stubSenderMonitor) MaxFloat(addr ethcommon.Address) (*big.Int, error) {
 	return s.maxFloat, nil
 }
 
+func (s *stubSenderMonitor) AcceptErr(addr ethcommon.Address) bool { return true }
+
 // MockRecipient is useful for testing components that depend on pm.Recipient
 type MockRecipient struct {
 	mock.Mock

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -268,6 +268,7 @@ type stubSenderMonitor struct {
 	maxFloat       *big.Int
 	redeemable     chan *SignedTicket
 	queued         []*SignedTicket
+	acceptable     bool
 	queueTicketErr error
 	addFloatErr    error
 	subFloatErr    error
@@ -323,7 +324,7 @@ func (s *stubSenderMonitor) MaxFloat(addr ethcommon.Address) (*big.Int, error) {
 	return s.maxFloat, nil
 }
 
-func (s *stubSenderMonitor) AcceptErr(addr ethcommon.Address) bool { return true }
+func (s *stubSenderMonitor) AcceptErr(addr ethcommon.Address) bool { return s.acceptable }
 
 // MockRecipient is useful for testing components that depend on pm.Recipient
 type MockRecipient struct {

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -67,11 +67,6 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 	if err := orch.ProcessPayment(payment, segData.ManifestID); err != nil {
 		glog.Errorf("Error processing payment: %v", err)
 
-		if !acceptablePaymentError(err) {
-			http.Error(w, err.Error(), http.StatusPaymentRequired)
-			return
-		}
-
 		oInfo, err = orchestratorInfo(orch, getPaymentSender(payment), orch.ServiceURI().String())
 		if err != nil {
 			glog.Errorf("Error updating orchestrator info: %v", err)
@@ -190,20 +185,6 @@ func getPaymentSender(payment net.Payment) ethcommon.Address {
 		return ethcommon.Address{}
 	}
 	return ethcommon.BytesToAddress(payment.Sender)
-}
-
-var acceptablePaymentErrStrings = []string{
-	"invalid ticket faceValue",
-	"invalid ticket winProb",
-	"invalid already revealed recipientRand",
-}
-
-var acceptablePaymentErrRegex = common.GenErrRegex(acceptablePaymentErrStrings)
-
-func acceptablePaymentError(err error) bool {
-	// TODO: Implement a grace period. O should only accept a certain number of these
-	// types of errors (more lenient since B might not have received updated info)
-	return acceptablePaymentErrRegex.MatchString(err.Error())
 }
 
 func verifySegCreds(orch Orchestrator, segCreds string, broadcaster ethcommon.Address) (*core.SegTranscodingMetadata, error) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds logic for handling "acceptable" PM ticket errors. See [this comment](https://github.com/livepeer/go-livepeer/issues/634#issuecomment-503741952) for additional details on what constitutes an acceptable PM ticket error.

The approach we take in this PR is as follows:

- Count the number of acceptable PM ticket errors for each tracked sender
- Define a custom `pm.Error` interface that exposes an `Acceptable()` method. Callers that are interested in checking if an error returned from the `pm` package can use a type assertion and check the output of `Acceptable()`
- `pm.Recipient` will return `pm.Error` for "invalid ticket faceValue", "invalid ticket winProb" and "invalid already revealed recipientRand" errors (see the comment linked at the beginning of this post for the rationale behind focusing on these errors)
- `pm.SenderMonitor` will handle error count resets for max float changes and gas price changes

Note that `(*lphttp).ServeSegment` will always send back an updated OrchestratorInfo message when an error is returned by `(*orchestrator).ProcessPayment()`. The thought here is that when a #895 is implemented, the minimum credit requirement check will prevent an orchestrator from transcoding a segment if the tickets received were unacceptable such that the broadcaster's credit balance is insufficient - `(*orchestrator).ProcessPayment()` would only add to the credit amount if there was not an error in receiving the ticket or if the error receiving the ticket was acceptable.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- dee67e9: Count acceptable errors for senders and compare with a max error count
- 6c2e38b: Reset a sender's error count when their max float changes. Since the recipient will update the sender's max float when redeeming a winning ticket, resetting the error count for max float changes should eliminate the need to also reset the error count when redeeming a winning ticket.
- 0ae12d6: Listen for changes to the cached gas price in GasPriceMonitor
- cf35fbd: Fixed a few data races in the GasPriceMonitor tests
- 6d7a970: Reset the error count for all senders when the SenderMonitor receives a cached gas price change notification from the GasPriceMonitor
- abdeb9a d7dcbd3 and 040bd39: Isolate the acceptable error logic in the `core` and `pm` packages. `(*lphttp).ServeSegment()` will send back an updated OrchestratorInfo message whenever there is an error from `(*orchestrator).ProcessPayment()`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Wrote additional unit tests. Still need to do some manual testing.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #634 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
