### PR TITLE
Improve caching of segment's data in memory object storage.

### DIFF
--- a/drivers/local.go
+++ b/drivers/local.go
@@ -132,7 +132,8 @@ func (ostore *MemorySession) getAbsoluteURI(name string) string {
 
 type dataCache struct {
 	cacheLen int
-	cache    []*dataCacheItem
+	nextFree int
+	cache    []dataCacheItem
 }
 
 type dataCacheItem struct {
@@ -141,7 +142,7 @@ type dataCacheItem struct {
 }
 
 func newDataCache(len int) *dataCache {
-	return &dataCache{cacheLen: len, cache: make([]*dataCacheItem, 0)}
+	return &dataCache{cacheLen: len, cache: make([]dataCacheItem, len)}
 }
 
 func (dc *dataCache) Insert(name string, data []byte) {
@@ -152,11 +153,12 @@ func (dc *dataCache) Insert(name string, data []byte) {
 			return
 		}
 	}
-	if len(dc.cache) >= dc.cacheLen {
-		dc.cache = dc.cache[1:]
+	dc.cache[dc.nextFree].name = name
+	dc.cache[dc.nextFree].data = data
+	dc.nextFree++
+	if dc.nextFree >= dc.cacheLen {
+		dc.nextFree = 0
 	}
-	item := &dataCacheItem{name: name, data: data}
-	dc.cache = append(dc.cache, item)
 }
 
 func (dc *dataCache) GetData(name string) []byte {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
More efficient cache in local (memory) object storage.
Previously for removing item from cache was used slicing operation like this:
```golang
		dc.cache = dc.cache[1:]
```
This doesn't free memory immediately - in my tests, underlying array can grow twice the size before it get garbage collected.

**Specific updates (required)**
Instead of slicing/appending array using fixed size array.

**How did you test each of these updates (required)**
Manually. In my tests this change increased number of simultaneous stream single broadcaster can handle (on `n1-highcpu-4` instance (3.6G memory)) from 16 to 24.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass