### PR TITLE
statically linked gnutls, fixed windows build, no more -dirty

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,18 +29,14 @@ jobs:
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
 
       # First, build the Linux-specific builder container
-      - run: docker pull livepeerci/build-platform:latest-linux || echo 'no pre-existing cache found'
-      - run: docker build -t livepeerci/build-platform:latest-linux --cache-from=livepeerci/build-platform:latest-linux -f docker/Dockerfile.build-linux .
-      - run: docker push livepeerci/build-platform:latest-linux
-      - run: docker manifest create livepeerci/build-platform:latest livepeerci/build-platform:latest-linux livepeerci/build-platform:latest-windows
-      - run: docker manifest push livepeerci/build-platform:latest
+      - run: docker pull livepeerci/build-platform:latest || echo 'no pre-existing cache found'
+      - run: docker build -t livepeerci/build-platform:latest --cache-from=livepeerci/build-platform:latest -f docker/Dockerfile.build-linux .
+      - run: docker push livepeerci/build-platform:latest
 
       # Then, build the actual app in a container shared between Linux and Windows
-      - run: docker pull livepeerci/build:latest-linux || echo 'no pre-existing cache found'
-      - run: docker build -t livepeerci/build:latest-linux --cache-from=livepeerci/build:latest-linux -f docker/Dockerfile.build .
-      - run: docker push livepeerci/build:latest-linux
-      - run: docker manifest create livepeerci/build:latest livepeerci/build:latest-linux livepeerci/build:latest-windows
-      - run: docker manifest push livepeerci/build:latest
+      - run: docker pull livepeerci/build:latest || echo 'no pre-existing cache found'
+      - run: docker build -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
+      - run: docker push livepeerci/build:latest
 
       # Finally, build the minimal go-livepeer distributable
       - run: |-
@@ -56,8 +52,8 @@ jobs:
     docker:
       # Note race condition - we might get the wrong builder if lots of builds are happening in
       # parallel because this pulls it down from Docker Hub.
-      - image: livepeerci/build:latest-linux
-    working_directory: /go/src/github.com/livepeer/go-livepeer
+      - image: livepeerci/build:latest
+    working_directory: /build
 
     environment:
       PKG_CONFIG_PATH: /root/compiled/lib/pkgconfig
@@ -72,19 +68,6 @@ jobs:
           docker_layer_caching: true
 
       - run: mkdir -p $TEST_RESULTS
-
-      # - restore_cache:
-      #     keys:
-      #       - v3-pkg-cache
-      - run:
-          name: Install linter
-          command: |
-            GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.18.0
-
-      - run:
-          name: Install junit
-          command: |
-            GO111MODULE=on go get github.com/jstemmer/go-junit-report
 
       - run:
           name: Lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - PKG_CONFIG_PATH=/Users/travis/compiled/lib/pkgconfig
 
 script:
+  - set -e
   - ./install_ffmpeg.sh
   - go mod download
   - make livepeer livepeer_cli

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,21 @@ net/lp_rpc.pb.go: net/lp_rpc.proto
 
 version=$(shell cat VERSION)
 
+ldflags := -X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)
+cgo_ldflags :=
+
+uname_s := $(shell uname -s)
+ifeq ($(uname_s),Darwin)
+		cgo_ldflags += -framework CoreFoundation -framework Security
+endif
+
 .PHONY: livepeer
 livepeer:
