### PR TITLE
Add basic payment metrics reporting

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"encoding/hex"
 	ogErrors "errors"
 	"fmt"
 	"io/ioutil"
@@ -185,7 +184,7 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 	}
 
 	if monitor.Enabled {
-		sender := "0x" + hex.EncodeToString(payment.Sender)
+		sender := ethcommon.BytesToAddress(payment.Sender).String()
 		mid := string(manifestID)
 
 		monitor.TicketValueRecv(sender, mid, totalEV)

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/hex"
 	ogErrors "errors"
 	"fmt"
 	"io/ioutil"
@@ -138,6 +139,10 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 		CreationRoundBlockHash: ethcommon.BytesToHash(payment.ExpirationParams.CreationRoundBlockHash),
 	}
 
+	totalEV := big.NewRat(0, 1)
+	totalTickets := 0
+	totalWinningTickets := 0
+
 	for _, tsp := range payment.TicketSenderParams {
 
 		ticket.SenderNonce = tsp.SenderNonce
@@ -158,7 +163,10 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 		pmErr, ok := err.(AcceptableError)
 		if acceptablePrice && err == nil || (ok && pmErr.Acceptable()) {
 			// Add ticket EV to credit
-			orch.node.Balances.Credit(manifestID, ticket.EV())
+			ev := ticket.EV()
+			orch.node.Balances.Credit(manifestID, ev)
+			totalEV.Add(totalEV, ev)
+			totalTickets++
 		} else {
 			unacceptableReceiveErr = true
 		}
@@ -166,12 +174,23 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 		if won {
 			glog.V(common.DEBUG).Infof("Received winning ticket manifestID=%v recipientRandHash=%x senderNonce=%v", manifestID, ticket.RecipientRandHash, ticket.SenderNonce)
 
+			totalWinningTickets++
+
 			go func(ticket *pm.Ticket, sig []byte, seed *big.Int) {
 				if err := orch.node.Recipient.RedeemWinningTicket(ticket, sig, seed); err != nil {
 					glog.Errorf("error redeeming ticket manifestID=%v recipientRandHash=%x senderNonce=%v: %v", manifestID, ticket.RecipientRandHash, ticket.SenderNonce, err)
 				}
 			}(ticket, tsp.Sig, seed)
 		}
+	}
+
+	if monitor.Enabled {
+		sender := "0x" + hex.EncodeToString(payment.Sender)
+		mid := string(manifestID)
+
+		monitor.TicketValueRecv(sender, mid, totalEV)
+		monitor.TicketsRecv(sender, mid, totalTickets)
+		monitor.WinningTicketsRecv(sender, totalWinningTickets)
 	}
 
 	if didPriceErr {

--- a/eth/gaspricemonitor.go
+++ b/eth/gaspricemonitor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/monitor"
 )
 
 // GasPriceOracle defines methods for fetching a suggested gas price
@@ -125,6 +126,10 @@ func (gpm *GasPriceMonitor) fetchAndUpdateGasPrice(ctx context.Context) error {
 	}
 
 	gpm.updateGasPrice(ctx, gasPrice)
+
+	if monitor.Enabled {
+		monitor.SuggestedGasPrice(gasPrice)
+	}
 
 	glog.V(common.DEBUG).Infof("Cached gas price: %v", gasPrice)
 

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -129,12 +129,12 @@ func InitCensus(nodeType, nodeID, version string) {
 		success:     make(map[uint64]*segmentsAverager),
 	}
 	var err error
