### PR TITLE
add new build notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,10 @@ jobs:
           name: Upload build
           command: ./upload_build.sh
 
+      - run:
+          name: Notify that new build has been uploaded
+          command: curl -X POST https://holy-bread-207a.livepeer.workers.dev
+
       - save_cache:
           key: v3-pkg-cache
           paths:


### PR DESCRIPTION
Just a tiny webhook that fires after the Docker build passes, triggering some other pieces of the infrastructure to check for new images.