### PR TITLE
cmd: Set smTTL to 1 minute

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -53,8 +53,8 @@ var (
 	gpmPollingInterval = 1 * time.Minute
 	// The interval at which to clean up cached max float values for PM senders and balances per stream
 	cleanupInterval = 1 * time.Minute
-	// The time to live for cached max float values for PM senders (else they will be cleaned up)
-	smTTL = 3600 // 1 minute
+	// The time to live for cached max float values for PM senders (else they will be cleaned up) in seconds
+	smTTL = 60 // 1 minute
 	// maxErrCount is the maximum number of acceptable errors tolerated by a payment recipient for a payment sender
 	maxErrCount = 3
 )


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR sets `smTTL` to 1 minute. Previously, it was set to 1 hour which meant that cached remote sender data would only be cleaned once an hour.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Set `smTTL` to 60 seconds in `cmd/livepeer.go`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Observed a cleanup in a test-harness deployment.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
