### PR TITLE
cmd: exit if blockwatch.Watch fails

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -381,6 +381,7 @@ func main() {
 		go func() {
 			if err := blockWatcher.Watch(blockWatchCtx); err != nil {
 				glog.Errorf("block watcher error: %v", err)
+				return
 			}
 		}()
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
If blockwatch.Watch() fails the node will now correctly exit rather than only log the error. 

See this comment : https://github.com/livepeer/go-livepeer/pull/1052#discussion_r315751704

**Specific updates (required)**
- Now returning from the go-routine that starts `blockwatch.Watch` when an error is returned

**How did you test each of these updates (required)**
ran unit tests


**Does this pull request close any open issues?**


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
