### PR TITLE
core, server: return PriceInfo in OrchestratorInfo gRPC call

### DIFF
--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -878,7 +878,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 
 	priceInfo, err := orch.PriceInfo(ethcommon.Address{})
 	assert.Nil(t, err)
-	assert.Zero(t, expPricePerPixel.Cmp(priceInfo))
+	assert.Zero(t, expPricePerPixel.Cmp(big.NewRat(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)))
 
 	// basePrice = 10/1, txMultiplier = 100/1 => expPricePerPixel = 1010/100
 	basePrice = big.NewRat(10, 1)
@@ -888,7 +888,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 
 	priceInfo, err = orch.PriceInfo(ethcommon.Address{})
 	assert.Nil(t, err)
-	assert.Zero(t, expPricePerPixel.Cmp(priceInfo))
+	assert.Zero(t, expPricePerPixel.Cmp(big.NewRat(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)))
 
 	// basePrice = 1/10, txMultiplier = 100 => expPricePerPixel = 101/1000
 	basePrice = big.NewRat(1, 10)
@@ -898,7 +898,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 
 	priceInfo, err = orch.PriceInfo(ethcommon.Address{})
 	assert.Nil(t, err)
-	assert.Zero(t, expPricePerPixel.Cmp(priceInfo))
+	assert.Zero(t, expPricePerPixel.Cmp(big.NewRat(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)))
 
 	// basePrice = 25/10 , txMultiplier = 100 => expPricePerPixel = 2525/1000
 	basePrice = big.NewRat(25, 10)
@@ -908,7 +908,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 
 	priceInfo, err = orch.PriceInfo(ethcommon.Address{})
 	assert.Nil(t, err)
-	assert.Zero(t, expPricePerPixel.Cmp(priceInfo))
+	assert.Zero(t, expPricePerPixel.Cmp(big.NewRat(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)))
 
 	// basePrice = 10/1 , txMultiplier = 100/10 => expPricePerPixel = 11
 	basePrice = big.NewRat(10, 1)
@@ -922,7 +922,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 
 	priceInfo, err = orch.PriceInfo(ethcommon.Address{})
 	assert.Nil(t, err)
-	assert.Zero(t, expPricePerPixel.Cmp(priceInfo))
+	assert.Zero(t, expPricePerPixel.Cmp(big.NewRat(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)))
 
 	// basePrice = 10/1 , txMultiplier = 1/10 => expPricePerPixel = 110
 	basePrice = big.NewRat(10, 1)
@@ -936,7 +936,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 
 	priceInfo, err = orch.PriceInfo(ethcommon.Address{})
 	assert.Nil(t, err)
-	assert.Zero(t, expPricePerPixel.Cmp(priceInfo))
+	assert.Zero(t, expPricePerPixel.Cmp(big.NewRat(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)))
 
 	// basePrice = 10, txMultiplier = 1 => expPricePerPixel = 20
 	basePrice = big.NewRat(10, 1)
@@ -950,7 +950,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 
 	priceInfo, err = orch.PriceInfo(ethcommon.Address{})
 	assert.Nil(t, err)
-	assert.Zero(t, expPricePerPixel.Cmp(priceInfo))
+	assert.Zero(t, expPricePerPixel.Cmp(big.NewRat(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)))
 }
 
 func TestPriceInfo_GivenNilNode_ReturnsNilError(t *testing.T) {

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -182,7 +182,7 @@ func (orch *orchestrator) TicketParams(sender ethcommon.Address) (*net.TicketPar
 	}, nil
 }
 
-func (orch *orchestrator) PriceInfo(sender ethcommon.Address) (*big.Rat, error) {
+func (orch *orchestrator) PriceInfo(sender ethcommon.Address) (*net.PriceInfo, error) {
 	if orch.node == nil || orch.node.Recipient == nil {
 		return nil, nil
 	}
@@ -193,7 +193,11 @@ func (orch *orchestrator) PriceInfo(sender ethcommon.Address) (*big.Rat, error) 
 	}
 	// pricePerPixel = basePrice * (1 + 1/ txCostMultiplier)
 	overhead := new(big.Rat).Add(big.NewRat(1, 1), new(big.Rat).Inv(txCostMultiplier))
-	return new(big.Rat).Mul(orch.node.PriceInfo, overhead), nil
+	price := new(big.Rat).Mul(orch.node.PriceInfo, overhead)
+	return &net.PriceInfo{
+		PricePerUnit:  price.Num().Int64(),
+		PixelsPerUnit: price.Denom().Int64(),
+	}, nil
 }
 
 // SufficientBalance checks whether the credit balance for a stream is sufficient

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -43,7 +43,7 @@ type Orchestrator interface {
 	TranscoderResults(job int64, res *core.RemoteTranscoderResult)
 	ProcessPayment(payment net.Payment, manifestID core.ManifestID) error
 	TicketParams(sender ethcommon.Address) (*net.TicketParams, error)
-	PriceInfo(sender ethcommon.Address) (*big.Rat, error)
+	PriceInfo(sender ethcommon.Address) (*net.PriceInfo, error)
 	SufficientBalance(manifestID core.ManifestID) bool
 }
 
@@ -214,9 +214,15 @@ func orchestratorInfo(orch Orchestrator, addr ethcommon.Address, serviceURI stri
 		return nil, err
 	}
 
+	priceInfo, err := orch.PriceInfo(addr)
+	if err != nil {
+		return nil, err
+	}
+
 	tr := net.OrchestratorInfo{
 		Transcoder:   serviceURI,
 		TicketParams: params,
+		PriceInfo:    priceInfo,
 	}
 
 	os := drivers.NodeStorage.NewSession(string(core.RandomManifestID()))

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -75,7 +75,7 @@ func (r *stubOrchestrator) TicketParams(sender ethcommon.Address) (*net.TicketPa
 	return nil, nil
 }
 