-	census.kNodeType, _ = tag.NewKey("node_type")
-	census.kNodeID, _ = tag.NewKey("node_id")
-	census.kProfile, _ = tag.NewKey("profile")
-	census.kProfiles, _ = tag.NewKey("profiles")
-	census.kErrorCode, _ = tag.NewKey("error_code")
-	census.kTry, _ = tag.NewKey("try")
+	census.kNodeType = tag.MustNewKey("node_type")
+	census.kNodeID = tag.MustNewKey("node_id")
+	census.kProfile = tag.MustNewKey("profile")
+	census.kProfiles = tag.MustNewKey("profiles")
+	census.kErrorCode = tag.MustNewKey("error_code")
+	census.kTry = tag.MustNewKey("try")
 	census.ctx, err = tag.New(context.Background(), tag.Insert(census.kNodeType, nodeType), tag.Insert(census.kNodeID, nodeID))
 	if err != nil {
 		glog.Fatal("Error creating context", err)
@@ -170,11 +170,11 @@ func InitCensus(nodeType, nodeID, version string) {
 	glog.Infof("Livepeer version: %s", version)
 	glog.Infof("Node type %s node ID %s", nodeType, nodeID)
 	mVersions := stats.Int64("versions", "Version information.", "Num")
-	compiler, _ := tag.NewKey("compiler")
-	goarch, _ := tag.NewKey("goarch")
-	goos, _ := tag.NewKey("goos")
-	goversion, _ := tag.NewKey("goversion")
-	livepeerversion, _ := tag.NewKey("livepeerversion")
+	compiler := tag.MustNewKey("compiler")
+	goarch := tag.MustNewKey("goarch")
+	goos := tag.MustNewKey("goos")
+	goversion := tag.MustNewKey("goversion")
+	livepeerversion := tag.MustNewKey("livepeerversion")
 	ctx, err := tag.New(context.Background(), tag.Insert(census.kNodeType, nodeType), tag.Insert(census.kNodeID, nodeID),
 		tag.Insert(compiler, runtime.Compiler), tag.Insert(goarch, runtime.GOARCH), tag.Insert(goos, runtime.GOOS),
 		tag.Insert(goversion, runtime.Version()), tag.Insert(livepeerversion, version))

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"math/big"
 	"runtime"
 	"strconv"
 	"strings"
@@ -42,6 +43,7 @@ const (
 	SegmentTranscodeErrorPlaylist           SegmentTranscodeError = "Playlist"
 
 	numberOfSegmentsToCalcAverage = 30
+	gweiConversionFactor          = 1000000000
 )
 
 // Enabled true if metrics was enabled in command line
@@ -61,6 +63,9 @@ type (
 		kProfiles                     tag.Key
 		kErrorCode                    tag.Key
 		kTry                          tag.Key
+		kSender                       tag.Key
+		kRecipient                    tag.Key
+		kManifestID                   tag.Key
 		mSegmentSourceAppeared        *stats.Int64Measure
 		mSegmentEmerged               *stats.Int64Measure
 		mSegmentEmergedUnprocessed    *stats.Int64Measure
@@ -85,9 +90,21 @@ type (
 		mTranscodeLatency             *stats.Float64Measure
 		mTranscodeOverallLatency      *stats.Float64Measure
 		mUploadTime                   *stats.Float64Measure
-		lock                          sync.Mutex
-		emergeTimes                   map[uint64]map[uint64]time.Time // nonce:seqNo
-		success                       map[uint64]*segmentsAverager
+
+		// Metrics for sending payments
+		mTicketValueSent *stats.Float64Measure
+		mTicketsSent     *stats.Int64Measure
+
+		// Metrics for receiving payments
+		mTicketValueRecv    *stats.Float64Measure
+		mTicketsRecv        *stats.Int64Measure
+		mWinningTicketsRecv *stats.Int64Measure
+		mValueRedeemed      *stats.Float64Measure
+		mSuggestedGasPrice  *stats.Float64Measure
+
+		lock        sync.Mutex
+		emergeTimes map[uint64]map[uint64]time.Time // nonce:seqNo
+		success     map[uint64]*segmentsAverager
 	}
 
 	segmentCount struct {
@@ -135,6 +152,9 @@ func InitCensus(nodeType, nodeID, version string) {
 	census.kProfiles = tag.MustNewKey("profiles")
 	census.kErrorCode = tag.MustNewKey("error_code")
 	census.kTry = tag.MustNewKey("try")
+	census.kSender = tag.MustNewKey("sender")
+	census.kRecipient = tag.MustNewKey("recipient")
+	census.kManifestID = tag.MustNewKey("manifestID")
 	census.ctx, err = tag.New(context.Background(), tag.Insert(census.kNodeType, nodeType), tag.Insert(census.kNodeID, nodeID))
 	if err != nil {
 		glog.Fatal("Error creating context", err)
@@ -165,6 +185,17 @@ func InitCensus(nodeType, nodeID, version string) {
 	census.mTranscodeOverallLatency = stats.Float64("transcode_overall_latency_seconds",
 		"Transcoding latency, from source segment emered from segmenter till all transcoded segment apeeared in manifest", "sec")
 	census.mUploadTime = stats.Float64("upload_time_seconds", "Upload (to Orchestrator) time", "sec")
+
+	// Metrics for sending payments
+	census.mTicketValueSent = stats.Float64("ticket_value_sent", "TicketValueSent", "gwei")
+	census.mTicketsSent = stats.Int64("tickets_sent", "TicketsSent", "tot")
+
+	// Metrics for receiving payments
+	census.mTicketValueRecv = stats.Float64("ticket_value_recv", "TicketValueRecv", "gwei")
+	census.mTicketsRecv = stats.Int64("tickets_recv", "TicketsRecv", "tot")
+	census.mWinningTicketsRecv = stats.Int64("winning_tickets_recv", "WinningTicketsRecv", "tot")
+	census.mValueRedeemed = stats.Float64("value_redeemed", "ValueRedeemed", "gwei")
+	census.mSuggestedGasPrice = stats.Float64("suggested_gas_price", "SuggestedGasPrice", "gwei")
 
 	glog.Infof("Compiler: %s Arch %s OS %s Go version %s", runtime.Compiler, runtime.GOARCH, runtime.GOOS, runtime.Version())
 	glog.Infof("Livepeer version: %s", version)
@@ -358,7 +389,61 @@ func InitCensus(nodeType, nodeID, version string) {
 			TagKeys:     append([]tag.Key{census.kTry}, baseTags...),
 			Aggregation: view.Count(),
 		},
+
+		// Metrics for sending payments
+		&view.View{
+			Name:        "ticket_value_sent",
+			Measure:     census.mTicketValueSent,
+			Description: "Ticket value sent",
+			TagKeys:     append([]tag.Key{census.kRecipient, census.kManifestID}, baseTags...),
+			Aggregation: view.Sum(),
+		},
+		&view.View{
+			Name:        "tickets_sent",
+			Measure:     census.mTicketsSent,
+			Description: "Tickets sent",
+			TagKeys:     append([]tag.Key{census.kRecipient, census.kManifestID}, baseTags...),
+			Aggregation: view.Sum(),
+		},
+
+		// Metrics for receiving payments
+		&view.View{
+			Name:        "ticket_value_recv",
+			Measure:     census.mTicketValueRecv,
+			Description: "Ticket value received",
+			TagKeys:     append([]tag.Key{census.kSender, census.kManifestID}, baseTags...),
+			Aggregation: view.Sum(),
+		},
+		&view.View{
+			Name:        "tickets_recv",
+			Measure:     census.mTicketsRecv,
+			Description: "Tickets received",
+			TagKeys:     append([]tag.Key{census.kSender, census.kManifestID}, baseTags...),
+			Aggregation: view.Sum(),
+		},
+		&view.View{
+			Name:        "winning_tickets_recv",
+			Measure:     census.mWinningTicketsRecv,
+			Description: "Winning tickets received",
+			TagKeys:     baseTags,
+			Aggregation: view.Sum(),
+		},
+		&view.View{
+			Name:        "value_redeemed",
+			Measure:     census.mValueRedeemed,
+			Description: "Winning ticket value redeemed",
+			TagKeys:     baseTags,
+			Aggregation: view.Sum(),
+		},
+		&view.View{
+			Name:        "suggested_gas_price",
+			Measure:     census.mSuggestedGasPrice,
+			Description: "Suggested gas price for winning ticket redemption",
+			TagKeys:     baseTags,
+			Aggregation: view.LastValue(),
+		},
 	}
+
 	// Register the views
 	if err := view.Register(views...); err != nil {
 		glog.Fatalf("Failed to register views: %v", err)
@@ -838,4 +923,126 @@ func (cen *censusMetricsCounter) streamEnded(nonce uint64) {
 		}
 	}
 	census.sendSuccess()
+}
+
+// TicketValueSent records the ticket value sent to a recipient for a manifestID
+func TicketValueSent(recipient string, manifestID string, value *big.Rat) {
+	census.lock.Lock()
+	defer census.lock.Unlock()
+
+	if value.Cmp(big.NewRat(0, 1)) <= 0 {
+		return
+	}
+
+	ctx, err := tag.New(census.ctx, tag.Insert(census.kRecipient, recipient), tag.Insert(census.kManifestID, manifestID))
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	stats.Record(ctx, census.mTicketValueSent.M(fracwei2gwei(value)))
+}
+
+// TicketsSent records the number of tickets sent to a recipient for a manifestID
+func TicketsSent(recipient string, manifestID string, numTickets int) {
+	census.lock.Lock()
+	defer census.lock.Unlock()
+
+	if numTickets <= 0 {
+		return
+	}
+
+	ctx, err := tag.New(census.ctx, tag.Insert(census.kRecipient, recipient), tag.Insert(census.kManifestID, manifestID))
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	stats.Record(ctx, census.mTicketsSent.M(int64(numTickets)))
+}
+
+// TicketValueRecv records the ticket value received from a sender for a manifestID
+func TicketValueRecv(sender string, manifestID string, value *big.Rat) {
+	census.lock.Lock()
+	defer census.lock.Unlock()
+
+	if value.Cmp(big.NewRat(0, 1)) <= 0 {
+		return
+	}
+
+	ctx, err := tag.New(census.ctx, tag.Insert(census.kSender, sender), tag.Insert(census.kManifestID, manifestID))
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	stats.Record(ctx, census.mTicketValueRecv.M(fracwei2gwei(value)))
+}
+
+// TicketsRecv records the number of tickets received from a sender for a manifestID
+func TicketsRecv(sender string, manifestID string, numTickets int) {
+	census.lock.Lock()
+	defer census.lock.Unlock()
+
+	if numTickets <= 0 {
+		return
+	}
+
+	ctx, err := tag.New(census.ctx, tag.Insert(census.kSender, sender), tag.Insert(census.kManifestID, manifestID))
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	stats.Record(ctx, census.mTicketsRecv.M(int64(numTickets)))
+}
+
+// WinningTicketsRecv records the number of winning tickets received from a sender
+func WinningTicketsRecv(sender string, numTickets int) {
+	census.lock.Lock()
+	defer census.lock.Unlock()
+
+	if numTickets <= 0 {
+		return
+	}
+
+	ctx, err := tag.New(census.ctx, tag.Insert(census.kSender, sender))
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	stats.Record(ctx, census.mWinningTicketsRecv.M(int64(numTickets)))
+}
+
+// ValueRedeemed records the value from redeeming winning tickets from a sender
+func ValueRedeemed(sender string, value *big.Int) {
+	census.lock.Lock()
+	defer census.lock.Unlock()
+
+	if value.Cmp(big.NewInt(0)) <= 0 {
+		return
+	}
+
+	ctx, err := tag.New(census.ctx, tag.Insert(census.kSender, sender))
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	stats.Record(ctx, census.mValueRedeemed.M(wei2gwei(value)))
+}
+
+// SuggestedGasPrice records the last suggested gas price
+func SuggestedGasPrice(gasPrice *big.Int) {
+	census.lock.Lock()
+	defer census.lock.Unlock()
+
+	stats.Record(census.ctx, census.mSuggestedGasPrice.M(wei2gwei(gasPrice)))
+}
+
+// Convert wei to gwei
+func wei2gwei(wei *big.Int) float64 {
+	gwei, _ := new(big.Float).Quo(new(big.Float).SetInt(wei), big.NewFloat(float64(gweiConversionFactor))).Float64()
+	return gwei
+}
+
+// Convert fractional wei to gwei
+func fracwei2gwei(wei *big.Rat) float64 {
+	floatWei, _ := wei.Float64()
+	return floatWei / gweiConversionFactor
 }

--- a/monitor/census_test.go
+++ b/monitor/census_test.go
@@ -3,8 +3,11 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAveragerCanBeRemoved(t *testing.T) {
@@ -118,4 +121,54 @@ func TestLastSegmentTimeout(t *testing.T) {
 	if sr := census.successRate(); sr != 0.5 {
 		t.Fatalf("Success rate should be 0.5, not %f", sr)
 	}
+}
+
+func TestWei2Gwei(t *testing.T) {
+	assert := assert.New(t)
+
+	wei := big.NewInt(gweiConversionFactor)
+	assert.Equal(1.0, wei2gwei(wei))
+
+	wei = big.NewInt(gweiConversionFactor / 2)
+	assert.Equal(0.5, wei2gwei(wei))
+
+	wei = big.NewInt(0)
+	assert.Equal(0.0, wei2gwei(wei))
+
+	wei = big.NewInt(gweiConversionFactor * 1.5)
+	assert.Equal(1.5, wei2gwei(wei))
+
+	wei = big.NewInt(gweiConversionFactor * 2)
+	assert.Equal(2.0, wei2gwei(wei))
+}
+
+func TestFracWei2Gwei(t *testing.T) {
+	assert := assert.New(t)
+
+	wei := big.NewRat(gweiConversionFactor, 1)
+	assert.Equal(1.0, fracwei2gwei(wei))
+
+	wei = big.NewRat(gweiConversionFactor/2, 1)
+	assert.Equal(0.5, fracwei2gwei(wei))
+
+	wei = big.NewRat(0, 1)
+	assert.Equal(0.0, fracwei2gwei(wei))
+
+	wei = big.NewRat(gweiConversionFactor*1.5, 1)
+	assert.Equal(1.5, fracwei2gwei(wei))
+
+	wei = big.NewRat(gweiConversionFactor*2, 1)
+	assert.Equal(2.0, fracwei2gwei(wei))
+
+	delta := .000000001
+
+	// Test wei amounts with a fractional part
+	wei = big.NewRat(gweiConversionFactor/2, 6)
+	assert.InDelta(.083333333, fracwei2gwei(wei), delta)
+
+	wei = big.NewRat(gweiConversionFactor*1.5, 7)
+	assert.InDelta(.214285714, fracwei2gwei(wei), delta)
+
+	wei = big.NewRat(gweiConversionFactor*2, 7)
+	assert.InDelta(.285714286, fracwei2gwei(wei), delta)
 }

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -10,6 +10,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/pkg/errors"
 )
 
@@ -388,6 +389,12 @@ func (r *recipient) redeemWinningTicket(ticket *Ticket, sig []byte, recipientRan
 	// Wait for transaction to confirm
 	if err := r.broker.CheckTx(tx); err != nil {
 		return err
+	}
+
+	if monitor.Enabled {
+		// TODO(yondonfu): Handle case where < ticket.FaceValue is actually
+		// redeemed i.e. if sender reserve cannot cover the full ticket.FaceValue
+		monitor.ValueRedeemed(ticket.Sender.String(), ticket.FaceValue)
 	}
 
 	return nil

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -317,7 +316,7 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 	// submitted as well so we consider the update's credit as spent
 	balUpdate.Status = CreditSpent
 	if monitor.Enabled && sess.OrchestratorInfo.TicketParams != nil {
-		recipient := "0x" + hex.EncodeToString(sess.OrchestratorInfo.TicketParams.Recipient)
+		recipient := ethcommon.BytesToAddress(sess.OrchestratorInfo.TicketParams.Recipient).String()
 		mid := string(sess.ManifestID)
 
 		monitor.TicketValueSent(recipient, mid, balUpdate.NewCredit)

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -315,6 +316,13 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 	// If the segment was submitted then we assume that any payment included was
 	// submitted as well so we consider the update's credit as spent
 	balUpdate.Status = CreditSpent
+	if monitor.Enabled && sess.OrchestratorInfo.TicketParams != nil {
+		recipient := "0x" + hex.EncodeToString(sess.OrchestratorInfo.TicketParams.Recipient)
+		mid := string(sess.ManifestID)
+
+		monitor.TicketValueSent(recipient, mid, balUpdate.NewCredit)
+		monitor.TicketsSent(recipient, mid, balUpdate.NumTickets)
+	}
 
 	if resp.StatusCode != 200 {
 		data, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds basic payment metrics reporting. The following metrics are included:

- `ticket_value_sent`
- `tickets_sent`
- `ticket_value_recv`
- `tickets_recv`
- `winning_tickets_recv`
- `value_redeemed`
- `suggested_gas_price`

A broadcaster will record `ticket_value_sent` and `tickets_sent` after submitting a segment with a payment.

An orchestrator will record `ticket_value_recv` and `tickets_recv` for each valid ticket in a payment received with a segment. It will also record `winning_tickets_recv` for each winning ticket received, `value_redeemed` when it successfully redeems a winning ticket and `suggested_gas_price` whenever it caches a new gas price to use for ticket param/price calculations.

Note: This is not a complete list of payment metrics. We'll likely also want to report error types, but I excluded those errors for now because the metrics included in this PR should already get us started with payment workflow testing.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Added new metrics to `monitor`
- Recorded metrics when a segment with payment is submitted, a segment with payment is received, a winning ticket is redeemed and when a new gas price is cached. Each of these additions is included in its own separate commit

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added some tests for helpers introduced in `monitor`. The current layout of the `monitor` package makes it a bit difficult to unit test the addition of new metrics - perhaps we can consider options to make unit testing easier separately.

Also tried using PromQL queries within the Grafana dashboard created in a local test-harness deployment to fetch the metrics reported. Graph templates still need to be added though.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #936 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
