### PR TITLE
blockwatch: Add stack

### DIFF
--- a/eth/blockwatch/LICENSE
+++ b/eth/blockwatch/LICENSE
@@ -1,0 +1,14 @@
+Copyright 2019 ZeroEx Intl.
+Modifications copyright 2019 Livepeer
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/eth/blockwatch/README.md
+++ b/eth/blockwatch/README.md
@@ -1,0 +1,3 @@
+# blockwatch
+
+Derived from [0x's blockwatch package](https://github.com/0xProject/0x-mesh/tree/development/ethereum/blockwatch) with a few modifications to allow it to be integrated into the Livepeer node.

--- a/eth/blockwatch/stack.go
+++ b/eth/blockwatch/stack.go
@@ -1,0 +1,94 @@
+package blockwatch
+
+import (
+	"math/big"
+	"sync"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// MiniHeader is a succinct representation of an Ethereum block header
+type MiniHeader struct {
+	Hash   ethcommon.Hash
+	Parent ethcommon.Hash
+	Number *big.Int
+	Logs   []types.Log
+}
+
+// MiniHeaderStore is an interface for a store that manages the state of a MiniHeader collection
+type MiniHeaderStore interface {
+	FindLatestMiniHeader() (*MiniHeader, error)
+	FindAllMiniHeadersSortedByNumber() ([]*MiniHeader, error)
+	InsertMiniHeader(header *MiniHeader) error
+	DeleteMiniHeader(hash ethcommon.Hash) error
+}
+
+// Stack allows performing basic stack operations on a stack of MiniHeaders.
+type Stack struct {
+	// TODO(albrow): Use Transactions when db supports them instead of a mutex
+	// here. There are cases where we need to make sure no modifications are made
+	// to the database in between a read/write or read/delete.
+	mut   sync.Mutex
+	store MiniHeaderStore
+	limit int
+}
+
+// NewStack instantiates a new stack with the specified size limit. Once the size limit
+// is reached, adding additional blocks will evict the deepest block.
+func NewStack(store MiniHeaderStore, limit int) *Stack {
+	return &Stack{
+		store: store,
+		limit: limit,
+	}
+}
+
+// Pop removes and returns the latest block header on the block stack. It
+// returns nil if the stack is empty.
+func (s *Stack) Pop() (*MiniHeader, error) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	latestMiniHeader, err := s.store.FindLatestMiniHeader()
+	if err != nil {
+		return nil, err
+	}
+	if latestMiniHeader == nil {
+		return nil, nil
+	}
+	if err := s.store.DeleteMiniHeader(latestMiniHeader.Hash); err != nil {
+		return nil, err
+	}
+	return latestMiniHeader, nil
+}
+
+// Push pushes a block header onto the block stack. If the stack limit is
+// reached, it will remove the oldest block header.
+func (s *Stack) Push(header *MiniHeader) error {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	miniHeaders, err := s.store.FindAllMiniHeadersSortedByNumber()
+	if err != nil {
+		return err
+	}
+	if len(miniHeaders) == s.limit {
+		oldestMiniHeader := miniHeaders[0]
+		if err := s.store.DeleteMiniHeader(oldestMiniHeader.Hash); err != nil {
+			return err
+		}
+	}
+	if err := s.store.InsertMiniHeader(header); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Peek returns the latest block header from the block stack without removing
+// it. It returns nil if the stack is empty.
+func (s *Stack) Peek() (*MiniHeader, error) {
+	return s.store.FindLatestMiniHeader()
+}
+
+// Inspect returns all the block headers currently on the stack
+func (s *Stack) Inspect() ([]*MiniHeader, error) {
+	return s.store.FindAllMiniHeadersSortedByNumber()
+}

--- a/eth/blockwatch/stack_test.go
+++ b/eth/blockwatch/stack_test.go
@@ -1,0 +1,214 @@
+package blockwatch
+
+import (
+	"errors"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubMiniHeaderStore struct {
+	headers           []*MiniHeader
+	latestErr         error
+	sortedByNumberErr error
+	insertErr         error
+	deleteErr         error
+}
+
+func (s *stubMiniHeaderStore) FindLatestMiniHeader() (*MiniHeader, error) {
+	if s.latestErr != nil {
+		return nil, s.latestErr
+	}
+
+	if len(s.headers) == 0 {
+		return nil, nil
+	}
+
+	return s.headers[len(s.headers)-1], nil
+}
+
+func (s *stubMiniHeaderStore) FindAllMiniHeadersSortedByNumber() ([]*MiniHeader, error) {
+	if s.sortedByNumberErr != nil {
+		return nil, s.sortedByNumberErr
+	}
+
+	return s.headers, nil
+}
+
+func (s *stubMiniHeaderStore) InsertMiniHeader(header *MiniHeader) error {
+	if s.insertErr != nil {
+		return s.insertErr
+	}
+
+	s.headers = append(s.headers, header)
+
+	return nil
+}
+
+func (s *stubMiniHeaderStore) DeleteMiniHeader(hash ethcommon.Hash) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+
+	for i, header := range s.headers {
+		if header.Hash == hash {
+			copy(s.headers[i:], s.headers[i+1:])
+			s.headers[len(s.headers)-1] = nil
+			s.headers = s.headers[:len(s.headers)-1]
+			return nil
+		}
+	}
+
+	return errors.New("MiniHeader not found")
+}
+
+func TestPop(t *testing.T) {
+	store := &stubMiniHeaderStore{}
+	stack := NewStack(store, 10)
+
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Test when store.FindLatestMiniHeader() returns error
+	store.latestErr = errors.New("FindLatestMiniHeader error")
+	_, err := stack.Pop()
+	assert.EqualError(err, store.latestErr.Error())
+
+	// Test when store returns nil MiniHeader
+	store.latestErr = nil
+	header, err := stack.Pop()
+	assert.Nil(header)
+	assert.Nil(err)
+
+	h0 := &MiniHeader{Hash: ethcommon.BytesToHash([]byte("h0"))}
+	require.Nil(store.InsertMiniHeader(h0))
+
+	// Test when store.DeleteMiniHeader() returns error
+	store.deleteErr = errors.New("DeleteMiniHeader error")
+	_, err = stack.Pop()
+	assert.EqualError(err, store.deleteErr.Error())
+
+	// Test header popped when size = 1
+	store.deleteErr = nil
+	header, err = stack.Pop()
+	assert.Equal(h0, header)
+	assert.Nil(err)
+	assert.Equal(0, len(store.headers))
+
+	// Test header popped when size > 1
+	h1 := &MiniHeader{Hash: ethcommon.BytesToHash([]byte("h1"))}
+	require.Nil(store.InsertMiniHeader(h0))
+	require.Nil(store.InsertMiniHeader(h1))
+
+	header, err = stack.Pop()
+	assert.Equal(h1, header)
+	assert.Nil(err)
+	assert.Equal(1, len(store.headers))
+}
+
+func TestPush(t *testing.T) {
+	store := &stubMiniHeaderStore{}
+	stack := NewStack(store, 2)
+
+	assert := assert.New(t)
+	require := require.New(t)
+
+	// Test when store.FindAllMiniHeadersSortedByNumber() returns error
+	store.sortedByNumberErr = errors.New("FindAllMiniHeadersSortedByNumber error")
+	h0 := &MiniHeader{Hash: ethcommon.BytesToHash([]byte("h0"))}
+	err := stack.Push(h0)
+	assert.EqualError(err, store.sortedByNumberErr.Error())
+
+	// Test stack at limit and store.DeleteMiniHeader() returns error
+	h1 := &MiniHeader{Hash: ethcommon.BytesToHash([]byte("h1"))}
+	require.Nil(store.InsertMiniHeader(h0))
+	require.Nil(store.InsertMiniHeader(h1))
+
+	h2 := &MiniHeader{Hash: ethcommon.BytesToHash([]byte("h2"))}
+	store.sortedByNumberErr = nil
+	store.deleteErr = errors.New("DeleteMiniHeader error")
+	err = stack.Push(h2)
+	assert.EqualError(err, store.deleteErr.Error())
+
+	// Test stack at limit, deleted bottom and store.InsertMiniHeader() returns error
+	store.deleteErr = nil
+	store.insertErr = errors.New("InsertMiniHeader error")
+	err = stack.Push(h2)
+	assert.EqualError(err, store.insertErr.Error())
+	assert.Equal(h1, store.headers[0])
+	assert.Equal(1, len(store.headers))
+
+	// Test stack at limit, deleted bottom and header inserted
+	store.insertErr = nil
+	require.Nil(store.InsertMiniHeader(h2))
+
+	h3 := &MiniHeader{Hash: ethcommon.BytesToHash([]byte("h3"))}
+	err = stack.Push(h3)
+	assert.Nil(err)
+	assert.Equal(h3, store.headers[len(store.headers)-1])
+	assert.Equal(h2, store.headers[0])
+	assert.Equal(2, len(store.headers))
+
+	// Test stack not at limit and store.InsertMiniHeader() returns error
+	require.Nil(store.DeleteMiniHeader(h2.Hash))
+
+	h4 := &MiniHeader{Hash: ethcommon.BytesToHash([]byte("h4"))}
+	store.insertErr = errors.New("InsertMiniHeader error")
+	err = stack.Push(h4)
+	assert.EqualError(err, store.insertErr.Error())
+
+	// Test not at limit and header inserted
+	store.insertErr = nil
+	err = stack.Push(h4)
+	assert.Nil(err)
+	assert.Equal(h4, store.headers[len(store.headers)-1])
+	assert.Equal(2, len(store.headers))
+}
+
+func TestPeek(t *testing.T) {
+	store := &stubMiniHeaderStore{}
+	stack := NewStack(store, 10)
+
+	assert := assert.New(t)
+
+	// Test store.FindLatestMiniHeader() returns error
+	store.latestErr = errors.New("FindLatestMiniHeader error")
+	_, err := stack.Peek()
+	assert.EqualError(err, store.latestErr.Error())
+
+	// Test header returned
+	h := &MiniHeader{Hash: ethcommon.BytesToHash([]byte("h"))}
+	require.Nil(t, store.InsertMiniHeader(h))
+
+	store.latestErr = nil
+	header, err := stack.Peek()
+	assert.Nil(err)
+	assert.Equal(h, header)
+}
+
+func TestInspect(t *testing.T) {
+	store := &stubMiniHeaderStore{}
+	stack := NewStack(store, 10)
+
+	assert := assert.New(t)
+
+	// Test store.FindAllMiniHeadersSortedByNumber() returns error
+	store.sortedByNumberErr = errors.New("FindAllMiniHeadersSortedByNumber error")
+	_, err := stack.Inspect()
+	assert.EqualError(err, store.sortedByNumberErr.Error())
+
+	// Test headers returned
+	h0 := &MiniHeader{Hash: ethcommon.BytesToHash([]byte("h0"))}
+	h1 := &MiniHeader{Hash: ethcommon.BytesToHash([]byte("h1"))}
+	require.Nil(t, store.InsertMiniHeader(h0))
+	require.Nil(t, store.InsertMiniHeader(h1))
+
+	store.sortedByNumberErr = nil
+	headers, err := stack.Inspect()
+	assert.Nil(err)
+	assert.Equal(2, len(headers))
+	assert.Equal(h0, headers[0])
+	assert.Equal(h1, headers[1])
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR introduces the `blockwatch` package which will largely be based off of the [0x blockwatch package](https://github.com/0xProject/0x-mesh/tree/development/ethereum/blockwatch) and also adds a stack implementation to track block headers along with additional unit tests.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Port https://github.com/0xProject/0x-mesh/blob/development/ethereum/blockwatch/stack.go
- Introduce the `MiniHeaderStore` interface in the package which allows the stack to be agnostic to how the block headers are stored (i.e. could be any DB, in-memory cache, etc.)
- Move the `MiniHeader` type definition into the package
- Added unit test coverage for `Stack`
- Added concurrency tests to confirm that the mutex locking/unlocking in `Push()` and `Pop()` are working correctly

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests. Ran `go test -race` in `eth/blockwatch`.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1024

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
