### PR TITLE
eth: EventDecoder for event watchers

### DIFF
--- a/eth/watchers/eventdecoder.go
+++ b/eth/watchers/eventdecoder.go
@@ -1,0 +1,64 @@
+package watchers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// EventDecoder decodes logs into events for known contracts
+type EventDecoder struct {
+	addr             ethcommon.Address
+	contract         *bind.BoundContract
+	topicToEventName map[ethcommon.Hash]string
+}
+
+// NewEventDecoder returns a new instance of EventDecoder with a contract binding to the provided ABI string
+func NewEventDecoder(addr ethcommon.Address, abiJSON string) (*EventDecoder, error) {
+	abi, err := abi.JSON(strings.NewReader(abiJSON))
+	if err != nil {
+		return nil, err
+	}
+
+	topicToEventName := make(map[ethcommon.Hash]string)
+	for _, event := range abi.Events {
+		topicToEventName[event.Id()] = event.Name
+	}
+
+	return &EventDecoder{
+		addr: addr,
+		// Create BoundContract without a backend because we just need to access
+		// log unpacking without contract interaction
+		contract:         bind.NewBoundContract(addr, abi, nil, nil, nil),
+		topicToEventName: topicToEventName,
+	}, nil
+}
+
+// FindEventName returns the event name for a log. An error will be returned if the log is not emitted
+// from a known contract or if it does not map to a known event
+func (e *EventDecoder) FindEventName(log types.Log) (string, error) {
+	if log.Address != e.addr {
+		return "", errors.New("log not from known contract")
+	}
+	eventName, ok := e.topicToEventName[log.Topics[0]]
+	if !ok {
+		return "", fmt.Errorf("unknown event for %v", e.addr.Hex())
+	}
+
+	return eventName, nil
+}
+
+// Decode decodes a log into an event struct. An error will be returned if the log is not emitted
+// from a known contract or if it does not map to a known event
+func (e *EventDecoder) Decode(eventName string, log types.Log, decodedLog interface{}) error {
+	if log.Address != e.addr {
+		return errors.New("log not from known contract")
+
+	}
+	return e.contract.UnpackLog(decodedLog, eventName, log)
+}

--- a/eth/watchers/eventdecoder_test.go
+++ b/eth/watchers/eventdecoder_test.go
@@ -1,0 +1,75 @@
+package watchers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/livepeer/go-livepeer/eth/contracts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTopicToEventName_AllEventsIncluded(t *testing.T) {
+	abi := "[{\"anonymous\": false,\"inputs\": [],\"name\": \"First\",\"type\": \"event\"},{\"anonymous\": false,\"inputs\": [],\"name\": \"Second\",\"type\": \"event\"},{\"anonymous\": false,\"inputs\": [],\"name\": \"Third\",\"type\": \"event\"}]"
+	assert := assert.New(t)
+
+	addr := ethcommon.HexToAddress("0x692a70d2e424a56d2c6c27aa97d1a86395877b3a")
+	dec, err := NewEventDecoder(addr, abi)
+	assert.Nil(err)
+	assert.Equal(dec.topicToEventName[crypto.Keccak256Hash([]byte("First()"))], "First")
+	assert.Equal(dec.topicToEventName[crypto.Keccak256Hash([]byte("Second()"))], "Second")
+	assert.Equal(dec.topicToEventName[crypto.Keccak256Hash([]byte("Third()"))], "Third")
+
+}
+
+func TestEventDecoder_FindEventType(t *testing.T) {
+	dec, err := NewEventDecoder(stubBondingManagerAddr, contracts.BondingManagerABI)
+	require.Nil(t, err)
+
+	assert := assert.New(t)
+
+	// Test unknown contract address
+	log := newStubBaseLog()
+	log.Address = common.BytesToAddress([]byte("foo"))
+	_, err = dec.FindEventName(log)
+	assert.EqualError(err, "log not from known contract")
+
+	// Test unknown contract event
+	log.Address = stubBondingManagerAddr
+	log.Topics = []common.Hash{common.BytesToHash([]byte("foo"))}
+	_, err = dec.FindEventName(log)
+	assert.EqualError(err, fmt.Sprintf("unknown event for %v", stubBondingManagerAddr.Hex()))
+
+	// Test known contract address
+	log = newStubUnbondLog()
+	eventName, err := dec.FindEventName(log)
+	assert.Nil(err)
+	assert.Equal("Unbond", eventName)
+}
+
+func TestEventDecoder_Decode(t *testing.T) {
+	dec, err := NewEventDecoder(stubBondingManagerAddr, contracts.BondingManagerABI)
+	require.Nil(t, err)
+
+	assert := assert.New(t)
+
+	// Test unknown contract address
+	log := newStubBaseLog()
+	log.Address = common.BytesToAddress([]byte("foo"))
+
+	var dummyEvent struct {
+		foo string
+	}
+	err = dec.Decode("foo", log, dummyEvent)
+	assert.EqualError(err, "log not from known contract")
+
+	// Test known contract address
+	log = newStubUnbondLog()
+
+	var unbondEvent contracts.BondingManagerUnbond
+	err = dec.Decode("Unbond", log, &unbondEvent)
+	assert.Nil(err)
+}

--- a/eth/watchers/stub.go
+++ b/eth/watchers/stub.go
@@ -1,0 +1,37 @@
+package watchers
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+var stubBondingManagerAddr = common.HexToAddress("0x511bc4556d823ae99630ae8de28b9b80df90ea2e")
+
+func newStubBaseLog() types.Log {
+	return types.Log{
+		BlockNumber: uint64(30),
+		TxHash:      common.HexToHash("0xd9bb5f9e888ee6f74bedcda811c2461230f247c205849d6f83cb6c3925e54586"),
+		TxIndex:     uint(0),
+		BlockHash:   common.HexToHash("0x6bbf9b6e836207ab25379c20e517a89090cbbaf8877746f6ed7fb6820770816b"),
+		Index:       uint(0),
+		Removed:     false,
+	}
+}
+
+func newStubUnbondLog() types.Log {
+	log := newStubBaseLog()
+	log.Address = stubBondingManagerAddr
+	log.Topics = []common.Hash{
+		common.HexToHash("0x2d5d98d189bee5496a08db2a5948cb7e5e786f09d17d0c3f228eb41776c24a06"),
+		// delegate = 0x525419FF5707190389bfb5C87c375D710F5fCb0E
+		common.HexToHash("0x000000000000000000000000525419ff5707190389bfb5c87c375d710f5fcb0e"),
+		// delegator = 0xF75b78571F6563e8Acf1899F682Fb10A9248CCE8
+		common.HexToHash("0x000000000000000000000000f75b78571f6563e8acf1899f682fb10a9248cce8"),
+	}
+	// unbondingLockId = 1
+	// amount = 11111000000000000000
+	// withdrawRound = 1457
+	log.Data = common.Hex2Bytes("0x00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000009a3233a1a35d800000000000000000000000000000000000000000000000000000000000000005b1")
+
+	return log
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Implement a generic event decoder according to the EventDecoder implemented in [this branch](https://github.com/livepeer/go-livepeer/compare/yf/refactor-unbondingservice#diff-3d0bf718180c420a3a3a7629e5e3bbf8R1).

The event decoder decodes
**Specific updates (required)**
- Introduces a new EventDecoder type
- Introduces logic to decode events based on the provided contract ABI's events

**How did you test each of these updates (required)**
unit tests

**Does this pull request close any open issues?**
Fixes #1043 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
