### PR TITLE
cmd, core, pm: O validates B's expected price for a payment

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -373,7 +373,9 @@ func main() {
 			}
 			defer gpm.Stop()
 
-			sm := pm.NewSenderMonitor(n.Eth.Account().Address, n.Eth, gasPriceUpdate, cleanupInterval, smTTL, smMaxErrCount)
+			em := core.NewErrorMonitor(3)
+			n.ErrorMonitor = em
+			sm := pm.NewSenderMonitor(n.Eth.Account().Address, n.Eth, gasPriceUpdate, cleanupInterval, smTTL, n.ErrorMonitor)
 			// Start sender monitor
 			sm.Start()
 			defer sm.Stop()
@@ -390,6 +392,7 @@ func main() {
 				n.Database,
 				gpm,
 				sm,
+				n.ErrorMonitor,
 				cfg,
 			)
 			if err != nil {

--- a/core/errormonitor.go
+++ b/core/errormonitor.go
@@ -59,3 +59,34 @@ func (em *errorMonitor) StartGasPriceUpdateLoop() {
 		em.resetErrCounts()
 	}
 }
+
+// AcceptableError is an interface that describes methods for a payment related error that
+// may be acceptable depending on the type of underlying error
+type AcceptableError interface {
+	error
+
+	// Acceptable returns whether the error is acceptable
+	Acceptable() bool
+}
+
+type acceptableError struct {
+	err        error
+	acceptable bool
+}
+
+func newAcceptableError(err error, acceptable bool) *acceptableError {
+	return &acceptableError{
+		err:        err,
+		acceptable: acceptable,
+	}
+}
+
+// Error returns the underlying error as a string
+func (re *acceptableError) Error() string {
+	return re.err.Error()
+}
+
+// Acceptable returns whether the error is acceptable
+func (re *acceptableError) Acceptable() bool {
+	return re.acceptable
+}

--- a/core/errormonitor.go
+++ b/core/errormonitor.go
@@ -7,18 +7,24 @@ import (
 )
 
 type errorMonitor struct {
-	mu          sync.RWMutex
-	maxErrCount int
-	errCount    map[ethcommon.Address]int
+	mu             sync.Mutex
+	maxErrCount    int
+	errCount       map[ethcommon.Address]int
+	gasPriceUpdate chan struct{}
 }
 
