### PR TITLE
core: allow empty ticketparams

### DIFF
--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -553,7 +553,7 @@ func TestProcessPayment_GivenNoSender_ReturnsError(t *testing.T) {
 	assert.False(ok)
 }
 
-func TestProcessPayment_GivenNoTicketParams_ReturnsError(t *testing.T) {
+func TestProcessPayment_GivenNoTicketParams_ReturnsNoError(t *testing.T) {
 	n, _ := NewLivepeerNode(nil, "", nil)
 	recipient := new(pm.MockRecipient)
 	n.Recipient = recipient
@@ -567,9 +567,7 @@ func TestProcessPayment_GivenNoTicketParams_ReturnsError(t *testing.T) {
 	err := orch.ProcessPayment(protoPayment, ManifestID("some manifest"))
 
 	assert := assert.New(t)
-	assert.Error(err)
-	_, ok := err.(AcceptableError)
-	assert.False(ok)
+	assert.Nil(err)
 }
 
 func TestProcessPayment_GivenNilNode_ReturnsNilError(t *testing.T) {

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -101,7 +101,7 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 	}
 
 	if payment.TicketParams == nil {
-		return fmt.Errorf("Could not find TicketParams for payment %v", payment)
+		return nil
 	}
 
 	if payment.Sender == nil || len(payment.Sender) == 0 {

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -65,7 +65,7 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 	if paymentError := orch.ProcessPayment(payment, segData.ManifestID); paymentError != nil {
 
 		acceptableErr, ok := paymentError.(core.AcceptableError)
-		if ok && !acceptableErr.Acceptable() {
+		if !ok || !acceptableErr.Acceptable() {
 			glog.Errorf("Unacceptable error occured processing payment: %v", paymentError)
 			http.Error(w, paymentError.Error(), http.StatusBadRequest)
 			return

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -361,13 +361,24 @@ func TestServeSegment_UnacceptableProcessPaymentError(t *testing.T) {
 	}
 
 	resp := httpPostResp(handler, bytes.NewReader(seg.Data), headers)
-	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	require.Nil(err)
 
 	assert.Equal(http.StatusBadRequest, resp.StatusCode)
 	assert.Equal("some error", strings.TrimSpace(string(body)))
+	resp.Body.Close()
+
+	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(errors.New("some error")).Once()
+	resp = httpPostResp(handler, bytes.NewReader(seg.Data), headers)
+	defer resp.Body.Close()
+
+	body, err = ioutil.ReadAll(resp.Body)
+	require.Nil(err)
+
+	assert.Equal(http.StatusBadRequest, resp.StatusCode)
+	assert.Equal("some error", strings.TrimSpace(string(body)))
+
 }
 
 func TestServeSegment_UpdateOrchestratorInfo(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
In case of an empty payment (`numTickets = 0`, B does not need to send tickets because his balance with O is still sufficient) we always populate the `Sender` and `ExpectedPrice` fields for a payment but `TicketParams` are `nil` this leads to an early error in `ProcessPayment`, while the payment might actually be valid (just without value). 

Since we are now populating the Sender in case of empty payments in https://github.com/livepeer/go-livepeer/pull/1000 and empty TicketParams return `nil` instead of an error we should also revert [this requested change](https://github.com/livepeer/go-livepeer/pull/991#discussion_r306030736) back to its original state. 

`if ok && !acceptableErr.Acceptable())` -> `if !ok || !acceptableErr.Acceptable()`

**Specific updates (required)**
- in `ProcessPayment` return `nil` error when `TicketParams` are `nil`
- Changed `TestProcessPayment_GivenNoTicketParams_ReturnsError` test to `TestProcessPayment_GivenNoTicketParams_ReturnsNoError_LogsMessage``
- reverted the acceptable error check for processed payments in `serveSegment` back to the original form

**How did you test each of these updates (required)**
Ran unit tests
Ran test-harness

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
