### PR TITLE
cmd/livepeer: fix "Errorf call has arguments but no formatting directives"

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -196,7 +196,7 @@ func main() {
 	//Set up DB
 	dbh, err := common.InitDB(*datadir + "/lp.sqlite3")
 	if err != nil {
-		glog.Errorf("Error opening DB", err)
+		glog.Errorf("Error opening DB: %v", err)
 		return
 	}
 	defer dbh.Close()


### PR DESCRIPTION
Fix build warning:
```
# github.com/livepeer/go-livepeer/cmd/livepeer
cmd/livepeer/livepeer.go:199:14: Errorf call has arguments but no formatting directives
```