### PR TITLE
Epic Labs verification classifier integration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run:
           name: Lint
           command: |
-            golangci-lint --disable-all --enable=gofmt --enable=vet --enable=golint --deadline=4m run pm
+            golangci-lint --disable-all --enable=gofmt --enable=vet --enable=golint --deadline=4m run pm verification
 
       - run:
           name: Run unit tests

--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ A standalone transcoder can be run which connects to a remote orchestrator. The 
 
 GPU transcoding on NVIDIA is supported; see the [GPU documentation](doc/gpu.md) for usage details.
 
+### Verification
+
+Experimental verification of video using the Epic Labs classifier can be enabled with the `-verifierUrl` flag. Pass in the address of the verifier API:
+
+- `livepeer -broadcaster -verifierUrl http://localhost:5000/verify -verifierPath /path/to/verifier`
+
+Refer to the [classifier documentation](https://github.com/livepeer/verification-classifier) for more details on getting the classifier API installed and running.
+
 ## Contribution
 Thank you for your interest in contributing to the core software of Livepeer.
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -90,6 +90,8 @@ func main() {
 	orchAddr := flag.String("orchAddr", "", "Orchestrator to connect to as a standalone transcoder")
 	verifierURL := flag.String("verifierUrl", "", "URL of the verifier to use")
 
+	verifierPath := flag.String("verifierPath", "", "Path to verifier shared volume")
+
 	// Transcoding:
 	orchestrator := flag.Bool("orchestrator", false, "Set to true to be an orchestrator")
 	transcoder := flag.Bool("transcoder", false, "Set to true to be a transcoder")
@@ -681,6 +683,13 @@ func main() {
 			server.Policy = &verification.Policy{Retries: 2, Verifier: &verification.EpicClassifier{Addr: *verifierURL}}
 			// TODO Set up a default "empty" verifier-less policy for onchain
 			//      that only checks sigs and pixels?
+
+			// Set the verifier path. Remove once [1] is implemented!
+			// [1] https://github.com/livepeer/verification-classifier/issues/64
+			if drivers.NodeStorage == nil && *verifierPath == "" {
+				glog.Fatal("Requires a path to the verifier shared volume when local storage is in use; use -verifierPath, S3 or GCS")
+			}
+			verification.VerifierPath = *verifierPath
 		}
 	} else if n.NodeType == core.OrchestratorNode {
 		suri, err := getServiceURI(n, *serviceAddr)

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -37,6 +37,7 @@ import (
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
 	"github.com/livepeer/go-livepeer/eth/eventservices"
 	"github.com/livepeer/go-livepeer/eth/watchers"
+	"github.com/livepeer/go-livepeer/verification"
 
 	lpmon "github.com/livepeer/go-livepeer/monitor"
 )
@@ -87,6 +88,7 @@ func main() {
 	httpAddr := flag.String("httpAddr", "", "Address to bind for HTTP commands")
 	serviceAddr := flag.String("serviceAddr", "", "Orchestrator only. Overrides the on-chain serviceURI that broadcasters can use to contact this node; may be an IP or hostname.")
 	orchAddr := flag.String("orchAddr", "", "Orchestrator to connect to as a standalone transcoder")
+	verifierURL := flag.String("verifierUrl", "", "URL of the verifier to use")
 
 	// Transcoding:
 	orchestrator := flag.Bool("orchestrator", false, "Set to true to be an orchestrator")
@@ -667,6 +669,16 @@ func main() {
 			}
 			glog.Info("Using auth webhook URL ", *authWebhookURL)
 			server.AuthWebhookURL = *authWebhookURL
+		}
+
+		// Set up verifier
+		if *verifierURL != "" {
+			_, err := validateURL(*verifierURL)
+			if err != nil {
+				glog.Fatal("Error setting verifier URL ", err)
+			}
+			glog.Info("Using the Epic Labs classifier for verification at ", *verifierURL)
+			server.Verifier = &verification.EpicClassifier{Addr: *verifierURL}
 		}
 	} else if n.NodeType == core.OrchestratorNode {
 		suri, err := getServiceURI(n, *serviceAddr)

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -678,7 +678,9 @@ func main() {
 				glog.Fatal("Error setting verifier URL ", err)
 			}
 			glog.Info("Using the Epic Labs classifier for verification at ", *verifierURL)
-			server.Verifier = &verification.EpicClassifier{Addr: *verifierURL}
+			server.Policy = &verification.Policy{Retries: 2, Verifier: &verification.EpicClassifier{Addr: *verifierURL}}
+			// TODO Set up a default "empty" verifier-less policy for onchain
+			//      that only checks sigs and pixels?
 		}
 	} else if n.NodeType == core.OrchestratorNode {
 		suri, err := getServiceURI(n, *serviceAddr)

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -26,6 +26,7 @@ import (
 	"github.com/livepeer/lpms/stream"
 )
 
+var Verifier verification.Verifier
 var BroadcastCfg = &BroadcastConfig{}
 
 type BroadcastConfig struct {
@@ -440,16 +441,17 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string) 
 			return dlErr
 		}
 
-		// Ignore errors for now
-		params := &verification.Params{
-			ManifestID:   sess.ManifestID,
-			Source:       seg,
-			Profiles:     sess.Profiles,
-			Orchestrator: sess.OrchestratorInfo,
-			Results:      res.TranscodeData,
+		if Verifier != nil {
+			// Ignore errors for now
+			params := &verification.Params{
+				ManifestID:   sess.ManifestID,
+				Source:       seg,
+				Profiles:     sess.Profiles,
+				Orchestrator: sess.OrchestratorInfo,
+				Results:      res.TranscodeData,
+			}
+			Verifier.Verify(params)
 		}
-		verifier := &verification.EpicClassifier{Addr: "http://localhost:5000/verify"}
-		verifier.Verify(params)
 
 		ticketParams := sess.OrchestratorInfo.GetTicketParams()
 		if ticketParams != nil && // may be nil in offchain mode

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/golang/glog"
@@ -19,6 +20,7 @@ import (
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/monitor"
+	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/go-livepeer/verification"
 
@@ -26,7 +28,7 @@ import (
 	"github.com/livepeer/lpms/stream"
 )
 
-var Verifier verification.Verifier
+var Policy *verification.Policy
 var BroadcastCfg = &BroadcastConfig{}
 
 type BroadcastConfig struct {
@@ -280,15 +282,21 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) error {
 		}
 	}
 
+	var sv *verification.SegmentVerifier
+	if Policy != nil {
+		sv = verification.NewSegmentVerifier(Policy)
+	}
+
 	for {
 		// if fails, retry; rudimentary
-		if err := transcodeSegment(cxn, seg, name); err == nil {
+		if err := transcodeSegment(cxn, seg, name, sv); err == nil {
 			return nil
 		}
 	}
 }
 
-func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string) error {
+func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
+	verifier *verification.SegmentVerifier) error {
 
 	nonce := cxn.nonce
 	rtmpStrm := cxn.stream
@@ -362,6 +370,7 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string) 
 
 		var dlErr, saveErr error
 		segHashes := make([][]byte, len(res.Segments))
