### PR TITLE
Add O Discovery Webhook

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -140,6 +140,7 @@ func main() {
 
 	// API
 	authWebhookURL := flag.String("authWebhookUrl", "", "RTMP authentication webhook URL")
+	orchWebhookURL := flag.String("orchWebhookUrl", "", "Orchestrator discovery callback URL")
 
 	flag.Parse()
 	vFlag.Value.Set(*verbosity)
@@ -585,7 +586,13 @@ func main() {
 		*httpAddr = defaultAddr(*httpAddr, "127.0.0.1", RpcPort)
 
 		// Set up orchestrator discovery
-		if len(orchURLs) > 0 {
+		if *orchWebhookURL != "" {
+			whurl, err := getOrchWebhook(*orchWebhookURL)
+			if err != nil {
+				glog.Fatal("Error setting orch webhook URL ", err)
+			}
+			n.OrchestratorPool = discovery.NewWebhookPool(n, whurl)
+		} else if len(orchURLs) > 0 {
 			n.OrchestratorPool = discovery.NewOrchestratorPool(n, orchURLs)
 		} else if *network != "offchain" {
 			n.OrchestratorPool = discovery.NewDBOrchestratorPoolCache(n)
@@ -704,6 +711,21 @@ func main() {
 	}
 }
 
+func getOrchWebhook(u string) (*url.URL, error) {
+	if u == "" {
+		return nil, nil
+	}
+	p, err := url.ParseRequestURI(u)
+	if err != nil {
+		return nil, err
+	}
+	if p.Scheme != "http" && p.Scheme != "https" {
+		return nil, errors.New("Webhook URL should be HTTP or HTTP")
+	}
+	glog.Infof("Using orchestrator webhook url %s", u)
+	return p, nil
+}
+
 func getAuthWebhookURL(u string) (string, error) {
 	if u == "" {
 		return "", nil
@@ -715,7 +737,7 @@ func getAuthWebhookURL(u string) (string, error) {
 	if p.Scheme != "http" && p.Scheme != "https" {
 		return "", errors.New("Webhook URL should be HTTP or HTTP")
 	}
-	glog.Infof("Using webhook url %s", u)
+	glog.Infof("Using auth webhook url %s", u)
 	return u, nil
 }
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -720,7 +720,7 @@ func getOrchWebhook(u string) (*url.URL, error) {
 		return nil, err
 	}
 	if p.Scheme != "http" && p.Scheme != "https" {
-		return nil, errors.New("Webhook URL should be HTTP or HTTP")
+		return nil, errors.New("Webhook URL should be HTTP or HTTPS")
 	}
 	glog.Infof("Using orchestrator webhook url %s", u)
 	return p, nil
@@ -735,7 +735,7 @@ func getAuthWebhookURL(u string) (string, error) {
 		return "", err
 	}
 	if p.Scheme != "http" && p.Scheme != "https" {
-		return "", errors.New("Webhook URL should be HTTP or HTTP")
+		return "", errors.New("Webhook URL should be HTTP or HTTPS")
 	}
 	glog.Infof("Using auth webhook url %s", u)
 	return u, nil

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -49,10 +49,10 @@ func NewDBOrchestratorPoolCache(node *core.LivepeerNode) *DBOrchestratorPoolCach
 	return &DBOrchestratorPoolCache{node: node}
 }
 
-func (dbo *DBOrchestratorPoolCache) GetURLs() []*url.URL {
+func (dbo *DBOrchestratorPoolCache) getURLs() ([]*url.URL, error) {
 	orchs, err := dbo.node.Database.SelectOrchs(&common.DBOrchFilter{MaxPrice: server.BroadcastCfg.MaxPrice()})
 	if err != nil || len(orchs) <= 0 {
-		return nil
+		return nil, err
 	}
 
 	var uris []*url.URL
@@ -61,19 +61,18 @@ func (dbo *DBOrchestratorPoolCache) GetURLs() []*url.URL {
 			uris = append(uris, uri)
 		}
 	}
+	return uris, nil
+}
+
+func (dbo *DBOrchestratorPoolCache) GetURLs() []*url.URL {
+	uris, _ := dbo.getURLs()
 	return uris
 }
 
 func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int) ([]*net.OrchestratorInfo, error) {
-	orchs, err := dbo.node.Database.SelectOrchs(&common.DBOrchFilter{MaxPrice: server.BroadcastCfg.MaxPrice()})
-	if err != nil || len(orchs) <= 0 {
+	uris, err := dbo.getURLs()
+	if err != nil || len(uris) <= 0 {
 		return nil, err
-	}
-
-	var uris []string
-	for _, orch := range orchs {
-		uri := orch.ServiceURI
-		uris = append(uris, uri)
 	}
 
 	pred := func(info *net.OrchestratorInfo) bool {

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -101,11 +101,7 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int) ([]*n
 }
 
 func (dbo *DBOrchestratorPoolCache) Size() int {
-	orchs, err := dbo.node.Database.SelectOrchs(&common.DBOrchFilter{MaxPrice: server.BroadcastCfg.MaxPrice()})
-	if err != nil {
-		return 0
-	}
-	return len(orchs)
+	return len(dbo.GetURLs())
 }
 
 func cacheRegisteredTranscoders(node *core.LivepeerNode) error {

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"math/rand"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
@@ -29,23 +28,11 @@ type orchestratorPool struct {
 
 var perm = func(len int) []int { return rand.Perm(len) }
 
-func NewOrchestratorPool(node *core.LivepeerNode, addresses []string) *orchestratorPool {
-	var uris []*url.URL
-
-	for _, addr := range addresses {
-		if !strings.HasPrefix(addr, "http") {
-			addr = "https://" + addr
-		}
-		uri, err := url.ParseRequestURI(addr)
-		if err != nil {
-			glog.Error("Could not parse orchestrator URI: ", err)
-			continue
-		}
-		uris = append(uris, uri)
-	}
+func NewOrchestratorPool(node *core.LivepeerNode, uris []*url.URL) *orchestratorPool {
 
 	if len(uris) <= 0 {
-		glog.Error("Could not parse orchAddresses given - no URIs returned ")
+		// Should we return here?
+		glog.Error("Orchestrator pool does not have any URIs")
 	}
 
 	var randomizedUris []*url.URL
@@ -58,7 +45,7 @@ func NewOrchestratorPool(node *core.LivepeerNode, addresses []string) *orchestra
 	return &orchestratorPool{bcast: bcast, uris: randomizedUris}
 }
 
-func NewOrchestratorPoolWithPred(node *core.LivepeerNode, addresses []string, pred func(*net.OrchestratorInfo) bool) *orchestratorPool {
+func NewOrchestratorPoolWithPred(node *core.LivepeerNode, addresses []*url.URL, pred func(*net.OrchestratorInfo) bool) *orchestratorPool {
 	// if livepeer running in offchain mode, return nil
 	if node.Eth == nil {
 		glog.Error("Could not refresh DB list of orchestrators: LivepeerNode nil")

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -69,27 +69,6 @@ func NewOrchestratorPoolWithPred(node *core.LivepeerNode, addresses []string, pr
 	return pool
 }
 
-func NewOnchainOrchestratorPool(node *core.LivepeerNode) *orchestratorPool {
-	// if livepeer running in offchain mode, return nil
-	if node.Eth == nil {
-		glog.Error("Could not refresh DB list of orchestrators: LivepeerNode nil")
-		return nil
-	}
-
-	orchestrators, err := node.Eth.RegisteredTranscoders()
-	if err != nil {
-		glog.Error("Could not refresh DB list of orchestrators: ", err)
-		return nil
-	}
-
-	var addresses []string
-	for _, orch := range orchestrators {
-		addresses = append(addresses, orch.ServiceURI)
-	}
-
-	return NewOrchestratorPool(node, addresses)
-}
-
 func (o *orchestratorPool) GetURLs() []*url.URL {
 	return o.uris
 }

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -67,15 +67,6 @@ func TestNewOrchestratorPoolWithPred_NilEthClient_ReturnsNil_LogsError(t *testin
 	assert.Nil(t, pool)
 }
 
-func TestNewOnchainOrchestratorPool_NilEthClient_ReturnsNil_LogsError(t *testing.T) {
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	errorLogsBefore := glog.Stats.Error.Lines()
-	pool := NewOnchainOrchestratorPool(node)
-	errorLogsAfter := glog.Stats.Error.Lines()
-	assert.NotZero(t, errorLogsAfter-errorLogsBefore)
-	assert.Nil(t, pool)
-}
-
 func TestNewDBOrchestratorPoolCache_NilEthClient_ReturnsNil_LogsError(t *testing.T) {
 	node, _ := core.NewLivepeerNode(nil, "", nil)
 	errorLogsBefore := glog.Stats.Error.Lines()
@@ -363,17 +354,6 @@ func TestNewOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *
 	offchainOrch := NewOrchestratorPool(node, addresses)
 
 	for i, uri := range offchainOrch.uris {
-		assert.Equal(uri.String(), expected[i])
-	}
-
-	orchestrators := StubOrchestrators(addresses)
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
-
-	// testing NewOnchainOrchestratorPool
-	rand.Seed(321)
-	perm = func(len int) []int { return rand.Perm(3) }
-	offchainOrchFromOnchainList := NewOnchainOrchestratorPool(node)
-	for i, uri := range offchainOrchFromOnchainList.uris {
 		assert.Equal(uri.String(), expected[i])
 	}
 }

--- a/discovery/wh_discovery.go
+++ b/discovery/wh_discovery.go
@@ -1,0 +1,82 @@
+package discovery
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/net"
+
+	"github.com/golang/glog"
+)
+
+type webhookResponse struct {
+	Address string
+}
+
+type webhookPool struct {
+	node     *core.LivepeerNode
+	callback *url.URL
+}
+
+func NewWebhookPool(node *core.LivepeerNode, callback *url.URL) *webhookPool {
+	return &webhookPool{node: node, callback: callback}
+}
+
+func getURLs(cbUrl *url.URL) ([]*url.URL, error) {
+	// TODO cache results for some time to avoid repeated callouts
+	var httpc = &http.Client{
+		Timeout: 3 * time.Second,
+	}
+	resp, err := httpc.Get(cbUrl.String())
+	if err != nil {
+		glog.Error("Unable to make webhook request ", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		glog.Error("Unable to read response body ", err)
+		return nil, err
+	}
+	var addrs []webhookResponse
+	if err := json.Unmarshal(body, &addrs); err != nil {
+		glog.Error("Unable to unmarshal JSON ", err)
+		return nil, err
+	}
+	var urls []*url.URL
+	for i := range addrs {
+		uri, err := url.ParseRequestURI(addrs[i].Address)
+		if err != nil {
+			glog.Errorf("Unable to parse address  %s : %s", addrs[i].Address, err)
+			continue
+		}
+		urls = append(urls, uri)
+	}
+	return urls, nil
+}
+
+func (w *webhookPool) GetURLs() []*url.URL {
+	uris, _ := getURLs(w.callback)
+	return uris
+}
+
+func (w *webhookPool) Size() int {
+	return len(w.GetURLs())
+}
+
+func (w *webhookPool) GetOrchestrators(numOrchestrators int) ([]*net.OrchestratorInfo, error) {
+	addrs, err := getURLs(w.callback)
+	if err != nil {
+		return nil, err
+	}
+	pool := NewOrchestratorPool(w.node, addrs)
+	if pool == nil {
+		return nil, errors.New("Nil orchestrator pool")
+	}
+	return pool.GetOrchestrators(numOrchestrators)
+}

--- a/doc/orchwebhook.md
+++ b/doc/orchwebhook.md
@@ -1,0 +1,19 @@
+# Orchestrator Webhook
+
+Livepeer supports orchestrator discovery using a webhook. Webhook orchestrator discovery can be
+enabled by starting a Livepeer Broadcaster node with the `-orchWebhookUrl <endpoint>` flag.
+The `<endpoint>` is a url that returns an array of objects that each contains an "address" key
+and a URL string value.
+
+For example:
+
+```json
+[
+    {"address":"https://10.4.3.2:8935"},
+    {"address":"https://10.4.4.3:8935"},
+    {"address":"https://10.4.5.2:8935"}
+]
+```
+
+The orchestrator webhook allows a Broadcaster node operator to periodically refresh its list of available orchestrators. 
+The list is refreshed no more than once per minute or as needed, depending on streaming conditions. Refer to the [reliability documentation](https://github.com/livepeer/go-livepeer/blob/master/doc/reliability.md) for more information.

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,8 @@ require (
 	github.com/livepeer/m3u8 v0.11.0
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-sqlite3 v1.11.0
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/oschwald/maxminddb-golang v1.5.0 // indirect

--- a/test_args.sh
+++ b/test_args.sh
@@ -141,6 +141,16 @@ res=0
 ./livepeer -broadcaster -authWebhookUrl http\\://host/ || res=$?
 [ $res -ne 0 ]
 
+# exit early if orchestrator webhook URL is not http
+res=0
+./livepeer -broadcaster -orchWebhookUrl tcp://host/ || res=$?
+[ $res -ne 0 ]
+
+# exit early if orchestrator webhook URL is not properly formatted
+res=0
+./livepeer -broadcaster -orchWebhookUrl http\\://host/ || res=$?
+[ $res -ne 0 ]
+
 # exit early if maxSessions less or equal to zero
 res=0
 ./livepeer -broadcaster -maxSessions -1 || res=$?


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds webhook support for O Discovery and various other cleanups around the discovery code.

Still needs a few things to move this out of WIP status:

* Caching responses. Currently, each method of the OrchestratorPool interface calls out to the webhook. This really is not necessary, since we typically invoke `Size()` then `GetOrchestrators` in quick succession within [`NewSessionManager`](https://github.com/livepeer/go-livepeer/blob/5c17d9d119255d4d4567cb8223fd5dd0ac8a07f3/server/broadcast.go#L162-L177). We really should cache the resulting OrchestratorPool and return its URIs immediately if the O list is requested within some interval, say 1 minute.

* Refresh on empty responses - currently, if an empty response is received from the webhook, then the session manager will not refresh, leading to no Os for the duration of the session. Should be fixed - need to check whether this is an issue within the session manager, or O Discovery.

* Unit tests, including CLI tests

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- https://github.com/livepeer/go-livepeer/commit/c92c0a36d66f8927c42b11b5135c11ad14eba8c7 : discovery: Remove OnchainOrchestratorPool.  …
No longer used.

- https://github.com/livepeer/go-livepeer/commit/98e4350358bcbd4ef9ea36d55657debb2a29734d : db_discovery: Use GetURLs as the basis for Size()  …
Code reuse avoids any potential discrepancy between GetURLs / Sizes.

Fixes an issue that was first flagged here : https://github.com/livepeer/go-livepeer/pull/939#discussion_r298403855 and https://github.com/livepeer/go-livepeer/pull/939#discussion_r298407762

- https://github.com/livepeer/go-livepeer/commit/fcc8d7f6958974f7bd0d1635369fedffb7a6073f : discovery: Take well-formed URLs within OrchestratorPool.  …
Reduces the amount of sanitzation the OrchestratorPool performs.
Makes it more explicit that any address cleanup done within the CLI
is a UX affordance.

Corrects an issue first flagged here: https://github.com/livepeer/go-livepeer/pull/939#discussion_r298327624

- https://github.com/livepeer/go-livepeer/commit/4f3696eb62f50b59c0beb0144076546873597ac0 : discovery: Add orchestrator discovery via webhooks.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Manual testing. (Unit testing needed!)

**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/go-livepeer/issues/851


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
