### PR TITLE
core, pm: cmd: O processes payments and checks credit

### DIFF
--- a/core/accounting.go
+++ b/core/accounting.go
@@ -1,0 +1,89 @@
+package core
+
+import (
+	"math/big"
+	"sync"
+	"time"
+)
+
+// Balances holds credit balances on a per-stream basis
+type Balances struct {
+	balances map[ManifestID]*balance
+	mtx      sync.RWMutex
+	ttl      time.Duration
+	quit     chan struct{}
+}
+
+type balance struct {
+	lastUpdate time.Time // Unix time since last update
+	amount     *big.Rat  // Balance represented as a big.Rat
+}
+
+// NewBalances creates a Balances instance with the given ttl
+func NewBalances(ttl time.Duration) *Balances {
+	return &Balances{
+		balances: make(map[ManifestID]*balance),
+		ttl:      ttl,
+		quit:     make(chan struct{}),
+	}
+}
+
+// Credit adds an an amount to the balance for a ManifestID
+func (b *Balances) Credit(id ManifestID, amount *big.Rat) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	if b.balances[id] == nil {
+		b.balances[id] = &balance{amount: big.NewRat(0, 1)}
+	}
+	b.balances[id].amount.Add(b.balances[id].amount, amount)
+	b.balances[id].lastUpdate = time.Now()
+}
+
+// Debit substracts an amount from the balance for a ManifestID
+func (b *Balances) Debit(id ManifestID, amount *big.Rat) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	if b.balances[id] == nil {
+		b.balances[id] = &balance{amount: big.NewRat(0, 1)}
+	}
+	b.balances[id].amount.Sub(b.balances[id].amount, amount)
+	b.balances[id].lastUpdate = time.Now()
+}
+
+// Balance retrieves the current balance for a ManifestID
+func (b *Balances) Balance(id ManifestID) *big.Rat {
+	b.mtx.RLock()
+	defer b.mtx.RUnlock()
+	if b.balances[id] == nil {
+		return nil
+	}
+	return b.balances[id].amount
+}
+
+func (b *Balances) cleanup() {
+	for id, balance := range b.balances {
+		b.mtx.Lock()
+		if int64(time.Since(balance.lastUpdate)) > int64(b.ttl) {
+			delete(b.balances, id)
+		}
+		b.mtx.Unlock()
+	}
+}
+
+// StartCleanup is a state flushing method to clean up the balances mapping
+func (b *Balances) StartCleanup() {
+	ticker := time.NewTicker(b.ttl)
+	for {
+		select {
+		case <-ticker.C:
+			b.cleanup()
+		case <-b.quit:
+			return
+		}
+	}
+}
+
+// StopCleanup stops the cleanup loop for Balances
+func (b *Balances) StopCleanup() {
+	close(b.quit)
+}

--- a/core/accounting_test.go
+++ b/core/accounting_test.go
@@ -1,0 +1,92 @@
+package core
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyBalances_ReturnsZeroedValues(t *testing.T) {
+	mid := ManifestID("some manifest id")
+	b := NewBalances(5 * time.Second)
+	assert := assert.New(t)
+
+	assert.Nil(b.Balance(mid))
+	assert.Nil(b.balances[mid])
+}
+
+func TestCredit_ReturnsNewCreditBalance(t *testing.T) {
+	mid := ManifestID("some manifest id")
+	b := NewBalances(5 * time.Second)
+	assert := assert.New(t)
+	amount := big.NewRat(100, 1)
+
+	b.Credit(mid, amount)
+	assert.Zero(b.Balance(mid).Cmp(amount))
+}
+
+func TestDebitAfterCredit_SameAmount_ReturnsZero(t *testing.T) {
+	mid := ManifestID("some manifest id")
+	b := NewBalances(5 * time.Second)
+	assert := assert.New(t)
+	amount := big.NewRat(100, 1)
+
+	b.Credit(mid, amount)
+	assert.Zero(b.Balance(mid).Cmp(amount))
+
+	b.Debit(mid, amount)
+	assert.Zero(b.Balance(mid).Cmp(big.NewRat(0, 1)))
+}
+
+func TestDebitHalfOfCredit_ReturnsHalfOfCredit(t *testing.T) {
+	mid := ManifestID("some manifest id")
+	b := NewBalances(5 * time.Second)
+	assert := assert.New(t)
+	credit := big.NewRat(100, 1)
+	debit := big.NewRat(50, 1)
+	b.Credit(mid, credit)
+	assert.Zero(b.Balance(mid).Cmp(credit))
+
+	b.Debit(mid, debit)
+	assert.Zero(b.Balance(mid).Cmp(debit))
+}
+
+func TestBalancesCleanup(t *testing.T) {
+	b := NewBalances(5 * time.Second)
+	assert := assert.New(t)
+
+	// Set up two mids
+	// One we will update after 2*time.Seconds
+	// The other one we will not update before timeout
+	// This should run clean only the second
+	mid1 := ManifestID("First MID")
+	mid2 := ManifestID("Second MID")
+	// Start cleanup loop
+	go b.StartCleanup()
+	defer b.StopCleanup()
+
+	// Fund balances
+	credit := big.NewRat(100, 1)
+	b.Credit(mid1, credit)
+	b.Credit(mid2, credit)
+	assert.Zero(b.Balance(mid1).Cmp(credit))
+	assert.Zero(b.Balance(mid2).Cmp(credit))
+
+	time.Sleep(2 * time.Second)
+	b.Credit(mid1, credit)
+	assert.Zero(b.Balance(mid1).Cmp(big.NewRat(200, 1)))
+
+	time.Sleep(4 * time.Second)
+
+	// Balance for mid1 should still be 200/1
+	assert.NotNil(b.Balance(mid1))
+	assert.Zero(b.Balance(mid1).Cmp(big.NewRat(200, 1)))
+	// Balance for mid2 should be cleaned
+	assert.Nil(b.Balance(mid2))
+
+	time.Sleep(5 * time.Second)
+	// Now balance for mid1 should be cleaned as well
+	assert.Nil(b.Balance(mid1))
+}

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -66,6 +66,7 @@ type LivepeerNode struct {
 	Transcoder        Transcoder
 	TranscoderManager *RemoteTranscoderManager
 	PriceInfo         *big.Rat
+	Balances          *Balances
 
 	// Broadcaster public fields
 	Sender pm.Sender

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -43,6 +43,9 @@ type Recipient interface {
 
 	// TxCostMultiplier returns the multiplier -
 	TxCostMultiplier(sender ethcommon.Address) (*big.Rat, error)
+
+	// EV returns the recipients EV requirement for a ticket as configured on startup
+	EV() *big.Rat
 }
 
 // TicketParamsConfig contains config information for a recipient to determine
@@ -438,4 +441,9 @@ func (r *recipient) redeemManager() {
 			return
 		}
 	}
