### PR TITLE
install_ffmpeg.sh: pin nv-codec-headers to 9fdaf11b8f79d4e41cde9af89656238f25fec6fd

### DIFF
--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -27,6 +27,7 @@ if [ $(uname) != "Darwin" ]; then
   if [ ! -e "$HOME/nv-codec-headers" ]; then
     git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git "$HOME/nv-codec-headers"
     cd $HOME/nv-codec-headers
+    git checkout 9fdaf11b8f79d4e41cde9af89656238f25fec6fd
     make -e PREFIX="$HOME/compiled"
     make install -e PREFIX="$HOME/compiled"
   fi


### PR DESCRIPTION
install_ffmpeg.sh: pin nv-codec-headers to 9fdaf11b8f79d4e41cde9af89656238f25fec6fd

This fixes the following runtime issue:
```
[h264_nvenc @ 0x7ff3e9b83c00] Driver does not support the required nvenc API version. Required: 9.1 Found: 9.0
[h264_nvenc @ 0x7ff3e9b83c00] The minimum required Nvidia driver for nvenc is 418.30 or newer
Error opening video encoder
transcoder: Unable to open output
I1001 14:23:09.589135    8007 ffmpeg.go:245] Transcoder Return : Function not implemented
E1001 14:23:09.589186    8007 ot_rpc.go:144] Unable to transcode Function not implemented
I1001 14:23:16.667831    8007 ot_rpc.go:119] End of stream recieve cylcle because of err="EOF", waiting for running
 transcode jobs to complete
I1001 14:23:16.668000    8007 ot_rpc.go:52] Unregistering transcoder: EOF
I1001 14:23:17.139262    8007 ot_rpc.go:50] Registering transcoder to 127.0.0.1:8935
```