### PR TITLE
eth+pm+server: Generate and verify signatures with v = 27/28

### DIFF
--- a/pm/helpers.go
+++ b/pm/helpers.go
@@ -1,11 +1,18 @@
 package pm
 
 import (
-	"fmt"
+	"math/big"
 	"math/rand"
 
+	"github.com/ethereum/go-ethereum/accounts"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/pkg/errors"
+)
+
+var (
+	secp256k1N, _  = new(big.Int).SetString("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16)
+	secp256k1halfN = new(big.Int).Div(secp256k1N, big.NewInt(2))
 )
 
 // VerifySig verifies that a ETH ECDSA signature over a given message
@@ -13,15 +20,42 @@ import (
 //
 // TODO refactor to a package that both eth and pm can import
 func VerifySig(addr ethcommon.Address, msg, sig []byte) bool {
-	personalMsg := fmt.Sprintf("\x19Ethereum Signed Message:\n%d%s", 32, msg)
-	personalHash := crypto.Keccak256([]byte(personalMsg))
-
-	pubkey, err := crypto.SigToPub(personalHash, sig)
+	recovered, err := ecrecover(msg, sig)
 	if err != nil {
 		return false
 	}
 
-	return crypto.PubkeyToAddress(*pubkey) == addr
+	return recovered == addr
+}
+
+func ecrecover(msg, sig []byte) (ethcommon.Address, error) {
+	if len(sig) != 65 {
+		return ethcommon.Address{}, errors.New("invalid signature length")
+	}
+
+	s := new(big.Int).SetBytes(sig[32:64])
+	if s.Cmp(secp256k1halfN) > 0 {
+		return ethcommon.Address{}, errors.New("signature s value too high")
+	}
+
+	v := sig[64]
+	if v != byte(27) && v != byte(28) {
+		return ethcommon.Address{}, errors.New("signature v value must be 27 or 28")
+	}
+
+	// crypto.SigToPub() expects signature v value = 0/1
+	// Copy the signature and convert its value to 0/1
+	ethSig := make([]byte, 65)
+	copy(ethSig[:], sig[:])
+	ethSig[64] -= 27
+
+	ethMsg := accounts.TextHash(msg)
+	pubkey, err := crypto.SigToPub(ethMsg, ethSig)
+	if err != nil {
+		return ethcommon.Address{}, err
+	}
+
+	return crypto.PubkeyToAddress(*pubkey), nil
 }
 
 // RandHash returns a random keccak256 hash

--- a/pm/helpers_test.go
+++ b/pm/helpers_test.go
@@ -1,0 +1,52 @@
+package pm
+
+import (
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEcrecover(t *testing.T) {
+	assert := assert.New(t)
+
+	addr := ethcommon.HexToAddress("3BadDb1eeE2105893136A3F96c8a963E9C6309d6")
+	msg := ethcommon.FromHex("b7da355477356fc4c47fcabcf232dc77a6db9b07b7e48b76261cc55cc8fbabb3")
+	sig := ethcommon.FromHex("206443228e8f784bc3a122de0d85eb3ebff82d6a79cca26c7eeb907099a6404f6dff57bc6828f28bd6cd073c89d94cf3364204679ed8365fa45b5ee6af19a9841c")
+
+	_, err := ecrecover(msg, sig[:64])
+	assert.EqualError(err, "invalid signature length")
+
+	sigHighS := ethcommon.FromHex("e742ff452d41413616a5bf43fe15dd88294e983d3d36206c2712f39083d638bde0a0fc89be718fbc1033e1d30d78be1c68081562ed2e97af876f286f3453231d1b")
+	_, err = ecrecover(msg, sigHighS)
+	assert.EqualError(err, "signature s value too high")
+
+	sigInvalidV := make([]byte, 65)
+	copy(sigInvalidV[:], sigInvalidV[:])
+	sigInvalidV[64] -= 27
+	_, err = ecrecover(msg, sigInvalidV)
+	assert.EqualError(err, "signature v value must be 27 or 28")
+
+	// Check that the correct address is recovered
+	recovered, err := ecrecover(msg, sig)
+	assert.Nil(err)
+	assert.Equal(addr, recovered)
+
+	// Check that the wrong address is recovered for a different message
+	recovered, err = ecrecover(ethcommon.FromHex("foo"), sig)
+	assert.Nil(err)
+	assert.NotEqual(addr, recovered)
+}
+
+func TestVerifySig(t *testing.T) {
+	assert := assert.New(t)
+
+	addr := ethcommon.HexToAddress("3BadDb1eeE2105893136A3F96c8a963E9C6309d6")
+	sig := ethcommon.FromHex("206443228e8f784bc3a122de0d85eb3ebff82d6a79cca26c7eeb907099a6404f6dff57bc6828f28bd6cd073c89d94cf3364204679ed8365fa45b5ee6af19a9841c")
+	msg := ethcommon.FromHex("b7da355477356fc4c47fcabcf232dc77a6db9b07b7e48b76261cc55cc8fbabb3")
+
+	// Check that verification passes
+	assert.True(VerifySig(addr, msg, sig))
+	// Check that verification fails for a different message
+	assert.False(VerifySig(addr, ethcommon.FromHex("foo"), sig))
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the node's signature format to always use 27 or 28 for the v value. Signatures are of the form `[r || s || v]` where r and s constitute the actual signature. v is the recovery ID that is used for recovering the public key associated with a signature. The [go-ethereum package the node uses for signing](https://github.com/ethereum/go-ethereum/blob/master/crypto/signature_nocgo.go#L59) generates signatures with v = 0/1.

The protocol contracts were recently updated to use the newest version of the OpenZeppelin signature verification library in [this commit](https://github.com/livepeer/protocol/pull/342/commits/325fe884b9c16e380ff1ba3cfb7dd9a000ecdefb). The updated [library](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol) includes the following additional checks to defend against malleable signatures:

- Checks that the signature's s value is in the lower range of the N (curve order)
- Checks that the signature's v value is either 27/28

In order to pass on-chain signature verification, the node needs to generate signatures that pass these additional checks.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Update `AccountManager.Sign()` to convert signatures' v value to 27/28
- Add tests for `AccountManager.Sign()`
- Update `pm.VerifySig()` to perform all the checks that are present in the on-chain signature verification library to ensure that the node verifies signatures the same way
- Add tests for `pm.VerifySig()`
- Update tests in the `server` package that rely on signature generation/verification

Note: As already mentioned in a comment, `pm.VerifySig()` should eventually be extracted out of the `pm` package, but I chose not to do so in this PR as it requires some additional package restructuring.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests and ran a B/O/T setup in on-chain mode using the test-harness.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
