### PR TITLE
cmd: Set default storage base URI for broadcaster

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -581,8 +581,16 @@ func main() {
 	*cliAddr = defaultAddr(*cliAddr, "127.0.0.1", CliPort)
 
 	if drivers.NodeStorage == nil {
-		// base URI will be empty for broadcasters; that's OK
-		drivers.NodeStorage = drivers.NewMemoryDriver(n.GetServiceURI())
+		if n.NodeType == core.OrchestratorNode {
+			drivers.NodeStorage = drivers.NewMemoryDriver(n.GetServiceURI())
+		} else {
+			uri, err := url.ParseRequestURI("http://" + *httpAddr)
+			if err != nil {
+				glog.Errorf("error parsing broadcaster default storage base URI: %v", err)
+				return
+			}
+			drivers.NodeStorage = drivers.NewMemoryDriver(uri)
+		}
 	}
 
 	//Create Livepeer Node


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR sets a default storage base URI for a broadcaster's memory driver when the broadcaster's storage is not configured (i.e. using a S3 or GS driver).

At the moment, if the broadcaster's storage is not configured, it will use a memory driver with an empty base URI. This is a problem because the [absolute URI](https://github.com/livepeer/go-livepeer/blob/master/drivers/local.go#L128) returned by `drivers.SaveData()` for a memory driver will not be resolvable. An example where the lack of a base URI can lead to undesirable behavior is during [pixel count verification](https://github.com/livepeer/go-livepeer/blob/master/server/broadcast.go#L405) - after receiving a transcoded result, the broadcaster will pass the result URI with the arguments to [ffmpeg.Transcode3()](https://github.com/livepeer/go-livepeer/blob/master/server/broadcast.go#L471), but the ffmpeg transcoder will be unable to resolve the URI.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- When `drivers.NodeStorage = nil` and the node is a broadcaster, set the base URI for the broadcaster's memory driver to `"http://" + *httpAddr` where `*httpAddr` is configured by the broadcaster operator

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I observed the e2e transcoding workflow with B + O as well as B + O/T in on-chain mode using the devtool.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
