### PR TITLE
Temp file for pixels verification

### DIFF
--- a/drivers/local.go
+++ b/drivers/local.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strings"
 	"sync"
 
 	"github.com/livepeer/go-livepeer/net"
@@ -72,9 +73,24 @@ func (ostore *MemorySession) EndSession() {
 	ostore.os.lock.Unlock()
 }
 
+// GetData returns the cached data for a name.
+//
+// A name can be an absolute or relative URI.
+// An absolute URI has the following format:
+// - ostore.os.baseURI + /stream/ + ostore.path + path + file
+// The following are valid relative URIs:
+// - /stream/ + ostore.path + path + file (if ostore.os.baseURI is empty)
+// - ostore.path + path + file
 func (ostore *MemorySession) GetData(name string) []byte {
+	// Since the memory cache uses the path as the key for fetching data we make sure that
+	// ostore.os.baseURI and /stream/ are stripped before splitting into a path and a filename
+	prefix := ""
+	if ostore.os.baseURI != nil {
+		prefix += ostore.os.baseURI.String()
+	}
+	prefix += "/stream/"
 
-	path, file := path.Split(name)
+	path, file := path.Split(strings.TrimPrefix(name, prefix))
 
 	ostore.dLock.RLock()
 	defer ostore.dLock.RUnlock()

--- a/drivers/local_test.go
+++ b/drivers/local_test.go
@@ -43,9 +43,22 @@ func TestLocalOS(t *testing.T) {
 	path, err = sess.SaveData("name1/2.ts", copyBytes(tempData3))
 	data = sess.GetData("sesspath/name1/2.ts")
 	assert.Equal(tempData3, string(data))
+	// Test trim prefix when baseURI != nil
+	data = sess.GetData(path)
+	assert.Equal(tempData3, string(data))
 	data = sess.GetData("sesspath/name1/1.ts")
 	assert.Nil(data)
 	sess.EndSession()
 	data = sess.GetData("sesspath/name1/2.ts")
 	assert.Nil(data)
+
+	// Test trim prefix when baseURI = nil
+	os = NewMemoryDriver(nil)
+	sess = os.NewSession("sesspath").(*MemorySession)
+	path, err = sess.SaveData("name1/1.ts", copyBytes(tempData1))
+	assert.Nil(err)
+	assert.Equal("/stream/sesspath/name1/1.ts", path)
+
+	data = sess.GetData(path)
+	assert.Equal(tempData1, string(data))
 }

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -3,8 +3,11 @@ package server
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"math/big"
+	"net/url"
+	"os"
 	"sync"
 
 	"github.com/golang/glog"
@@ -401,12 +404,15 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string) 
 				segHashLock.Unlock()
 			}
 
-			go func() {
-				if err := verifyPixels(url, pixels); err != nil {
-					glog.Error(err)
-					cxn.sessManager.removeSession(sess)
-				}
-			}()
+			// If running in on-chain mode, run pixels verification asynchronously
+			if sess.Sender != nil {
+				go func() {
+					if err := verifyPixels(url, sess.BroadcasterOS, pixels); err != nil {
+						glog.Error(err)
+						cxn.sessManager.removeSession(sess)
+					}
+				}()
+			}
 
 			if monitor.Enabled {
 				monitor.TranscodedSegmentAppeared(nonce, seg.SeqNo, sess.Profiles[i].Name)
@@ -455,7 +461,30 @@ func shouldStopSession(err error) bool {
 	return sessionErrRegex.MatchString(err.Error())
 }
 
-func verifyPixels(fname string, reportedPixels int64) error {
+func verifyPixels(fname string, bos drivers.OSSession, reportedPixels int64) error {
+	uri, err := url.ParseRequestURI(fname)
+	memOS, ok := bos.(*drivers.MemorySession)
+	// If the filename is a relative URI and the broadcaster is using local memory storage
+	// fetch the data and write it to a temp file
+	if err == nil && !uri.IsAbs() && ok {
+		tempfile, err := ioutil.TempFile("", common.RandName())
+		if err != nil {
+			return fmt.Errorf("error creating temp file for pixels verification: %v", err)
+		}
+		defer os.Remove(tempfile.Name())
+
+		data := memOS.GetData(fname)
+		if data == nil {
+			return errors.New("error fetching data from local memory storage")
+		}
+
+		if _, err := tempfile.Write(memOS.GetData(fname)); err != nil {
+			return fmt.Errorf("error writing temp file for pixels verification: %v", err)
+		}
+
+		fname = tempfile.Name()
+	}
+
 	p, err := pixels(fname)
 	if err != nil {
 		return err

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -439,6 +439,9 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string) 
 		ticketParams := sess.OrchestratorInfo.GetTicketParams()
 		if ticketParams != nil && // may be nil in offchain mode
 			saveErr == nil && // save error leads to early exit before sighash computation
+			// Might not have seg hashes if results are directly uploaded to the broadcaster's OS
+			// TODO: Consider downloading the results to generate seg hashes if results are directly uploaded to the broadcaster's OS
+			len(segHashes) != len(res.Segments) &&
 			!pm.VerifySig(ethcommon.BytesToAddress(ticketParams.Recipient), crypto.Keccak256(segHashes...), res.Sig) {
 			glog.Errorf("Sig check failed for segment nonce=%d seqNo=%d", nonce, seg.SeqNo)
 			cxn.sessManager.removeSession(sess)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR writes a temp file for pixels verification if the transcoded result url is a relative URI and the broadcaster is using local memory storage.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 4da8ac9 updates `(*MemorySession).GetData()` to handle input names with a prefix (i.e. if the name is an absolute URI or prepended with "/stream/"). This change makes it easier to use the return value of `(*MemorySession).SaveData()` to then fetch the saved data using `(*MemorySession).GetData()`
- 138494b updates pixels verification to write a temp file if the transcoded result is a relative URI and the broadcaster is using local memory storage. This commit also updates pixels verification to only run when the node is in on-chain mode

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
