### PR TITLE
Broadcaster ticket param validation

### DIFF
--- a/pm/broker.go
+++ b/pm/broker.go
@@ -45,6 +45,8 @@ type SenderInfo struct {
 // smart contract that handles the administrative tasks in a probabilistic micropayment protocol
 // including processing deposits and pay outs
 type Broker interface {
+	SenderManager
+
 	// FundDepositAndReserve funds a sender's deposit and reserve
 	FundDepositAndReserve(depositAmount, reserveAmount *big.Int) (*types.Transaction, error)
 
@@ -72,9 +74,6 @@ type Broker interface {
 	// IsUsedTicket checks if a ticket has been used
 	IsUsedTicket(ticket *Ticket) (bool, error)
 
-	// GetSenderInfo returns a sender's information
-	GetSenderInfo(addr ethcommon.Address) (*SenderInfo, error)
-
 	// ClaimableReserve returns the amount from the reserveHolder's reserve that the claimant
 	// can claim
 	ClaimableReserve(reserveHolder, claimant ethcommon.Address) (*big.Int, error)
@@ -91,4 +90,10 @@ type RoundsManager interface {
 	LastInitializedRound() (*big.Int, error)
 	// BlockHashForRound returns the block hash for a given round of the Livepeer protocol
 	BlockHashForRound(round *big.Int) ([32]byte, error)
+}
+
+// SenderManager defines the methods for fetching sender information
+type SenderManager interface {
+	// GetSenderInfo returns a sender's information
+	GetSenderInfo(addr ethcommon.Address) (*SenderInfo, error)
 }

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -256,6 +256,19 @@ func (m *stubRoundsManager) BlockHashForRound(round *big.Int) ([32]byte, error) 
 	return m.blkHash, m.blockHashForRoundErr
 }
 
+type stubSenderManager struct {
+	info *SenderInfo
+	err  error
+}
+
+func (s *stubSenderManager) GetSenderInfo(addr ethcommon.Address) (*SenderInfo, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+
+	return s.info, nil
+}
+
 type stubGasPriceMonitor struct {
 	gasPrice *big.Int
 }
@@ -413,4 +426,10 @@ func (m *MockSender) CreateTicket(sessionID string) (*Ticket, *big.Int, []byte, 
 	}
 
 	return ticket, seed, sig, args.Error(3)
+}
+
+// ValidateTicketParams checks if ticket params are acceptable
+func (m *MockSender) ValidateTicketParams(ticketParams *TicketParams) error {
+	args := m.Called(ticketParams)
+	return args.Error(0)
 }

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -194,16 +194,7 @@ func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core
 		var sessionID string
 
 		if n.Sender != nil {
-			protoParams := tinfo.TicketParams
-			params := pm.TicketParams{
-				Recipient:         ethcommon.BytesToAddress(protoParams.Recipient),
-				FaceValue:         new(big.Int).SetBytes(protoParams.FaceValue),
-				WinProb:           new(big.Int).SetBytes(protoParams.WinProb),
-				RecipientRandHash: ethcommon.BytesToHash(protoParams.RecipientRandHash),
-				Seed:              new(big.Int).SetBytes(protoParams.Seed),
-			}
-
-			sessionID = n.Sender.StartSession(params)
+			sessionID = n.Sender.StartSession(*pmTicketParams(tinfo.TicketParams))
 		}
 
 		var orchOS drivers.OSSession

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -234,3 +234,17 @@ func verifyOrchestratorReq(orch Orchestrator, addr ethcommon.Address, sig []byte
 	}
 	return orch.CheckCapacity("")
 }
+
+func pmTicketParams(params *net.TicketParams) *pm.TicketParams {
+	if params == nil {
+		return nil
+	}
+
+	return &pm.TicketParams{
+		Recipient:         ethcommon.BytesToAddress(params.Recipient),
+		FaceValue:         new(big.Int).SetBytes(params.FaceValue),
+		WinProb:           new(big.Int).SetBytes(params.WinProb),
+		RecipientRandHash: ethcommon.BytesToHash(params.RecipientRandHash),
+		Seed:              new(big.Int).SetBytes(params.Seed),
+	}
+}

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -441,6 +441,23 @@ func TestSubmitSegment_GenSegCredsError(t *testing.T) {
 	assert.Equal(t, "Sign error", err.Error())
 }
 
