### PR TITLE
server: Populate Sender and ExpectedPrice for 0 ticket payments

### DIFF
--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -386,7 +386,7 @@ func TestGenPayment(t *testing.T) {
 	protoPayment := decodePayment(payment)
 
 	assert.Equal(batch.Recipient, ethcommon.BytesToAddress(protoPayment.TicketParams.Recipient))
-	assert.Equal(batch.Sender, ethcommon.BytesToAddress(protoPayment.Sender))
+	assert.Equal(b.Address(), ethcommon.BytesToAddress(protoPayment.Sender))
 	assert.Equal(batch.FaceValue, new(big.Int).SetBytes(protoPayment.TicketParams.FaceValue))
 	assert.Equal(batch.WinProb, new(big.Int).SetBytes(protoPayment.TicketParams.WinProb))
 	assert.Equal(batch.SenderParams[0].SenderNonce, protoPayment.TicketSenderParams[0].SenderNonce)
@@ -423,7 +423,10 @@ func TestGenPayment(t *testing.T) {
 
 	payment, err = genPayment(s, 0)
 	assert.Nil(err)
-	assert.Equal("", payment)
+
+	protoPayment = decodePayment(payment)
+	assert.Equal(b.Address(), ethcommon.BytesToAddress(protoPayment.Sender))
+	assert.Zero(big.NewRat(oinfo.PriceInfo.PricePerUnit, oinfo.PriceInfo.PixelsPerUnit).Cmp(big.NewRat(protoPayment.ExpectedPrice.PricePerUnit, protoPayment.ExpectedPrice.PixelsPerUnit)))
 
 	sender.AssertNotCalled(t, "CreateTicketBatch", s.PMSessionID, 0)
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR populates the `Sender` and `ExpectedPrice` fields of a payment with 0 tickets. Currently, a B will not generate a payment if it already meets O's minimum credit requirement. Generating a 0 ticket payment in this scenario allows B to top off its balance past the minimum credit requirement (O would just debit fees from the balance for each segment transcoded). This change also helps in testing scenarios where O's price is 0 or if O is not counting any pixels in results.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Always create a payment with `Sender` and `ExpectedPrice` populated in `genPayment()`
- Embed tickets in a payment if the number of tickets required is greater than 0

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