-func (r *stubOrchestrator) PriceInfo(sender ethcommon.Address) (*big.Rat, error) {
+func (r *stubOrchestrator) PriceInfo(sender ethcommon.Address) (*net.PriceInfo, error) {
 	return nil, nil
 }
 
@@ -411,7 +411,7 @@ func TestGetOrchestrator_GivenValidSig_ReturnsTranscoderURI(t *testing.T) {
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 	orch.On("ServiceURI").Return(url.Parse(uri))
 	orch.On("TicketParams", mock.Anything).Return(nil, nil)
-
+	orch.On("PriceInfo", mock.Anything).Return(nil, nil)
 	oInfo, err := getOrchestrator(orch, &net.OrchestratorRequest{})
 
 	assert := assert.New(t)
@@ -439,7 +439,7 @@ func TestGetOrchestrator_GivenValidSig_ReturnsOrchTicketParams(t *testing.T) {
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 	orch.On("ServiceURI").Return(url.Parse(uri))
 	orch.On("TicketParams", mock.Anything).Return(expectedParams, nil)
-
+	orch.On("PriceInfo", mock.Anything).Return(nil, nil)
 	oInfo, err := getOrchestrator(orch, &net.OrchestratorRequest{})
 
 	assert := assert.New(t)
@@ -460,6 +460,41 @@ func TestGetOrchestrator_TicketParamsError(t *testing.T) {
 
 	assert := assert.New(t)
 	assert.EqualError(err, expErr.Error())
+}
+
+func TestGetOrchestrator_GivenValidSig_ReturnsOrchPriceInfo(t *testing.T) {
+	orch := &mockOrchestrator{}
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
+	uri := "http://someuri.com"
+	expectedPrice := &net.PriceInfo{
+		PricePerUnit:  2,
+		PixelsPerUnit: 3,
+	}
+	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
+	orch.On("ServiceURI").Return(url.Parse(uri))
+	orch.On("TicketParams", mock.Anything).Return(nil, nil)
+	orch.On("PriceInfo", mock.Anything).Return(expectedPrice, nil)
+	oInfo, err := getOrchestrator(orch, &net.OrchestratorRequest{})
+
+	assert := assert.New(t)
+	assert.Nil(err)
+	assert.Equal(expectedPrice, oInfo.PriceInfo)
+}
+
+func TestGetOrchestrator_PriceInfoError(t *testing.T) {
+	orch := &mockOrchestrator{}
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
+	uri := "http://someuri.com"
+	expErr := errors.New("PriceInfo error")
+
+	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
+	orch.On("ServiceURI").Return(url.Parse(uri))
+	orch.On("TicketParams", mock.Anything).Return(&net.TicketParams{}, nil)
+	orch.On("PriceInfo", mock.Anything).Return(nil, expErr)
+
+	_, err := getOrchestrator(orch, &net.OrchestratorRequest{})
+
+	assert.EqualError(t, err, expErr.Error())
 }
 
 type mockOSSession struct {
@@ -548,10 +583,10 @@ func (o *mockOrchestrator) TicketParams(sender ethcommon.Address) (*net.TicketPa
 	return nil, args.Error(1)
 }
 
-func (o *mockOrchestrator) PriceInfo(sender ethcommon.Address) (*big.Rat, error) {
+func (o *mockOrchestrator) PriceInfo(sender ethcommon.Address) (*net.PriceInfo, error) {
 	args := o.Called(sender)
 	if args.Get(0) != nil {
-		return args.Get(0).(*big.Rat), args.Error(1)
+		return args.Get(0).(*net.PriceInfo), args.Error(1)
 	}
 	return nil, args.Error(1)
 }

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -354,11 +354,16 @@ func TestServeSegment_UpdateOrchestratorInfo(t *testing.T) {
 		Seed:              []byte("baz"),
 	}
 
+	price := &net.PriceInfo{
+		PricePerUnit:  2,
+		PixelsPerUnit: 3,
+	}
 	// Return an acceptable payment error to trigger an update to orchestrator info
 	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(errors.New("some error")).Once()
 	orch.On("SufficientBalance", s.ManifestID).Return(true)
 
 	orch.On("TicketParams", mock.Anything).Return(params, nil).Once()
+	orch.On("PriceInfo", mock.Anything).Return(price, nil)
 
 	uri, err := url.Parse("http://google.com")
 	require.Nil(err)
@@ -396,7 +401,8 @@ func TestServeSegment_UpdateOrchestratorInfo(t *testing.T) {
 	assert.Equal(params.WinProb, tr.Info.TicketParams.WinProb)
 	assert.Equal(params.RecipientRandHash, tr.Info.TicketParams.RecipientRandHash)
 	assert.Equal(params.Seed, tr.Info.TicketParams.Seed)
-
+	assert.Equal(price.PricePerUnit, tr.Info.PriceInfo.PricePerUnit)
+	assert.Equal(price.PixelsPerUnit, tr.Info.PriceInfo.PixelsPerUnit)
 	// Return an acceptable payment error to trigger an update to orchestrator info
 	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(errors.New("some other error")).Once()
 	orch.On("TicketParams", mock.Anything).Return(params, nil).Once()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Populates `OrchestratorInfo` correctly with `PriceInfo` when calling `grpcClient.GetOrchestrator`,
patch for #911 and #916 

**Specific updates (required)**
- Add call to `orch.PriceInfo(address)` to `rpc.getOrchestrator`
- Changed `orch.PriceInfo(address) (*big.Rat, error)` to `orch.PriceInfo(address) (*net.PriceInfo, error) `
- Added unit tests and adjusted necessary unit tests

**How did you test each of these updates (required)**
Added & adjusted unit tests

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
