### PR TITLE
HTTP Segment Ingest

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -633,7 +633,7 @@ func main() {
 	}
 
 	//Set up the media server
-	s := server.NewLivepeerServer(*rtmpAddr, *httpAddr, n)
+	s := server.NewLivepeerServer(*rtmpAddr, n)
 	ec := make(chan error)
 	tc := make(chan struct{})
 	wc := make(chan struct{})
@@ -655,7 +655,7 @@ func main() {
 		close(wc)
 	}()
 	go func() {
-		ec <- s.StartMediaServer(msCtx, *transcodingOptions)
+		ec <- s.StartMediaServer(msCtx, *transcodingOptions, *httpAddr)
 	}()
 
 	go func() {

--- a/doc/ingest.md
+++ b/doc/ingest.md
@@ -84,3 +84,36 @@ Here, the stream name is `movie` and the stream key is `Secret/Stream/Key`.
 The RTMP stream can then be played back with this complete RTMP URL. The key is
 optional; if one is not supplied, then a random key will be generated. The key
 may also be specified via webhook.
+
+### HTTP Push
+
+Livepeer starts an HTTP server on the default port of 8935, as another ingest point
+into the Livepeer network. Upon ingest, HTTP stream is pushed to the segmenter
+prior to transcoding. The stream can be pushed via a PUT or POST HTTP request to the
+`/live/` endpoint. HTTP request timeout is 8 seconds.
+
+The following are expected in the request:
+
+* MPEG TS segments with segment numbers
+
+* `Content-Resolution` and `Content-Duration` headers
+
+* Stream name must be provided. In the examples below, the stream name is `movie`
+
+
+Sample URLs and requests:
+
+```
+# Push URL
+http://localhost:8935/live/movie/
+
+# HLS Playback URL
+http://localhost:8935/stream/movie.m3u8
+
+# Curl request
+curl -X PUT -H "Content-Duration: 2000" -H "Content-Resolution: 1920x1080"  --data-binary
+"@bbb0.ts" http://localhost:8935/live/movie/bbb0.ts
+
+# FFMPEG request
+ffmpeg -re -i movie.mp4 -c:a copy -c:v copy -f hls http://localhost:8935/live/movie/
+```

--- a/server/cliserver_test.go
+++ b/server/cliserver_test.go
@@ -23,7 +23,7 @@ func newMockServer() *httptest.Server {
 	go func() { n.TranscoderManager.Manage(strm, 5) }()
 	time.Sleep(1 * time.Millisecond)
 	n.Transcoder = n.TranscoderManager
-	s := NewLivepeerServer("127.0.0.1:1938", "127.0.0.1:8080", n)
+	s := NewLivepeerServer("127.0.0.1:1938", n)
 	mux := s.cliWebServerHandlers("addr")
 	srv := httptest.NewServer(mux)
 	return srv

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -39,8 +39,8 @@ func setupServer() *LivepeerServer {
 	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	if S == nil {
 		n, _ := core.NewLivepeerNode(nil, "./tmp", nil)
-		S = NewLivepeerServer("127.0.0.1:1938", "127.0.0.1:8080", n)
-		go S.StartMediaServer(context.Background(), "")
+		S = NewLivepeerServer("127.0.0.1:1938", n)
+		go S.StartMediaServer(context.Background(), "", "127.0.0.1:8080")
 		go S.StartCliWebserver("127.0.0.1:8938")
 	}
 	return S
@@ -873,4 +873,5 @@ func TestParsePresets(t *testing.T) {
 
 	p = parsePresets(presets)
 	assert.Equal([]ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P720p30fps16x9}, p)
+
 }

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/drivers"
+)
+
+func requestSetup(s *LivepeerServer) (http.Handler, *strings.Reader, *httptest.ResponseRecorder) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.HandlePush(w, r)
+	})
+	reader := strings.NewReader("")
+	writer := httptest.NewRecorder()
+	return handler, reader, writer
+}
+
+func TestNoErrors(t *testing.T) {
+	assert := assert.New(t)
+	handler, reader, w := requestSetup(setupServer())
+	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
+
+	handler.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+	assert.Equal(200, resp.StatusCode)
+	assert.Equal(strings.TrimSpace(string(body)), "")
+}
+
+func TestMemoryRequestError(t *testing.T) {
+	// assert http request body error returned
+	assert := assert.New(t)
+	handler, _, w := requestSetup(setupServer())
+	f, err := os.Open(`doesn't exist`)
+	req := httptest.NewRequest("POST", "/live/seg.ts", f)
+
+	handler.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+	assert.Equal(http.StatusInternalServerError, resp.StatusCode)
+	assert.Contains(strings.TrimSpace(string(body)), "Error reading http request body")
+}
+
+func TestFileExtensionError(t *testing.T) {
+	// assert file extension error returned
+	assert := assert.New(t)
+	handler, reader, w := requestSetup(setupServer())
+	req := httptest.NewRequest("POST", "/live/seg.m3u8", reader)
+
+	handler.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+	assert.Equal(http.StatusBadRequest, resp.StatusCode)
+	assert.Contains(strings.TrimSpace(string(body)), "ignoring file extension")
+}
+
+func TestStorageError(t *testing.T) {
+	// assert storage error
+	assert := assert.New(t)
+	s := setupServer()
+	handler, reader, w := requestSetup(s)
+
+	tempStorage := drivers.NodeStorage
+	drivers.NodeStorage = nil
+	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
+	mid := parseManifestID(req.URL.Path)
+	err := removeRTMPStream(s, mid)
+
+	handler.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+	assert.Equal(http.StatusInternalServerError, resp.StatusCode)
+	assert.Contains(strings.TrimSpace(string(body)), "ErrStorage")
+
+	// reset drivers.NodeStorage to original value
+	drivers.NodeStorage = tempStorage
+}
+
+func TestForAuthWebhookFailure(t *testing.T) {
+	// assert app data error
+	assert := assert.New(t)
+	s := setupServer()
+	handler, reader, w := requestSetup(s)
+
+	AuthWebhookURL = "notaurl"
+	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
+
+	handler.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.Nil(t, err)
+	assert.Equal(http.StatusInternalServerError, resp.StatusCode)
+	assert.Contains(strings.TrimSpace(string(body)), "Could not create stream ID")
+
+	// reset AuthWebhookURL to original value
+	AuthWebhookURL = ""
+}
+
+func TestResolutionWithoutContentResolutionHeader(t *testing.T) {
+	assert := assert.New(t)
+	server := setupServer()
+	server.rtmpConnections = map[core.ManifestID]*rtmpConnection{}
+	handler, reader, w := requestSetup(server)
+	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
+	defaultRes := "0x0"
+
+	handler.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	for _, cxn := range server.rtmpConnections {
+		assert.Equal(cxn.profile.Resolution, defaultRes)
+	}
+
+	server.rtmpConnections = map[core.ManifestID]*rtmpConnection{}
+}
+
+func TestResolutionWithContentResolutionHeader(t *testing.T) {
+	assert := assert.New(t)
+	server := setupServer()
+	server.rtmpConnections = map[core.ManifestID]*rtmpConnection{}
+	handler, reader, w := requestSetup(server)
+	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
+	resolution := "123x456"
+	req.Header.Set("Content-Resolution", resolution)
+
+	handler.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	for _, cxn := range server.rtmpConnections {
+		assert.Equal(resolution, cxn.profile.Resolution)
+	}
+
+	server.rtmpConnections = map[core.ManifestID]*rtmpConnection{}
+}
+
+func TestWebhookRequestURL(t *testing.T) {
+	assert := assert.New(t)
+	s := setupServer()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		out, _ := ioutil.ReadAll(r.Body)
+		var req authWebhookReq
+		err := json.Unmarshal(out, &req)
+		if err != nil {
+			glog.Error("Error parsing URL: ", err)
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		assert.Equal(req.URL, "http://example.com/live/seg.ts")
+		w.Write(nil)
+	}))
+
+	defer ts.Close()
+
+	AuthWebhookURL = ts.URL
+	handler, reader, w := requestSetup(s)
+	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
+	handler.ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(200, resp.StatusCode)
+}


