### PR TITLE
Check for supported network when node starts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ version=$(shell cat VERSION)
 
 .PHONY: livepeer
 livepeer:
-	GO111MODULE=on go build -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer/*.go
+	GO111MODULE=on go build -tags "$(HIGHEST_CHAIN_TAG)" -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer/*.go
 
 .PHONY: livepeer_cli
 livepeer_cli:
-	GO111MODULE=on go build -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer_cli/*.go
+	GO111MODULE=on go build -tags "$(HIGHEST_CHAIN_TAG)" -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)" cmd/livepeer_cli/*.go
 
 .PHONY: localdocker
 localdocker:

--- a/build/chain.go
+++ b/build/chain.go
@@ -1,0 +1,27 @@
+package build
+
+// SupportedChains is an enum that indicates the chains supported by the node
+// All chains represented by an enum value less than or equal than this value are supported
+// All chains represented by an enum value greater than this value are not supported
+type SupportedChains int
+
+const (
+	// Dev is a development chain
+	Dev SupportedChains = iota
+	// Rinkeby is the Ethereum Rinkeby test network chain
+	Rinkeby
+	// Mainnet is the Ethereum main network chain
+	Mainnet
+)
+
+// ChainSupported returns whether the node can connect to the chain with the given ID
+func ChainSupported(chainID int64) bool {
+	switch chainID {
+	case 4:
+		return Rinkeby <= HighestChain
+	case 1:
+		return Mainnet <= HighestChain
+	default:
+		return Dev <= HighestChain
+	}
+}

--- a/build/chain_dev.go
+++ b/build/chain_dev.go
@@ -1,0 +1,5 @@
+// +build !mainnet,!rinkeby
+
+package build
+
+const HighestChain = Dev

--- a/build/chain_mainnet.go
+++ b/build/chain_mainnet.go
@@ -1,0 +1,5 @@
+// +build mainnet
+
+package build
+
+const HighestChain = Mainnet

--- a/build/chain_rinkeby.go
+++ b/build/chain_rinkeby.go
@@ -1,0 +1,5 @@
+// +build rinkeby
+
+package build
+
+const HighestChain = Rinkeby

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/livepeer/go-livepeer/build"
 	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/go-livepeer/server"
 
@@ -325,6 +326,12 @@ func main() {
 			glog.Errorf("failed to get chain ID from remote ethereum node: %v", err)
 			return
 		}
+
+		if !build.ChainSupported(chainID.Int64()) {
+			glog.Errorf("node does not support chainID = %v right now", chainID)
+			return
+		}
+
 		if err := checkOrStoreChainID(dbh, chainID); err != nil {
 			glog.Error(err)
 			return

--- a/test_args.sh
+++ b/test_args.sh
@@ -3,7 +3,7 @@
 set -eux
 
 # build the binary
-go build cmd/livepeer/livepeer.go
+HIGHEST_CHAIN_TAG=mainnet make livepeer
 
 # set a clean slate "home dir" for testing
 TMPDIR=/tmp/livepeer-test-"$RANDOM"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds a check when the node starts to determine if the chain to connect to is supported. If the chain is not supported, the node will log an error and exit. Supported chains are configured when the node is built using the `HIGHEST_CHAIN_TAG` build tag. 

The order of supported chains is:

`everything else (i.e. dev chains) -> rinkeby -> mainnet`

All chains less than or equal to `HIGHEST_CHAIN_TAG` in the ordering will be supported by the node.

For example:

A node built using `make livepeer` will only connect to a dev chain. It will not connect with Rinkeby or mainnet.

A node built using `HIGHEST_CHAIN_TAG=rinkeby make livepeer` will connect to Rinkeby or a dev chain. It will not connect with mainnet.

A node build using `HIGHEST_CHAIN_TAG=mainnet make livepeer` will connect to any chain.

Since the highest chain tag is configured at build time, supported chains can be configured for official releases (i.e. testnet only releases, mainnet releases, etc.). Developers can always build the node from scratch and configure that tag by themselves.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- be2ba8b: Adds a `build` package with build specific code. Currently, `chain_mainnet.go`, `chain_rinkeby.go` and `chain_dev.go` use build constraints to determine how the constant `HighestChain` is set based on the build tags used
- cdad028: Use the `HIGHEST_CHAIN_TAG` env variable in the Makefile when building `livepeer` and `livepeer_cli`
- 380730b: Add a check on node startup to determine if the chain is supported

The `build` package could also be used to implement build tag configurable feature/experimental flags in the future.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Built `livepeer` with different values for `HIGHEST_CHAIN_TAG`.

Note: `livepeer_cli` doesn't actually check for supported chains right now despite being built with the `HIGHEST_CHAIN_TAG` because the node is not yet compatible with the contracts on Rinkeby so the node will pass the supported chain check, but exit soon thereafter because it cannot query the contracts. Since `livepeer_cli` relies on the node's web server, it would be a bit tough to test if `livepeer_cli` exits properly when it does not support the chain that the node is connected to. We can add the supported chains check in `livepeer_cli` when the node is actually compatible with Rinkeby since testing will be easier then.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1092 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