+		segURLs := make([]string, len(res.Segments))
 		n := len(res.Segments)
 		segHashLock := &sync.Mutex{}
 		cond := sync.NewCond(segHashLock)
@@ -418,6 +427,15 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string) 
 				}()
 			}
 
+			// Store URLs for the verifier. Be aware that the segment is
+			// already within object storage  at this point, whether local or
+			// external. If a client were to ignore the playlist and
+			// preemptively fetch segments, they could be reading tampered
+			// data. Not an issue if the delivery protocol is being obeyed.
+			segHashLock.Lock()
+			segURLs[i] = url
+			segHashLock.Unlock()
+
 			if monitor.Enabled {
 				monitor.TranscodedSegmentAppeared(nonce, seg.SeqNo, sess.Profiles[i].Name)
 			}
@@ -441,16 +459,12 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string) 
 			return dlErr
 		}
 
-		if Verifier != nil {
-			// Ignore errors for now
-			params := &verification.Params{
-				ManifestID:   sess.ManifestID,
-				Source:       seg,
-				Profiles:     sess.Profiles,
-				Orchestrator: sess.OrchestratorInfo,
-				Results:      res.TranscodeData,
+		if verifier != nil {
+			err := verify(verifier, cxn, sess, seg, res.TranscodeData, segURLs)
+			if err != nil {
+				glog.Errorf("Error verifying nonce=%d manifestID=%s seqNo=%d err=%s", nonce, cxn.mid, seg.SeqNo, err)
+				return err
 			}
-			Verifier.Verify(params)
 		}
 
 		ticketParams := sess.OrchestratorInfo.GetTicketParams()
@@ -479,6 +493,96 @@ var sessionErrRegex = common.GenErrRegex(sessionErrStrings)
 
 func shouldStopSession(err error) bool {
 	return sessionErrRegex.MatchString(err.Error())
+}
+
+func verify(verifier *verification.SegmentVerifier, cxn *rtmpConnection,
+	sess *BroadcastSession, source *stream.HLSSegment,
+	res *net.TranscodeData, URIs []string) error {
+
+	// Cache segment contents if necessary.
+	// If we need to retry transcoding because verification fails,
+	// the the segments' OS location will be overwritten.
+	// Cache the segments so we can restore them in OS if necessary.
+	renditionData := make([][]byte, len(URIs))
+	for i, fname := range URIs {
+		if sess.BroadcasterOS.IsExternal() && drivers.IsOwnExternal(fname) {
+			// If broadcaster is using external storage and segments are there
+			// Then have the verifier use that external storage.
+			continue
+		}
+
+		// Sanity check for absolute URIs to ensure we're actually local.
+		uri, err := url.ParseRequestURI(fname)
+		if err != nil {
+			return err // Implies this is retryable?
+		}
+		memOS, ok := sess.BroadcasterOS.(*drivers.MemorySession)
+		if !uri.IsAbs() && ok {
+			data := memOS.GetData(fname)
+			if data == nil {
+				return errors.New("Missing Local Data")
+			}
+			renditionData[i] = data
+		} else {
+			return errors.New("Expected local storage but did not have it")
+		}
+	}
+
+	params := &verification.Params{
+		ManifestID:   sess.ManifestID,
+		Source:       source,
+		Profiles:     sess.Profiles,
+		Orchestrator: sess.OrchestratorInfo,
+		Results:      res,
+		URIs:         URIs,
+		Renditions:   renditionData,
+	}
+
+	// The return value from the verifier, if any, are the *accepted* params.
+	// The accepted params are not necessarily the same as `params` sent here.
+	// The accepted params may be from an earlier iteration if max retries hit.
+	accepted, err := verifier.Verify(params)
+	if verification.IsRetryable(err) {
+		// If retryable, means tampering was detected from this O
+		// Remove the O from the working set for now
+		// Error falls through towards end if necessary
+		cxn.sessManager.removeSession(sess)
+	}
+	if accepted != nil {
+		// The returned set of results has been accepted by the verifier
+
+		// Check if an earlier verification attempt was the one accepted.
+		// If so, reset the local OS if we're using that since it's been
+		// overwritten with this rendition.
+		for i, data := range accepted.Renditions {
+			if accepted != params && !sess.BroadcasterOS.IsExternal() {
+				// Sanity check that we actually have the rendition data?
+				if len(data) <= 0 {
+					return errors.New("MissingLocalData")
+				}
+				// SaveData only takes the /<rendition>/<seqNo> part of the URI
+				// However, it returns /stream/<manifestID>/<rendition>/<seqNo>
+				// The incoming URI is likely to be in the longer format.
+				// Hence, trim the /stream/<manifestID> prefix if it exists.
+				pfx := fmt.Sprintf("/stream/%s/", sess.ManifestID)
+				uri := strings.TrimPrefix(accepted.URIs[i], pfx)
+				_, err := sess.BroadcasterOS.SaveData(uri, data)
+				if err != nil {
+					return err
+				}
+			} else {
+				// Normally we don't need to reset the URI here, but we do
+				// if an external OS is used and an earlier attempt is accepted
+				// (Recall that each O uploads segments to a different location
+				// if a B-supplied external OS is used)
+				URIs[i] = accepted.URIs[i]
+			}
+		}
+
+		// Ignore any errors from the Verify call; don't need to retry anymore
+		return nil
+	}
+	return err // possibly nil
 }
 
 func verifyPixels(fname string, bos drivers.OSSession, reportedPixels int64) error {

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -418,7 +418,8 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 			}
 
 			// If running in on-chain mode, run pixels verification asynchronously
-			if sess.Sender != nil {
+			// Only run if a verifier is not being used
+			if sess.Sender != nil && verifier == nil {
 				go func() {
 					if err := verifyPixels(url, sess.BroadcasterOS, pixels); err != nil {
 						glog.Error(err)

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -20,6 +20,7 @@ import (
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/pm"
+	"github.com/livepeer/go-livepeer/verification"
 
 	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/livepeer/lpms/stream"
@@ -438,6 +439,18 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string) 
 		if dlErr != nil {
 			return dlErr
 		}
+
+		// Ignore errors for now
+		params := &verification.Params{
+			ManifestID:   sess.ManifestID,
+			Source:       seg,
+			Profiles:     sess.Profiles,
+			Orchestrator: sess.OrchestratorInfo,
+			Results:      res.TranscodeData,
+		}
+		verifier := &verification.EpicClassifier{Addr: "http://localhost:5000/verify"}
+		verifier.Verify(params)
+
 		ticketParams := sess.OrchestratorInfo.GetTicketParams()
 		if ticketParams != nil && // may be nil in offchain mode
 			saveErr == nil && // save error leads to early exit before sighash computation

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -439,7 +439,7 @@ func TestTranscodeSegment_CompleteSession(t *testing.T) {
 		sessManager: bsm,
 	}
 
-	assert.Nil(transcodeSegment(cxn, &stream.HLSSegment{Data: []byte("dummy"), Duration: 2.0}, "dummy"))
+	assert.Nil(transcodeSegment(cxn, &stream.HLSSegment{Data: []byte("dummy"), Duration: 2.0}, "dummy", nil))
 
 	completedSess := bsm.sessMap[ts.URL]
 	assert.NotEqual(completedSess, sess)
@@ -455,7 +455,7 @@ func TestTranscodeSegment_CompleteSession(t *testing.T) {
 	buf, err = proto.Marshal(tr)
 	require.Nil(err)
 
-	assert.Nil(transcodeSegment(cxn, &stream.HLSSegment{Data: []byte("dummy"), Duration: 2.0}, "dummy"))
+	assert.Nil(transcodeSegment(cxn, &stream.HLSSegment{Data: []byte("dummy"), Duration: 2.0}, "dummy", nil))
 
 	// Check that BroadcastSession.OrchestratorInfo was updated
 	completedSessInfo := bsm.sessMap[ts.URL].OrchestratorInfo
@@ -506,7 +506,7 @@ func TestTranscodeSegment_VerifyPixels(t *testing.T) {
 		sessManager: bsm,
 	}
 
-	err = transcodeSegment(cxn, &stream.HLSSegment{Data: []byte("dummy")}, "dummy")
+	err = transcodeSegment(cxn, &stream.HLSSegment{Data: []byte("dummy")}, "dummy", nil)
 	assert.Nil(err)
 
 	// Wait for async pixels verification to finish (or in this case we are just making sure that it did NOT run)
@@ -521,7 +521,7 @@ func TestTranscodeSegment_VerifyPixels(t *testing.T) {
 	bsm = bsmWithSessList([]*BroadcastSession{sess})
 	cxn.sessManager = bsm
 
-	err = transcodeSegment(cxn, &stream.HLSSegment{Data: []byte("dummy")}, "dummy")
+	err = transcodeSegment(cxn, &stream.HLSSegment{Data: []byte("dummy")}, "dummy", nil)
 	assert.Nil(err)
 
 	// Wait for async pixels verification to finish
@@ -544,7 +544,7 @@ func TestTranscodeSegment_VerifyPixels(t *testing.T) {
 	bsm = bsmWithSessList([]*BroadcastSession{sess})
 	cxn.sessManager = bsm
 
-	err = transcodeSegment(cxn, &stream.HLSSegment{Data: []byte("dummy")}, "dummy")
+	err = transcodeSegment(cxn, &stream.HLSSegment{Data: []byte("dummy")}, "dummy", nil)
 	assert.Nil(err)
 
 	// Wait for async pixels verification to finish

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/pm"
+	"github.com/livepeer/go-livepeer/verification"
 	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/m3u8"
@@ -72,8 +73,32 @@ func (bsm *sessionsManagerLIFO) sessList() []*BroadcastSession {
 	return *sessList
 }
 
+type stubVerifier struct {
+	retries int
+	calls   int
+	params  *verification.Params
+	err     error
+	results []verification.Results
+}
+
+func (v *stubVerifier) Verify(params *verification.Params) (*verification.Results, error) {
+	var res *verification.Results
+	if v.calls < len(v.results) {
+		res = &v.results[v.calls]
+	}
+	v.calls++
+	v.params = params
+	return res, v.err
+}
+func newStubSegmentVerifier(v *stubVerifier) *verification.SegmentVerifier {
+	return verification.NewSegmentVerifier(&verification.Policy{Retries: v.retries, Verifier: v})
+}
+
 type stubPlaylistManager struct {
 	manifestID core.ManifestID
+	seq        uint64
+	profile    ffmpeg.VideoProfile
+	uri        string
 }
 
 func (pm *stubPlaylistManager) ManifestID() core.ManifestID {
@@ -81,6 +106,9 @@ func (pm *stubPlaylistManager) ManifestID() core.ManifestID {
 }
 
 func (pm *stubPlaylistManager) InsertHLSSegment(profile *ffmpeg.VideoProfile, seqNo uint64, uri string, duration float64) error {
+	pm.profile = *profile
+	pm.seq = seqNo
+	pm.uri = uri
 	return nil
 }
 
@@ -434,7 +462,7 @@ func TestTranscodeSegment_CompleteSession(t *testing.T) {
 	cxn := &rtmpConnection{
 		mid:         core.ManifestID("foo"),
 		nonce:       7,
-		pl:          &stubPlaylistManager{core.ManifestID("foo")},
+		pl:          &stubPlaylistManager{manifestID: core.ManifestID("foo")},
 		profile:     &ffmpeg.P144p30fps16x9,
 		sessManager: bsm,
 	}
@@ -501,7 +529,7 @@ func TestTranscodeSegment_VerifyPixels(t *testing.T) {
 	cxn := &rtmpConnection{
 		mid:         core.ManifestID("foo"),
 		nonce:       7,
-		pl:          &stubPlaylistManager{core.ManifestID("foo")},
+		pl:          &stubPlaylistManager{manifestID: core.ManifestID("foo")},
 		profile:     &ffmpeg.P144p30fps16x9,
 		sessManager: bsm,
 	}
@@ -677,4 +705,302 @@ func TestUpdateSession(t *testing.T) {
 	assert.Equal("bar", newSess.PMSessionID)
 	// Check that PMSessionID of old session is not mutated
 	assert.Equal("foo", sess.PMSessionID)
+}
+
+func TestHLSInsertion(t *testing.T) {
+	assert := assert.New(t)
+
+	segData := []*net.TranscodedSegmentData{
+		&net.TranscodedSegmentData{Url: "/path/to/video", Pixels: 100},
+	}
+
+	buf, err := proto.Marshal(&net.TranscodeResult{
+		Result: &net.TranscodeResult_Data{
+			Data: &net.TranscodeData{Segments: segData},
+		},
+	})
+	assert.Nil(err)
+
+	ts, mux := stubTLSServer()
+	defer ts.Close()
+	mux.HandleFunc("/segment", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(buf)
+	})
+
+	sess := StubBroadcastSession(ts.URL)
+	sess.Profiles = []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9}
+	sess.ManifestID = core.ManifestID("foo")
+	bsm := bsmWithSessList([]*BroadcastSession{sess})
+	pl := &stubPlaylistManager{manifestID: core.ManifestID("foo")}
+	cxn := &rtmpConnection{
+		mid:         sess.ManifestID,
+		nonce:       7,
+		pl:          pl,
+		profile:     &ffmpeg.P240p30fps16x9,
+		sessManager: bsm,
+	}
+
+	seg := &stream.HLSSegment{SeqNo: 93}
+	err = transcodeSegment(cxn, seg, "dummy", nil)
+	assert.Nil(err)
+
+	// some sanity checks
+	assert.Greater(len(sess.Profiles), 0)
+	assert.NotEqual(pl.profile, *cxn.profile, "HLS profile matched")
+
+	// Check HLS insertion
+	assert.Equal(seg.SeqNo, pl.seq, "HLS insertion failed")
+	assert.Equal(pl.profile, sess.Profiles[0], "HLS profile mismatch")
+}
+
+func TestVerifier_Invocation(t *testing.T) {
+	// Various tests around ensuring that the verifier itself is invoked within
+	// transcodeSegment, as well as various unusual verifier configurations
+
+	require := require.New(t)
+	assert := assert.New(t)
+
+	// Stub verifier
+	verifier := &stubVerifier{}
+	policy := &verification.Policy{Verifier: verifier}
+	segmentVerifier := verification.NewSegmentVerifier(policy)
+
+	// Create stub server
+	ts, mux := stubTLSServer()
+	defer ts.Close()
+	buf, err := proto.Marshal(&net.TranscodeResult{
+		Result: &net.TranscodeResult_Data{
+			Data: &net.TranscodeData{},
+		},
+	})
+	require.Nil(err)
+	mux.HandleFunc("/segment", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(buf)
+	})
+
+	sess := StubBroadcastSession(ts.URL)
+	sess.Profiles = []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9}
+	sess.ManifestID = core.ManifestID("foo")
+	bsm := bsmWithSessList([]*BroadcastSession{sess})
+	pl := &stubPlaylistManager{manifestID: core.ManifestID("foo")}
+	cxn := &rtmpConnection{
+		mid:         sess.ManifestID,
+		nonce:       7,
+		pl:          pl,
+		profile:     &ffmpeg.P144p30fps16x9,
+		sessManager: bsm,
+	}
+
+	seg := &stream.HLSSegment{}
+	err = transcodeSegment(cxn, seg, "dummy", segmentVerifier)
+	assert.Nil(err)
+	assert.Equal(1, verifier.calls)
+	require.NotNil(verifier.params)
+	assert.Equal(cxn.mid, verifier.params.ManifestID)
+	assert.Equal(seg, verifier.params.Source)
+	// Do it again for good measure
+	err = transcodeSegment(cxn, seg, "dummy", segmentVerifier)
+	assert.Nil(err)
+	assert.Equal(2, verifier.calls)
+
+	// now "disable" the verifier and ensure no calls
+	err = transcodeSegment(cxn, seg, "dummy", nil)
+	assert.Nil(err)
+	assert.Equal(2, verifier.calls)
+
+	// Pass in a nil policy
+	err = transcodeSegment(cxn, seg, "dummy", verification.NewSegmentVerifier(nil))
+	assert.Nil(err)
+
+	// Pass in a policy but no verifier specified
+	policy = &verification.Policy{}
+	err = transcodeSegment(cxn, seg, "dummy", verification.NewSegmentVerifier(policy))
+	assert.Nil(err)
+}
+
+func TestVerifier_Verify(t *testing.T) {
+	assert := assert.New(t)
+
+	cxn := &rtmpConnection{}
+	sess := &BroadcastSession{}
+	source := &stream.HLSSegment{}
+	res := &net.TranscodeData{}
+	verifier := verification.NewSegmentVerifier(&verification.Policy{})
+	URIs := []string{}
+	err := verify(verifier, cxn, sess, source, res, URIs)
+	assert.Nil(err)
+
+	// Test local OS: Should fail with an invalid path
+	sess.ManifestID = core.ManifestID("streamName")
+	sess.BroadcasterOS = drivers.NewMemoryDriver(nil).NewSession("streamName")
+	URIs = append(URIs, "filename")
+	err = verify(verifier, cxn, sess, source, res, URIs)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "invalid URI for request")
+
+	// Test local OS : Should fail if data does not exist in OS
+	URIs[0] = "/filename"
+	err = verify(verifier, cxn, sess, source, res, URIs)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "Missing Local Data")
+
+	// Test for segment not in broadcaster's own OS - "livepeer" S3 bucket
+	drivers.S3BUCKET = "livepeer"
+	sess.BroadcasterOS = drivers.NewS3Driver("", drivers.S3BUCKET, "", "").NewSession("")
+	err = verify(verifier, cxn, sess, source, res, URIs)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "Expected local storage but did not have it")
+
+	// Set broadcaster's OS to "livepeer" S3 bucket and fix the URL
+	URIs[0] = "https://livepeer.s3.amazonaws.com"
+	err = verify(verifier, cxn, sess, source, res, URIs)
+	assert.Nil(err)
+
+	// Check non-retryable errors
+	sess.OrchestratorInfo = &net.OrchestratorInfo{Transcoder: "asdf"}
+	bsm := bsmWithSessList([]*BroadcastSession{sess})
+	cxn.sessManager = bsm
+	sv := &stubVerifier{err: errors.New("NonRetryable")}
+	verifier = newStubSegmentVerifier(sv)
+	assert.Equal(0, sv.calls)  // sanity check initial call count
+	assert.Len(bsm.sessMap, 1) // sanity check initial bsm map
+	err = verify(verifier, cxn, sess, source, res, URIs)
+	assert.NotNil(err)
+	assert.Equal(1, sv.calls)
+	assert.Equal(sv.err, err)
+	assert.Len(bsm.sessMap, 1) // No effect on map for now
+
+	// Check retryable errors, esp broadcast session removal from manager
+	sv.err = verification.ErrTampered
+	sv.retries = 10 // Do this to ensure we get a nil result
+	_, retryable := sv.err.(verification.Retryable)
+	assert.True(retryable)
+	verifier = newStubSegmentVerifier(sv)
+	err = verify(verifier, cxn, sess, source, res, URIs)
+	assert.NotNil(err)
+	assert.Equal(2, sv.calls)
+	assert.Equal(sv.err, err)
+	assert.Len(bsm.sessMap, 0)
+
+	// When retries are set to 0, results are returned anyway in case of error
+	// (and more generally, when attempts > retries)
+
+	// Check data gets re-saved into OS if retry succeeds with earlier params
+	sv = &stubVerifier{
+		retries: 1,
+		err:     verification.ErrTampered,
+		results: []verification.Results{
+			verification.Results{Score: 9},
+			verification.Results{Score: 1},
+		},
+	}
+	mem, ok := drivers.NewMemoryDriver(nil).NewSession("streamName").(*drivers.MemorySession)
+	assert.True(ok)
+	name, err := mem.SaveData("/rendition/seg/1", []byte("attempt1"))
+	assert.Nil(err)
+	assert.Equal([]byte("attempt1"), mem.GetData(name))
+	sess.BroadcasterOS = mem
+	verifier = newStubSegmentVerifier(sv)
+	URIs[0] = name
+	err = verify(verifier, cxn, sess, source, res, URIs)
+	assert.Equal(sv.err, err)
+
+	// Now "insert" 2nd attempt into OS
+	// and ensure 1st attempt is what remains after verification
+	_, err = mem.SaveData("/rendition/seg/1", []byte("attempt2"))
+	assert.Nil(err)
+	assert.Equal([]byte("attempt2"), mem.GetData(name))
+	err = verify(verifier, cxn, sess, source, res, URIs)
+	assert.Nil(err)
+	assert.Equal([]byte("attempt1"), mem.GetData(name))
+}
+
+func TestVerifier_HLSInsertion(t *testing.T) {
+	assert := assert.New(t)
+
+	// Ensure that the playlist has the correct URL after verification
+	// Following this sequence:
+	//   1. Verify seg1. Verification fails.
+	//   2. Verify seg2. Verification fails.
+	//   3. Verify seg3. Verification fails
+	//   4. Max retries hit, assume false positives
+	//   5. Return seg2 as highest scoring result
+	//   6. Insert seg2 into playlist
+	mid := core.ManifestID("foo")
+	pl := &stubPlaylistManager{manifestID: mid}
+	drivers.S3BUCKET = "livepeer"
+	mem := drivers.NewS3Driver("", drivers.S3BUCKET, "", "").NewSession(string(mid))
+	assert.NotNil(mem)
+	genBcastSess := func(url string) *BroadcastSession {
+		segData := []*net.TranscodedSegmentData{
+			&net.TranscodedSegmentData{Url: url, Pixels: 100},
+		}
+
+		buf, err := proto.Marshal(&net.TranscodeResult{
+			Result: &net.TranscodeResult_Data{
+				Data: &net.TranscodeData{Segments: segData},
+			},
+		})
+		assert.Nil(err, fmt.Sprintf("Could not marshal results for %s", url))
+		ts, mux := stubTLSServer()
+		mux.HandleFunc("/segment", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(buf)
+		})
+		defer func() {
+			// Work around a weird timing issue. Tests fail if the server closes
+			// in-scope (prob leads to something like the client being unable
+			// to read the response?), so we delay the close for a little bit
+			go func() {
+				// We assume this test doesn't take more than 1s
+				// But if it does (eg, we get a POST error), then bump this up
+				time.Sleep(1 * time.Second)
+				ts.Close()
+			}()
+		}()
+		return &BroadcastSession{
+			Broadcaster:      stubBroadcaster2(),
+			ManifestID:       mid,
+			Profiles:         []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9},
+			BroadcasterOS:    mem,
+			OrchestratorInfo: &net.OrchestratorInfo{Transcoder: ts.URL},
+		}
+	}
+
+	baseURL := "https://livepeer.s3.amazonaws.com"
+	bsm := bsmWithSessList([]*BroadcastSession{
+		genBcastSess(baseURL + "/resp1"),
+		genBcastSess(baseURL + "/resp2"),
+		genBcastSess(baseURL + "/resp3"),
+	})
+	cxn := &rtmpConnection{
+		mid:         mid,
+		pl:          pl,
+		profile:     &ffmpeg.P240p30fps16x9,
+		sessManager: bsm,
+	}
+	seg := &stream.HLSSegment{}
+	verifier := newStubSegmentVerifier(&stubVerifier{
+		retries: 2,
+		err:     verification.ErrTampered,
+		results: []verification.Results{
+			{Score: 5, Pixels: []int64{100}},
+			{Score: 9, Pixels: []int64{100}},
+			{Score: 1, Pixels: []int64{100}},
+		},
+	})
+
+	err := transcodeSegment(cxn, seg, "dummy", verifier)
+	assert.Equal(verification.ErrTampered, err)
+	assert.Empty(pl.uri) // sanity check that no insertion happened
+
+	err = transcodeSegment(cxn, seg, "dummy", verifier)
+	assert.Equal(verification.ErrTampered, err)
+	assert.Empty(pl.uri)
+
+	err = transcodeSegment(cxn, seg, "dummy", verifier)
+	assert.Nil(err)
+	assert.Equal(baseURL+"/resp2", pl.uri)
 }

--- a/test_args.sh
+++ b/test_args.sh
@@ -171,4 +171,25 @@ run_lp -broadcaster
 curl -sI http://127.0.0.1:7935/debug/pprof/allocs | grep "200 OK"
 kill $pid
 
+# exit early if verifier URL is not http
+res=0
+$TMPDIR/livepeer -broadcaster -verifierUrl tcp://host/ || res=$?
+[ $res -ne 0 ]
+
+# exit early if verifier URL is not properly formatted
+res=0
+$TMPDIR/livepeer -broadcaster -verifierUrl http\\://host/ || res=$?
+[ $res -ne 0 ]
+
+# Check that verifier shared path is required
+$TMPDIR/livepeer -broadcaster -verifierUrl http://host 2>&1 | grep "Requires a path to the"
+
+# Check OK with verifier shared path
+run_lp -broadcaster -verifierUrl http://host -verifierPath path
+kill $pid
+
+# Check OK with verifier + external storage
+run_lp -broadcaster -verifierUrl http://host -s3bucket foo/bar -s3creds baz/bat
+kill $pid
+
 rm -rf $TMPDIR

--- a/verification/epic.go
+++ b/verification/epic.go
@@ -1,0 +1,97 @@
+package verification
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+
+	"github.com/livepeer/go-livepeer/common"
+
+	"github.com/livepeer/lpms/ffmpeg"
+)
+
+type epicResolution struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+type epicRendition struct {
+	URI        string         `json:"uri"`
+	Resolution epicResolution `json:"resolution"`
+	Framerate  uint           `json:"frame_rate"`
+	Pixels     int64          `json:"pixels"`
+}
+type epicRequest struct {
+	Source         string          `json:"source"`
+	Renditions     []epicRendition `json:"renditions"`
+	OrchestratorID string          `json:"orchestratorID"`
+	Model          string          `json:"model"`
+}
+
+type EpicClassifier struct {
+	Addr string
+}
+
+func (e *EpicClassifier) Verify(params *Params) error {
+	mid, source, profiles := params.ManifestID, params.Source, params.Profiles
+	orch, res := params.Orchestrator, params.Results
+	glog.V(common.DEBUG).Infof("Verifying segment manifestID=%s seqNo=%d\n",
+		mid, source.SeqNo)
+	src := fmt.Sprintf("http://127.0.0.1:8935/stream/%s/source/%d.ts", mid, source.SeqNo)
+	renditions := []epicRendition{}
+	for i, v := range res.Segments {
+		p := profiles[i]
+		w, h, _ := ffmpeg.VideoProfileResolution(p) // XXX check err
+		uri := fmt.Sprintf("http://127.0.0.1:8935/stream/%s/%s/%d.ts",
+			mid, p.Name, source.SeqNo)
+		r := epicRendition{
+			URI:        uri,
+			Resolution: epicResolution{Width: w, Height: h},
+			Framerate:  p.Framerate,
+			Pixels:     v.Pixels,
+		}
+		renditions = append(renditions, r)
+	}
+
+	oid := orch.Transcoder
+	if orch.TicketParams != nil {
+		oid = hex.EncodeToString(orch.TicketParams.Recipient)
+	}
+	req := epicRequest{
+		Source:         src,
+		Renditions:     renditions,
+		OrchestratorID: oid,
+		Model:          "https://storage.googleapis.com/verification-models/verification.tar.xz",
+	}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		glog.Error("Could not marshal JSON for verifier! ", err)
+		return err
+	}
+	glog.V(common.DEBUG).Info("Request Body: ", string(reqData))
+	startTime := time.Now()
+	resp, err := http.Post(e.Addr, "application/json", bytes.NewBuffer(reqData))
+	if err != nil {
+		glog.Error("Could not submit request ", err)
+		return err
+	}
+	defer resp.Body.Close()
+	var deferErr error // short variable re-declaration of `err` bites us with defer
+	body, err := ioutil.ReadAll(resp.Body)
+	endTime := time.Now()
+	// `defer` param evaluation semantics force us into an anonymous function
+	defer func() {
+		glog.Infof("Verification complete manifestID=%s seqNo=%d err=%v dur=%v",
+			mid, source.SeqNo, deferErr, endTime.Sub(startTime))
+	}()
+	if deferErr = err; err != nil {
+		return err
+	}
+	glog.V(common.DEBUG).Info("Response Body: ", string(body))
+	return nil
+}

--- a/verification/epic_test.go
+++ b/verification/epic_test.go
@@ -1,0 +1,253 @@
+package verification
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/livepeer/go-livepeer/drivers"
+	"github.com/livepeer/go-livepeer/net"
+
+	"github.com/livepeer/lpms/ffmpeg"
+	"github.com/livepeer/lpms/stream"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEpic_EpicResultsToVerificationResults(t *testing.T) {
+	assert := assert.New(t)
+
+	// This function name is too long, shorten for this test
+	fn := epicResultsToVerificationResults
+
+	// Empty case
+	r := &epicResults{}
+	res, err := fn(r)
+	assert.Nil(err)
+	assert.NotNil(res)
+	assert.Equal(0., res.Score)
+	assert.Empty(res.Pixels)
+
+	// Success case
+	r = &epicResults{
+		Results: []epicResultFields{
+			{VideoAvailable: true, Pixels: 123, Tamper: 2.0},
+			{VideoAvailable: true, Pixels: 456, Tamper: 3.0},
+		},
+	}
+	res, err = fn(r)
+	assert.Nil(err)
+	assert.Equal([]int64{123, 456}, res.Pixels)
+	assert.Equal((2.0+3.0)/2., res.Score)
+
+	// Check various errors. Should always count pixels/score for each rendition
+
+	// Check audio mismatch. Should still count pixels / score
+	r.Results[0].AudioAvailable = true
+	r.Results[0].AudioDistance = 1.0
+	res, err = fn(r)
+	assert.Equal(ErrAudioMismatch, err)
+	assert.Equal([]int64{123, 456}, res.Pixels)
+	assert.Equal((2.0+3.0)/2., res.Score)
+
+	// Check tampering. Tamper first result only.
+	// We have audio mismatch set already, which takes precedence, being fatal
+	r.Results[0].Tamper = -2.0
+	res, err = fn(r)
+	assert.Equal(ErrAudioMismatch, err)
+	assert.Equal([]int64{123, 456}, res.Pixels)
+	assert.Equal((-2.0+3.0)/2., res.Score)
+	// Disable audio mismatch and we should get a tamper error
+	r.Results[0].AudioDistance = 0.0
+	res, err = fn(r)
+	assert.Equal(ErrTampered, err)
+	assert.Equal([]int64{123, 456}, res.Pixels)
+	assert.Equal((-2.0+3.0)/2., res.Score)
+
+	// Tamper both results
+	r.Results[1].Tamper = -3.0
+	res, err = fn(r)
+	assert.Equal(ErrTampered, err)
+	assert.Equal([]int64{123, 456}, res.Pixels)
+	assert.Equal((-2.0+-3.0)/2., res.Score)
+
+	// Tamper second result only
+	r.Results[0].Tamper = 2.0
+	res, err = fn(r)
+	assert.Equal(ErrTampered, err)
+	assert.Equal([]int64{123, 456}, res.Pixels)
+	assert.Equal((2.0-3.0)/2., res.Score)
+
+	// Unset tamper, sanity check success
+	r.Results[1].Tamper = 3.0
+	res, err = fn(r)
+	assert.Nil(err)
+	assert.Equal([]int64{123, 456}, res.Pixels)
+	assert.Equal((2.0+3.0)/2., res.Score)
+
+	// Unset video availability
+	r.Results[0].VideoAvailable = false
+	res, err = fn(r)
+	assert.Equal(ErrVideoUnavailable, err)
+	assert.Equal([]int64{123, 456}, res.Pixels) // Does this even make sense?
+	assert.Equal((2.0+3.0)/2., res.Score)
+}
+
+func TestEpic_WriteSegments(t *testing.T) {
+	assert := assert.New(t)
+
+	dir, err := ioutil.TempDir("", t.Name())
+	assert.Nil(err)
+	defer os.RemoveAll(dir) // clean up
+	baseDir := filepath.Base(dir)
+	bucketPath := "https://livepeer.s3.amazonaws.com"
+
+	// empty case
+	_, _, err = writeSegments(&Params{}, dir)
+	assert.Equal(ErrMissingSource, err)
+
+	// successful cases
+	p := &Params{
+		Source: &stream.HLSSegment{
+			Name: bucketPath + "/a/b/c",
+			Data: []byte("SourceData"),
+		},
+		Renditions: [][]byte{
+			[]byte("Rendition1"),
+			[]byte("Rendition2"),
+		},
+		URIs:     []string{bucketPath + "/r1/s", bucketPath + "r2/s"},
+		Profiles: []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9, ffmpeg.P240p30fps16x9},
+	}
+
+	// Should write to disk since we haven't set an external bucket
+	srcPath, rPaths, err := writeSegments(p, dir)
+	assert.Nil(err)
+	checkContents := func(fname string, generatedName string, contents []byte) {
+		assert.Equal("/stream/"+baseDir+"/"+fname, generatedName)
+		data, err := ioutil.ReadFile(filepath.Join(dir, fname))
+		assert.Nil(err)
+		assert.Equal(contents, data)
+	}
+	checkContents("source", srcPath, p.Source.Data)
+	checkContents("P144p30fps16x9", rPaths[0], p.Renditions[0])
+	checkContents("P240p30fps16x9", rPaths[1], p.Renditions[1])
+
+	// TODO Trigger an error writing to disk, for both source and renditions
+
+	// Set an external bucket
+	drivers.S3BUCKET = "livepeer"
+	defer func() { drivers.S3BUCKET = "" }()
+	srcPath, rPaths, err = writeSegments(p, dir)
+	assert.Nil(err)
+	assert.Equal(p.Source.Name, srcPath)
+	assert.Equal(p.URIs[0], rPaths[0])
+	assert.Equal(p.URIs[1], rPaths[1])
+
+	// Zero out renditions; sanity check things are still OK
+	p.URIs = nil
+	srcPath, rPaths, err = writeSegments(p, dir)
+	assert.Nil(err)
+	assert.Equal(p.Source.Name, srcPath)
+	assert.Empty(rPaths)
+}
+
+func TestEpic_Verify(t *testing.T) {
+	assert := assert.New(t)
+
+	// Use external S3 bucket
+	drivers.S3BUCKET = "livepeer"
+	defer func() { drivers.S3BUCKET = "" }()
+
+	ts, mux := stubVerificationServer()
+	defer ts.Close()
+	mux.HandleFunc("/verify", func(w http.ResponseWriter, r *http.Request) {
+		buf, err := json.Marshal(&epicResults{
+			Results: []epicResultFields{
+				{VideoAvailable: true, Tamper: -1.0},
+			},
+		})
+		assert.Nil(err)
+		w.Write(buf)
+	})
+
+	ec := &EpicClassifier{Addr: ts.URL + "/verify"}
+	// There's a lot room to segfault here if `Params` isn't correctly populated
+	params := &Params{
+		Source:       &stream.HLSSegment{SeqNo: 73},
+		Results:      &net.TranscodeData{},
+		Orchestrator: &net.OrchestratorInfo{Transcoder: "pretend"},
+	}
+	_, err := ec.Verify(params)
+	assert.Equal(ErrTampered, err)
+
+	// Check invalid URLs
+	ec.Addr = ""
+	_, err = ec.Verify(params)
+	assert.NotNil(err)
+	assert.Equal(`Post : unsupported protocol scheme ""`, err.Error())
+
+	ec.Addr = ts.URL + "/nonexistent" // 404s
+	_, err = ec.Verify(params)
+	assert.NotNil(err)
+	assert.Equal(ErrVerifierStatus, err)
+
+	// TODO Error out on `resp.Body` read and ensure the error is there?
+
+	// Nil JSON body
+	mux.HandleFunc("/nilJSON", func(w http.ResponseWriter, r *http.Request) {
+		w.Write(nil)
+	})
+	ec.Addr = ts.URL + "/nilJSON"
+	_, err = ec.Verify(params)
+	assert.NotNil(err)
+	assert.IsType(&json.SyntaxError{}, err)
+
+	// check various request parameters
+	bucketPath := "https://livepeer.s3.amazonaws.com"
+	params.Source.Name = bucketPath + "/source"
+	params.Results = &net.TranscodeData{Segments: []*net.TranscodedSegmentData{{}, {}}}
+	params.Profiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P720p60fps16x9}
+	params.URIs = []string{bucketPath + "/r1", bucketPath + "/r2"}
+	mux.HandleFunc("/checkReq", func(w http.ResponseWriter, r *http.Request) {
+		var req epicRequest
+		defer r.Body.Close()
+		err := json.NewDecoder(r.Body).Decode(&req)
+		assert.Nil(err)
+		// Build up our expected value struct and do a single comparison
+		expected := epicRequest{
+			Source:         params.Source.Name,
+			OrchestratorID: params.Orchestrator.Transcoder,
+			Renditions: []epicRendition{
+				{URI: params.URIs[0], Framerate: 30, Resolution: epicResolution{Width: 426, Height: 240}},
+				{URI: params.URIs[1], Framerate: 60, Resolution: epicResolution{Width: 1280, Height: 720}},
+			},
+			Model: "https://storage.googleapis.com/verification-models/verification.tar.xz",
+		}
+		assert.Equal(expected, req)
+
+		buf, err := json.Marshal(&epicResults{
+			Results: []epicResultFields{
+				{VideoAvailable: true, Tamper: 1.0, Pixels: 123},
+				{VideoAvailable: true, Tamper: 2.0, Pixels: 456},
+			},
+		})
+		assert.Nil(err)
+		w.Write(buf)
+	})
+	ec.Addr = ts.URL + "/checkReq"
+	res, err := ec.Verify(params)
+	assert.Nil(err)
+	assert.Equal([]int64{123, 456}, res.Pixels)
+	assert.Equal((1.0+2.0)/2.0, res.Score)
+}
+
+func stubVerificationServer() (*httptest.Server, *http.ServeMux) {
+	mux := http.NewServeMux()
+	ts := httptest.NewServer(mux)
+	return ts, mux
+}

