### PR TITLE
cmd, server: O can set/get priceInfo in CLI

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -338,7 +338,7 @@ func main() {
 				// Prevent orchestrator from unknowingly provide free transcoding
 				panic(fmt.Errorf("Price per unit of pixels must be greater than 0, provided %d instead\n", *pricePerUnit))
 			}
-			n.PriceInfo = big.NewRat(int64(*pricePerUnit), int64(*pixelsPerUnit))
+			n.SetBasePrice(big.NewRat(int64(*pricePerUnit), int64(*pixelsPerUnit)))
 			glog.Infof("Price: %d wei for %d pixels\n ", *pricePerUnit, *pixelsPerUnit)
 
 			ctx, cancel := context.WithCancel(context.Background())

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"io/ioutil"
+	"math/big"
 	"net/url"
 	"os"
 	"testing"
@@ -128,4 +129,18 @@ func TestServiceURIChange(t *testing.T) {
 	surl, err := sesh.SaveData("testdata3", []byte{0, 0, 0})
 	require.Nil(err)
 	assert.Equal("test://secondurl.com/stream/testpath/testdata3", surl)
+}
+
+func TestSetAndGetBasePrice(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	n, err := NewLivepeerNode(nil, "", nil)
+	require.Nil(err)
+
+	price := big.NewRat(1, 1)
+
+	n.SetBasePrice(price)
+	assert.Zero(n.priceInfo.Cmp(price))
+	assert.Zero(n.GetBasePrice().Cmp(price))
 }

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -869,7 +869,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 	expPricePerPixel := big.NewRat(101, 100)
 
 	n, _ := NewLivepeerNode(nil, "", nil)
-	n.PriceInfo = basePrice
+	n.SetBasePrice(basePrice)
 
 	recipient := new(pm.MockRecipient)
 	n.Recipient = recipient
@@ -882,7 +882,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 
 	// basePrice = 10/1, txMultiplier = 100/1 => expPricePerPixel = 1010/100
 	basePrice = big.NewRat(10, 1)
-	n.PriceInfo = basePrice
+	n.SetBasePrice(basePrice)
 	orch = NewOrchestrator(n)
 	expPricePerPixel = big.NewRat(1010, 100)
 
@@ -892,7 +892,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 
 	// basePrice = 1/10, txMultiplier = 100 => expPricePerPixel = 101/1000
 	basePrice = big.NewRat(1, 10)
-	n.PriceInfo = basePrice
+	n.SetBasePrice(basePrice)
 	orch = NewOrchestrator(n)
 	expPricePerPixel = big.NewRat(101, 1000)
 
@@ -902,7 +902,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 
 	// basePrice = 25/10 , txMultiplier = 100 => expPricePerPixel = 2525/1000
 	basePrice = big.NewRat(25, 10)
-	n.PriceInfo = basePrice
+	n.SetBasePrice(basePrice)
 	orch = NewOrchestrator(n)
 	expPricePerPixel = big.NewRat(2525, 1000)
 
@@ -913,7 +913,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 	// basePrice = 10/1 , txMultiplier = 100/10 => expPricePerPixel = 11
 	basePrice = big.NewRat(10, 1)
 	txMultiplier = big.NewRat(100, 10)
-	n.PriceInfo = basePrice
+	n.SetBasePrice(basePrice)
 	recipient = new(pm.MockRecipient)
 	n.Recipient = recipient
 	recipient.On("TxCostMultiplier", mock.Anything).Return(txMultiplier, nil)
@@ -927,7 +927,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 	// basePrice = 10/1 , txMultiplier = 1/10 => expPricePerPixel = 110
 	basePrice = big.NewRat(10, 1)
 	txMultiplier = big.NewRat(1, 10)
-	n.PriceInfo = basePrice
+	n.SetBasePrice(basePrice)
 	recipient = new(pm.MockRecipient)
 	n.Recipient = recipient
 	recipient.On("TxCostMultiplier", mock.Anything).Return(txMultiplier, nil)
@@ -941,7 +941,7 @@ func TestPriceInfo_ReturnsBigRat(t *testing.T) {
 	// basePrice = 10, txMultiplier = 1 => expPricePerPixel = 20
 	basePrice = big.NewRat(10, 1)
 	txMultiplier = big.NewRat(1, 1)
-	n.PriceInfo = basePrice
+	n.SetBasePrice(basePrice)
 	recipient = new(pm.MockRecipient)
 	n.Recipient = recipient
 	recipient.On("TxCostMultiplier", mock.Anything).Return(txMultiplier, nil)

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -193,7 +193,7 @@ func (orch *orchestrator) PriceInfo(sender ethcommon.Address) (*net.PriceInfo, e
 	}
 	// pricePerPixel = basePrice * (1 + 1/ txCostMultiplier)
 	overhead := new(big.Rat).Add(big.NewRat(1, 1), new(big.Rat).Inv(txCostMultiplier))
-	price := new(big.Rat).Mul(orch.node.PriceInfo, overhead)
+	price := new(big.Rat).Mul(orch.node.GetBasePrice(), overhead)
 	return &net.PriceInfo{
 		PricePerUnit:  price.Num().Int64(),
 		PixelsPerUnit: price.Denom().Int64(),

--- a/server/webserver_test.go
+++ b/server/webserver_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetOrchestratorPriceInfo(t *testing.T) {
+	n, _ := core.NewLivepeerNode(nil, "", nil)
+	s := &LivepeerServer{
+		LivepeerNode: n,
+	}
+
+	// pricePerUnit is not an integer
+	err := s.setOrchestratorPriceInfo("nil", "1")
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Error converting pricePerUnit string to int64"))
+
+	// pixelsPerUnit is not an integer
+	err = s.setOrchestratorPriceInfo("1", "nil")
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Error converting pixelsPerUnit string to int64"))
+
+	err = s.setOrchestratorPriceInfo("1", "1")
+	assert.Nil(t, err)
+	assert.Zero(t, s.LivepeerNode.GetBasePrice().Cmp(big.NewRat(1, 1)))
+
+	//Price per unit <= 0
+	err = s.setOrchestratorPriceInfo("0", "1")
+	assert.EqualErrorf(t, err, err.Error(), "price unit must be greater than 0, provided %d\n", 0)
+	err = s.setOrchestratorPriceInfo("-5", "1")
+	assert.EqualErrorf(t, err, err.Error(), "price unit must be greater than 0, provided %d\n", -5)
+
+	// pixels per unit <= 0
+	err = s.setOrchestratorPriceInfo("1", "0")
+	assert.EqualErrorf(t, err, err.Error(), "pixels per unit must be greater than 0, provided %d\n", 0)
+	err = s.setOrchestratorPriceInfo("1", "-5")
+	assert.EqualErrorf(t, err, err.Error(), "pixels per unit must be greater than 0, provided %d\n", -5)
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Enables orchestrators to set new base price info and query its current base price through the CLI

_* This update contains some code duplication but the wizard is due for a rework so we limit the amount of time spent working on it currently_ 

IMPORTANT! 
Breaking change introduced in CLI: `pricePerUnit` is now a required field

**Specific updates (required)**
- Added user input prompts for `pricePerUnit` and `pixelsPerUnit`
- Added these new fields to the cli server http handlers
- Return `PriceInfo` as a `big.Rat` from `/getOrchestratorInfo`

**How did you test each of these updates (required)**
**TODO:** run the CLI 

**Does this pull request close any open issues?**
Fixes #924

**Checklist:**
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