-func NewErrorMonitor(maxErrCount int) *errorMonitor {
+// NewErrorMonitor returns a new errorMonitor instance
+func NewErrorMonitor(maxErrCount int, gasPriceUpdate chan struct{}) *errorMonitor {
 	return &errorMonitor{
-		maxErrCount: maxErrCount,
-		errCount:    make(map[ethcommon.Address]int),
+		maxErrCount:    maxErrCount,
+		errCount:       make(map[ethcommon.Address]int),
+		gasPriceUpdate: gasPriceUpdate,
 	}
 }
 
+// AcceptErr checks if a sender has reached the max error count
+// returns false if no more errors can be accepted
+// returns true and increments the error count when smaller than the max error count
 func (em *errorMonitor) AcceptErr(sender ethcommon.Address) bool {
 	em.mu.Lock()
 	defer em.mu.Unlock()
@@ -30,14 +36,26 @@ func (em *errorMonitor) AcceptErr(sender ethcommon.Address) bool {
 	return true
 }
 
+// ClearErrCount zeroes the error count for a sender
 func (em *errorMonitor) ClearErrCount(sender ethcommon.Address) {
 	em.mu.Lock()
 	defer em.mu.Unlock()
 	em.errCount[sender] = 0
 }
 
-func (em *errorMonitor) ResetErrCounts() {
-	for s := range em.errCount {
-		em.ClearErrCount(s)
+// ResetErrCounts clears error counts for all senders
+func (em *errorMonitor) resetErrCounts() {
+	em.mu.Lock()
+	defer em.mu.Unlock()
+	// Init a fresh map
+	em.errCount = make(map[ethcommon.Address]int)
+}
+
+// StartGasPriceUpdateLoop initiates a loop that runs a worker
+// to reset the errCount for senders every time a gas price change
+// notification is received
+func (em *errorMonitor) StartGasPriceUpdateLoop() {
+	for range em.gasPriceUpdate {
+		em.resetErrCounts()
 	}
 }

--- a/core/errormonitor.go
+++ b/core/errormonitor.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"sync"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+type errorMonitor struct {
+	mu          sync.RWMutex
+	maxErrCount int
+	errCount    map[ethcommon.Address]int
+}
+
+func NewErrorMonitor(maxErrCount int) *errorMonitor {
+	return &errorMonitor{
+		maxErrCount: maxErrCount,
+		errCount:    make(map[ethcommon.Address]int),
+	}
+}
+
+func (em *errorMonitor) AcceptErr(sender ethcommon.Address) bool {
+	em.mu.Lock()
+	defer em.mu.Unlock()
+
+	if em.errCount[sender] >= em.maxErrCount {
+		return false
+	}
+	em.errCount[sender]++
+	return true
+}
+
+func (em *errorMonitor) ClearErrCount(sender ethcommon.Address) {
+	em.mu.Lock()
+	defer em.mu.Unlock()
+	em.errCount[sender] = 0
+}
+
+func (em *errorMonitor) ResetErrCounts() {
+	for s := range em.errCount {
+		em.ClearErrCount(s)
+	}
+}

--- a/core/errormonitor_test.go
+++ b/core/errormonitor_test.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/livepeer/go-livepeer/pm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAcceptErr(t *testing.T) {
+	sender := pm.RandAddress()
+	em := NewErrorMonitor(2, make(chan struct{}))
+
+	ok := em.AcceptErr(sender)
+	assert.True(t, ok)
+	assert.Equal(t, em.errCount[sender], 1)
+
+	ok = em.AcceptErr(sender)
+	assert.True(t, ok)
+	assert.Equal(t, em.errCount[sender], 2)
+
+	ok = em.AcceptErr(sender)
+	assert.False(t, ok)
+	assert.Equal(t, em.errCount[sender], 2)
+}
+
+func TestClearErrCount(t *testing.T) {
+	sender := pm.RandAddress()
+	em := NewErrorMonitor(3, make(chan struct{}))
+
+	em.AcceptErr(sender)
+	em.AcceptErr(sender)
+	assert.Equal(t, em.errCount[sender], 2)
+
+	em.ClearErrCount(sender)
+	assert.Equal(t, em.errCount[sender], 0)
+}
+
+func TestResetErrCounts(t *testing.T) {
+	sender := pm.RandAddress()
+	senderB := pm.RandAddress()
+	assert.NotEqual(t, sender, senderB)
+	em := NewErrorMonitor(3, make(chan struct{}))
+
+	em.AcceptErr(sender)
+	em.AcceptErr(sender)
+	em.AcceptErr(senderB)
+	assert.Equal(t, em.errCount[sender], 2)
+	assert.Equal(t, em.errCount[senderB], 1)
+
+	em.resetErrCounts()
+	assert.Equal(t, em.errCount[sender], 0)
+	assert.Equal(t, em.errCount[senderB], 0)
+
+}
+
+func TestGasPriceUpdateLoop(t *testing.T) {
+	em := NewErrorMonitor(3, make(chan struct{}))
+	go em.StartGasPriceUpdateLoop()
+	assert := assert.New(t)
+
+	// add some counts for senders
+	sender := pm.RandAddress()
+	senderB := pm.RandAddress()
+	em.AcceptErr(sender)
+	em.AcceptErr(sender)
+	em.AcceptErr(senderB)
+	assert.Equal(em.errCount[sender], 2)
+	assert.Equal(em.errCount[senderB], 1)
+
+	// Send a gasPriceUpdate
+	em.gasPriceUpdate <- struct{}{}
+
+	time.Sleep(1 * time.Second)
+
+	// Map should be reinitialized
+	count, ok := em.errCount[sender]
+	assert.False(ok)
+	assert.Equal(count, 0)
+
+	count, ok = em.errCount[senderB]
+	assert.False(ok)
+	assert.Equal(count, 0)
+	close(em.gasPriceUpdate)
+}

--- a/core/errormonitor_test.go
+++ b/core/errormonitor_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -83,4 +84,18 @@ func TestGasPriceUpdateLoop(t *testing.T) {
 	assert.False(ok)
 	assert.Equal(count, 0)
 	close(em.gasPriceUpdate)
+}
+
+func TestAcceptableError(t *testing.T) {
+	expectedErr := &acceptableError{
+		err:        errors.New("hello error"),
+		acceptable: true,
+	}
+	assert := assert.New(t)
+	// test constructor
+	acceptableErr := newAcceptableError(errors.New("hello error"), true)
+	assert.Equal(expectedErr, acceptableErr)
+
+	assert.Equal(expectedErr.acceptable, acceptableErr.Acceptable())
+	assert.Equal("hello error", acceptableErr.Error())
 }

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -66,6 +66,7 @@ type LivepeerNode struct {
 	Transcoder        Transcoder
 	TranscoderManager *RemoteTranscoderManager
 	Balances          *Balances
+	ErrorMonitor      *errorMonitor
 
 	// Broadcaster public fields
 	Sender pm.Sender

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -493,7 +493,7 @@ func TestProcessPayment_GivenRecipientError_ReturnsNil(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	recipient.On("TxCostMultiplier", mock.Anything).Return(big.NewRat(1, 1), nil)
 
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", false, nil)
@@ -545,7 +545,7 @@ func TestProcessPayment_GivenLosingTicket_DoesNotRedeem(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	recipient.On("TxCostMultiplier", mock.Anything).Return(big.NewRat(1, 1), nil)
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("some sessionID", false, nil)
 
@@ -564,7 +564,7 @@ func TestProcessPayment_GivenWinningTicket_RedeemError(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 
 	manifestID := ManifestID("some manifest")
 	sessionID := "some sessionID"
@@ -592,7 +592,7 @@ func TestProcessPayment_GivenWinningTicket_Redeems(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	manifestID := ManifestID("some manifest")
 	sessionID := "some sessionID"
 
@@ -619,7 +619,7 @@ func TestProcessPayment_GivenMultipleWinningTickets_RedeemsAll(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	manifestID := ManifestID("some manifest")
 	sessionID := "some sessionID"
 
@@ -652,7 +652,7 @@ func TestProcessPayment_GivenConcurrentWinningTickets_RedeemsAll(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	manifestIDs := make([]string, 5)
 
 	for i := 0; i < 5; i++ {
@@ -698,7 +698,7 @@ func TestProcessPayment_GivenReceiveTicketError_ReturnsError(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	manifestID := ManifestID("some manifest")
 
 	recipient.On("TxCostMultiplier", mock.Anything).Return(big.NewRat(1, 1), nil)
@@ -734,7 +734,7 @@ func TestProcessPayment_AcceptablePaymentError_IncreasesCreditBalance(t *testing
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 
 	manifestID := ManifestID("some manifest")
 	acceptableError := pm.NewMockReceiveError(errors.New("Acceptable ReceiveTicket error"), true)
@@ -767,7 +767,7 @@ func TestProcessPayment_UnacceptablePaymentError_DoesNotIncreaseCreditBalance(t 
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	manifestID := ManifestID("some manifest")
 	unacceptableError := pm.NewMockReceiveError(errors.New("Unacceptable ReceiveTicket error"), false)
 
@@ -787,7 +787,7 @@ func TestProcesspayment_NoPriceError_IncreasesCredit(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(5, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	manifestID := ManifestID("some manifest")
 	sender := pm.RandAddress()
 
@@ -826,7 +826,7 @@ func TestProcessPayment_AcceptablePriceError_IncreasesCredit_ReturnsError(t *tes
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(5, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(1)
+	orch.node.ErrorMonitor = NewErrorMonitor(1, make(chan struct{}))
 	manifestID := ManifestID("some manifest")
 	sender := pm.RandAddress()
 
@@ -866,7 +866,7 @@ func TestProcessPayment_UnacceptablePriceError_ReturnsError_DoesNotIncreaseCredi
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(5, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	manifestID := ManifestID("some manifest")
 	sender := pm.RandAddress()
 
@@ -904,7 +904,7 @@ func TestAcceptablePrice(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(5, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	assert := assert.New(t)
 
 	sender := pm.RandAddress()
@@ -927,7 +927,7 @@ func TestAcceptablePrice(t *testing.T) {
 	assert.False(ok)
 
 	// Within Grace period and price too low: returns true, error
-	orch.node.ErrorMonitor = NewErrorMonitor(1)
+	orch.node.ErrorMonitor = NewErrorMonitor(1, make(chan struct{}))
 	ok, err = orch.acceptablePrice(sender, expectedPrice)
 	assert.Error(err)
 	assert.True(ok)
@@ -944,6 +944,27 @@ func TestAcceptablePrice(t *testing.T) {
 	ok, err = orch.acceptablePrice(sender, expectedPrice)
 	assert.Nil(err)
 	assert.True(ok)
+
+	// expected price is nil
+	expectedPrice = nil
+	ok, err = orch.acceptablePrice(sender, expectedPrice)
+	assert.Error(err)
+	assert.False(ok)
+
+	// expectedPrice.PixelsPerUnit is 0
+	expectedPrice = &net.PriceInfo{
+		PricePerUnit:  3,
+		PixelsPerUnit: 0,
+	}
+	ok, err = orch.acceptablePrice(sender, expectedPrice)
+	assert.Error(err)
+	assert.False(ok)
+
+	// expectedPrice.PixelsPerUnit is negative
+	expectedPrice.PixelsPerUnit = -5
+	ok, err = orch.acceptablePrice(sender, expectedPrice)
+	assert.Error(err)
+	assert.False(ok)
 }
 
 func TestAcceptablePrice_PriceInfoError_ReturnsErr(t *testing.T) {
@@ -952,7 +973,7 @@ func TestAcceptablePrice_PriceInfoError_ReturnsErr(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(5, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	assert := assert.New(t)
 
 	sender := pm.RandAddress()
@@ -972,7 +993,7 @@ func TestSufficientBalance_IsSufficient_ReturnsTrue(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	manifestID := ManifestID("some manifest")
 
 	recipient.On("TxCostMultiplier", mock.Anything).Return(big.NewRat(1, 1), nil)
@@ -998,7 +1019,7 @@ func TestSufficientBalance_IsNotSufficient_ReturnsFalse(t *testing.T) {
 	n.Recipient = recipient
 	orch := NewOrchestrator(n)
 	orch.node.PriceInfo = big.NewRat(0, 1)
-	orch.node.ErrorMonitor = NewErrorMonitor(0)
+	orch.node.ErrorMonitor = NewErrorMonitor(0, make(chan struct{}))
 	manifestID := ManifestID("some manifest")
 
 	recipient.On("TxCostMultiplier", mock.Anything).Return(big.NewRat(1, 1), nil)

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -235,6 +235,9 @@ func (orch *orchestrator) DebitFees(manifestID ManifestID, price *net.PriceInfo,
 
 // Acceptable price checks whether the payment sender's expected price sent with a payment is acceptable
 func (orch *orchestrator) acceptablePrice(sender ethcommon.Address, ep *net.PriceInfo) (bool, error) {
+	if ep == nil || ep.GetPixelsPerUnit() <= 0 {
+		return false, fmt.Errorf("Expected price is not valid")
+	}
 	epRat := big.NewRat(ep.GetPricePerUnit(), ep.GetPixelsPerUnit())
 
 	oPrice, err := orch.PriceInfo(sender)

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -107,6 +107,16 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 		return fmt.Errorf("Could not find Sender for payment: %v", payment)
 	}
 
+	var (
+		acceptablePriceErr error
+		okPrice            bool
+		didReceiveErr      bool
+	)
+
+	if okPrice, acceptablePriceErr = orch.acceptablePrice(ethcommon.BytesToAddress(payment.Sender), payment.GetExpectedPrice()); !okPrice {
+		return acceptablePriceErr
+	}
+
 	seed := new(big.Int).SetBytes(payment.TicketParams.Seed)
 
 	ticket := &pm.Ticket{
@@ -118,8 +128,6 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 		CreationRound:          payment.ExpirationParams.CreationRound,
 		CreationRoundBlockHash: ethcommon.BytesToHash(payment.ExpirationParams.CreationRoundBlockHash),
 	}
-
-	var didReceiveErr bool
 
 	for _, tsp := range payment.TicketSenderParams {
 
@@ -153,6 +161,10 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 				}
 			}(ticket, tsp.Sig, seed)
 		}
+	}
+
+	if acceptablePriceErr != nil {
+		return acceptablePriceErr
 	}
 
 	if didReceiveErr {
@@ -219,6 +231,23 @@ func (orch *orchestrator) DebitFees(manifestID ManifestID, price *net.PriceInfo,
 	}
 	priceRat := big.NewRat(price.GetPricePerUnit(), price.GetPixelsPerUnit())
 	orch.node.Balances.Debit(manifestID, priceRat.Mul(priceRat, big.NewRat(pixels, 1)))
+}
+
+// Acceptable price checks whether the payment sender's expected price sent with a payment is acceptable
+func (orch *orchestrator) acceptablePrice(sender ethcommon.Address, ep *net.PriceInfo) (bool, error) {
+	epRat := big.NewRat(ep.GetPricePerUnit(), ep.GetPixelsPerUnit())
+
+	oPrice, err := orch.PriceInfo(sender)
+	if err != nil {
+		return false, err
+	}
+	oPriceRat := big.NewRat(oPrice.GetPricePerUnit(), oPrice.GetPixelsPerUnit())
+
+	// expected price is too small, check if sender is still within grace period
+	if epRat.Cmp(oPriceRat) < 0 {
+		return orch.node.ErrorMonitor.AcceptErr(sender), fmt.Errorf("Expected price of %v wei per %v pixels is too small, expecting at least %v wei per %v pixels", ep.GetPricePerUnit(), ep.GetPixelsPerUnit(), oPrice.GetPricePerUnit(), oPrice.GetPixelsPerUnit())
+	}
+	return true, nil
 }
 
 func NewOrchestrator(n *LivepeerNode) *orchestrator {

--- a/eth/gaspricemonitor.go
+++ b/eth/gaspricemonitor.go
@@ -112,6 +112,9 @@ func (gpm *GasPriceMonitor) Stop() error {
 	gpm.cancel = nil
 	gpm.polling = false
 
+	// Close the update channel when gpm is stopped
+	close(gpm.update)
+
 	return nil
 }
 

--- a/eth/gaspricemonitor_test.go
+++ b/eth/gaspricemonitor_test.go
@@ -219,4 +219,8 @@ func TestStop(t *testing.T) {
 
 	// Ensure there are no more queries
 	assert.Equal(queries, gpo.queries)
+
+	// check gasPriceUpdate channel is closed
+	_, ok := (<-gpm.update)
+	assert.False(ok)
 }

--- a/pm/errors.go
+++ b/pm/errors.go
@@ -1,14 +1,5 @@
 package pm
 
-// Error is an interface that describes methods for a PM related error that
-// may be acceptable depending on the type of underlying error
-type Error interface {
-	error
-
-	// Acceptable returns whether the error is acceptable
-	Acceptable() bool
-}
-
 type receiveError struct {
 	err        error
 	acceptable bool

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -140,7 +140,7 @@ func TestReceiveTicket_InvalidFaceValue_AcceptableError(t *testing.T) {
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "invalid ticket faceValue")
 
-	rerr, ok := err.(Error)
+	rerr, ok := err.(acceptableError)
 	assert.True(ok)
 	assert.False(rerr.Acceptable())
 
@@ -154,9 +154,10 @@ func TestReceiveTicket_InvalidFaceValue_AcceptableError(t *testing.T) {
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "invalid ticket faceValue")
 
-	rerr, ok = err.(Error)
+	rerr, ok = err.(acceptableError)
 	assert.True(ok)
 	assert.True(rerr.Acceptable())
+
 }
 
 func TestReceiveTicket_InvalidFaceValue_GasPriceChange(t *testing.T) {
@@ -241,7 +242,7 @@ func TestReceiveTicket_InvalidWinProb_AcceptableError(t *testing.T) {
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "invalid ticket winProb")
 
-	rerr, ok := err.(Error)
+	rerr, ok := err.(acceptableError)
 	assert.True(ok)
 	assert.False(rerr.Acceptable())
 
@@ -255,9 +256,10 @@ func TestReceiveTicket_InvalidWinProb_AcceptableError(t *testing.T) {
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "invalid ticket winProb")
 
-	rerr, ok = err.(Error)
+	rerr, ok = err.(acceptableError)
 	assert.True(ok)
 	assert.True(rerr.Acceptable())
+
 }
 
 func TestReceiveTicket_InvalidTicket(t *testing.T) {
@@ -489,7 +491,7 @@ func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed_AcceptableError(t *t
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "invalid already revealed recipientRand")
 
-	rerr, ok := err.(Error)
+	rerr, ok := err.(acceptableError)
 	assert.True(ok)
 	assert.False(rerr.Acceptable())
 
@@ -500,8 +502,7 @@ func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed_AcceptableError(t *t
 	_, _, err = r.ReceiveTicket(ticket, sig, params.Seed)
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "invalid already revealed recipientRand")
-
-	rerr, ok = err.(Error)
+	rerr, ok = err.(acceptableError)
 	assert.True(ok)
 	assert.True(rerr.Acceptable())
 }

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newRecipientFixtureOrFatal(t *testing.T) (ethcommon.Address, *stubBroker, *stubValidator, *stubTicketStore, *stubGasPriceMonitor, *stubSenderMonitor, TicketParamsConfig, []byte) {
+func newRecipientFixtureOrFatal(t *testing.T) (ethcommon.Address, *stubBroker, *stubValidator, *stubTicketStore, *stubGasPriceMonitor, *stubSenderMonitor, *stubErrorMonitor, TicketParamsConfig, []byte) {
 	sender := RandAddress()
 
 	b := newStubBroker()
@@ -32,17 +32,18 @@ func newRecipientFixtureOrFatal(t *testing.T) (ethcommon.Address, *stubBroker, *
 	gm := &stubGasPriceMonitor{gasPrice: big.NewInt(100)}
 	sm := newStubSenderMonitor()
 	sm.maxFloat = big.NewInt(10000000000)
+	em := &stubErrorMonitor{}
 	cfg := TicketParamsConfig{
 		EV:               big.NewInt(5),
 		RedeemGas:        10000,
 		TxCostMultiplier: 100,
 	}
 
-	return sender, b, v, newStubTicketStore(), gm, sm, cfg, []byte("foo")
+	return sender, b, v, newStubTicketStore(), gm, sm, em, cfg, []byte("foo")
 }
 
-func newRecipientOrFatal(t *testing.T, addr ethcommon.Address, b Broker, v Validator, ts TicketStore, gpm GasPriceMonitor, sm SenderMonitor, cfg TicketParamsConfig) Recipient {
-	r, err := NewRecipient(addr, b, v, ts, gpm, sm, cfg)
+func newRecipientOrFatal(t *testing.T, addr ethcommon.Address, b Broker, v Validator, ts TicketStore, gpm GasPriceMonitor, sm SenderMonitor, em ErrorMonitor, cfg TicketParamsConfig) Recipient {
+	r, err := NewRecipient(addr, b, v, ts, gpm, sm, em, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,8 +78,8 @@ func genRecipientRand(sender ethcommon.Address, secret [32]byte, seed *big.Int) 
 }
 
 func TestReceiveTicket_InvalidFaceValue(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -122,14 +123,15 @@ func TestReceiveTicket_InvalidFaceValue(t *testing.T) {
 }
 
 func TestReceiveTicket_InvalidFaceValue_AcceptableError(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
 	assert := assert.New(t)
 
 	// Test unacceptable error
+	em.acceptable = false
 
 	ticket := newTicket(sender, params, 0)
 	ticket.FaceValue = big.NewInt(0) // Using invalid faceValue
@@ -144,7 +146,7 @@ func TestReceiveTicket_InvalidFaceValue_AcceptableError(t *testing.T) {
 
 	// Test acceptable error
 
-	sm.acceptable = true
+	em.acceptable = true
 	ticket = newTicket(sender, params, 1)
 	ticket.FaceValue = big.NewInt(0) // Using invalid faceValue
 
@@ -158,8 +160,8 @@ func TestReceiveTicket_InvalidFaceValue_AcceptableError(t *testing.T) {
 }
 
 func TestReceiveTicket_InvalidFaceValue_GasPriceChange(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -178,8 +180,8 @@ func TestReceiveTicket_InvalidFaceValue_GasPriceChange(t *testing.T) {
 }
 
 func TestReceiveTicket_InvalidWinProb(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -223,15 +225,15 @@ func TestReceiveTicket_InvalidWinProb(t *testing.T) {
 }
 
 func TestReceiveTicket_InvalidWinProb_AcceptableError(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
 	assert := assert.New(t)
 
 	// Test unacceptable error
-
+	em.acceptable = false
 	ticket := newTicket(sender, params, 0)
 	ticket.WinProb = big.NewInt(0) // Using invalid winProb
 
@@ -245,7 +247,7 @@ func TestReceiveTicket_InvalidWinProb_AcceptableError(t *testing.T) {
 
 	// Test acceptable error
 
-	sm.acceptable = true
+	em.acceptable = true
 	ticket = newTicket(sender, params, 1)
 	ticket.WinProb = big.NewInt(0) // Using invalid winProb
 
@@ -259,8 +261,8 @@ func TestReceiveTicket_InvalidWinProb_AcceptableError(t *testing.T) {
 }
 
 func TestReceiveTicket_InvalidTicket(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -280,9 +282,9 @@ func TestReceiveTicket_InvalidTicket(t *testing.T) {
 }
 
 func TestReceiveTicket_ValidNonWinningTicket(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -310,9 +312,9 @@ func TestReceiveTicket_ValidNonWinningTicket(t *testing.T) {
 }
 
 func TestReceiveTicket_ValidWinningTicket(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -370,9 +372,9 @@ func TestReceiveTicket_ValidWinningTicket(t *testing.T) {
 }
 
 func TestReceiveTicket_ValidWinningTicket_StoreError(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -419,8 +421,8 @@ func TestReceiveTicket_ValidWinningTicket_StoreError(t *testing.T) {
 }
 
 func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -459,8 +461,8 @@ func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed(t *testing.T) {
 }
 
 func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed_AcceptableError(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -482,7 +484,7 @@ func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed_AcceptableError(t *t
 	assert := assert.New(t)
 
 	// Test unacceptable error
-
+	em.acceptable = false
 	_, _, err = r.ReceiveTicket(ticket, sig, params.Seed)
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "invalid already revealed recipientRand")
@@ -493,7 +495,7 @@ func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed_AcceptableError(t *t
 
 	// Test acceptable error
 
-	sm.acceptable = true
+	em.acceptable = true
 
 	_, _, err = r.ReceiveTicket(ticket, sig, params.Seed)
 	assert.NotNil(err)
@@ -505,8 +507,8 @@ func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed_AcceptableError(t *t
 }
 
 func TestReceiveTicket_InvalidSenderNonce(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -547,8 +549,8 @@ func TestReceiveTicket_InvalidSenderNonce(t *testing.T) {
 }
 
 func TestReceiveTicket_ValidNonWinningTicket_Concurrent(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -578,8 +580,8 @@ func TestReceiveTicket_ValidNonWinningTicket_Concurrent(t *testing.T) {
 }
 
 func TestRedeemWinningTickets_InvalidSessionID(t *testing.T) {
-	_, b, v, ts, gm, sm, cfg, _ := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	_, b, v, ts, gm, sm, em, cfg, _ := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 
 	// Config stub ticket store to fail load
 	ts.loadShouldFail = true
@@ -594,8 +596,8 @@ func TestRedeemWinningTickets_InvalidSessionID(t *testing.T) {
 }
 
 func TestRedeemWinningTickets_SingleTicket_GetSenderInfoError(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -626,8 +628,8 @@ func TestRedeemWinningTickets_SingleTicket_GetSenderInfoError(t *testing.T) {
 }
 
 func TestRedeemWinningTickets_SingleTicket_ZeroDepositAndReserve(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
-	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, cfg)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -659,9 +661,9 @@ func TestRedeemWinningTickets_SingleTicket_ZeroDepositAndReserve(t *testing.T) {
 }
 
 func TestRedeemWinningTickets_SingleTicket_RedeemError(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -713,9 +715,9 @@ func TestRedeemWinningTickets_SingleTicket_CheckTxError(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(err)
 
@@ -736,9 +738,9 @@ func TestRedeemWinningTickets_SingleTicket_CheckTxError(t *testing.T) {
 }
 
 func TestRedeemWinningTickets_SingleTicket(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -781,9 +783,9 @@ func TestRedeemWinningTickets_SingleTicket(t *testing.T) {
 }
 
 func TestRedeemWinningTickets_MultipleTickets(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 	params, err := r.TicketParams(sender)
 	require.Nil(t, err)
 
@@ -846,9 +848,9 @@ func TestRedeemWinningTickets_MultipleTickets(t *testing.T) {
 }
 
 func TestRedeemWinningTickets_MultipleTicketsFromMultipleSessions(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 	// Config stub validator with valid winning tickets
 	v.SetIsWinningTicket(true)
 	require := require.New(t)
@@ -895,9 +897,9 @@ func TestRedeemWinningTickets_MultipleTicketsFromMultipleSessions(t *testing.T) 
 func TestRedeemWinningTicket_MaxFloatError(t *testing.T) {
 	assert := assert.New(t)
 
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 
 	params := ticketParamsOrFatal(t, r, sender)
 	ticket := newTicket(sender, params, 1)
@@ -910,9 +912,9 @@ func TestRedeemWinningTicket_MaxFloatError(t *testing.T) {
 func TestRedeemWinningTicket_InsufficientMaxFloat_QueueTicketError(t *testing.T) {
 	assert := assert.New(t)
 
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 
 	params := ticketParamsOrFatal(t, r, sender)
 	ticket := newTicket(sender, params, 1)
@@ -926,9 +928,9 @@ func TestRedeemWinningTicket_InsufficientMaxFloat_QueueTicketError(t *testing.T)
 func TestRedeemWinningTicket_InsufficientMaxFloat_QueueTicket(t *testing.T) {
 	assert := assert.New(t)
 
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 
 	params := ticketParamsOrFatal(t, r, sender)
 	ticket := newTicket(sender, params, 1)
@@ -945,9 +947,9 @@ func TestRedeemWinningTicket_InsufficientMaxFloat_QueueTicket(t *testing.T) {
 func TestRedeemWinningTicket_SubFloatError(t *testing.T) {
 	assert := assert.New(t)
 
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 
 	params := ticketParamsOrFatal(t, r, sender)
 	ticket := newTicket(sender, params, 1)
@@ -961,9 +963,9 @@ func TestRedeemWinningTicket_AddFloatError(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 
 	params := ticketParamsOrFatal(t, r, sender)
 	ticket := newTicket(sender, params, 1)
@@ -999,9 +1001,9 @@ func TestRedeemWinningTicket(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 
 	params := ticketParamsOrFatal(t, r, sender)
 	ticket := newTicket(sender, params, 1)
@@ -1036,9 +1038,9 @@ func TestRedeemManager_Error(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 	r.Start()
 	defer r.Stop()
 
@@ -1075,9 +1077,9 @@ func TestRedeemManager(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	sender, b, v, ts, gm, sm, cfg, sig := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(RandAddress(), b, v, ts, gm, sm, em, secret, cfg)
 	r.Start()
 	defer r.Stop()
 
@@ -1112,10 +1114,10 @@ func TestRedeemManager(t *testing.T) {
 }
 
 func TestTicketParams(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, _ := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, _ := newRecipientFixtureOrFatal(t)
 	recipient := RandAddress()
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(recipient, b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(recipient, b, v, ts, gm, sm, em, secret, cfg)
 
 	require := require.New(t)
 	assert := assert.New(t)
@@ -1241,10 +1243,10 @@ func TestTicketParams(t *testing.T) {
 }
 
 func TestTxCostMultiplier_UsingFaceValue_ReturnsDefaultMultiplier(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, _ := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, _ := newRecipientFixtureOrFatal(t)
 	recipient := RandAddress()
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(recipient, b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(recipient, b, v, ts, gm, sm, em, secret, cfg)
 
 	mul, err := r.TxCostMultiplier(sender)
 	assert.Nil(t, err)
@@ -1252,10 +1254,10 @@ func TestTxCostMultiplier_UsingFaceValue_ReturnsDefaultMultiplier(t *testing.T) 
 }
 
 func TestTxCostMultiplier_UsingMaxFloat_ReturnsScaledMultiplier(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, _ := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, _ := newRecipientFixtureOrFatal(t)
 	recipient := RandAddress()
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(recipient, b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(recipient, b, v, ts, gm, sm, em, secret, cfg)
 
 	sm.maxFloat = big.NewInt(500000)
 
@@ -1268,10 +1270,10 @@ func TestTxCostMultiplier_UsingMaxFloat_ReturnsScaledMultiplier(t *testing.T) {
 }
 
 func TestTxCostMultiplier_MaxFloatError_ReturnsError(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, _ := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, _ := newRecipientFixtureOrFatal(t)
 	recipient := RandAddress()
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(recipient, b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(recipient, b, v, ts, gm, sm, em, secret, cfg)
 
 	sm.maxFloatErr = errors.New("MaxFloat error")
 	mul, err := r.TxCostMultiplier(sender)
@@ -1280,10 +1282,10 @@ func TestTxCostMultiplier_MaxFloatError_ReturnsError(t *testing.T) {
 }
 
 func TestTxCostMultiplier_InsufficientReserve_ReturnsError(t *testing.T) {
-	sender, b, v, ts, gm, sm, cfg, _ := newRecipientFixtureOrFatal(t)
+	sender, b, v, ts, gm, sm, em, cfg, _ := newRecipientFixtureOrFatal(t)
 	recipient := RandAddress()
 	secret := [32]byte{3}
-	r := NewRecipientWithSecret(recipient, b, v, ts, gm, sm, secret, cfg)
+	r := NewRecipientWithSecret(recipient, b, v, ts, gm, sm, em, secret, cfg)
 
 	sm.maxFloat = big.NewInt(0) // Set maxFloat to some value less than EV
 

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -37,10 +37,12 @@ type SenderMonitor interface {
 
 	// MaxFloat returns a remote sender's max float
 	MaxFloat(addr ethcommon.Address) (*big.Int, error)
+}
 
-	// AcceptErr checks whether additional errors should be accepted and if so increments the acceptable error count
-	// for a sender
-	AcceptErr(addr ethcommon.Address) bool
+type ErrorMonitor interface {
+	AcceptErr(sender ethcommon.Address) bool
+	ClearErrCount(sender ethcommon.Address)
+	ResetErrCounts()
 }
 
 type remoteSender struct {
@@ -53,10 +55,6 @@ type remoteSender struct {
 
 	queue *ticketQueue
 
-	// errCount is the current number of acceptable errors counted
-	// for the sender
-	errCount int
-
 	done chan struct{}
 
 	lastAccess int64
@@ -66,9 +64,6 @@ type senderMonitor struct {
 	claimant        ethcommon.Address
 	cleanupInterval time.Duration
 	ttl             int
-	// maxErrCount is the maximum number of acceptable errors allowed
-	// for a sender
-	maxErrCount int
 
 	mu      sync.RWMutex
 	senders map[ethcommon.Address]*remoteSender
@@ -84,20 +79,22 @@ type senderMonitor struct {
 	gasPriceUpdate chan struct{}
 
 	quit chan struct{}
+
+	em ErrorMonitor
 }
 
 // NewSenderMonitor returns a new SenderMonitor
-func NewSenderMonitor(claimant ethcommon.Address, broker Broker, gasPriceUpdate chan struct{}, cleanupInterval time.Duration, ttl int, maxErrCount int) SenderMonitor {
+func NewSenderMonitor(claimant ethcommon.Address, broker Broker, gasPriceUpdate chan struct{}, cleanupInterval time.Duration, ttl int, em ErrorMonitor) SenderMonitor {
 	return &senderMonitor{
 		claimant:        claimant,
 		cleanupInterval: cleanupInterval,
 		ttl:             ttl,
-		maxErrCount:     maxErrCount,
 		broker:          broker,
 		senders:         make(map[ethcommon.Address]*remoteSender),
 		redeemable:      make(chan *SignedTicket),
 		gasPriceUpdate:  gasPriceUpdate,
 		quit:            make(chan struct{}),
+		em:              em,
 	}
 }
 
@@ -138,7 +135,7 @@ func (sm *senderMonitor) AddFloat(addr ethcommon.Address, amount *big.Int) error
 	// Reset errCount for sender
 	// An updated max float results in updated ticket params
 	// The sender could plausibly send tickets that trigger acceptable errors
-	sm.senders[addr].errCount = 0
+	sm.em.ClearErrCount(addr)
 
 	// Whenever a sender's max float increases, signal the updated max float to the
 	// sender's associated ticket queue in case there are queued tickets that
@@ -164,7 +161,7 @@ func (sm *senderMonitor) SubFloat(addr ethcommon.Address, amount *big.Int) error
 	// Reset errCount for sender
 	// An updated max float results in updated ticket params
 	// The sender could plausibly send tickets that trigger acceptable errors
-	sm.senders[addr].errCount = 0
+	sm.em.ClearErrCount(addr)
 
 	return nil
 }
@@ -193,21 +190,6 @@ func (sm *senderMonitor) QueueTicket(addr ethcommon.Address, ticket *SignedTicke
 	sm.senders[addr].queue.Add(ticket)
 
 	return nil
-}
-
-// AcceptErr checks whether additional errors should be accepted and if so increments the acceptable error count
-// for a sender
-func (sm *senderMonitor) AcceptErr(addr ethcommon.Address) bool {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
-
-	if sm.senders[addr].errCount >= sm.maxErrCount {
-		return false
-	}
-
-	sm.senders[addr].errCount++
-
-	return true
 }
 
 // maxFloat is a helper that returns the sender's max float as:
@@ -304,7 +286,7 @@ func (sm *senderMonitor) startGasPriceUpdateLoop() {
 	for {
 		select {
 		case <-sm.gasPriceUpdate:
-			sm.resetErrCounts()
+			sm.em.ResetErrCounts()
 		case <-sm.quit:
 			return
 		}
@@ -324,16 +306,5 @@ func (sm *senderMonitor) cleanup() {
 
 			delete(sm.senders, k)
 		}
-	}
-}
-
-// resetErrCounts resets the error count for all tracked
-// remote senders
-func (sm *senderMonitor) resetErrCounts() {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
-
-	for _, v := range sm.senders {
-		v.errCount = 0
 	}
 }

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -337,8 +337,6 @@ func (s *stubSenderMonitor) MaxFloat(addr ethcommon.Address) (*big.Int, error) {
 	return s.maxFloat, nil
 }
 
-func (s *stubSenderMonitor) AcceptErr(addr ethcommon.Address) bool { return s.acceptable }
-
 // MockRecipient is useful for testing components that depend on pm.Recipient
 type MockRecipient struct {
 	mock.Mock
@@ -462,4 +460,16 @@ func NewMockReceiveError(err error, acceptable bool) *MockReceiveError {
 		err,
 		acceptable,
 	}
+}
+
+type stubErrorMonitor struct {
+	acceptable bool
+}
+
+func (em *stubErrorMonitor) AcceptErr(sender ethcommon.Address) bool {
+	return em.acceptable
+}
+
+func (em *stubErrorMonitor) ClearErrCount(sender ethcommon.Address) {
+	em.acceptable = true
 }

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -444,6 +444,13 @@ type MockReceiveError struct {
 	acceptable bool
 }
 
+type acceptableError interface {
+	error
+
+	// Acceptable returns whether the error is acceptable
+	Acceptable() bool
+}
+
 // Error returns the underlying error as a string
 func (re *MockReceiveError) Error() string {
 	return re.err.Error()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR allows an orchestrator to check whether a broadcaster's `payment.ExpectedPrice` matches the dynamically generated `PriceInfo` broadcaster based on the orchestrator's `basePrice` and transaction cost overhead. 

If the `payment.ExpectedPrice` is outdated (doesn't match) this will count as an acceptable error , similar to acceptable errors for pm tickets, as long as the broadcaster is still within the grace period (hasn't reached the maximum error count). 

The orchestrator uses a shared  error counter defined on the `LivepeerNode`  for both acceptable price errors and acceptable pm ticket errors. 

**Specific updates (required)**
- Created (extracted out of `SenderMonitor`)  an `ErrorMonitor` that tracks both acceptable pm ticket errors as well as acceptable price errors.
- Added a price check in `orch.ProcessPayment`
- Added an unexported helper method on `orchestrator` to check expected price vs the orchestrator's price for a sender
- Added an `ErrorMonitor` interface in the `pm` package
- Added a `stubErrorMonitor` to `pm` stubs/mocks

**How did you test each of these updates (required)**
Added unit tests

**Does this pull request close any open issues?**
Fixes #955 

**Checklist:**

- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
