### PR TITLE
server: Complete balance update when SubmitSegment() returns

### DIFF
--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -349,7 +349,7 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 
 	// update OrchestratorInfo if necessary
 	if tr.Info != nil {
-		updateOrchestratorInfo(sess, tr.Info)
+		defer updateOrchestratorInfo(sess, tr.Info)
 	}
 
 	// check for errors and exit early if there's anything unusual

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -264,11 +264,10 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 		return nil, err
 	}
 
-	// TODO(yondonfu):
-	// // The balance update should be completed when this function returns
-	// // The logic of balance update completion depends on the status of the update
-	// // at the time of completion
-	// defer completeBalanceUpdate(sess, balUpdate)
+	// The balance update should be completed when this function returns
+	// The logic of balance update completion depends on the status of the update
+	// at the time of completion
+	defer completeBalanceUpdate(sess, balUpdate)
 
 	payment, err := genPayment(sess, balUpdate.NumTickets)
 	if err != nil {
@@ -307,10 +306,9 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 	}
 	defer resp.Body.Close()
 
-	// TODO(yondonfu):
 	// If the segment was submitted then we assume that any payment included was
 	// submitted as well so we consider the update's credit as spent
-	// balUpdate.Status = CreditSpent
+	balUpdate.Status = CreditSpent
 
 	if resp.StatusCode != 200 {
 		data, _ := ioutil.ReadAll(resp.Body)
@@ -386,9 +384,19 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 		return nil, err
 	}
 
