### PR TITLE
tweak content-duration logic

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"math/big"
 	"math/rand"
 	"net/http"

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -594,7 +594,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration, err := strconv.ParseFloat(r.Header.Get("Content-Duration"), 64)
-	duration = math.Floor(duration * 1000)
+	duration = duration / 1000
 	if err != nil {
 		duration = 0
 	}


### PR DESCRIPTION
this appears to get the current durations to show up in the output segment