-	GO111MODULE=on go build -mod=readonly -tags "$(HIGHEST_CHAIN_TAG)" -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer/*.go
+	GO111MODULE=on CGO_LDFLAGS="$(cgo_ldflags)" go build -tags "$(HIGHEST_CHAIN_TAG)" -ldflags="$(ldflags)" cmd/livepeer/*.go
 
 .PHONY: livepeer_cli
 livepeer_cli:
-	GO111MODULE=on go build -mod=readonly -tags "$(HIGHEST_CHAIN_TAG)" -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer_cli/*.go
+	GO111MODULE=on CGO_LDFLAGS="$(cgo_ldflags)" go build -tags "$(HIGHEST_CHAIN_TAG)" -ldflags="$(ldflags)" cmd/livepeer_cli/*.go
 
 .PHONY: localdocker
 localdocker:

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ version=$(shell cat VERSION)
 
 .PHONY: livepeer
 livepeer:
-	GO111MODULE=on go build -tags "$(HIGHEST_CHAIN_TAG)" -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer/*.go
+	GO111MODULE=on go build -mod=readonly -tags "$(HIGHEST_CHAIN_TAG)" -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer/*.go
 
 .PHONY: livepeer_cli
 livepeer_cli:
-	GO111MODULE=on go build -tags "$(HIGHEST_CHAIN_TAG)" -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer_cli/*.go
+	GO111MODULE=on go build -mod=readonly -tags "$(HIGHEST_CHAIN_TAG)" -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer_cli/*.go
 
 .PHONY: localdocker
 localdocker:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,9 +13,10 @@ jobs:
       - script: git config --global core.autocrlf false
       - checkout: self
       - bash: |-
+          set -e
           # First, build/cache the platform-specific root container
           docker login -u '$(DOCKER_USER)' -p '$(DOCKER_PASS)'
-          docker pull livepeerci/build-platform:latest-windows || echo "build cache not found"
+          docker pull livepeerci/build-platform:latest-windows || echo "build cache not found."
           docker build -m 4gb --cache-from=livepeerci/build-platform:latest-windows -t livepeerci/build-platform:latest-windows -f ./docker/Dockerfile.build-windows .
           docker push livepeerci/build-platform:latest-windows
           docker tag livepeerci/build-platform:latest-windows livepeerci/build-platform:latest
@@ -29,9 +30,4 @@ jobs:
           # Push the release image at the tag name with non-alphanums removed
           docker run --rm -e GCLOUD_KEY=$(GCLOUD_KEY) -e GCLOUD_SECRET=$(GCLOUD_SECRET)  -e DISCORD_URL=$(DISCORD_URL) -e CIRCLE_BRANCH=$(Build.SourceBranchName) livepeerci/build:latest-windows
           TAG=`echo $CIRCLE_BRANCH | tr -cd '[:alnum:]_'`
-          docker build -t livepeer/go-livepeer:$TAG-windows -f docker/Dockerfile.release-windows . ;
-          docker push livepeer/go-livepeer:$TAG-windows
-          # Manifest step is optional in case the Linux build hasn't completed yet
-          docker manifest create livepeer/go-livepeer:$TAG livepeer/go-livepeer:$TAG-linux livepeer/go-livepeer:$TAG-windows || echo "linux image not found, not creating manifest"
-          docker manifest push livepeer/go-livepeer:$TAG || echo "linux image not found, not pushing manifest"
         failOnStderr: false

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -8,6 +8,10 @@ FROM livepeerci/build-platform:latest
 COPY ./install_ffmpeg.sh ./install_ffmpeg.sh
 RUN ./install_ffmpeg.sh
 
+RUN go get -v github.com/golangci/golangci-lint/cmd/golangci-lint github.com/jstemmer/go-junit-report
+
+ENV GOFLAGS "-mod=readonly"
+
 COPY go.mod go.mod
 COPY go.sum go.sum
 RUN go mod download
@@ -15,4 +19,4 @@ RUN go mod download
 COPY . .
 RUN make livepeer livepeer_cli
 
-CMD  ./upload_build.sh
+CMD ./upload_build.sh

--- a/docker/Dockerfile.build-linux
+++ b/docker/Dockerfile.build-linux
@@ -18,4 +18,4 @@ RUN apt-get update \
 
 ENV GOPATH /go
 RUN mkdir -p /go
-WORKDIR /go/src/github.com/livepeer/go-livepeer
+WORKDIR /build

--- a/docker/Dockerfile.build-windows
+++ b/docker/Dockerfile.build-windows
@@ -73,15 +73,11 @@ RUN C:\msys64\usr\bin\bash.exe -l -c 'exit 0'; `
   C:\msys64\usr\bin\bash.exe -l -c 'pacman -Syu  --needed --noconfirm --noprogressbar --ask=20'; `
   C:\msys64\usr\bin\bash.exe -l -c 'pacman -Su   --needed --noconfirm --noprogressbar --ask=20'; `
   # Install our packages. Use the mingw-w64-x86_64 version of everything run-time; it's faster
-  C:\msys64\usr\bin\bash.exe -l -c 'pacman -S perl binutils git make autoconf zip mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-pkg-config --noconfirm --noprogressbar --ask=20'; `
-  # Need golang 1.11 for now
-  C:\msys64\usr\bin\bash.exe -l -c 'pacman -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-go-1.12.4-1-any.pkg.tar.xz --noconfirm --noprogressbar --ask=20'; `
+  C:\msys64\usr\bin\bash.exe -l -c 'pacman -S perl binutils git make autoconf zip mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-pkg-config mingw-w64-x86_64-go --noconfirm --noprogressbar --ask=20'; `
   C:\msys64\usr\bin\bash.exe -l -c 'pacman -Scc --noconfirm'; `
-  C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully installed MSYS2"'; `
-  # MSYS2 leaves processes running or something - this step hangs? Hard shutdown to fix that.
-  Stop-Computer -Force
+  C:\msys64\usr\bin\bash.exe -l -c 'echo "Successfully installed MSYS2"';
 
-WORKDIR C:\msys64\go\src\github.com\livepeer\go-livepeer
+WORKDIR C:\msys64\gobuild
 
 # Tell MSYS2 not to do "cd $HOME" all the freakin' time
 ENV CHERE_INVOKING 1
@@ -92,6 +88,8 @@ ENV GOPATH "/go"
 ENV GOROOT "/mingw64/lib/go"
 ENV PKG_CONFIG_PATH "/mingw64/lib/pkgconfig:/build/compiled/lib/pkgconfig"
 
-SHELL ["C:\\msys64\\usr\\bin\\bash.exe", "-c"]
+# Shim to properly pass arguments to bash from "RUN" blocks
+ADD ./docker/run.ps1 C:\\msys64\\usr\\bin\\run.ps1
+SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "C:\\msys64\\usr\\bin\\run.ps1"]
 
 CMD ["C:\\msys64\\usr\\bin\\bash.exe"]

--- a/docker/Dockerfile.release-linux
+++ b/docker/Dockerfile.release-linux
@@ -5,5 +5,5 @@ ENTRYPOINT ["/usr/bin/livepeer"]
 # this is needed to access GPU inside Docker Swarm
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
-COPY --from=livepeerci/build:latest /go/src/github.com/livepeer/go-livepeer/livepeer /usr/bin/livepeer
-COPY --from=livepeerci/build:latest /go/src/github.com/livepeer/go-livepeer/livepeer_cli /usr/bin/livepeer_cli
+COPY --from=livepeerci/build:latest /build/livepeer /usr/bin/livepeer
+COPY --from=livepeerci/build:latest /build/livepeer_cli /usr/bin/livepeer_cli

--- a/docker/run.ps1
+++ b/docker/run.ps1
@@ -1,0 +1,8 @@
+# Shim to properly invoke Bash from "RUN" commands on Windows
+$ErrorActionPreference = 'Stop';
+$ProgressPreference = 'SilentlyContinue';
+$output = Start-Process -FilePath C:\msys64\usr\bin\bash.exe -PassThru -Wait -NoNewWindow -ArgumentList "-c","'$args'"
+If($output.Exitcode -ne 0)
+{
+     Throw "bash errored"
+}

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -53,13 +53,62 @@ if [ ! -e "$HOME/x264" ]; then
   make install-lib-static
 fi
 
+# Static linking of gnutls on Linux/Mac
+if [[ $(uname) != *"MSYS2_NT"* ]]; then
+  # rm -rf "$HOME/gmp-6.1.2"
+  if [ ! -e "$HOME/gmp-6.1.2" ]; then
+    cd "$HOME"
+    curl -LO https://ftp.gnu.org/gnu/gmp/gmp-6.1.2.tar.xz
+    xz -d gmp-6.1.2.tar.xz
+    tar xf gmp-6.1.2.tar
+    rm gmp-6.1.2.tar
+    cd "$HOME/gmp-6.1.2"
+    ./configure --prefix="$HOME/compiled" --disable-shared  --with-pic
+    make
+    make install
+  fi
+
+  # rm -rf "$HOME/nettle-3.4.1"
+  if [ ! -e "$HOME/nettle-3.4.1" ]; then
+    cd $HOME
+    curl -LO https://ftp.gnu.org/gnu/nettle/nettle-3.4.1.tar.gz
+    tar xf nettle-3.4.1.tar.gz
+    rm nettle-3.4.1.tar.gz
+    cd nettle-3.4.1
+    LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --disable-shared --enable-pic
+    make
+    make install
+  fi
+
+  # rm -rf "$HOME/gnutls-3.5.18"
+  if [ ! -e "$HOME/gnutls-3.5.18" ]; then
+    cd $HOME
+    curl -LO https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.18.tar.xz
+    xz -d gnutls-3.5.18.tar.xz
+    tar xf gnutls-3.5.18.tar
+    rm gnutls-3.5.18.tar
+    cd gnutls-3.5.18
+    LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" LIBS="-lhogweed -lnettle -lgmp" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools
+    make
+    make install
+    # gnutls doesn't properly set up its pkg-config or something? without this line ffmpeg and go
+    # don't know that they need gmp, nettle, and hogweed
+    sed -i'' -e 's/-lgnutls/-lgnutls -lhogweed -lnettle -lgmp/g' ~/compiled/lib/pkgconfig/gnutls.pc
+  fi
+fi
+
 EXTRA_FFMPEG_FLAGS=""
+EXTRA_LDFLAGS=""
 # Only Linux supports CUDA... for now.
 if [ $(uname) == "Linux" ]; then
   if [ -e /usr/local/cuda/include ]; then
     echo "CUDA detected, building with GPU support"
     EXTRA_FFMPEG_FLAGS="--enable-cuda --enable-cuvid --enable-nvenc --enable-filter=scale_cuda --enable-encoder=h264_nvenc --enable-cuda-nvcc"
   fi
+fi
+
+if [ $(uname) == "Darwin" ]; then
+  EXTRA_LDFLAGS="-framework CoreFoundation -framework Security"
 fi
 
 if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
@@ -80,7 +129,7 @@ if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
     --enable-encoder=aac,libx264 \
     --enable-decoder=aac,h264 \
     --extra-cflags="-I${HOME}/compiled/include" \
-    --extra-ldflags="-L${HOME}/compiled/lib" \
+    --extra-ldflags="-L${HOME}/compiled/lib ${EXTRA_LDFLAGS}" \
     --prefix="$HOME/compiled" \
     $EXTRA_FFMPEG_FLAGS
   make

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -16,6 +16,10 @@ fi
 BASE="livepeer-$ARCH-amd64"
 BRANCH="${TRAVIS_BRANCH:-${CIRCLE_BRANCH:-unknown}}"
 VERSION="$(cat VERSION)-$(git describe --always --long --abbrev=8 --dirty)"
+if echo $VERSION | grep dirty; then
+  echo "Error: git state dirty, refusing to upload build"
+  exit 1
+fi
 
 mkdir $BASE
 cp ./livepeer${EXT} $BASE

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -18,7 +18,7 @@ BRANCH="${TRAVIS_BRANCH:-${CIRCLE_BRANCH:-unknown}}"
 VERSION="$(cat VERSION)-$(git describe --always --long --abbrev=8 --dirty)"
 if echo $VERSION | grep dirty; then
   echo "Error: git state dirty, refusing to upload build"
-  git diff
+  git diff | cat
   git status
   exit 1
 fi
@@ -31,7 +31,7 @@ cp ./livepeer_cli${EXT} $BASE
 if [[ $ARCH == "windows" ]]; then
   FILE=$BASE.zip
   # This list was produced by `ldd livepeer.exe`
-  LIBS="libffi-6.dll libgcc_s_seh-1.dll libgmp-10.dll libgnutls-30.dll libhogweed-4.dll libiconv-2.dll libidn2-0.dll libintl-8.dll libnettle-6.dll libp11-kit-0.dll libtasn1-6.dll libunistring-2.dll libwinpthread-1.dll zlib1.dll"
+  LIBS="libffi-6.dll libgcc_s_seh-1.dll libgmp-10.dll libgnutls-30.dll libhogweed-5.dll libiconv-2.dll libidn2-0.dll libintl-8.dll libnettle-7.dll libp11-kit-0.dll libtasn1-6.dll libunistring-2.dll libwinpthread-1.dll zlib1.dll"
   for LIB in $LIBS; do
     cp -r /mingw64/bin/$LIB ./$BASE
   done

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -18,6 +18,8 @@ BRANCH="${TRAVIS_BRANCH:-${CIRCLE_BRANCH:-unknown}}"
 VERSION="$(cat VERSION)-$(git describe --always --long --abbrev=8 --dirty)"
 if echo $VERSION | grep dirty; then
   echo "Error: git state dirty, refusing to upload build"
+  git diff
+  git status
   exit 1
 fi
 


### PR DESCRIPTION
Three things here:

* statically-linked gnutls on Linux and Mac, no more external dependency (#1094)
* tweaks to the Windows build to get Go 1.13 and gomodules working (#1121)
* fix the `-dirty` suffix showing up on the Linux build by preinstalling the necessary go linting and testing tools prior to the test execution. (i never actually filed this but this commit incorporates #1095)

The Windows build still has some external DLL dependencies but Windows apps are pretty routinely distributed with an `.exe` and its supporting `.dll`s so I don't see that as a big deal.

Fixes #1094 #1121

Proof:

```
> ldd ./livepeer
	linux-vdso.so.1 (0x00007fff109a7000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f9559933000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f955992e000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f95597ab000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f955958d000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f9559583000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f95593c2000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f9559959000)
```

```
> otool -L ./livepeer                                                                                            19:06:31
./livepeer:
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1570.15.0)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 58286.251.4)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1252.250.1)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.11)
	/System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo (compatibility version 1.2.0, current version 1.5.0)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 944.3.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
```