### PR TITLE
Propagate pixel counts from transcoders

### DIFF
--- a/core/core_test.go
+++ b/core/core_test.go
@@ -59,16 +59,16 @@ func TestTranscode(t *testing.T) {
 		t.Error("Error transcoding ", err)
 	}
 
-	if len(tr.TranscodeData) != len(videoProfiles) && len(videoProfiles) != 2 {
+	if len(tr.TranscodeData.Segments) != len(videoProfiles) && len(videoProfiles) != 2 {
 		t.Error("Job profile count did not match broadcasters")
 	}
 
 	// 	Check transcode result
-	if Over1Pct(len(tr.TranscodeData[0].Data), 73132) { // 144p
-		t.Error("Unexpected transcode result ", len(tr.TranscodeData[0].Data))
+	if Over1Pct(len(tr.TranscodeData.Segments[0].Data), 73132) { // 144p
+		t.Error("Unexpected transcode result ", len(tr.TranscodeData.Segments[0].Data))
 	}
-	if Over1Pct(len(tr.TranscodeData[1].Data), 99640) { // 240p
-		t.Error("Unexpected transcode result ", len(tr.TranscodeData[1].Data))
+	if Over1Pct(len(tr.TranscodeData.Segments[1].Data), 99640) { // 240p
+		t.Error("Unexpected transcode result ", len(tr.TranscodeData.Segments[1].Data))
 	}
 
 	// TODO check transcode loop expiry, storage, sig construction, etc
@@ -96,8 +96,8 @@ func TestTranscodeSeg(t *testing.T) {
 	assert.Nil(res.Sig)
 	// sanity check results
 	resBytes, _ := n.Transcoder.Transcode("", profiles)
-	for i, trData := range res.TranscodeData {
-		assert.Equal(resBytes[i], trData.Data)
+	for i, trData := range res.TranscodeData.Segments {
+		assert.Equal(resBytes.Segments[i].Data, trData.Data)
 	}
 
 	// Test onchain mode
@@ -107,8 +107,8 @@ func TestTranscodeSeg(t *testing.T) {
 	assert.NotNil(res.Sig)
 	// check sig
 	resHashes := make([][]byte, len(profiles))
-	for i, v := range resBytes {
-		resHashes[i] = ethCrypto.Keccak256(v)
+	for i, v := range resBytes.Segments {
+		resHashes[i] = ethCrypto.Keccak256(v.Data)
 	}
 	resHash := ethCrypto.Keccak256(resHashes...)
 	assert.Equal(resHash, res.Sig)

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -21,18 +21,19 @@ type StubTranscoder struct {
 	FailTranscode bool
 }
 
-func (t *StubTranscoder) Transcode(fname string, profiles []ffmpeg.VideoProfile) ([][]byte, error) {
+func (t *StubTranscoder) Transcode(fname string, profiles []ffmpeg.VideoProfile) (*TranscodeData, error) {
 	if t.FailTranscode {
 		return nil, ErrTranscode
 	}
 
 	t.SegCount++
 
-	result := make([][]byte, 0)
+	segments := make([]*TranscodedSegmentData, 0)
 	for _, p := range t.Profiles {
-		result = append(result, []byte(fmt.Sprintf("Transcoded_%v", p.Name)))
+		segments = append(segments, &TranscodedSegmentData{Data: []byte(fmt.Sprintf("Transcoded_%v", p.Name))})
 	}
-	return result, nil
+
+	return &TranscodeData{Segments: segments}, nil
 }
 
 func TestTranscodeAndBroadcast(t *testing.T) {
@@ -57,8 +58,8 @@ func TestTranscodeAndBroadcast(t *testing.T) {
 		t.Errorf("Error: %v", res.Err)
 	}
 
-	if len(res.TranscodeData) != len(p) {
-		t.Errorf("Expecting %v profiles, got %v", len(p), len(res.TranscodeData))
+	if len(res.TranscodeData.Segments) != len(p) {
+		t.Errorf("Expecting %v profiles, got %v", len(p), len(res.TranscodeData.Segments))
 	}
 
 	//Should have 1 transcoded segment into 2 different profiles

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -99,7 +99,7 @@ func TestRemoteTranscoder(t *testing.T) {
 	// happy path
 	tc, strm := initTranscoder()
 	res, err := tc.Transcode("", nil)
-	if err != nil || string(res[0]) != "asdf" {
+	if err != nil || string(res.Segments[0].Data) != "asdf" {
 		t.Error("Error transcoding ", err)
 	}
 
@@ -299,8 +299,8 @@ func TestTranscoderManagerTranscoding(t *testing.T) {
 	// happy path
 	res, err := m.Transcode("", nil)
 	assert.Nil(err)
-	assert.Len(res, 1)
-	assert.Equal(string(res[0]), "asdf")
+	assert.Len(res.Segments, 1)
+	assert.Equal(string(res.Segments[0].Data), "asdf")
 
 	// non-fatal error should not remove from list
 	s.TranscodeError = fmt.Errorf("TranscodeError")
@@ -423,7 +423,14 @@ type StubTranscoderServer struct {
 }
 
 func (s *StubTranscoderServer) Send(n *net.NotifySegment) error {
-	res := RemoteTranscoderResult{Segments: [][]byte{[]byte("asdf")}, Err: s.TranscodeError}
+	res := RemoteTranscoderResult{
+		TranscodeData: &TranscodeData{
+			Segments: []*TranscodedSegmentData{
+				&TranscodedSegmentData{Data: []byte("asdf")},
+			},
+		},
+		Err: s.TranscodeError,
+	}
 	if !s.WithholdResults {
 		s.manager.transcoderResults(n.TaskId, &res)
 	}

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -507,7 +507,6 @@ func (n *LivepeerNode) transcodeSeg(config transcodeConfig, seg *stream.HLSSegme
 	}
 
 	took := time.Since(start)
-	tProfileData := make(map[ffmpeg.VideoProfile][]byte, 0)
 	glog.V(common.DEBUG).Infof("Transcoding of segment manifestID=%s seqNo=%d took=%v", string(md.ManifestID), seg.SeqNo, took)
 	if isLocal && monitor.Enabled {
 		monitor.SegmentTranscoded(0, seg.SeqNo, took, common.ProfilesNames(md.Profiles))
@@ -523,7 +522,6 @@ func (n *LivepeerNode) transcodeSeg(config transcodeConfig, seg *stream.HLSSegme
 				string(md.ManifestID), seg.SeqNo, len(tData[i]))
 			return terr(fmt.Errorf("ZeroSegments"))
 		}
-		tProfileData[md.Profiles[i]] = tData[i]
 		tr.TranscodeData = append(tr.TranscodeData, &TranscodeData{
 			Data: tData[i],
 			// TODO: ADD NUMBER OF OUTPUT PIXELS

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -22,14 +22,14 @@ func TestLocalTranscoder(t *testing.T) {
 	if err != nil {
 		t.Error("Error transcoding ", err)
 	}
-	if len(res) != len(profiles) {
+	if len(res.Segments) != len(profiles) {
 		t.Error("Mismatched results")
 	}
-	if Over1Pct(len(res[0]), 164312) {
-		t.Errorf("Wrong data %v", len(res[0]))
+	if Over1Pct(len(res.Segments[0].Data), 164312) {
+		t.Errorf("Wrong data %v", len(res.Segments[0].Data))
 	}
-	if Over1Pct(len(res[1]), 227668) {
-		t.Errorf("Wrong data %v", len(res[1]))
+	if Over1Pct(len(res.Segments[1].Data), 227668) {
+		t.Errorf("Wrong data %v", len(res.Segments[1].Data))
 	}
 }
 
@@ -68,11 +68,11 @@ func TestNvidiaTranscoder(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if Over1Pct(len(res[0]), 650292) {
-		t.Errorf("Wrong data %v", len(res[0]))
+	if Over1Pct(len(res.Segments[0].Data), 650292) {
+		t.Errorf("Wrong data %v", len(res.Segments[0].Data))
 	}
-	if Over1Pct(len(res[1]), 884164) {
-		t.Errorf("Wrong data %v", len(res[1]))
+	if Over1Pct(len(res.Segments[1].Data), 884164) {
+		t.Errorf("Wrong data %v", len(res.Segments[1].Data))
 	}
 }
 
@@ -87,9 +87,8 @@ func TestResToTranscodeData(t *testing.T) {
 
 	// Test immediate error
 	opts := []ffmpeg.TranscodeOptions{ffmpeg.TranscodeOptions{Oname: "badfile"}}
-	tData, err := resToTranscodeData(opts)
+	_, err := resToTranscodeData(opts)
 	assert.EqualError(err, "open badfile: no such file or directory")
-	assert.Equal(0, len(tData))
 
 	// Test error after a successful read
 	tempDir, err := ioutil.TempDir("", "TestResToTranscodeData")
@@ -106,17 +105,16 @@ func TestResToTranscodeData(t *testing.T) {
 	opts[1].Oname = "badfile"
 	opts[2].Oname = file2.Name()
 
-	tData, err = resToTranscodeData(opts)
+	_, err = resToTranscodeData(opts)
 	assert.EqualError(err, "open badfile: no such file or directory")
-	assert.Equal(0, len(tData))
 	assert.True(fileDNE(file1.Name()))
 	assert.False(fileDNE(file2.Name()))
 
 	// Test success for 1 output file
 	opts = []ffmpeg.TranscodeOptions{ffmpeg.TranscodeOptions{Oname: file2.Name()}}
-	tData, err = resToTranscodeData(opts)
+	tData, err := resToTranscodeData(opts)
 	assert.Nil(err)
-	assert.Equal(1, len(tData))
+	assert.Equal(1, len(tData.Segments))
 	assert.True(fileDNE(file2.Name()))
 
 	// Test succes for 2 output files
@@ -131,7 +129,7 @@ func TestResToTranscodeData(t *testing.T) {
 
 	tData, err = resToTranscodeData(opts)
 	assert.Nil(err)
-	assert.Equal(2, len(tData))
+	assert.Equal(2, len(tData.Segments))
 	assert.True(fileDNE(file1.Name()))
 	assert.True(fileDNE(file2.Name()))
 }

--- a/server/ot_rpc_test.go
+++ b/server/ot_rpc_test.go
@@ -25,9 +25,14 @@ type stubTranscoder struct {
 	fname  string
 }
 
-var testRemoteTranscoderResults = [][]byte{[]byte("body1"), []byte("body2")}
+var testRemoteTranscoderResults = &core.TranscodeData{
+	Segments: []*core.TranscodedSegmentData{
+		&core.TranscodedSegmentData{Data: []byte("body1")},
+		&core.TranscodedSegmentData{Data: []byte("body2")},
+	},
+}
 
-func (st *stubTranscoder) Transcode(fname string, profiles []ffmpeg.VideoProfile) ([][]byte, error) {
+func (st *stubTranscoder) Transcode(fname string, profiles []ffmpeg.VideoProfile) (*core.TranscodeData, error) {
 	st.called++
 	st.fname = fname
 	return testRemoteTranscoderResults, nil
@@ -87,7 +92,7 @@ func TestRemoteTranscoder(t *testing.T) {
 		assert.NoError(err)
 		bodyPart, err := ioutil.ReadAll(p)
 		assert.NoError(err)
-		assert.Equal(testRemoteTranscoderResults[i], bodyPart)
+		assert.Equal(testRemoteTranscoderResults.Segments[i].Data, bodyPart)
 		i++
 	}
 }

--- a/server/ot_rpc_test.go
+++ b/server/ot_rpc_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/livepeer/go-livepeer/common"
@@ -27,9 +28,10 @@ type stubTranscoder struct {
 
 var testRemoteTranscoderResults = &core.TranscodeData{
 	Segments: []*core.TranscodedSegmentData{
-		&core.TranscodedSegmentData{Data: []byte("body1")},
-		&core.TranscodedSegmentData{Data: []byte("body2")},
+		&core.TranscodedSegmentData{Data: []byte("body1"), Pixels: 777},
+		&core.TranscodedSegmentData{Data: []byte("body2"), Pixels: 888},
 	},
+	Pixels: 999,
 }
 
 func (st *stubTranscoder) Transcode(fname string, profiles []ffmpeg.VideoProfile) (*core.TranscodeData, error) {
@@ -76,6 +78,7 @@ func TestRemoteTranscoder(t *testing.T) {
 	assert.Equal(2, tr.called)
 	assert.NotNil(body)
 	assert.Equal("742", headers.Get("TaskId"))
+	assert.Equal("999", headers.Get("Pixels"))
 	assert.Equal("multipart/mixed; boundary=17b336b6e6ae071e928f", headers.Get("Content-Type"))
 	assert.Equal(node.OrchSecret, headers.Get("Credentials"))
 	assert.Equal(protoVerLPT, headers.Get("Authorization"))
@@ -93,6 +96,11 @@ func TestRemoteTranscoder(t *testing.T) {
 		bodyPart, err := ioutil.ReadAll(p)
 		assert.NoError(err)
 		assert.Equal(testRemoteTranscoderResults.Segments[i].Data, bodyPart)
+
+		pixels, err := strconv.ParseInt(p.Header.Get("Pixels"), 10, 64)
+		assert.NoError(err)
+		assert.Equal(testRemoteTranscoderResults.Segments[i].Pixels, pixels)
+
 		i++
 	}
 }

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -139,17 +139,17 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 	// Upload to OS and construct segment result set
 	var segments []*net.TranscodedSegmentData
 	var pixels int64
-	for i := 0; err == nil && i < len(res.TranscodeData); i++ {
+	for i := 0; err == nil && i < len(res.TranscodeData.Segments); i++ {
 		name := fmt.Sprintf("%s/%d.ts", segData.Profiles[i].Name, segData.Seq) // ANGIE - NEED TO EDIT OUT JOB PROFILES
-		uri, err := res.OS.SaveData(name, res.TranscodeData[i].Data)
+		uri, err := res.OS.SaveData(name, res.TranscodeData.Segments[i].Data)
 		if err != nil {
 			glog.Error("Could not upload segment ", segData.Seq)
 			break
 		}
-		pixels += res.TranscodeData[i].Pixels
+		pixels += res.TranscodeData.Segments[i].Pixels
 		d := &net.TranscodedSegmentData{
 			Url:    uri,
-			Pixels: res.TranscodeData[i].Pixels,
+			Pixels: res.TranscodeData.Segments[i].Pixels,
 		}
 		segments = append(segments, d)
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds support for propagating encoded & decoded pixel counts from transcoders. Both the local (software) and NVIDIA (GPU) transcoders will access the pixel counts returned from `ffmpeg.Transcode3()` which are included in a struct that is returned to the caller. 

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- a0d580b updates the transcoders to use the `ffmpeg.Transcode3()` method
- 77a4ffa updates the `transcoder.Transcode()` interface method to return `*TranscodeData` instead of `[][]byte`. Returning the `*TranscodeData` allows the transcoder to not only return the encoded pixel count for each rendition in the `[]*TranscodedSegmentData` field nested in `*TranscodeData`, but it also allows the transcoder to return the decoded pixel count (for the input segment)
- 5ebca25 populates the encoded pixel count for each rendition in the `[]*TranscodedSegmentData` field of the `*TranscodeData` returned by the transcoder
- 91e942e updates remote transcoders to include the encoded and decoded pixel count (via headers) in the HTTP request sent to orchestrators. The orchestrators then parse the pixel counts from the headers

The structure of the network messages between O & a remote T is updated to include pixel counts:

- The decoded pixel count is included in the "Pixels" header of the HTTP request
- The encoded pixel count for each rendition is included in the "Pixels" header of each part of the multipart body of the HTTP request

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests and updated existing unit tests. Manually tested the transcoding workflow with B + O as well as B + O/T.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1049 
Fixes #1050

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