+}
+
+// EV Returns the required ticket EV for a recipient
+func (r *recipient) EV() *big.Rat {
+	return new(big.Rat).SetFrac(r.cfg.EV, big.NewInt(1))
 }

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -392,6 +392,12 @@ func (m *MockRecipient) TxCostMultiplier(sender ethcommon.Address) (*big.Rat, er
 	return multiplier, args.Error(1)
 }
 
+// EV Returns the recipient's request ticket EV
+func (m *MockRecipient) EV() *big.Rat {
+	args := m.Called()
+	return args.Get(0).(*big.Rat)
+}
+
 // MockSender is useful for testing components that depend on pm.Sender
 type MockSender struct {
 	mock.Mock
@@ -432,4 +438,28 @@ func (m *MockSender) CreateTicket(sessionID string) (*Ticket, *big.Int, []byte, 
 func (m *MockSender) ValidateTicketParams(ticketParams *TicketParams) error {
 	args := m.Called(ticketParams)
 	return args.Error(0)
+}
+
+// MockReceiveError is for testing acceptable/unacceptable PM ticket errors
+type MockReceiveError struct {
+	err        error
+	acceptable bool
+}
+
+// Error returns the underlying error as a string
+func (re *MockReceiveError) Error() string {
+	return re.err.Error()
+}
+
+// Acceptable returns whether the error is acceptable
+func (re *MockReceiveError) Acceptable() bool {
+	return re.acceptable
+}
+
+// NewMockReceiveError creates a new acceptable/unacceptable MocKReceiveError
+func NewMockReceiveError(err error, acceptable bool) *MockReceiveError {
+	return &MockReceiveError{
+		err,
+		acceptable,
+	}
 }

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -44,6 +44,7 @@ type Orchestrator interface {
 	ProcessPayment(payment net.Payment, manifestID core.ManifestID) error
 	TicketParams(sender ethcommon.Address) (*net.TicketParams, error)
 	PriceInfo(sender ethcommon.Address) (*big.Rat, error)
+	SufficientBalance(manifestID core.ManifestID) bool
 }
 
 type Broadcaster interface {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -79,6 +79,10 @@ func (r *stubOrchestrator) PriceInfo(sender ethcommon.Address) (*big.Rat, error)
 	return nil, nil
 }
 
+func (r *stubOrchestrator) SufficientBalance(manifestID core.ManifestID) bool {
+	return false
+}
+
 func newStubOrchestrator() *stubOrchestrator {
 	pk, err := ethcrypto.GenerateKey()
 	if err != nil {
@@ -554,6 +558,11 @@ func (o *mockOrchestrator) PriceInfo(sender ethcommon.Address) (*big.Rat, error)
 
 func (o *mockOrchestrator) CheckCapacity(mid core.ManifestID) error {
 	return nil
+}
+
+func (o *mockOrchestrator) SufficientBalance(manifestID core.ManifestID) bool {
+	args := o.Called(manifestID)
+	return args.Bool(0)
 }
 
 func defaultTicketParams() *net.TicketParams {

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -73,6 +73,12 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if !orch.SufficientBalance(segData.ManifestID) {
+		glog.Errorf("Insufficient credit balance for stream with manifestID %v\n", segData.ManifestID)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
 	// download the segment and check the hash
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is a work in progress PR to receive feedback on a first implementation attempt as outlined in #895 

This PR allows an orchestrator to add processed tickets (received and acceptable errors) to a stream's credit balance and checks whether the minimum credit requirements on a per stream basis are met in `ProcessPayment` 

**Specific updates (required)**
- Added a new type alias `Accounts` with `Credit`, `Debit`, `Balance` and `Cleanup` methods 
- Added a new method to `pm.Recipient` to retrieve the desired EV 
- Added a new `Accounts` field to the `LivepeerNode` and initialized the `Accounts.Balances` mapping in the `NewLivepeerNode` constructor
- Added logic in `ProcessPayment` (TicketSenderParams loop) to add a received ticket's `EV` to the credit balance for a `ManifestID`
- Added logic at the end of `ProcessPayment` , after all tickets are processed to check if the credit requirement for a `ManifestID` meets the orchestrators configured `EV` 
- Start a cleanup routine for `Accounts` on node startup (orchestrator mode only).

**How did you test each of these updates (required)**
Wrote unit tests for the new accounting type alias
Mocked out MaxEV for `ProcessPayment` tests. 

**Does this pull request close any open issues?**
Fixes #895 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
