### PR TITLE
Initial proof of concept for orchestrator webhook

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -83,6 +83,7 @@ func main() {
 	httpAddr := flag.String("httpAddr", "", "Address to bind for HTTP commands")
 	serviceAddr := flag.String("serviceAddr", "", "Orchestrator only. Overrides the on-chain serviceURI that broadcasters can use to contact this node; may be an IP or hostname.")
 	orchAddr := flag.String("orchAddr", "", "Orchestrator to connect to as a standalone transcoder")
+	orchWebhook := flag.String("orchWebbook", "", "Webhook to obtain updated available Orchestrator info in offchain mode")
 
 	// Transcoding:
 	orchestrator := flag.Bool("orchestrator", false, "Set to true to be an orchestrator")
@@ -499,6 +500,8 @@ func main() {
 		// Set up orchestrator discovery
 		if len(orchAddresses) > 0 {
 			n.OrchestratorPool = discovery.NewOrchestratorPool(n, orchAddresses)
+		} else if *orchWebhook != "" {
+			n.OrchestratorPool = discovery.NewWebhookOrchestratorPoolCache(n, *orchWebhook)
 		} else if *network != "offchain" {
 			n.OrchestratorPool = discovery.NewDBOrchestratorPoolCache(n)
 		}

--- a/discovery/webhook_discovery.go
+++ b/discovery/webhook_discovery.go
@@ -1,0 +1,137 @@
+package discovery
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/net"
+	"github.com/livepeer/go-livepeer/server"
+
+	"github.com/golang/glog"
+)
+
+var webhookCacheRefreshInterval = 1 * time.Minute
+var getWebhookTicker = func() *time.Ticker {
+	return time.NewTicker(webhookCacheRefreshInterval)
+}
+
+type WHOrchestratorPoolCache struct {
+	node       *core.LivepeerNode
+	webhookURL string
+}
+
+type orchAddress struct {
+	address string `json:address`
+}
+
+func NewWebhookOrchestratorPoolCache(node *core.LivepeerNode, orchWebhookUrl string) *WHOrchestratorPoolCache {
+	_ = cacheWebhookTranscoders(node, orchWebhookUrl)
+
+	ticker := getWebhookTicker()
+	go func(node *core.LivepeerNode) {
+		for _ = range ticker.C {
+			err := cacheWebhookTranscoders(node, orchWebhookUrl)
+			if err != nil {
+				continue
+			}
+		}
+	}(node)
+
+	return &WHOrchestratorPoolCache{node: node, webhookURL: orchWebhookUrl}
+}
+
+func getOrchAddresses(orchWebhookUrl string) ([]string, error) {
+	// Get data from the Orchestrator Webhook URL
+	resp, err := http.Get(orchWebhookUrl)
+	if err != nil || resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Http.Get error: %v ", err)
+	}
+	defer resp.Body.Close()
+
+	// Read json info on available orchestrators
+	orchAddrBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("File ReadAll error: %v", err)
+	}
+
+	var orchAddresses []orchAddress
+	err = json.Unmarshal(orchAddrBytes, &orchAddresses)
+	if err != nil {
+		return nil, fmt.Errorf("Json unmarshal error: %v", err)
+	}
+
+	var stringAddr []string
+	for _, addr := range orchAddresses {
+		stringAddr = append(stringAddr, addr.address)
+	}
+
+	return stringAddr, err
+}
+
+func (who *WHOrchestratorPoolCache) GetOrchestrators(numOrchestrators int) ([]*net.OrchestratorInfo, error) {
+	orchs, err := who.node.Database.SelectOrchs(&common.DBOrchFilter{MaxPrice: server.BroadcastCfg.MaxPrice()})
+	if err != nil || len(orchs) <= 0 {
+		return nil, err
+	}
+
+	var uris []string
+	for _, orch := range orchs {
+		uri := orch.ServiceURI
+		uris = append(uris, uri)
+	}
+
+	orchPool := NewOrchestratorPool(who.node, uris)
+
+	orchInfos, err := orchPool.GetOrchestrators(numOrchestrators)
+	if err != nil || len(orchInfos) <= 0 {
+		return nil, err
+	}
+
+	return orchInfos, nil
+}
+
+func cacheWebhookTranscoders(node *core.LivepeerNode, webhookURL string) error {
+	orchAddresses, err := getOrchAddresses(webhookURL)
+	if err != nil {
+		glog.Error("Could not refresh webhook list of orchestrators: ", err)
+		return err
+	}
+
+	for _, addr := range orchAddresses {
+		DBOrch := common.NewDBOrch(addr, addr)
+		if err := node.Database.UpdateOrch(DBOrch); err != nil {
+			glog.Error("Error updating Orchestrator in webhook: ", err)
+		}
+	}
+
+	return nil
+}
+
+func (who *WHOrchestratorPoolCache) GetURLs() []*url.URL {
+	orchs, err := who.node.Database.SelectOrchs(&common.DBOrchFilter{MaxPrice: server.BroadcastCfg.MaxPrice()})
+	if err != nil || len(orchs) <= 0 {
+		return nil
+	}
+
+	var uris []*url.URL
+	for _, orch := range orchs {
+		if uri, err := url.Parse(orch.ServiceURI); err == nil {
+			uris = append(uris, uri)
+		}
+	}
+	return uris
+}
+
+func (who *WHOrchestratorPoolCache) Size() int {
+	orchs, err := who.node.Database.SelectOrchs(&common.DBOrchFilter{MaxPrice: server.BroadcastCfg.MaxPrice()})
+	if err != nil {
+		return 0
+	}
+	return len(orchs)
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

In `offchain` mode, O's passed in through the `-orchAddr` flag are added to `OrchestratorPool`. Once the node is started, there is no way to update that list currently. This PR populates `n.OrchestratorPool` from `--orchestrator-webhook-url=https://livepeer.live/api/orchestrator` when flag is supplied. The cached DB list is refreshed every minute. When list is too short to handle all incoming work, `OrchestratorPool` is refreshed from DB as works now.

_Looking for initial thoughts on approach! Tests have still not been included, nor have I done extensive review._

Read more here: https://github.com/livepeer/go-livepeer/issues/851



**Specific updates (required)**

**How did you test each of these updates (required)**
TBD

**Does this pull request close any open issues?**
https://github.com/livepeer/go-livepeer/issues/851


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
