### PR TITLE
discovery: Check for nil error before monitor.LogDiscoveryError

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -112,7 +112,8 @@ func (o *orchestratorPool) GetOrchestrators(numOrchestrators int) ([]*net.Orches
 		if err == nil && (o.pred == nil || o.pred(info)) {
 			orchInfos = append(orchInfos, info)
 			numSuccessResp++
-		} else if monitor.Enabled {
+		}
+		if err != nil && monitor.Enabled {
 			monitor.LogDiscoveryError(err.Error())
 		}
 		if numSuccessResp >= numOrchestrators || numResp >= len(o.uris) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes a bug in `(*orchestatorPool).GetOrchestrators()` that results in a nil pointer exception if `err = nil` and `(o.pred == nil || o.pred(info)) = false`. In this scenario, we report the discovery error using `monitor.LogDiscoveryError()` if `monitor.Enabled = true` - since `err = nil`, the statement `err.Error()` will result in a nil pointer exception. A B can run into this scenario if it has monitoring enabled and receives a response from a O, but the O is not acceptable because it fails the predicate check (i.e. unacceptable ticket params or price).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Check if `err != nil` before calling `monitor.LogDiscoveryError()`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Set up the described scenario by running nodes via the test-harness.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