+func TestSubmitSegment_GenPaymentError(t *testing.T) {
+	b := stubBroadcaster2()
+	sender := &pm.MockSender{}
+	expErr := errors.New("CreateTicket error")
+	sender.On("CreateTicket", mock.Anything).Return(nil, nil, nil, expErr)
+
+	s := &BroadcastSession{
+		Broadcaster: b,
+		ManifestID:  core.RandomManifestID(),
+		Sender:      sender,
+	}
+
+	_, err := SubmitSegment(s, &stream.HLSSegment{}, 0)
+
+	assert.EqualError(t, err, expErr.Error())
+}
+
 func TestSubmitSegment_HttpPostError(t *testing.T) {
 	s := &BroadcastSession{
 		Broadcaster: stubBroadcaster2(),
@@ -684,10 +701,11 @@ func TestSubmitSegment_UpdateOrchestratorInfo(t *testing.T) {
 
 	// Test does not crash if OrchestratorInfo.TicketParams is nil
 
+	sender = &pm.MockSender{}
 	s.OrchestratorInfo = &net.OrchestratorInfo{
 		Transcoder: ts.URL,
 	}
-	s.Sender = nil
+	s.Sender = sender
 
 	// Update stub server to return OrchestratorInfo without TicketParams
 	tr.Info = &net.OrchestratorInfo{
@@ -696,10 +714,14 @@ func TestSubmitSegment_UpdateOrchestratorInfo(t *testing.T) {
 	buf, err = proto.Marshal(tr)
 	require.Nil(err)
 
+	sender.On("CreateTicket", mock.Anything).Return(ticket, big.NewInt(7), []byte("bar"), nil)
+	sender.On("StartSession", mock.Anything).Return("foobar")
+
 	_, err = SubmitSegment(s, &stream.HLSSegment{Data: []byte("dummy")}, 0)
 
 	assert.Nil(err)
 	assert.Equal("http://google.com", s.OrchestratorInfo.Transcoder)
+	sender.AssertNotCalled(t, "StartSession", mock.Anything)
 
 	// Test update OrchestratorOS
 

--- a/test_args.sh
+++ b/test_args.sh
@@ -113,6 +113,19 @@ res=0
 ./livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pixelsPerUnit -5 -pricePerUnit 5 -network rinkeby $ETH_ARGS || res=$?
 [ $res -ne 0 ]
 
+# Broadcaster needs a valid rational number for -maxTicketEV
+res=0
+./livepeer -broadcaster -maxTicketEV abcd -network rinkeby $ETH_ARGS || res=$?
+[ $res -ne 0 ]
+# Broadcaster needs a non-negative number for -maxTicketEV
+res=0
+./livepeer -broadcaster -maxTicketEV -1 -network rinkeby $ETH_ARGS || res=$?
+[ $res -ne 0 ]
+# Broadcaster needs a postive number for -depositMultiplier
+res=0
+./livepeer -broadcaster -depositMultiplier 0 -network rinkeby $ETH_ARGS || res=$?
+[ $res -ne 0 ]
+
 # transcoder needs -orchSecret
 res=0
 ./livepeer -transcoder || res=$?


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR implements ticket param validation for a broadcaster. The ticket params that are most important for a broadcaster to validate are the ticket `faceValue` and the ticket `EV`.

See below for a summary of a description from from #831

The ticket EV is important to validate because the higher the `EV`, the more value B must put at risk prior to O performing any transcoding. This is because we are planning on treating the ticket `EV` as a minimum credit requirement enforced by O. B has to send a ticket worth `EV` to top off its balance with O before receiving transcoded results.

The ticket `faceValue` is important to validate because B wants to avoid having its reserve frozen (inaccessible for a fixed period of time) by overspending from its deposit. The higher the ticket `faceValue`, the higher the chance that B will overspend from its deposit by sending out successive winning tickets that not only draw from B's deposit, but also draw from its reserve (thereby freezing it). While we cannot completely guarantee that B will not overspend from its deposit, we can try to reduce the probability by checking for an acceptable `faceValue` that is not too high.

One approach could involve B defining a `depositMultiplier` config option. `depositMultiplier can be used to derive `maxFaceValue = deposit / depositMultiplier`. 

B would validate ticket params in the following scenarios:

- During O discovery upon receiving an `OrchestratorInfo` message containing ticket params
- When O sends an updated `OrchestratorInfo` message containing new ticket params
- When creating a ticket. Since B's deposit will be consistently decreasing, the `maxFaceValue` will be consistently decreasing as well. So, whenever B creates a ticket it should check that the ticket params it is currently using are still acceptable given its current deposit - in other words, B should check that the face value of a new ticket is less than its most up to date `maxFaceValue`

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 9c8384c: Implements ticket param validation on `pm.Sender`. When a broadcaster node is initialized, the `-maxTicketEV` and `-depositMultiplier` flags can be used to pass in values other than the defaults.
- 81ea445: Implements ticket param validation whenever B receives an updated `OrchestratorInfo` message
- 0db1672: Implements ticket param validation during O discovery (Os that fail validation will be filtered out)

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added additional unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #831 
Fixes #927

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