-	// TODO(yondonfu):
-	// Set balUpdate.Debit = fee computed based on returned results
-	// Set balUpdate.Status = ReceivedChange
+	// We treat a response as "receiving change" where the change is the difference between the credit and debit for the update
+	balUpdate.Status = ReceivedChange
+	priceInfo := sess.OrchestratorInfo.PriceInfo
+	if priceInfo != nil {
+		// The update's debit is the transcoding fee which is computed as the total number of pixels processed
+		// for all results returned multiplied by the orchestrator's price
+		var pixelCount int64
+		for _, res := range tdata.Segments {
+			pixelCount += res.Pixels
+		}
+
+		balUpdate.Debit.Mul(new(big.Rat).SetInt64(pixelCount), big.NewRat(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit))
+	}
 
 	// transcode succeeded; continue processing response
 	if monitor.Enabled {
@@ -477,31 +485,31 @@ func newBalanceUpdate(sess *BroadcastSession) (*BalanceUpdate, error) {
 	return update, nil
 }
 
-// func completeBalanceUpdate(sess *BroadcastSession, update *BalanceUpdate) {
-// 	if sess.Balance == nil {
-// 		return
-// 	}
+func completeBalanceUpdate(sess *BroadcastSession, update *BalanceUpdate) {
+	if sess.Balance == nil {
+		return
+	}
 
-// 	// If the update's credit has not been spent then add the existing credit
-// 	// back to the balance
-// 	if update.Status == Staged {
-// 		sess.Balance.Credit(update.ExistingCredit)
-// 		return
-// 	}
+	// If the update's credit has not been spent then add the existing credit
+	// back to the balance
+	if update.Status == Staged {
+		sess.Balance.Credit(update.ExistingCredit)
+		return
+	}
 
-// 	// If the update did not include a processed debit then no change was received
-// 	// so we exit without updating the balance because the credit was spent already
-// 	if update.Status != ReceivedChange {
-// 		return
-// 	}
+	// If the update did not include a processed debit then no change was received
+	// so we exit without updating the balance because the credit was spent already
+	if update.Status != ReceivedChange {
+		return
+	}
 
-// 	credit := new(big.Rat).Add(update.ExistingCredit, update.NewCredit)
-// 	// The change could be negative if the debit > credit
-// 	change := credit.Sub(credit, update.Debit)
+	credit := new(big.Rat).Add(update.ExistingCredit, update.NewCredit)
+	// The change could be negative if the debit > credit
+	change := credit.Sub(credit, update.Debit)
 
-// 	// If the change is negative then this is equivalent to debiting abs(change)
-// 	sess.Balance.Credit(change)
-// }
+	// If the change is negative then this is equivalent to debiting abs(change)
+	sess.Balance.Credit(change)
+}
 
 func genPayment(sess *BroadcastSession, numTickets int) (string, error) {
 	if sess.Sender == nil || numTickets == 0 {

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -1109,13 +1109,17 @@ func TestSubmitSegment_UpdateOrchestratorInfo(t *testing.T) {
 		Result: &net.TranscodeResult_Data{
 			Data: &net.TranscodeData{
 				Segments: []*net.TranscodedSegmentData{
-					&net.TranscodedSegmentData{Url: "foo"},
+					&net.TranscodedSegmentData{Url: "foo", Pixels: 10},
 				},
 				Sig: []byte("bar"),
 			},
 		},
 		Info: &net.OrchestratorInfo{
 			Transcoder: "http://google.com",
+			PriceInfo: &net.PriceInfo{
+				PricePerUnit:  1,
+				PixelsPerUnit: 1,
+			},
 			TicketParams: &net.TicketParams{
 				Recipient:         params.Recipient.Bytes(),
 				FaceValue:         params.FaceValue.Bytes(),
@@ -1188,6 +1192,38 @@ func TestSubmitSegment_UpdateOrchestratorInfo(t *testing.T) {
 	assert.Equal("foobar", s.PMSessionID)
 	sender.AssertCalled(t, "StartSession", params)
 
+	// Test balance update completion with last known price and NOT the price
+	// included in an updated OrchestratorInfo message
+
+	ratMatcher := func(rat *big.Rat) interface{} {
+		return mock.MatchedBy(func(x *big.Rat) bool { return x.Cmp(rat) == 0 })
+	}
+
+	existingCredit := big.NewRat(100, 1)
+	// change = existingCredit - (pixelCount * price) = 100 - (10 * 2) = 80
+	// Note that price = 2 which is the last known price and not the price = 1 included in the
+	// updated OrchestratorInfo message
+	change := big.NewRat(80, 1)
+	balance := &mockBalance{}
+	balance.On("StageUpdate", mock.Anything, mock.Anything).Return(0, big.NewRat(0, 1), existingCredit)
+	balance.On("Credit", ratMatcher(change))
+	sender = &pm.MockSender{}
+	sender.On("EV", mock.Anything).Return(nil, nil)
+	sender.On("StartSession", params).Return("foobar")
+	s.Balance = balance
+	s.Sender = sender
+	s.OrchestratorInfo = &net.OrchestratorInfo{
+		Transcoder: ts.URL,
+		PriceInfo: &net.PriceInfo{
+			PricePerUnit:  2,
+			PixelsPerUnit: 1,
+		},
+	}
+
+	_, err = SubmitSegment(s, &stream.HLSSegment{Data: []byte("dummy")}, 0)
+
+	balance.AssertCalled(t, "Credit", ratMatcher(change))
+
 	// Test does not crash if OrchestratorInfo.TicketParams is nil
 
 	sender = &pm.MockSender{}
@@ -1195,6 +1231,7 @@ func TestSubmitSegment_UpdateOrchestratorInfo(t *testing.T) {
 		Transcoder: ts.URL,
 	}
 	s.Sender = sender
+	s.Balance = nil
 
 	// Update stub server to return OrchestratorInfo without TicketParams
 	tr.Info = &net.OrchestratorInfo{


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR implements balance update completion within `SubmitSegment()` with logic that differs depending on the update's status at the time of completion. There are three possible update statuses:

- `Staged`: This is the initial status of the `BalanceUpdate` type. The update remains in this status until the HTTP request for a segment (and its payment header) is submitted.
- `CreditSpent`: This is the status of the `BalanceUpdate` after the HTTP request for a segment is submitted and before a response from O is received. Note: there is no distinction between a HTTP request with a success code and a failure code - as long as the HTTP request was submitted without an error in the Go code, the `BalanceUpdate` status is `CreditSpent`
- `ReceivedChange`: This is the status of the `BalanceUpdate` after a response with transcoded results is received from O

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add the `completeBalanceUpdate()` helper in `server/segment_rpc.go` which executes the logic for completing a balance update depending on the update's status
- Defer the execution of `completeBalanceUpdate()` in `SubmitSegment()` to guarantee its execution before the function returns
- Change the status of `BalanceUpdate` created when preparing a payment at different points of the execution of `SubmitSegment`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #898 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
