### PR TITLE
common, discovery: add price info to DB cache

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -160,3 +160,15 @@ func GenErrRegex(errStrings []string) *regexp.Regexp {
 	}
 	return regexp.MustCompile(strings.Join(groups, "|"))
 }
+
+// PriceToFixed converts a big.Rat into a fixed point number represented as int64
+// using a scaleFactor of 1000 resulting in max decimal places of 3
+func PriceToFixed(price *big.Rat) (int64, error) {
+	scalingFactor := int64(1000)
+	if price == nil {
+		return 0, fmt.Errorf("reference to rat is nil")
+	}
+	scaled := new(big.Rat).Mul(price, big.NewRat(scalingFactor, 1))
+	fp, _ := new(big.Float).SetRat(scaled).Int64()
+	return fp, nil
+}

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -2,10 +2,12 @@ package common
 
 import (
 	"encoding/hex"
+	"math/big"
 	"testing"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/livepeer/lpms/ffmpeg"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTxDataToVideoProfile(t *testing.T) {
@@ -61,4 +63,33 @@ func TestProfilesToHex(t *testing.T) {
 	// compare([]ffmpeg.VideoProfile{})
 	compare([]ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9})
 	compare([]ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P360p30fps16x9})
+}
+
+func TestPriceToFixed(t *testing.T) {
+	assert := assert.New(t)
+
+	// if rat is nil returns 0 and error
+	fp, err := PriceToFixed(nil)
+	assert.Zero(fp)
+	assert.Error(err)
+
+	// 1/10 rat returns 100
+	fp, err = PriceToFixed(big.NewRat(1, 10))
+	assert.Nil(err)
+	assert.Equal(fp, int64(100))
+
+	// 500/1 returns 500000 with
+	fp, err = PriceToFixed(big.NewRat(500, 1))
+	assert.Nil(err)
+	assert.Equal(fp, int64(500000))
+
+	// 125/100 returns 1250
+	fp, err = PriceToFixed(big.NewRat(125, 100))
+	assert.Nil(err)
+	assert.Equal(fp, int64(1250))
+
+	// rat smaller than 1/1000 returns 0
+	fp, err = PriceToFixed(big.NewRat(1, 5000))
+	assert.Nil(err)
+	assert.Zero(fp)
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds pricing info for orchestrators to the DBcache after fetching them on-chain. This cache refreshes just like before every hour currently. 

Broadcasters can now use the pricing info stored in the cache to pre-filter orchestrators that don't match their pricing preferences (see #906 ), rather than getting all orchestrators from the cache and sending `OrchestratorInfo` messages to all of them. 

**Specific updates (required)**
- Added a column to the orchestrator table containing priceInfo as a fixed point
- Added an SQL query `db.FilterOrchs(maxPrice *big.Rat)` to filter stored price info based on the `maxPrice` passed to this function, which is fetched from `BroadcastCfg.MaxPrice()`
- Added a helper function in `util`to convert `big.Rat` to fixed point (`int64`)
- Changed `cacheDBOrchs`in `db_discovery.go` to concurrently fetch `OrchestratorInfo` messages for all orchestrators found on-chain. We are now discarding orchestrators with bad URLs as well (I'm not sure if this is behaviour that we want; but we can't query those URL's anyway)

**How did you test each of these updates (required)**
Added unit tests in `db_test.go` , `util_test.go` and slightly altered unit tests in `db_discovery.go`
tests in the latter aren't really pretty and `serverGetOrchInfo` is defined repeadetly

**Does this pull request close any open issues?**
Fixes #934 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
