### PR TITLE
eth, cmd: return error from roundswatcher.Watch if init fails

### DIFF
--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -127,6 +127,7 @@ type StubClient struct {
 	LatestBlockError             error
 	ProcessHistoricalUnbondError error
 	Orchestrators                []*lpTypes.Transcoder
+	RoundsErr                    error
 }
 
 type stubTranscoder struct {
@@ -140,8 +141,8 @@ func (e *StubClient) Backend() (*ethclient.Client, error)                       
 // Rounds
 
 func (e *StubClient) InitializeRound() (*types.Transaction, error)       { return nil, nil }
-func (e *StubClient) CurrentRound() (*big.Int, error)                    { return big.NewInt(0), nil }
-func (e *StubClient) LastInitializedRound() (*big.Int, error)            { return big.NewInt(0), nil }
+func (e *StubClient) CurrentRound() (*big.Int, error)                    { return big.NewInt(0), e.RoundsErr }
+func (e *StubClient) LastInitializedRound() (*big.Int, error)            { return big.NewInt(0), e.RoundsErr }
 func (e *StubClient) BlockHashForRound(round *big.Int) ([32]byte, error) { return [32]byte{}, nil }
 func (e *StubClient) CurrentRoundInitialized() (bool, error)             { return false, nil }
 func (e *StubClient) CurrentRoundLocked() (bool, error)                  { return false, nil }

--- a/eth/watchers/roundswatcher.go
+++ b/eth/watchers/roundswatcher.go
@@ -64,14 +64,14 @@ func (rw *RoundsWatcher) setLastInitializedRound(round *big.Int, hash [32]byte) 
 }
 
 // Watch the blockwatch subscription for NewRound events
-func (rw *RoundsWatcher) Watch() {
+func (rw *RoundsWatcher) Watch() error {
 	lr, err := rw.lpEth.LastInitializedRound()
 	if err != nil {
-		glog.Errorf("error fetching initial lastInitializedRound value: %v", err)
+		return fmt.Errorf("error fetching initial lastInitializedRound value: %v", err)
 	}
 	bh, err := rw.lpEth.BlockHashForRound(lr)
 	if err != nil {
-		glog.Errorf("error fetching initial lastInitializedBlockHash value: %v", err)
+		return fmt.Errorf("error fetching initial lastInitializedBlockHash value: %v", err)
 	}
 	rw.setLastInitializedRound(lr, bh)
 
@@ -81,7 +81,7 @@ func (rw *RoundsWatcher) Watch() {
 	for {
 		select {
 		case <-rw.quit:
-			return
+			return nil
 		case err := <-sub.Err():
 			glog.Error(err)
 		case events := <-events:

--- a/eth/watchers/roundswatcher_test.go
+++ b/eth/watchers/roundswatcher_test.go
@@ -1,6 +1,7 @@
 package watchers
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 	"time"
@@ -82,6 +83,16 @@ func TestWatchAndStop(t *testing.T) {
 	rw.Stop()
 	time.Sleep(2 * time.Millisecond)
 	assert.True(watcher.sub.unsubscribed)
+
+	// Test watch error when RPC calls fail
+	rw = &RoundsWatcher{
+		lpEth: &eth.StubClient{
+			RoundsErr: errors.New("roundswatcher error"),
+		},
+	}
+	err = rw.Watch()
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "roundswatcher error")
 }
 
 func TestRoundsWatcher_HandleLog(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR makes `RoundsWatcher.Watch()` throw an error when the initial RPC requests to populate the cache fail, this will in turn exit the node. 

See https://github.com/livepeer/go-livepeer/pull/1052#discussion_r315754345 

**Specific updates (required)**
- Added an error as return value from `RoundsWatcher.Watch()`
- Added a test to check for this error, also added a stub error for this case to the `stubEthClient`
- Now exiting the node when `RoundsWatcher `fails to initialize

**How did you test each of these updates (required)**
added and ran unit tests

**Does this pull request close any open issues?**


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
