### PR TITLE
core: fix sendernonce race condition

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -134,12 +134,15 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 
 	seed := new(big.Int).SetBytes(payment.TicketParams.Seed)
 
-	ticket := &pm.Ticket{
-		Recipient:              ethcommon.BytesToAddress(payment.TicketParams.Recipient),
-		Sender:                 ethcommon.BytesToAddress(payment.Sender),
-		FaceValue:              new(big.Int).SetBytes(payment.TicketParams.FaceValue),
-		WinProb:                new(big.Int).SetBytes(payment.TicketParams.WinProb),
-		RecipientRandHash:      ethcommon.BytesToHash(payment.TicketParams.RecipientRandHash),
+	ticketParams := &pm.TicketParams{
+		Recipient:         ethcommon.BytesToAddress(payment.TicketParams.Recipient),
+		FaceValue:         new(big.Int).SetBytes(payment.TicketParams.FaceValue),
+		WinProb:           new(big.Int).SetBytes(payment.TicketParams.WinProb),
+		RecipientRandHash: ethcommon.BytesToHash(payment.TicketParams.RecipientRandHash),
+		Seed:              seed,
+	}
+
+	ticketExpirationParams := &pm.TicketExpirationParams{
 		CreationRound:          payment.ExpirationParams.CreationRound,
 		CreationRoundBlockHash: ethcommon.BytesToHash(payment.ExpirationParams.CreationRoundBlockHash),
 	}
@@ -150,7 +153,12 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 
 	for _, tsp := range payment.TicketSenderParams {
 
-		ticket.SenderNonce = tsp.SenderNonce
+		ticket := pm.NewTicket(
+			ticketParams,
+			ticketExpirationParams,
+			sender,
+			tsp.SenderNonce,
+		)
 
 		glog.V(common.DEBUG).Infof("Receiving ticket manifestID=%v faceValue=%v winProb=%v ev=%v", manifestID, ticket.FaceValue, ticket.WinProbRat().FloatString(10), ticket.EV().FloatString(2))
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes a race condition in `ProcessPayment` where the ticket pointer in the redemption for-loop was overwritten with an already incremented `SenderNonce` prematurely. This resulted in a signature validation failure in the TicketBroker contracts when trying to redeem the ticket on chain.

**Specific updates (required)**
- Allocated a new instance of `Ticket` for each iteration of the for loop


**How did you test each of these updates (required)**
ran unit tests and test-harness
![image](https://user-images.githubusercontent.com/22256858/62509530-dccbb700-b80b-11e9-8ae5-db1e907667bb.png)



**Does this pull request close any open issues?**
Fixes #1014 


**Checklist:**
- [ ] README and other documentation updated
- [X] Node runs in OSX and devenv
- [X] All tests in `./test.sh` pass
