### PR TITLE
devtool: allow passing service host as optional arg, `svchost`

### DIFF
--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -64,8 +64,8 @@ func main() {
 	}
 	if *svcHost != "" {
 		serviceHost = *svcHost
+		serviceURI = fmt.Sprintf("https://%s:", serviceHost)
 	}
-	serviceURI = fmt.Sprintf("https://%s:", serviceHost)
 	args := flag.Args()
 	goodToGo := false
 	isBroadcaster := true


### PR DESCRIPTION
* allow passing service host other than the default, `127.0.0.1` as optional arg, `svchost`
* necessary for container orchestration tools such as `docker-compose` and `kubernetes`

relates-to: #919 