### PR TITLE
Makefile: `go build -mod=readonly` to avoid dirty git state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
 jobs:
   build-builder:
     docker:
-      - image: circleci/golang:1-stretch
+      - image: circleci/golang:1.13-stretch
     working_directory: /go/src/github.com/livepeer/go-livepeer
 
     environment:

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ version=$(shell cat VERSION)
 
 .PHONY: livepeer
 livepeer:
-	GO111MODULE=on go build -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer/*.go
+	GO111MODULE=on go build -mod=readonly -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer/*.go
 
 .PHONY: livepeer_cli
 livepeer_cli:
-	GO111MODULE=on go build -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer_cli/*.go
+	GO111MODULE=on go build -mod=readonly -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer_cli/*.go
 
 .PHONY: localdocker
 localdocker:

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -2,7 +2,7 @@
 # Shouild be used by running `make localdocker`
 FROM livepeer/ffmpeg-base:latest as builder
 
-FROM golang:1-stretch as builder2
+FROM golang:1.13-stretch as builder2
 ENV PKG_CONFIG_PATH /root/compiled/lib/pkgconfig
 WORKDIR /root
 RUN apt update \

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,8 @@ require (
 	github.com/livepeer/m3u8 v0.11.0
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-sqlite3 v1.11.0
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/oschwald/maxminddb-golang v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 // indirect
 	// github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20190403181518-312b5175032f // indirect
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
@@ -35,8 +34,6 @@ require (
 	github.com/livepeer/m3u8 v0.11.0
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-sqlite3 v1.11.0
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/olekukonko/tablewriter v0.0.1
 	github.com/oschwald/maxminddb-golang v1.5.0 // indirect

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -18,6 +18,8 @@ BRANCH="${TRAVIS_BRANCH:-${CIRCLE_BRANCH:-unknown}}"
 VERSION="$(cat VERSION)-$(git describe --always --long --abbrev=8 --dirty)"
 if echo $VERSION | grep dirty; then
   echo "Error: git state dirty, refusing to upload build"
+  git diff
+  git status
   exit 1
 fi
 


### PR DESCRIPTION
This is an attempt to prevent the "dirty git state" that @iameli points out in #1095 