### PR TITLE
Set timeout for downloading segments

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -18,6 +18,9 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
+// HTTPTimeout timeout used in HTTP connections between nodes
+const HTTPTimeout = 8 * time.Second
+
 var (
 	ErrParseBigInt = fmt.Errorf("failed to parse big integer")
 	ErrProfile     = fmt.Errorf("failed to parse profile")

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -626,8 +626,8 @@ func (rt *RemoteTranscoder) Transcode(fname string, profiles []ffmpeg.VideoProfi
 	case <-ctx.Done():
 		return signalEOF(ErrRemoteTranscoderTimeout)
 	case chanData := <-taskChan:
-		glog.Infof("Successfully received results from remote transcoder=%s segments=%d taskId=%d fname=%s",
-			rt.addr, len(chanData.Segments), taskID, fname)
+		glog.Infof("Successfully received results from remote transcoder=%s segments=%d taskId=%d fname=%s err=%v",
+			rt.addr, len(chanData.Segments), taskID, fname, chanData.Err)
 		return chanData.Segments, chanData.Err
 	}
 }

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -63,25 +63,28 @@ func GetSegmentData(uri string) ([]byte, error) {
 	return getSegmentDataHTTP(uri)
 }
 
-var httpc = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+var httpc = &http.Client{
+	Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	Timeout:   common.HTTPTimeout / 2,
+}
 
 func getSegmentDataHTTP(uri string) ([]byte, error) {
-	glog.V(common.VERBOSE).Info("Downloading ", uri)
+	glog.V(common.VERBOSE).Infof("Downloading uri=%s", uri)
 	resp, err := httpc.Get(uri)
 	if err != nil {
-		glog.Error("Error getting HTTP ", err)
+		glog.Errorf("Error getting HTTP uri=%s err=%v", uri, err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		glog.Error("Non-200 response ", resp.Status)
+		glog.Errorf("Non-200 response for status=%v uri=%s", resp.Status, uri)
 		return nil, fmt.Errorf(resp.Status)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		glog.Error("Error reading body: ", err)
+		glog.Errorf("Error reading body uri=%s err=%v", uri, err)
 		return nil, err
 	}
-	glog.V(common.VERBOSE).Info("Downloaded ", uri)
+	glog.V(common.VERBOSE).Infof("Downloaded uri=%s", uri)
 	return body, nil
 }

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -164,7 +164,7 @@ func NewSessionManager(node *core.LivepeerNode, params *streamParameters, pl cor
 	if node.OrchestratorPool != nil {
 		poolSize = float64(node.OrchestratorPool.Size())
 	}
-	maxInflight := HTTPTimeout.Seconds() / SegLen.Seconds()
+	maxInflight := common.HTTPTimeout.Seconds() / SegLen.Seconds()
 	numOrchs := int(math.Min(poolSize, maxInflight*2))
 	bsm := &BroadcastSessionsManager{
 		sessMap:        make(map[string]*BroadcastSession),

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/net"
@@ -88,7 +89,7 @@ func TestNewSessionManager(t *testing.T) {
 	// Check numOrchs up to maximum and a bit beyond
 	sd := &stubDiscovery{}
 	n.OrchestratorPool = sd
-	max := int(HTTPTimeout.Seconds()/SegLen.Seconds()) * 2
+	max := int(common.HTTPTimeout.Seconds()/SegLen.Seconds()) * 2
 	for i := 0; i < 10; i++ {
 		sess = NewSessionManager(n, params, pl)
 		if i < max {

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -237,12 +237,12 @@ func (h *lphttp) TranscodeResults(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("OK"))
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			glog.Error("Unable to read transcoding error body ", err)
+			glog.Errorf("Unable to read transcoding error body taskID=%v err=%v", tid, err)
 			res.Err = err
 		} else {
 			res.Err = fmt.Errorf(string(body))
 		}
-		glog.Error("Trascoding error ", res.Err)
+		glog.Errorf("Trascoding error for taskID=%v err=%v", tid, res.Err)
 		orch.TranscoderResults(tid, &res)
 		return
 	}

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -28,7 +28,6 @@ import (
 
 const GRPCConnectTimeout = 3 * time.Second
 const GRPCTimeout = 8 * time.Second
-const HTTPTimeout = 8 * time.Second
 
 type Orchestrator interface {
 	ServiceURI() *url.URL

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -36,7 +36,7 @@ var errSegSig = errors.New("ErrSegSig")
 var tlsConfig = &tls.Config{InsecureSkipVerify: true}
 var httpClient = &http.Client{
 	Transport: &http2.Transport{TLSClientConfig: tlsConfig},
-	Timeout:   HTTPTimeout,
+	Timeout:   common.HTTPTimeout,
 }
 
 func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
@@ -107,7 +107,7 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "BadRequest", http.StatusBadRequest)
 			return
 		}
-		if took > HTTPTimeout {
+		if took > common.HTTPTimeout {
 			// download from object storage took more time when broadcaster will be waiting for result
 			// so there is no point to start transcoding process
 			glog.Errorf(" Getting segment from %s took too long, aborting", uri)
@@ -160,7 +160,7 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 	// construct the response
 	var result net.TranscodeResult
 	if err != nil {
-		glog.Error("Could not transcode ", err)
+		glog.Errorf("Could not transcode seqNo=%d mid=%s err=%v", segData.Seq, segData.ManifestID, err)
 		result = net.TranscodeResult{Result: &net.TranscodeResult_Error{Error: err.Error()}}
 	} else {
 		result = net.TranscodeResult{Result: &net.TranscodeResult_Data{


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
There was no timeout set for downloading segments. Without timeout, under the load, sometimes TCP connection just stalled, and breaked after 15 minutes with 'connection reset by peer' error. This prevented B to retry segment in time.

**Specific updates (required)**
Added timeout

**How did you test each of these updates (required)**
Manually


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass