### PR TITLE
Keep balance when removing session

### DIFF
--- a/core/accounting.go
+++ b/core/accounting.go
@@ -50,11 +50,6 @@ func (b *Balance) StageUpdate(minCredit, ev *big.Rat) (int, *big.Rat, *big.Rat) 
 	return int(size), new(big.Rat).Mul(new(big.Rat).SetInt64(size), ev), existingCredit
 }
 
-// Clear zeros the balance
-func (b *Balance) Clear() {
-	delete(b.balances.balances, b.manifestID)
-}
-
 // Balances holds credit balances on a per-stream basis
 type Balances struct {
 	balances map[ManifestID]*balance

--- a/core/accounting_test.go
+++ b/core/accounting_test.go
@@ -80,23 +80,6 @@ func TestBalance_StageUpdate(t *testing.T) {
 	assert.Zero(big.NewRat(0, 1).Cmp(balances.Balance(mid)))
 }
 
-func TestBalance_Clear(t *testing.T) {
-	mid := ManifestID("some manifestID")
-	balances := NewBalances(5 * time.Second)
-	b := NewBalance(mid, balances)
-
-	assert := assert.New(t)
-
-	// Test non-nil key
-	b.Credit(big.NewRat(5, 1))
-	b.Clear()
-	assert.Nil(balances.balances[mid])
-
-	// Test nil key
-	b.Clear()
-	assert.Nil(balances.balances[mid])
-}
-
 func TestEmptyBalances_ReturnsZeroedValues(t *testing.T) {
 	mid := ManifestID("some manifest id")
 	b := NewBalances(5 * time.Second)

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -92,10 +92,6 @@ func (bsm *BroadcastSessionsManager) removeSession(session *BroadcastSession) {
 	bsm.sessLock.Lock()
 	defer bsm.sessLock.Unlock()
 
-	if session.Balance != nil {
-		session.Balance.Clear()
-	}
-
 	delete(bsm.sessMap, session.OrchestratorInfo.Transcoder)
 }
 

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -238,15 +238,6 @@ func TestRemoveSession(t *testing.T) {
 	bsm.removeSession(sess2)
 	assert.Nil(bsm.sessMap[sess2.OrchestratorInfo.Transcoder])
 	assert.Len(bsm.sessMap, 0)
-
-	// sesssion.Balance != nil
-	b := &mockBalance{}
-	b.On("Clear")
-	sess1.Balance = b
-
-	bsm.removeSession(sess1)
-
-	b.AssertCalled(t, "Clear")
 }
 
 func TestCompleteSessions(t *testing.T) {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -56,7 +56,6 @@ type Broadcaster interface {
 type Balance interface {
 	Credit(amount *big.Rat)
 	StageUpdate(minCredit *big.Rat, ev *big.Rat) (int, *big.Rat, *big.Rat)
-	Clear()
 }
 
 // BalanceUpdateStatus indicates the current status of a balance update


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates `BroadcastSessionsManager.removeSession()` to *not* clear the balance associated with the session when the session is removed. This prevents the following scenario:

- B has negative balance with O
- B disconnects because it encounters an error and removes the session
- B refreshes its session list
- B reconnects with O - its session balance is 0, but O's view of B's balance is still negative
- B sends a payment to O with its value calculated based on a session balance of 0
- B encounters an insufficient balance error

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Do not call `Balance.Clear()` in `removeSession()`
- Remove `Balance.Clear()` because it is no longer used

After this change, B will only clear the balance for a manifestID if it has not been accessed for longer than the TTL defined in `core.Balances`.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Checked that B did not encounter insufficient balance errors in a setup (using the devtool script) replicating the scenario described in #1079.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1079

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
