### PR TITLE
pm: Validate params for multiple tickets in CreateTicketBatch()

### DIFF
--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -108,6 +108,7 @@ func TestCreateTicketBatch_GetSenderInfoError_ReturnsError(t *testing.T) {
 }
 
 func TestCreateTicketBatch_EVTooHigh_ReturnsError(t *testing.T) {
+	// Test single ticket EV too high
 	sender := defaultSender(t)
 	sender.maxEV = big.NewRat(100, 1)
 
@@ -121,9 +122,20 @@ func TestCreateTicketBatch_EVTooHigh_ReturnsError(t *testing.T) {
 	sessionID := sender.StartSession(ticketParams)
 	_, err := sender.CreateTicketBatch(sessionID, 1)
 	assert.EqualError(t, err, "ticket EV higher than max EV")
+
+	// Test multiple tickets EV too high
+	sender.maxEV = big.NewRat(102, 1)
+
+	_, err = sender.CreateTicketBatch(sessionID, 2)
+	assert.EqualError(t, err, "ticket EV higher than max EV")
+
+	// Check that EV is acceptable for a single ticket
+	_, err = sender.CreateTicketBatch(sessionID, 1)
+	assert.Nil(t, err)
 }
 
 func TestCreateTicketBatch_FaceValueTooHigh_ReturnsError(t *testing.T) {
+	// Test single ticket faceValue too high
 	sender := defaultSender(t)
 	sm := sender.senderManager.(*stubSenderManager)
 	sm.info = &SenderInfo{
@@ -140,6 +152,17 @@ func TestCreateTicketBatch_FaceValueTooHigh_ReturnsError(t *testing.T) {
 	sessionID := sender.StartSession(ticketParams)
 	_, err := sender.CreateTicketBatch(sessionID, 1)
 	assert.EqualError(t, err, "ticket faceValue higher than max faceValue")
+
+	// Test multiple tickets faceValue too high
+	sender.depositMultiplier = 2
+	sm.info.Deposit = big.NewInt(2224)
+
+	_, err = sender.CreateTicketBatch(sessionID, 2)
+	assert.EqualError(t, err, "ticket faceValue higher than max faceValue")
+
+	// Check that faceValue is acceptable for a single ticket
+	_, err = sender.CreateTicketBatch(sessionID, 1)
+	assert.Nil(t, err)
 }
 
 func TestCreateTicketBatch_LastInitializedRoundError_ReturnsError(t *testing.T) {


### PR DESCRIPTION
Refactor ValidateTicketParams() to use a helper that accepts a
numTickets params

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR implements the ability for a `pm.Sender` to validate ticket params for sending multiple tickets in `CreateTicketBatch()`. Previously, ticket param validation consisted of checking if the EV and faceValue for a single ticket were too high. Now, ticket param validation can check if the total EV and faceValue for multiple tickets are too high.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Refactor `ValidateTicketParams()` to use a helper that accepts a
numTickets param
- Use the aforementioned helper in `CreateTicketBatch()` with the size of the batch as the value for the `numTickets` param

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #982 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