--- a/verification/verify.go
+++ b/verification/verify.go
@@ -8,6 +8,13 @@ import (
 	"github.com/livepeer/lpms/stream"
 )
 
+// Special error type indicating a retryable error
+// Such errors typically mean re-trying the transcode might help
+// (Non-retryable errors usually indicate unrecoverable system errors)
+type Retryable struct {
+	error
+}
+
 type Params struct {
 	// ManifestID should go away once we do direct push of video
 	ManifestID core.ManifestID
@@ -25,6 +32,14 @@ type Params struct {
 	Results *net.TranscodeData
 }
 
+type Results struct {
+	// Verifier specific score
+	Score float64
+
+	// Number of pixels decoded in this result
+	Pixels []int64
+}
+
 type Verifier interface {
-	Verify(params *Params) error
+	Verify(params *Params) (*Results, error)
 }

--- a/verification/verify.go
+++ b/verification/verify.go
@@ -1,0 +1,30 @@
+package verification
+
+import (
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/net"
+
+	"github.com/livepeer/lpms/ffmpeg"
+	"github.com/livepeer/lpms/stream"
+)
+
+type Params struct {
+	// ManifestID should go away once we do direct push of video
+	ManifestID core.ManifestID
+
+	// Bytes of the source video segment
+	Source *stream.HLSSegment
+
+	// Rendition parameters to be checked
+	Profiles []ffmpeg.VideoProfile
+
+	// Information on the orchestrator that performed the transcoding
+	Orchestrator *net.OrchestratorInfo
+
+	// Transcoded result metadata
+	Results *net.TranscodeData
+}
+
+type Verifier interface {
+	Verify(params *Params) error
+}

--- a/verification/verify.go
+++ b/verification/verify.go
@@ -1,6 +1,8 @@
 package verification
 
 import (
+	"sort"
+
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/net"
 
@@ -30,6 +32,12 @@ type Params struct {
 
 	// Transcoded result metadata
 	Results *net.TranscodeData
+
+	// Rendition locations; typically when the data is in object storage
+	URIs []string
+
+	// Cached data when local object storage is used
+	Renditions [][]byte
 }
 
 type Results struct {
@@ -42,4 +50,85 @@ type Results struct {
 
 type Verifier interface {
 	Verify(params *Params) (*Results, error)
+}
+
+type Policy struct {
+
+	// Verification function to run
+	Verifier Verifier
+
+	// Maximum number of retries until the policy chooses a winner
+	Retries int
+
+	// How often to invoke the verifier, on a per-segment basis
+	SampleRate float64 // XXX for later
+
+	// How many parallel transcodes to support
+	Redundancy int // XXX for later
+}
+
+type SegmentVerifierResults struct {
+	params *Params
+	res    *Results
+}
+
+type byResScore []SegmentVerifierResults
+
+func (a byResScore) Len() int           { return len(a) }
+func (a byResScore) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byResScore) Less(i, j int) bool { return a[i].res.Score < a[j].res.Score }
+
+type SegmentVerifier struct {
+	policy  *Policy
+	results []SegmentVerifierResults
+	count   int
+}
+
+func NewSegmentVerifier(p *Policy) *SegmentVerifier {
+	return &SegmentVerifier{policy: p}
+}
+
+func (sv *SegmentVerifier) Verify(params *Params) (*Params, error) {
+
+	if sv.policy == nil {
+		return nil, nil
+	}
+
+	// TODO sig checking; extract from broadcast.go
+
+	if sv.policy.Verifier == nil {
+		return nil, nil
+	}
+	// TODO Use policy sampling rate to determine whether to invoke verifier.
+	//      If not, exit early. Seed sample using source data for repeatability!
+	res, err := sv.policy.Verifier.Verify(params)
+	if err != nil {
+		// Verification passed successfully, so use this set of params
+		return params, nil
+	}
+	sv.count++
+
+	// Append retryable errors to results
+	// The caller should terminate processing for non-retryable errors
+	if IsRetryable(err) {
+		r := SegmentVerifierResults{params: params, res: res}
+		sv.results = append(sv.results, r)
+	}
+
+	// Check for max retries
+	// If max hit, return best params so far
+	if sv.count > sv.policy.Retries {
+		if len(sv.results) <= 0 {
+			return nil, err
+		}
+		sort.Sort(byResScore(sv.results))
+		return sv.results[len(sv.results)-1].params, err
+	}
+
+	return nil, err
+}
+
+func IsRetryable(err error) bool {
+	_, retryable := err.(Retryable)
+	return retryable
 }

--- a/verification/verify_test.go
+++ b/verification/verify_test.go
@@ -1,0 +1,137 @@
+package verification
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/livepeer/go-livepeer/net"
+)
+
+type stubVerifier struct {
+	results *Results
+	err     error
+}
+
+func (sv *stubVerifier) Verify(params *Params) (*Results, error) {
+	return sv.results, sv.err
+}
+
+func TestVerify(t *testing.T) {
+
+	assert := assert.New(t)
+
+	verifier := &stubVerifier{
+		results: &Results{Score: 9.3, Pixels: []int64{123, 456}},
+		err:     errors.New("Stub Verifier Error")}
+
+	// Check empty policy and verifier
+	sv := NewSegmentVerifier(nil)
+	res, err := sv.Verify(&Params{})
+	assert.Nil(res)
+	assert.Nil(err)
+	sv = NewSegmentVerifier(&Policy{Retries: 3})
+	res, err = sv.Verify(&Params{})
+	assert.Nil(res)
+	assert.Nil(err)
+
+	// Check verifier error is propagated
+	sv = NewSegmentVerifier(&Policy{Verifier: verifier, Retries: 3})
+	res, err = sv.Verify(&Params{})
+	assert.Nil(res)
+	assert.Equal(verifier.err, err)
+
+	// Check successful verification
+	// Should skip pixel counts since parameters don't specify pixels
+	verifier.err = nil
+	res, err = sv.Verify(&Params{})
+	assert.Nil(err)
+	assert.NotNil(res)
+
+	// Check pixel list from verifier isn't what's expected
+	data := &net.TranscodeData{Segments: []*net.TranscodedSegmentData{
+		{Url: "abc", Pixels: verifier.results.Pixels[0] + 1},
+	}}
+	res, err = sv.Verify(&Params{Results: data})
+	assert.Nil(res)
+	assert.Equal(ErrPixelsAbsent, err)
+
+	// check pixel count fails
+	data.Segments = append(data.Segments, &net.TranscodedSegmentData{Url: "def", Pixels: verifier.results.Pixels[1]})
+	assert.Len(data.Segments, len(verifier.results.Pixels)) // sanity check
+	res, err = sv.Verify(&Params{Results: data})
+	assert.Nil(res)
+	assert.Equal(ErrPixelMismatch, err)
+
+	// Check pixel count succeeds
+	data.Segments[0].Pixels = verifier.results.Pixels[0]
+	res, err = sv.Verify(&Params{Results: data})
+	assert.Nil(err)
+	assert.NotNil(res)
+
+	// Check retryable: 3 attempts
+	sv = NewSegmentVerifier(&Policy{Verifier: verifier, Retries: 2}) // reset
+	verifier.err = Retryable{errors.New("Stub Verifier Retryable Error")}
+	assert.True(IsRetryable(verifier.err))
+	// first attempt
+	verifier.results = &Results{Score: 1.0, Pixels: []int64{123, 456}}
+	res, err = sv.Verify(&Params{ManifestID: "abc", Results: data})
+	assert.Equal(err, verifier.err)
+	assert.Nil(res)
+	// second attempt
+	verifier.results = &Results{Score: 3.0, Pixels: []int64{123, 456}}
+	res, err = sv.Verify(&Params{ManifestID: "def", Results: data})
+	assert.Equal(err, verifier.err)
+	assert.Nil(res)
+	// final attempt should return highest scoring
+	verifier.results = &Results{Score: 2.0, Pixels: []int64{123, 456}}
+	res, err = sv.Verify(&Params{ManifestID: "ghi", Results: data})
+	assert.Equal(err, verifier.err)
+	assert.NotNil(res)
+	assert.Equal("def", string(res.ManifestID))
+	// Additional attempts should still return best score winner
+	verifier.results = &Results{Score: -1.0, Pixels: []int64{123, 456}}
+	res, err = sv.Verify(&Params{ManifestID: "jkl", Results: data})
+	assert.Equal(err, verifier.err)
+	assert.NotNil(res)
+	assert.Equal("def", string(res.ManifestID))
+	// If we pass in a result with a better score, that should be returned
+	verifier.results = &Results{Score: 4.0, Pixels: []int64{123, 456}}
+	res, err = sv.Verify(&Params{ManifestID: "mno", Results: data})
+	assert.Equal(err, verifier.err)
+	assert.NotNil(res)
+	assert.Equal("mno", string(res.ManifestID))
+
+	// Pixel count handling
+	verifier.err = nil
+	// Good score but incorrect pixel list should still fail
+	verifier.results = &Results{Score: 10.0, Pixels: []int64{789}}
+	res, err = sv.Verify(&Params{ManifestID: "pqr", Results: data})
+	assert.Equal(ErrPixelsAbsent, err)
+	assert.Equal("mno", string(res.ManifestID)) // Still return best result
+	// Higher score and incorrect pixel list should prioritize pixel count
+	verifier.results = &Results{Score: 20.0, Pixels: []int64{789}}
+	res, err = sv.Verify(&Params{ManifestID: "stu", Results: data})
+	assert.Equal(ErrPixelsAbsent, err)
+	assert.Equal("mno", string(res.ManifestID)) // Still return best result
+
+	// Check *not* retryable; should never get a result
+	sv = NewSegmentVerifier(&Policy{Verifier: verifier, Retries: 1}) // reset
+	verifier.err = errors.New("Stub Verifier Non-Retryable Error")
+	// first attempt
+	verifier.results = &Results{Score: 1.0, Pixels: []int64{123, 456}}
+	res, err = sv.Verify(&Params{ManifestID: "abc", Results: data})
+	assert.Equal(err, verifier.err)
+	assert.Nil(res)
+	// second attempt
+	verifier.results = &Results{Score: 3.0, Pixels: []int64{123, 456}}
+	res, err = sv.Verify(&Params{ManifestID: "def", Results: data})
+	assert.Equal(err, verifier.err)
+	assert.Nil(res)
+	// third attempt, just to make sure?
+	verifier.results = &Results{Score: 2.0, Pixels: []int64{123, 456}}
+	res, err = sv.Verify(&Params{ManifestID: "ghi", Results: data})
+	assert.Equal(err, verifier.err)
+	assert.Nil(res)
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Extremely early integration of the Epic Labs verification classifier API. This should be enough to start running some experiments locally.

Refer to https://github.com/livepeer/go-livepeer/issues/1093 for some details on the following items:

 - Due to https://github.com/livepeer/verification-classifier/issues/64 this works when the verifier is running on localhost only. There is a lot hard-coded in here.
- Results (and errors) from the verification function are ignored completely.
- Adds a new CLI flag, `-verifierUrl` (but this may change in later iterations of the integration)
- Only performs verification if the `-verifierUrl` address is set.
- Currently works in off-chain mode to facilitate quick testing.
- Verifies all segments and renditions; no sampling is done.
- Structure is subject to change as more of the policy is designed and implemented.
- Leaves surrounding code intact, eg pixel counting and sig checking.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
