### PR TITLE
cmd: patch broadcastStats nil pointer panic for nil price

### DIFF
--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -144,10 +144,14 @@ func (w *wizard) broadcastStats() {
 	}
 
 	price, transcodingOptions := w.getBroadcastConfig()
+	priceString := "n/a"
+	if price != nil {
+		priceString = fmt.Sprintf("%v pixels / %v wei", price.Num().Int64(), price.Denom().Int64())
+	}
 
 	table := tablewriter.NewWriter(os.Stdout)
 	data := [][]string{
-		[]string{"Broadcast Price Per Segment in Wei", price.String()},
+		[]string{"Max Price Per Pixel", priceString},
 		[]string{"Broadcast Transcoding Options", transcodingOptions},
 		[]string{"Deposit", eth.FormatUnits(sender.Deposit, "ETH")},
 		[]string{"Reserve", eth.FormatUnits(sender.Reserve, "ETH")},


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixed broadcaster CLI nil pointer panic when maximum transcoding job price is not set.

```
+-----------------+
|BROADCASTER STATS|
+-----------------+
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x48dde1c]

goroutine 1 [running]:
math/big.(*Int).Int64(...)
	/usr/local/go/src/math/big/int.go:372
main.(*wizard).broadcastStats(0xc0000c2300)
	/Users/nico/go/src/github.com/livepeer/go-livepeer/cmd/livepeer_cli/wizard_stats.go:150 +0x20c
main.(*wizard).stats(0xc0000c2300, 0xc000010000)
	/Users/nico/go/src/github.com/livepeer/go-livepeer/cmd/livepeer_cli/wizard_stats.go:76 +0x9f8
main.(*wizard).run(0xc0000c2300)
```

**Specific updates (required)**
- Default to `"n/a"` string to display unless `price (*big.rat) != nil` , then display `"x wei / y pixels"`

**How did you test each of these updates (required)**
- Ran CLI


**Does this pull request close any open issues?**


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
