### PR TITLE
eth, cmd: SenderWatcher with cache

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -380,6 +380,14 @@ func main() {
 		go unbondingWatcher.Watch()
 		defer unbondingWatcher.Stop()
 
+		senderWatcher, err := watchers.NewSenderWatcher(addrMap["TicketBroker"], blockWatcher, n.Eth)
+		if err != nil {
+			glog.Errorf("Failed to setup senderwatcher: %v", err)
+			return
+		}
+		go senderWatcher.Watch()
+		defer senderWatcher.Stop()
+
 		blockWatchCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -519,11 +527,7 @@ func main() {
 				panic(fmt.Errorf("-depositMultiplier must be greater than 0, but %v provided. Restart the node with a valid value for -depositMultiplier", *depositMultiplier))
 			}
 
-			// TODO: Initialize Sender with an implementation
-			// of RoundsManager that reads from a cache
-			// TODO: Initialize Sender with an implementation
-			// of SenderManager that reads from a cache
-			n.Sender = pm.NewSender(n.Eth, roundsWatcher, n.Eth, ev, *depositMultiplier)
+			n.Sender = pm.NewSender(n.Eth, roundsWatcher, senderWatcher, ev, *depositMultiplier)
 
 			if *pixelsPerUnit <= 0 {
 				// Can't divide by 0

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -167,6 +167,7 @@ type StubClient struct {
 	ProcessHistoricalUnbondError error
 	Orchestrators                []*lpTypes.Transcoder
 	RoundsErr                    error
+	SenderInfo                   *pm.SenderInfo
 }
 
 type stubTranscoder struct {
@@ -270,7 +271,7 @@ func (e *StubClient) Senders(addr ethcommon.Address) (sender struct {
 	return
 }
 func (e *StubClient) GetSenderInfo(addr ethcommon.Address) (*pm.SenderInfo, error) {
-	return nil, nil
+	return e.SenderInfo, nil
 }
 func (e *StubClient) ClaimableReserve(reserveHolder, claimant ethcommon.Address) (*big.Int, error) {
 	return nil, nil

--- a/eth/watchers/roundswatcher_test.go
+++ b/eth/watchers/roundswatcher_test.go
@@ -7,10 +7,8 @@ import (
 	"time"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
-	"github.com/livepeer/go-livepeer/pm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -111,19 +109,4 @@ func TestRoundsWatcher_HandleLog(t *testing.T) {
 	assert.Nil(err)
 	assert.Nil(rw.LastInitializedRound())
 	assert.Equal([32]byte{}, rw.LastInitializedBlockHash())
-}
-
-func defaultMiniHeader() *blockwatch.MiniHeader {
-	block := &blockwatch.MiniHeader{
-		Number: big.NewInt(450),
-		Parent: pm.RandHash(),
-		Hash:   pm.RandHash(),
-	}
-	log := types.Log{
-		Topics:    []ethcommon.Hash{pm.RandHash(), pm.RandHash()},
-		Data:      pm.RandBytes(32),
-		BlockHash: block.Hash,
-	}
-	block.Logs = []types.Log{log}
-	return block
 }

--- a/eth/watchers/senderwatcher.go
+++ b/eth/watchers/senderwatcher.go
@@ -1,0 +1,218 @@
+package watchers
+
+import (
+	"fmt"
+	"math/big"
+	"sync"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	"github.com/livepeer/go-livepeer/eth/contracts"
+	"github.com/livepeer/go-livepeer/pm"
+)
+
+// SenderWatcher maintains a concurrency-safe map with SenderInfo
+type SenderWatcher struct {
+	senders map[ethcommon.Address]*pm.SenderInfo
+	mu      sync.RWMutex
+	quit    chan struct{}
+	watcher BlockWatcher
+	lpEth   eth.LivepeerEthClient
+	dec     *EventDecoder
+}
+
+// NewSenderWatcher initiates a new SenderWatcher
+func NewSenderWatcher(ticketBrokerAddr ethcommon.Address, watcher BlockWatcher, lpEth eth.LivepeerEthClient) (*SenderWatcher, error) {
+	dec, err := NewEventDecoder(ticketBrokerAddr, contracts.TicketBrokerABI)
+	if err != nil {
+		return nil, err
+	}
+	return &SenderWatcher{
+		quit:    make(chan struct{}),
+		watcher: watcher,
+		lpEth:   lpEth,
+		senders: make(map[ethcommon.Address]*pm.SenderInfo),
+		dec:     dec,
+	}, nil
+}
+
+// GetSenderInfo returns the senderInfo for a sender
+// if values for a sender are not cached an RPC call to a remote ethereum node will be made to initialize the cache
+func (sw *SenderWatcher) GetSenderInfo(addr ethcommon.Address) (*pm.SenderInfo, error) {
+	sw.mu.RLock()
+	cache := sw.senders[addr]
+	sw.mu.RUnlock()
+	if cache == nil {
+		info, err := sw.lpEth.GetSenderInfo(addr)
+		if err != nil {
+			return nil, fmt.Errorf("GetSenderInfo RPC call to remote node failed: %v", err)
+		}
+		sw.setSenderInfo(addr, info)
+		return info, nil
+	}
+	return cache, nil
+}
+
+func (sw *SenderWatcher) setSenderInfo(addr ethcommon.Address, info *pm.SenderInfo) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	sw.senders[addr] = info
+}
+
+// Watch starts the event watching loop
+func (sw *SenderWatcher) Watch() {
+	events := make(chan []*blockwatch.Event, 10)
+	sub := sw.watcher.Subscribe(events)
+	defer sub.Unsubscribe()
+	for {
+		select {
+		case <-sw.quit:
+			return
+		case err := <-sub.Err():
+			glog.Error(err)
+		case events := <-events:
+			sw.handleBlockEvents(events)
+		}
+	}
+}
+
+// Stop watching for events
+func (sw *SenderWatcher) Stop() {
+	close(sw.quit)
+}
+
+// Clear removes a key-value pair from the map
+func (sw *SenderWatcher) Clear(addr ethcommon.Address) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	if _, ok := sw.senders[addr]; ok {
+		delete(sw.senders, addr)
+	}
+}
+
+func (sw *SenderWatcher) handleBlockEvents(events []*blockwatch.Event) {
+	for _, event := range events {
+		for _, log := range event.BlockHeader.Logs {
+			if event.Type == blockwatch.Removed {
+				log.Removed = true
+			}
+			if err := sw.handleLog(log); err != nil {
+				glog.Error(err)
+			}
+		}
+	}
+}
+
+func (sw *SenderWatcher) handleLog(log types.Log) error {
+	eventName, err := sw.dec.FindEventName(log)
+	if err != nil {
+		// Noop if we cannot find the event name
+		return nil
+	}
+
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+
+	var sender ethcommon.Address
+	switch eventName {
+	case "DepositFunded":
+		var depositFunded contracts.TicketBrokerDepositFunded
+		if err := sw.dec.Decode("DepositFunded", log, &depositFunded); err != nil {
+			return fmt.Errorf("failed to decode DepositFunded event: %v", err)
+		}
+		sender = depositFunded.Sender
+		if info, ok := sw.senders[sender]; ok && !log.Removed {
+			info.Deposit.Add(info.Deposit, depositFunded.Amount)
+		}
+	case "ReserveFunded":
+		var reserveFunded contracts.TicketBrokerReserveFunded
+		if err := sw.dec.Decode("ReserveFunded", log, &reserveFunded); err != nil {
+			return fmt.Errorf("failed to decode ReserveFunded event: %v", err)
+		}
+		sender = reserveFunded.ReserveHolder
+		if info, ok := sw.senders[sender]; ok && !log.Removed {
+			info.Reserve.Add(info.Reserve, reserveFunded.Amount)
+		}
+	case "Withdrawal":
+		var withdrawal contracts.TicketBrokerWithdrawal
+		if err := sw.dec.Decode("Withdrawal", log, &withdrawal); err != nil {
+			return fmt.Errorf("failed to decode Withdrawal event: %v", err)
+		}
+		sender = withdrawal.Sender
+		if info, ok := sw.senders[sender]; ok && !log.Removed {
+			info.Deposit = big.NewInt(0)
+			info.Reserve = big.NewInt(0)
+		}
+	case "WinningTicketTransfer":
+		var winningTicketTransfer contracts.TicketBrokerWinningTicketTransfer
+		if err := sw.dec.Decode("WinningTicketTransfer", log, &winningTicketTransfer); err != nil {
+			return fmt.Errorf("failed to decode WinningTicketTransfer event: %v", err)
+		}
+		amount := winningTicketTransfer.Amount
+		sender = winningTicketTransfer.Sender
+
+		if info, ok := sw.senders[sender]; ok && !log.Removed {
+			// See if amount > deposit
+			if info.Deposit.Cmp(amount) < 0 {
+				// Draw from reserve
+				// ReserveFrozen will be handled in it's own event log handler
+				diff := new(big.Int).Sub(amount, info.Deposit)
+				info.Deposit = big.NewInt(0)
+				info.Reserve.Sub(info.Reserve, diff)
+			} else {
+				// Draw from deposit
+				info.Deposit.Sub(info.Deposit, amount)
+			}
+		}
+	case "ReserveFrozen":
+		// Set reserveStatus and thawround
+		var reserveFrozen contracts.TicketBrokerReserveFrozen
+		if err := sw.dec.Decode("ReserveFrozen", log, &reserveFrozen); err != nil {
+			return fmt.Errorf("failed to decode ReserveFrozen event: %v", err)
+		}
+		sender = reserveFrozen.ReserveHolder
+		if info, ok := sw.senders[sender]; ok && !log.Removed {
+			info.ReserveState = pm.Frozen
+			// TODO: fetch freezePeriod instead of hardcoding or use a const
+			// TODO: how to handle unthaw
+			// frozen checks will have to be against ReserveFrozen and ThawRound < CurrentRound
+			// But how do we handle state updates when the reserve thaws?
+			info.ThawRound.Add(reserveFrozen.FreezeRound, big.NewInt(2))
+		}
+	case "Unlock":
+		// Set withdraw block
+		var unlock contracts.TicketBrokerUnlock
+		if err := sw.dec.Decode("Unlock", log, &unlock); err != nil {
+			return fmt.Errorf("failed to decode Unlock event: %v", err)
+		}
+		sender = unlock.Sender
+		if info, ok := sw.senders[sender]; ok && !log.Removed {
+			info.WithdrawBlock = unlock.EndBlock
+		}
+	case "UnlockCancelled":
+		// Unset withdrawblock
+		var unlockCancelled contracts.TicketBrokerUnlockCancelled
+		if err := sw.dec.Decode("UnlockCancelled", log, &unlockCancelled); err != nil {
+			return fmt.Errorf("failed to decode UnlockCancelled event: %v", err)
+		}
+		sender = unlockCancelled.Sender
+		if info, ok := sw.senders[sender]; ok && !log.Removed {
+			info.WithdrawBlock = big.NewInt(0)
+		}
+	default:
+		return nil
+	}
+
+	if _, ok := sw.senders[sender]; ok && log.Removed {
+		info, err := sw.lpEth.GetSenderInfo(sender)
+		if err != nil {
+			return fmt.Errorf("GetSenderInfo RPC call to remote node failed: %v", err)
+		}
+		sw.senders[sender] = info
+	}
+
+	return nil
+}

--- a/eth/watchers/senderwatcher_test.go
+++ b/eth/watchers/senderwatcher_test.go
@@ -1,0 +1,576 @@
+package watchers
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	"github.com/livepeer/go-livepeer/pm"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAndSetSenderInfo(t *testing.T) {
+	assert := assert.New(t)
+	sw := &SenderWatcher{
+		senders: make(map[ethcommon.Address]*pm.SenderInfo),
+		lpEth: &eth.StubClient{
+			SenderInfo: &pm.SenderInfo{
+				Deposit: big.NewInt(10),
+				Reserve: big.NewInt(5),
+			},
+		},
+	}
+
+	info := &pm.SenderInfo{
+		Deposit:      big.NewInt(1000000000000000000),
+		Reserve:      big.NewInt(1000000000000000000),
+		ReserveState: pm.NotFrozen,
+	}
+	sender := pm.RandAddress()
+
+	sw.setSenderInfo(sender, info)
+	entry, err := sw.GetSenderInfo(sender)
+	assert.Nil(err)
+	assert.Equal(sw.senders[sender], info)
+	assert.Equal(info, entry)
+
+	// If map entry is nil and we call get, make RPC call and set the returned data
+	sw.Clear(sender)
+	info, err = sw.GetSenderInfo(sender)
+	assert.Nil(err)
+	assert.Zero(info.Deposit.Cmp(big.NewInt(10)))
+	assert.Zero(info.Reserve.Cmp(big.NewInt(5)))
+	info = sw.senders[sender]
+	assert.Zero(info.Deposit.Cmp(big.NewInt(10)))
+	assert.Zero(info.Reserve.Cmp(big.NewInt(5)))
+}
+
+func TestSenderWatcher_Clear(t *testing.T) {
+	assert := assert.New(t)
+	stubClientSenderInfo := &pm.SenderInfo{
+		Deposit: big.NewInt(10),
+		Reserve: big.NewInt(5),
+	}
+	sw := &SenderWatcher{
+		senders: make(map[ethcommon.Address]*pm.SenderInfo),
+		lpEth: &eth.StubClient{
+			SenderInfo: stubClientSenderInfo,
+		},
+	}
+	info := &pm.SenderInfo{
+		Deposit:      big.NewInt(1000000000000000000),
+		Reserve:      big.NewInt(1000000000000000000),
+		ReserveState: pm.NotFrozen,
+	}
+	sender := pm.RandAddress()
+
+	sw.setSenderInfo(sender, info)
+
+	getInfo, err := sw.GetSenderInfo(sender)
+	assert.Nil(err)
+	assert.Equal(info, getInfo)
+
+	sw.Clear(sender)
+
+	getInfo = sw.senders[sender]
+	assert.Nil(getInfo)
+	// on calling GetSenderInfo should be back to RPC stub values
+	getInfo, err = sw.GetSenderInfo(sender)
+	assert.Nil(err)
+	assert.Equal(getInfo, stubClientSenderInfo)
+}
+
+func TestSenderWatcher_WatchAndStop(t *testing.T) {
+	assert := assert.New(t)
+	lpEth := &eth.StubClient{}
+	watcher := &stubBlockWatcher{}
+	sw, err := NewSenderWatcher(stubTicketBrokerAddr, watcher, lpEth)
+	assert.Nil(err)
+
+	go sw.Watch()
+	time.Sleep(2 * time.Millisecond)
+	sw.Stop()
+	time.Sleep(2 * time.Millisecond)
+	assert.True(watcher.sub.unsubscribed)
+}
+
+func TestSenderWatcher_HandleLog(t *testing.T) {
+	lpEth := &eth.StubClient{}
+	watcher := &stubBlockWatcher{}
+	rw, err := NewSenderWatcher(stubTicketBrokerAddr, watcher, lpEth)
+	require.Nil(t, err)
+
+	assert := assert.New(t)
+
+	// Test unknown event
+	log := newStubBaseLog()
+	log.Topics = []ethcommon.Hash{ethcommon.BytesToHash([]byte("foo"))}
+
+	err = rw.handleLog(log)
+	assert.Nil(err)
+}
+
+func TestFundDepositEvent(t *testing.T) {
+	assert := assert.New(t)
+	startDeposit := big.NewInt(10)
+	lpEth := &eth.StubClient{
+		SenderInfo: &pm.SenderInfo{
+			Deposit: big.NewInt(10),
+			Reserve: big.NewInt(5),
+		},
+	}
+	watcher := &stubBlockWatcher{}
+	sw, err := NewSenderWatcher(stubTicketBrokerAddr, watcher, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	newDepositEvent := newStubDepositFundedLog()
+	header.Logs = append(header.Logs, newDepositEvent)
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go sw.Watch()
+	defer sw.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	// If map entry is nil don't handle event
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok := sw.senders[stubSender]
+	assert.False(ok)
+
+	// if block removed, make RPC call
+	blockEvent.Type = blockwatch.Removed
+	sw.senders[stubSender] = &pm.SenderInfo{}
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, ok := sw.senders[stubSender]
+	assert.True(ok)
+	assert.Zero(info.Deposit.Cmp(startDeposit))
+
+	// If map entry exists parse event log
+	blockEvent.Type = blockwatch.Added
+	expectedDeposit := new(big.Int).Add(startDeposit, new(big.Int).SetBytes(newDepositEvent.Data))
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, err = sw.GetSenderInfo(stubSender)
+	assert.Nil(err)
+	assert.Zero(info.Deposit.Cmp(expectedDeposit))
+
+	// If we don't care about the address, don't handle the event
+	s := pm.RandAddress()
+	sender := ethcommon.LeftPadBytes(s.Bytes(), 32)
+	var senderTopic ethcommon.Hash
+	copy(senderTopic[:], sender[:])
+	newDepositEvent.Topics[1] = senderTopic
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok = sw.senders[s]
+	assert.False(ok)
+}
+
+func TestFundReserveEvent(t *testing.T) {
+	assert := assert.New(t)
+	startDeposit := big.NewInt(10)
+	startReserve := big.NewInt(5)
+	startThawR := big.NewInt(1)
+	lpEth := &eth.StubClient{
+		SenderInfo: &pm.SenderInfo{
+			Deposit:   big.NewInt(10),
+			Reserve:   big.NewInt(5),
+			ThawRound: big.NewInt(1),
+		},
+	}
+	watcher := &stubBlockWatcher{}
+	sw, err := NewSenderWatcher(stubTicketBrokerAddr, watcher, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	newReserveEvent := newStubReserveFundedLog()
+	header.Logs = append(header.Logs, newReserveEvent)
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go sw.Watch()
+	defer sw.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	// If map entry is nil don't handle event
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok := sw.senders[stubSender]
+	assert.False(ok)
+
+	// if block removed, make RPC call
+	blockEvent.Type = blockwatch.Removed
+	sw.senders[stubSender] = &pm.SenderInfo{}
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, ok := sw.senders[stubSender]
+	assert.True(ok)
+	assert.Equal(info.Deposit, startDeposit)
+	assert.Equal(info.Reserve, startReserve)
+	assert.Equal(info.ThawRound, startThawR)
+
+	// If map entry exists parse event log
+	blockEvent.Type = blockwatch.Added
+	expectedReserve := new(big.Int).Add(startReserve, new(big.Int).SetBytes(newReserveEvent.Data))
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, err = sw.GetSenderInfo(stubSender)
+	assert.Nil(err)
+	assert.Zero(info.Reserve.Cmp(expectedReserve))
+
+	// If we don't care about the address, don't handle the event
+	s := pm.RandAddress()
+	sender := ethcommon.LeftPadBytes(s.Bytes(), 32)
+	var senderTopic ethcommon.Hash
+	copy(senderTopic[:], sender[:])
+	newReserveEvent.Topics[1] = senderTopic
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok = sw.senders[s]
+	assert.False(ok)
+}
+
+func TestWithdrawalEvent(t *testing.T) {
+	assert := assert.New(t)
+	startDeposit := big.NewInt(10)
+	startReserve := big.NewInt(5)
+	lpEth := &eth.StubClient{
+		SenderInfo: &pm.SenderInfo{
+			Deposit: big.NewInt(10),
+			Reserve: big.NewInt(5),
+		},
+	}
+	watcher := &stubBlockWatcher{}
+	sw, err := NewSenderWatcher(stubTicketBrokerAddr, watcher, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	newWithdrawalEvent := newStubWithdrawalLog()
+	header.Logs = append(header.Logs, newWithdrawalEvent)
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go sw.Watch()
+	defer sw.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	// If map entry is nil don't handle event
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok := sw.senders[stubSender]
+	assert.False(ok)
+
+	// if block removed, make RPC call
+	blockEvent.Type = blockwatch.Removed
+	sw.senders[stubSender] = &pm.SenderInfo{}
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, ok := sw.senders[stubSender]
+	assert.True(ok)
+	assert.Zero(info.Deposit.Cmp(startDeposit))
+	assert.Zero(info.Reserve.Cmp(startReserve))
+
+	// If map entry exists parse event log
+	blockEvent.Type = blockwatch.Added
+	time.Sleep(2 * time.Millisecond)
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, err = sw.GetSenderInfo(stubSender)
+	assert.Nil(err)
+	assert.Zero(info.Deposit.Cmp(big.NewInt(0)))
+	assert.Zero(info.Reserve.Cmp(big.NewInt(0)))
+
+	// If we don't care about the address, don't handle the event
+	s := pm.RandAddress()
+	sender := ethcommon.LeftPadBytes(s.Bytes(), 32)
+	var senderTopic ethcommon.Hash
+	copy(senderTopic[:], sender[:])
+	newWithdrawalEvent.Topics[1] = senderTopic
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok = sw.senders[s]
+	assert.False(ok)
+}
+
+func TestWinningTicketTransferEvent(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	deposit, _ := new(big.Int).SetString("10000000000000000000", 10)
+	reserve, _ := new(big.Int).SetString("5000000000000000000", 10)
+	startDeposit, _ := new(big.Int).SetString("10000000000000000000", 10)
+	startReserve, _ := new(big.Int).SetString("5000000000000000000", 10)
+	senderInfo := &pm.SenderInfo{
+		Deposit: deposit,
+		Reserve: reserve,
+	}
+	lpEth := &eth.StubClient{
+		SenderInfo: senderInfo,
+	}
+	watcher := &stubBlockWatcher{}
+	sw, err := NewSenderWatcher(stubTicketBrokerAddr, watcher, lpEth)
+	require.Nil(err)
+
+	header := defaultMiniHeader()
+	newWinningTicketEvent := newStubWinningTicketLog()
+	header.Logs = append(header.Logs, newWinningTicketEvent)
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go sw.Watch()
+	defer sw.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	// If map entry is nil don't handle event
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, ok := sw.senders[stubSender]
+	assert.False(ok)
+
+	// if block removed, make RPC call
+	blockEvent.Type = blockwatch.Removed
+	sw.senders[stubSender] = &pm.SenderInfo{}
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, ok = sw.senders[stubSender]
+	assert.True(ok)
+	assert.Equal(info.Deposit, startDeposit)
+	assert.Equal(info.Reserve, startReserve)
+
+	// If map entry exists parse event log
+	// ticket amount is 200 gwei
+	// init the map entry
+	blockEvent.Type = blockwatch.Added
+	faceValue := big.NewInt(200000000000)
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, err = sw.GetSenderInfo(stubSender)
+	assert.Nil(err)
+	assert.Zero(startDeposit.Sub(startDeposit, faceValue).Cmp(info.Deposit))
+	assert.Zero(startReserve.Cmp(info.Reserve))
+
+	// Test facevalue > deposit
+	senderInfo.Deposit = big.NewInt(100000000000)
+	info, err = sw.GetSenderInfo(stubSender)
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, err = sw.GetSenderInfo(stubSender)
+	assert.Nil(err)
+	assert.Zero(info.Deposit.Int64())
+	diff := new(big.Int).Sub(faceValue, big.NewInt(100000000000))
+	expectedReserve := new(big.Int).Sub(startReserve, diff)
+	assert.Zero(expectedReserve.Cmp(info.Reserve))
+
+	// If we don't care about the address, don't handle the event
+	s := pm.RandAddress()
+	sender := ethcommon.LeftPadBytes(s.Bytes(), 32)
+	var senderTopic ethcommon.Hash
+	copy(senderTopic[:], sender[:])
+	newWinningTicketEvent.Topics[1] = senderTopic
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok = sw.senders[s]
+	assert.False(ok)
+}
+
+func TestReserveFrozenEvent(t *testing.T) {
+	assert := assert.New(t)
+	startThawR := big.NewInt(10)
+	lpEth := &eth.StubClient{
+		SenderInfo: &pm.SenderInfo{
+			ThawRound:    big.NewInt(10),
+			ReserveState: pm.Frozen,
+		},
+	}
+	watcher := &stubBlockWatcher{}
+	sw, err := NewSenderWatcher(stubTicketBrokerAddr, watcher, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	newReserveFrozenEvent := newStubReserveFrozenLog()
+	header.Logs = append(header.Logs, newReserveFrozenEvent)
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go sw.Watch()
+	defer sw.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	// If map entry is nil don't handle event
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok := sw.senders[stubSender]
+	assert.False(ok)
+
+	// if block removed, make RPC call
+	blockEvent.Type = blockwatch.Removed
+	sw.senders[stubSender] = &pm.SenderInfo{}
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, ok := sw.senders[stubSender]
+	assert.True(ok)
+	assert.Equal(info.ReserveState, pm.Frozen)
+	assert.Zero(startThawR.Cmp(info.ThawRound))
+
+	// If map entry exists parse event log
+	blockEvent.Type = blockwatch.Added
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, err = sw.GetSenderInfo(stubSender)
+	assert.Nil(err)
+	assert.Equal(info.ReserveState, pm.Frozen)
+	expectedThawRound := new(big.Int).Add(new(big.Int).SetBytes(newReserveFrozenEvent.Data[:32]), big.NewInt(2))
+	assert.Zero(expectedThawRound.Cmp(info.ThawRound))
+
+	// If we don't care about the address, don't handle the event
+	s := pm.RandAddress()
+	sender := ethcommon.LeftPadBytes(s.Bytes(), 32)
+	var senderTopic ethcommon.Hash
+	copy(senderTopic[:], sender[:])
+	newReserveFrozenEvent.Topics[1] = senderTopic
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok = sw.senders[s]
+	assert.False(ok)
+}
+
+func TestUnlockEvent(t *testing.T) {
+	assert := assert.New(t)
+	startWithdrawBlock := big.NewInt(5)
+	lpEth := &eth.StubClient{
+		SenderInfo: &pm.SenderInfo{
+			WithdrawBlock: big.NewInt(5),
+		},
+	}
+	watcher := &stubBlockWatcher{}
+	sw, err := NewSenderWatcher(stubTicketBrokerAddr, watcher, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	newUnlockEvent := newStubUnlockLog()
+	header.Logs = append(header.Logs, newUnlockEvent)
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go sw.Watch()
+	defer sw.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	// If map entry is nil don't handle event
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok := sw.senders[stubSender]
+	assert.False(ok)
+
+	// if block removed, make RPC call
+	blockEvent.Type = blockwatch.Removed
+	sw.senders[stubSender] = &pm.SenderInfo{}
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, ok := sw.senders[stubSender]
+	assert.True(ok)
+	assert.Zero(info.WithdrawBlock.Cmp(startWithdrawBlock))
+
+	// If map entry exists parse event log
+	blockEvent.Type = blockwatch.Added
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, err = sw.GetSenderInfo(stubSender)
+	assert.Nil(err)
+	assert.Zero(info.WithdrawBlock.Cmp(big.NewInt(150)))
+
+	// If we don't care about the address, don't handle the event
+	s := pm.RandAddress()
+	sender := ethcommon.LeftPadBytes(s.Bytes(), 32)
+	var senderTopic ethcommon.Hash
+	copy(senderTopic[:], sender[:])
+	newUnlockEvent.Topics[1] = senderTopic
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok = sw.senders[s]
+	assert.False(ok)
+}
+
+func TestUnlockCancelledEvent(t *testing.T) {
+	assert := assert.New(t)
+	lpEth := &eth.StubClient{
+		SenderInfo: &pm.SenderInfo{
+			WithdrawBlock: big.NewInt(10),
+		},
+	}
+	watcher := &stubBlockWatcher{}
+	sw, err := NewSenderWatcher(stubTicketBrokerAddr, watcher, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	newUnlockCancelledEvent := newStubUnlockCancelledLog()
+	header.Logs = append(header.Logs, newUnlockCancelledEvent)
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go sw.Watch()
+	defer sw.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	// If map entry is nil don't handle event
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok := sw.senders[stubSender]
+	assert.False(ok)
+
+	// if block removed, make RPC call
+	blockEvent.Type = blockwatch.Removed
+	sw.senders[stubSender] = &pm.SenderInfo{}
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, ok := sw.senders[stubSender]
+	assert.True(ok)
+	assert.Zero(info.WithdrawBlock.Cmp(big.NewInt(10)))
+
+	// If map entry exists parse event log
+	blockEvent.Type = blockwatch.Added
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	info, err = sw.GetSenderInfo(stubSender)
+	assert.Nil(err)
+	assert.Zero(info.WithdrawBlock.Int64())
+
+	// If we don't care about the address, don't handle the event
+	s := pm.RandAddress()
+	sender := ethcommon.LeftPadBytes(s.Bytes(), 32)
+	var senderTopic ethcommon.Hash
+	copy(senderTopic[:], sender[:])
+	newUnlockCancelledEvent.Topics[1] = senderTopic
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	_, ok = sw.senders[s]
+	assert.False(ok)
+}

--- a/eth/watchers/stub.go
+++ b/eth/watchers/stub.go
@@ -298,6 +298,8 @@ func (s *stubUnbondingLockStore) UseUnbondingLock(id *big.Int, delegator common.
 
 func (s *stubUnbondingLockStore) Get(id int64) *stubUnbondingLock {
 	return s.unbondingLocks[id]
+}
+
 func defaultMiniHeader() *blockwatch.MiniHeader {
 	block := &blockwatch.MiniHeader{
 		Number: big.NewInt(450),

--- a/eth/watchers/stub.go
+++ b/eth/watchers/stub.go
@@ -9,10 +9,15 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	"github.com/livepeer/go-livepeer/pm"
 )
+
+var stubSender = pm.RandAddress()
 
 var stubBondingManagerAddr = common.HexToAddress("0x511bc4556d823ae99630ae8de28b9b80df90ea2e")
 var stubRoundsManagerAddr = common.HexToAddress("0xc1F9BB72216E5ecDc97e248F65E14df1fE46600a")
+
+var stubTicketBrokerAddr = common.HexToAddress("0x9d6d492bD500DA5B33cf95A5d610a73360FcaAa0")
 
 func newStubBaseLog() types.Log {
 	return types.Log{
@@ -84,6 +89,132 @@ func newStubNewRoundLog() types.Log {
 	roundBytes := common.BytesToHash(common.LeftPadBytes(round.Bytes(), 32))
 	log.Topics = []common.Hash{topic, roundBytes}
 	log.Data, _ = hexutil.Decode("0x15063b24c3dfd390370cd13eaf27fd0b079c60f31bf1414c574f865e906a8964")
+	return log
+}
+
+func newStubDepositFundedLog() types.Log {
+	log := newStubBaseLog()
+	log.Address = stubTicketBrokerAddr
+	amount, _ := new(big.Int).SetString("5000000000000000000", 10)
+	amountData := common.LeftPadBytes(amount.Bytes(), 32)
+	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic common.Hash
+	copy(senderTopic[:], sender[:])
+	log.Topics = []common.Hash{
+		crypto.Keccak256Hash([]byte("DepositFunded(address,uint256)")),
+		senderTopic,
+	}
+	log.Data = amountData
+	return log
+}
+
+func newStubReserveFundedLog() types.Log {
+	log := newStubBaseLog()
+	log.Address = stubTicketBrokerAddr
+	amount, _ := new(big.Int).SetString("5000000000000000000", 10)
+	amountData := common.LeftPadBytes(amount.Bytes(), 32)
+	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic common.Hash
+	copy(senderTopic[:], sender[:])
+	log.Topics = []common.Hash{
+		crypto.Keccak256Hash([]byte("ReserveFunded(address,uint256)")),
+		senderTopic,
+	}
+	log.Data = amountData
+	return log
+}
+
+func newStubWithdrawalLog() types.Log {
+	log := newStubBaseLog()
+	log.Address = stubTicketBrokerAddr
+	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic common.Hash
+	copy(senderTopic[:], sender[:])
+	log.Topics = []common.Hash{
+		crypto.Keccak256Hash([]byte("Withdrawal(address,uint256,uint256)")),
+		senderTopic,
+	}
+
+	deposit, _ := new(big.Int).SetString("5000000000000000000", 10)
+	reserve, _ := new(big.Int).SetString("1000000000000000000", 10)
+	depositData := common.LeftPadBytes(deposit.Bytes(), 32)
+	reserveData := common.LeftPadBytes(reserve.Bytes(), 32)
+	var data []byte
+	data = append(data, depositData...)
+	data = append(data, reserveData...)
+	log.Data = data
+	return log
+}
+
+func newStubWinningTicketLog() types.Log {
+	log := newStubBaseLog()
+	log.Address = stubTicketBrokerAddr
+	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic [32]byte
+	copy(senderTopic[:], sender[:])
+	recipient := common.LeftPadBytes(pm.RandAddress().Bytes(), 32)
+	var recipientTopic [32]byte
+	copy(recipientTopic[:], recipient[:])
+	log.Topics = []common.Hash{
+		crypto.Keccak256Hash([]byte("WinningTicketTransfer(address,address,uint256)")),
+		senderTopic,
+		recipientTopic,
+	}
+	amount, _ := new(big.Int).SetString("200000000000", 10)
+	amountData := common.LeftPadBytes(amount.Bytes(), 32)
+	log.Data = amountData
+	return log
+}
+
+func newStubReserveFrozenLog() types.Log {
+	log := newStubBaseLog()
+	log.Address = stubTicketBrokerAddr
+	holder := common.LeftPadBytes(stubSender.Bytes(), 32)
+	claimant := common.LeftPadBytes(pm.RandAddress().Bytes(), 32)
+	var holderTopic [32]byte
+	copy(holderTopic[:], holder[:])
+	var claimantTopic [32]byte
+	copy(claimantTopic[:], claimant[:])
+	log.Topics = []common.Hash{
+		crypto.Keccak256Hash([]byte("ReserveFrozen(address,address,uint256,uint256)")),
+		holderTopic,
+		claimantTopic,
+	}
+	var data []byte
+	data = append(data, common.LeftPadBytes(big.NewInt(5).Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(big.NewInt(25).Bytes(), 32)...)
+	log.Data = data
+	return log
+}
+
+func newStubUnlockLog() types.Log {
+	log := newStubBaseLog()
+	log.Address = stubTicketBrokerAddr
+	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic common.Hash
+	copy(senderTopic[:], sender[:])
+	log.Topics = []common.Hash{
+		crypto.Keccak256Hash([]byte("Unlock(address,uint256,uint256)")),
+		senderTopic,
+	}
+	var data []byte
+	data = append(data, common.LeftPadBytes(big.NewInt(100).Bytes(), 32)...)
+	data = append(data, common.LeftPadBytes(big.NewInt(150).Bytes(), 32)...)
+	log.Data = data
+	return log
+}
+
+func newStubUnlockCancelledLog() types.Log {
+	log := newStubBaseLog()
+	log.Address = stubTicketBrokerAddr
+	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic common.Hash
+	copy(senderTopic[:], sender[:])
+	log.Topics = []common.Hash{
+		crypto.Keccak256Hash([]byte("UnlockCancelled(address)")),
+		senderTopic,
+	}
+	log.Data = []byte{}
 	return log
 }
 
@@ -167,4 +298,17 @@ func (s *stubUnbondingLockStore) UseUnbondingLock(id *big.Int, delegator common.
 
 func (s *stubUnbondingLockStore) Get(id int64) *stubUnbondingLock {
 	return s.unbondingLocks[id]
+func defaultMiniHeader() *blockwatch.MiniHeader {
+	block := &blockwatch.MiniHeader{
+		Number: big.NewInt(450),
+		Parent: pm.RandHash(),
+		Hash:   pm.RandHash(),
+	}
+	log := types.Log{
+		Topics:    []common.Hash{pm.RandHash(), pm.RandHash()},
+		Data:      pm.RandBytes(32),
+		BlockHash: block.Hash,
+	}
+	block.Logs = []types.Log{log}
+	return block
 }

--- a/eth/watchers/topics.go
+++ b/eth/watchers/topics.go
@@ -10,6 +10,13 @@ var eventSignatures = []string{
 	"Rebond(address,address,uint256,uint256)",
 	"WithdrawStake(address,uint256,uint256,uint256)",
 	"NewRound(uint256,bytes32)",
+	"DepositFunded(address,uint256)",
+	"ReserveFunded(address,uint256)",
+	"Withdrawal(address,uint256,uint256)",
+	"WinningTicketTransfer(address,address,uint256,uint256)",
+	"ReserveFrozen(address,address,uint256,uint256)",
+	"Unlock(address,uint256,uint256)",
+	"UnlockCancelled(address)",
 }
 
 // FilterTopics returns a list of topics to be used when filtering logs

--- a/test.sh
+++ b/test.sh
@@ -22,7 +22,7 @@ go test -logtostderr=true
 t4=$?
 cd ..
 
-cd eth/eventservices
+cd eth/watchers
 go test -logtostderr=true
 t5=$?
 cd ../..


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR implements a senderwatcher that adheres to the `SenderManager` interface with a concurrency safe map that keeps track of `pm.SenderInfo` for an ethereum address. 

In this case the map will keep track of a single entry for the broadcaster.


**Specific updates (required)**
- Created a `SenderWatcher` type that adheres to the `SenderManager` interfaces and used it to initiate `pm.Sender` 
- Init a `SenderWatcher` instance watching for on-chain events log on node startup 
- Added unit tests for `SenderWatcher`
- Added event signatures to `watchers/topics.go`
- added a `*pm.SenderInfo` field to the `eth.stubClient` so that we can test for values returned by stubbed out RPC calls made by `SenderWatcher`. Now returning the new value from `stubClient.GetSenderInfo()` as well

**How did you test each of these updates (required)**
created unit tests


**Does this pull request close any open issues?**
Fixes #947 


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
