### PR TITLE
eth, cmd: roundswatcher with cache

### DIFF
--- a/eth/watchers/roundswatcher.go
+++ b/eth/watchers/roundswatcher.go
@@ -1,0 +1,151 @@
+package watchers
+
+import (
+	"fmt"
+	"log"
+	"math/big"
+	"sync"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/livepeer/go-livepeer/eth/contracts"
+
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+)
+
+// RoundsWatcher is a type for a thread safe in-memory cache that watches on-chain events for new initialized rounds
+type RoundsWatcher struct {
+	mu                       sync.RWMutex
+	lastInitializedRound     *big.Int
+	lastInitializedBlockHash [32]byte
+
+	quit chan struct{}
+
+	watcher BlockWatcher
+	lpEth   eth.LivepeerEthClient
+	dec     *EventDecoder
+}
+
+// NewRoundsWatcher creates a new instance of RoundsWatcher and sets the initial cache through an RPC call to an ethereum node
+func NewRoundsWatcher(roundsManagerAddr ethcommon.Address, watcher BlockWatcher, lpEth eth.LivepeerEthClient) (*RoundsWatcher, error) {
+	dec, err := NewEventDecoder(roundsManagerAddr, contracts.RoundsManagerABI)
+	if err != nil {
+		return nil, err
+	}
+	lr, err := lpEth.LastInitializedRound()
+	if err != nil {
+		return nil, err
+	}
+	bh, err := lpEth.BlockHashForRound(lr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RoundsWatcher{
+		quit:                     make(chan struct{}),
+		watcher:                  watcher,
+		lpEth:                    lpEth,
+		lastInitializedRound:     lr,
+		lastInitializedBlockHash: bh,
+		dec: dec,
+	}, nil
+}
+
+// LastInitializedRound gets the last initialized round from cache
+func (rw *RoundsWatcher) LastInitializedRound() *big.Int {
+	rw.mu.RLock()
+	defer rw.mu.RUnlock()
+	return rw.lastInitializedRound
+}
+
+// LastInitializedBlockHash returns the blockhash of the block the last round was initiated in
+func (rw *RoundsWatcher) LastInitializedBlockHash() [32]byte {
+	rw.mu.RLock()
+	defer rw.mu.RUnlock()
+	return rw.lastInitializedBlockHash
+}
+
+func (rw *RoundsWatcher) setLastInitializedRound(round *big.Int, hash [32]byte) {
+	rw.mu.Lock()
+	defer rw.mu.Unlock()
+	rw.lastInitializedRound = round
+	rw.lastInitializedBlockHash = hash
+}
+
+// Watch the blockwatch subscription for NewRound events
+func (rw *RoundsWatcher) Watch() {
+	lr, err := rw.lpEth.LastInitializedRound()
+	if err != nil {
+		glog.Errorf("error fetching initial lastInitializedRound value: %v", err)
+	}
+
+	bh, err := rw.lpEth.BlockHashForRound(lr)
+	if err != nil {
+		glog.Errorf("error fetching initial lastInitializedBlockHash value: %v", err)
+	}
+	rw.setLastInitializedRound(lr, bh)
+
+	events := make(chan []*blockwatch.Event, 10)
+	sub := rw.watcher.Subscribe(events)
+	defer sub.Unsubscribe()
+	for {
+		select {
+		case <-rw.quit:
+			return
+		case err := <-sub.Err():
+			log.Fatal(err)
+		case events := <-events:
+			rw.handleBlockEvents(events)
+		}
+	}
+}
+
+// Stop watching for NewRound events
+func (rw *RoundsWatcher) Stop() {
+	close(rw.quit)
+}
+
+func (rw *RoundsWatcher) handleBlockEvents(events []*blockwatch.Event) {
+	for _, event := range events {
+		for _, log := range event.BlockHeader.Logs {
+			if event.Type == blockwatch.Removed {
+				log.Removed = true
+			}
+			if err := rw.handleLog(log); err != nil {
+				glog.Error(err)
+			}
+		}
+	}
+}
+
+func (rw *RoundsWatcher) handleLog(log types.Log) error {
+	eventName, err := rw.dec.FindEventName(log)
+	if err != nil {
+		return fmt.Errorf("could not find event name: %v", err)
+	}
+
+	if eventName != "NewRound" {
+		return fmt.Errorf("eventName is not NewRound")
+	}
+
+	var nr contracts.RoundsManagerNewRound
+	if err := rw.dec.Decode("NewRound", log, &nr); err != nil {
+		return fmt.Errorf("unable to decode event: %v", err)
+	}
+	if log.Removed {
+		lr, err := rw.lpEth.LastInitializedRound()
+		if err != nil {
+			return err
+		}
+		bh, err := rw.lpEth.BlockHashForRound(lr)
+		if err != nil {
+			return err
+		}
+		rw.setLastInitializedRound(lr, bh)
+	} else {
+		rw.setLastInitializedRound(nr.Round, nr.BlockHash)
+	}
+	return nil
+}

--- a/eth/watchers/roundswatcher_test.go
+++ b/eth/watchers/roundswatcher_test.go
@@ -1,0 +1,99 @@
+package watchers
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	"github.com/livepeer/go-livepeer/pm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetAndGet_LastInitializedRound_LastInitializedBlockHash(t *testing.T) {
+	assert := assert.New(t)
+	rw := &RoundsWatcher{}
+	round := big.NewInt(5)
+	var hash [32]byte
+	copy(hash[:], "hello world")
+	rw.setLastInitializedRound(round, hash)
+	assert.Equal(rw.lastInitializedRound, round)
+	assert.Equal(rw.lastInitializedBlockHash, hash)
+
+	r := rw.LastInitializedRound()
+	assert.Equal(r, round)
+	h := rw.LastInitializedBlockHash()
+	assert.Equal(h, hash)
+}
+
+func TestWatchAndStop(t *testing.T) {
+	assert := assert.New(t)
+	lpEth := &eth.StubClient{}
+	watcher := &stubBlockWatcher{}
+	rw, err := NewRoundsWatcher(stubRoundsManagerAddr, watcher, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	newRoundEvent := newStubNewRoundLog()
+
+	header.Logs = append(header.Logs, newRoundEvent)
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go rw.Watch()
+	time.Sleep(2 * time.Millisecond)
+
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	lastRound := rw.LastInitializedRound()
+	assert.Zero(lastRound.Cmp(big.NewInt(8)))
+	bhForRound := rw.LastInitializedBlockHash()
+	var expectedHashForRound [32]byte
+	copy(expectedHashForRound[:], newRoundEvent.Data[:])
+	assert.Equal(bhForRound, expectedHashForRound)
+
+	// Test no NewRound events, values on rw remain the same
+	blockEvent.BlockHeader.Logs = header.Logs[:1]
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	lastRound = rw.LastInitializedRound()
+	assert.Zero(lastRound.Cmp(big.NewInt(8)))
+	bhForRound = rw.LastInitializedBlockHash()
+	copy(expectedHashForRound[:], newRoundEvent.Data[:])
+	assert.Equal(bhForRound, expectedHashForRound)
+
+	// Test RPC paths (event removed)
+	blockEvent.BlockHeader.Logs = append(blockEvent.BlockHeader.Logs, newRoundEvent)
+	blockEvent.Type = blockwatch.Removed
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	lastRound = rw.LastInitializedRound()
+	bhForRound = rw.LastInitializedBlockHash()
+	assert.Equal(lastRound.Int64(), int64(0))
+	assert.Equal(bhForRound, [32]byte{})
+
+	// Test Stop
+	rw.Stop()
+	time.Sleep(2 * time.Millisecond)
+	assert.True(watcher.sub.unsubscribed)
+}
+
+func defaultMiniHeader() *blockwatch.MiniHeader {
+	block := &blockwatch.MiniHeader{
+		Number: big.NewInt(450),
+		Parent: pm.RandHash(),
+		Hash:   pm.RandHash(),
+	}
+	log := types.Log{
+		Topics:    []ethcommon.Hash{pm.RandHash(), pm.RandHash()},
+		Data:      pm.RandBytes(32),
+		BlockHash: block.Hash,
+	}
+	block.Logs = []types.Log{log}
+	return block
+}

--- a/eth/watchers/topics.go
+++ b/eth/watchers/topics.go
@@ -1,0 +1,23 @@
+package watchers
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var eventSignatures = []string{
+	"Unbond(address,address,uint256,uint256,uint256)",
+	"Rebond(address,address,uint256,uint256)",
+	"WithdrawStake(address,uint256,uint256,uint256)",
+	"NewRound(uint256,bytes32)",
+}
+
+// FilterTopics returns a list of topics to be used when filtering logs
+func FilterTopics() []common.Hash {
+	topics := make([]common.Hash, len(eventSignatures))
+	for i, sig := range eventSignatures {
+		topics[i] = crypto.Keccak256Hash([]byte(sig))
+	}
+
+	return topics
+}

--- a/eth/watchers/types.go
+++ b/eth/watchers/types.go
@@ -1,0 +1,10 @@
+package watchers
+
+import (
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+)
+
+type BlockWatcher interface {
+	Subscribe(sink chan<- []*blockwatch.Event) event.Subscription
+}

--- a/pm/broker.go
+++ b/pm/broker.go
@@ -87,9 +87,9 @@ type Broker interface {
 // initialized round and associated block hash of the Livepeer protocol
 type RoundsManager interface {
 	// LastInitializedRound returns the last initialized round of the Livepeer protocol
-	LastInitializedRound() (*big.Int, error)
-	// BlockHashForRound returns the block hash for a given round of the Livepeer protocol
-	BlockHashForRound(round *big.Int) ([32]byte, error)
+	LastInitializedRound() *big.Int
+	// LastInitializedBlockHash returns the blockhash of the block the last round was initiated in
+	LastInitializedBlockHash() [32]byte
 }
 
 // SenderManager defines the methods for fetching sender information

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -85,10 +85,7 @@ func (s *sender) CreateTicketBatch(sessionID string, size int) (*TicketBatch, er
 		return nil, err
 	}
 
-	expirationParams, err := s.expirationParams()
-	if err != nil {
-		return nil, err
-	}
+	expirationParams := s.expirationParams()
 
 	batch := &TicketBatch{
 		TicketParams:           &session.ticketParams,
@@ -138,21 +135,14 @@ func (s *sender) validateTicketParams(ticketParams *TicketParams, numTickets int
 	return nil
 }
 
-func (s *sender) expirationParams() (*TicketExpirationParams, error) {
-	round, err := s.roundsManager.LastInitializedRound()
-	if err != nil {
-		return nil, err
-	}
-
-	blkHash, err := s.roundsManager.BlockHashForRound(round)
-	if err != nil {
-		return nil, err
-	}
+func (s *sender) expirationParams() *TicketExpirationParams {
+	round := s.roundsManager.LastInitializedRound()
+	blkHash := s.roundsManager.LastInitializedBlockHash()
 
 	return &TicketExpirationParams{
 		CreationRound:          round.Int64(),
 		CreationRoundBlockHash: blkHash,
-	}, nil
+	}
 }
 
 func (s *sender) loadSession(sessionID string) (*session, error) {

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -165,28 +165,6 @@ func TestCreateTicketBatch_FaceValueTooHigh_ReturnsError(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestCreateTicketBatch_LastInitializedRoundError_ReturnsError(t *testing.T) {
-	sender := defaultSender(t)
-	rm := sender.roundsManager.(*stubRoundsManager)
-	expErr := errors.New("LastInitializedRound error")
-	rm.lastInitializedRoundErr = expErr
-
-	sessionID := sender.StartSession(defaultTicketParams(t, RandAddress()))
-	_, err := sender.CreateTicketBatch(sessionID, 1)
-	assert.EqualError(t, err, expErr.Error())
-}
-
-func TestCreateTicketBatch_BlockHashForRoundError_ReturnsError(t *testing.T) {
-	sender := defaultSender(t)
-	rm := sender.roundsManager.(*stubRoundsManager)
-	expErr := errors.New("BlockHashForRound error")
-	rm.blockHashForRoundErr = expErr
-
-	sessionID := sender.StartSession(defaultTicketParams(t, RandAddress()))
-	_, err := sender.CreateTicketBatch(sessionID, 1)
-	assert.EqualError(t, err, expErr.Error())
-}
-
 func TestCreateTicketBatch_UsesSessionParamsInBatch(t *testing.T) {
 	sender := defaultSender(t)
 	rm := sender.roundsManager.(*stubRoundsManager)

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -242,18 +242,16 @@ func (s *stubSigner) Account() accounts.Account {
 }
 
 type stubRoundsManager struct {
-	round                   *big.Int
-	blkHash                 [32]byte
-	lastInitializedRoundErr error
-	blockHashForRoundErr    error
+	round   *big.Int
+	blkHash [32]byte
 }
 
-func (m *stubRoundsManager) LastInitializedRound() (*big.Int, error) {
-	return m.round, m.lastInitializedRoundErr
+func (m *stubRoundsManager) LastInitializedRound() *big.Int {
+	return m.round
 }
 
-func (m *stubRoundsManager) BlockHashForRound(round *big.Int) ([32]byte, error) {
-	return m.blkHash, m.blockHashForRoundErr
+func (m *stubRoundsManager) LastInitializedBlockHash() [32]byte {
+	return m.blkHash
 }
 
 type stubSenderManager struct {

--- a/pm/validator.go
+++ b/pm/validator.go
@@ -80,19 +80,11 @@ func (v *validator) IsWinningTicket(ticket *Ticket, sig []byte, recipientRand *b
 }
 
 func (v *validator) validateCreationRound(creationRound int64, creationRoundBlockHash ethcommon.Hash) error {
-	round, err := v.roundsManager.LastInitializedRound()
-	if err != nil {
-		return err
-	}
-
+	round := v.roundsManager.LastInitializedRound()
+	blkHash := v.roundsManager.LastInitializedBlockHash()
 	// Check that creationRound matches last initialized round
 	if big.NewInt(creationRound).Cmp(round) != 0 {
 		return errInvalidCreationRound
-	}
-
-	blkHash, err := v.roundsManager.BlockHashForRound(round)
-	if err != nil {
-		return err
 	}
 
 	// Check that creationRoundBlockHash is valid for creationRound

--- a/pm/validator_test.go
+++ b/pm/validator_test.go
@@ -6,7 +6,6 @@ import (
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -122,14 +121,7 @@ func TestValidateTicket(t *testing.T) {
 	// Test LastInitializedRound error
 	// Set signature verification to return true
 	sv.SetVerifyResult(true)
-	expErr := errors.New("LastInitializedRound error")
-	rm.lastInitializedRoundErr = expErr
 
-	err = v.ValidateTicket(recipient, ticket, sig, recipientRand)
-	assert.EqualError(err, expErr.Error())
-
-	// Test invalid creation round
-	rm.lastInitializedRoundErr = nil
 	rm.round = big.NewInt(7)
 
 	creationRound := big.NewInt(5)
@@ -148,14 +140,8 @@ func TestValidateTicket(t *testing.T) {
 
 	// Test BlockHashForRound error
 	rm.round = creationRound
-	expErr = errors.New("BlockHashForRound error")
-	rm.blockHashForRoundErr = expErr
-
-	err = v.ValidateTicket(recipient, ticket, sig, recipientRand)
-	assert.EqualError(err, expErr.Error())
 
 	// Test invalid creation round block hash
-	rm.blockHashForRoundErr = nil
 	rm.blkHash = [32]byte{5}
 
 	creationRoundBlockHash := [32]byte{9}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds an implementation of the `RoundsManager` interface that watches for on-chain event logs using the `blockwatch` package introduced in #1037. 

When a new block is added that contains event logs for the `NewRound` event, we update the cached values accordingly. When a re-org occurs we make an RPC call to a remote ethereum node to fetch the most up-to-date contract data. 

**Specific updates (required)**
- Created a type alias `RoundsWatcher` adhering to the `RoundsManager` interface that represents a concurrency safe cache 
- Initialize a `RoundsWatcher` on node startup and pass it into the constructor for a `Sender`
- Add unit tests for the new `RoundsWatcher` type 
- added the `NewRound` event signature to `watchers/topics.go`

**How did you test each of these updates (required)**
Added & ran unit tests 

**Does this pull request close any open issues?**
Fixes #946 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