### PR DESCRIPTION
### What is it?

A sketch of a push-based HTTP segment ingest. Refer to #953 for details.

This doesn't attempt to address the push vs pull debate. This is only a sketch of one possible implementation of HTTP segment push.

Not really meant for review / merging, but more as an overview of what might need to be addressed if we take this approach all the way to production.

### Usage

Check out the [`ja/liveingest`](https://github.com/livepeer/go-livepeer/compare/33fa9b2...ja/liveingest?expand=1) branch of go-livepeer

Input : `ffmpeg -re -i <input> -c:a copy -c:v copy -f hls http://localhost:7935/live/<streamname>/` Wowza might work as well.

Output: Same as existing HLS playback. `ffplay http://localhost:8935/stream/<streamname>.m3u8` 

### Path Prefix

Currently `/live/` , as opposed to the proposed `/stream/`.  LPMS hijacks the `/stream/` prefix so it's easier to just use a new prefix. Transcoded HLS is still available for playback under `/stream/` as before.

### Port numbering

Currently use port 7935, mostly out of expediency - the B doesn't pass in a custom mux that can be shared between LPMS and the goclient.

We have an internal CLI  API running on port 7935 that is mostly used for node management and diagnostics. An "external" port lives on 8935. The broadcaster uses the external port for HLS playback.  (O uses 8935 for gRPC and segment handling as well).

We may want to switch the `/live/` endpoint to port 8935. One bit of concern here is relating to "safe defaults". Historically, we have attempted to keep all potentially Eth-draining operations segregated from the port on 8935, which is considered public. Since there is no authentication by default, a B operator may unintentionally open itself up to drive-by transcoding.

One mitigating factor is that the broadcaster listens to 8935 on localhost by default. (We do the same for RTMP.) Another layer of safety would be to have a flag to toggle the push API. For an improved UX, this flag could be enabled by default. It would be disabled by default if 8935 is listening to non-localhost *and* webhook auth is not enabled. Enabling the flag under those conditions would be an explicit signal - "I know this is potentially an expensive choice, do it anyway."

### Durations

The duration of the source segment is currently not passed in. The duration is necessary to insert valid timings for the resulting HLS playlist. Other features such as [latency-based O selection](https://github.com/livepeer/go-livepeer/issues/938) need the duration.

To solve this, it would be nice to send a HTTP header, eg `Content-Duration` with the value in seconds. We could also probe each segment but that's not desirable on the broadcaster: it's format-specific and another step in the process.

### Other Missing Metadata

Might be nice to incorporate the width/height of the source segment as a header. We use this information in the master playlist to describe the dimensions of the source stream.

### State Timeouts

Need to monitor liveness of a given broadcast. There is a bunch of state associated with each job such as the working set of orchestrators, payments, etc. This state needs to be cleaned up after a certain period of idleness.

One way to do this is to look a the O's [transcode loop](https://github.com/livepeer/go-livepeer/blob/3b6a1918a646383f4413b8a3a8f3469d9fa27818/core/orchestrator.go#L456-L481). Uses a context timeout to clean itself up. Nice because it serializes work for a given job onto the same thread. Not so nice because the async dispatching of request/response makes the overall flow hard to follow. We don't really need the serialization either.

Another way is to have a separate goroutine sweep live sessions periodically. Even a naive linear scan should be OK with a few hundred streams.

### Rate Limiting

If auth fails or there is an unrecoverable error, we should stop processing requests for that stream for a while (at least until the state expires).

### Reconstruct Target URL

The golang `request.URL` field is simply extracted from the Request-URI part of the HTTP request, and is usually missing the scheme, host, port, etc. Having the full target URL would be useful for the auth webhook. The URL needs to be reconstructed from the data available in the [Request](https://golang.org/pkg/net/http/#Request) object.

### Responses

Currently, nothing is returned in response. A [`multipart/mixed` implementation](https://github.com/livepeer/go-livepeer/blob/3b6a1918a646383f4413b8a3a8f3469d9fa27818/server/ot_rpc.go#L145-L160) can be borrowed from the standalone transcoder.

### Non-Segmented Transcodes

There is an easy path towards standalone (non-segmented) transcoding. This would enable a semblance of JIT VOD.

If there is no stream name (eg, the ingest path is `http://localhost:7935/live`) then we can create a standalone "rtmp connection" (without registering), use that for the duration of the transcode, and [clean it up](https://github.com/livepeer/go-livepeer/blob/3b6a1918a646383f4413b8a3a8f3469d9fa27818/server/mediaserver.go#L325-L326) after `processSegment` completes.

### RTMP Segmentation

This type of push ingest can also be used to receive segments via HTTP as they are produced from a RTMP stream [2]. This would remove a lot of complexity from the LPMS side: it would avoid disk writes [1], polling the disk for segments and manifests, and so forth. This would also give us a mechanism to accommodate RTMP reconnects for the same broadcast session, rather than starting fresh as we do now.

However, the RTMP workflow is still just different enough that this should be looked at a bit more closely. Some issues:

* We authenticate the RTMP stream *prior* to starting segmentation. With push, we authenticate *after* segmentation.
* A naive application of may unintentionally block the segmenter. ffmpeg will shut down the segmeter if there is a backlog in HTTP.

[1] https://github.com/livepeer/go-livepeer/issues/846
[2] https://github.com/livepeer/lpms/issues/128#issuecomment-506794144