### PR TITLE
cmd, eth: use blockPollingInterval flag

### DIFF
--- a/eth/eventservices/rewardservice.go
+++ b/eth/eventservices/rewardservice.go
@@ -13,20 +13,20 @@ import (
 var (
 	ErrRewardServiceStarted = fmt.Errorf("reward service already started")
 	ErrRewardServiceStopped = fmt.Errorf("reward service already stopped")
-
-	TryRewardPollingInterval = time.Minute * 30 // Poll to try to call reward once 30 minutes
 )
 
 type RewardService struct {
-	client       eth.LivepeerEthClient
-	pendingTx    *types.Transaction
-	working      bool
-	cancelWorker context.CancelFunc
+	client          eth.LivepeerEthClient
+	pendingTx       *types.Transaction
+	working         bool
+	cancelWorker    context.CancelFunc
+	pollingInterval time.Duration
 }
 
-func NewRewardService(client eth.LivepeerEthClient) *RewardService {
+func NewRewardService(client eth.LivepeerEthClient, pollingInterval time.Duration) *RewardService {
 	return &RewardService{
-		client: client,
+		client:          client,
+		pollingInterval: pollingInterval,
 	}
 }
 
@@ -38,7 +38,7 @@ func (s *RewardService) Start(ctx context.Context) error {
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	s.cancelWorker = cancel
 
-	tickCh := time.NewTicker(TryRewardPollingInterval).C
+	tickCh := time.NewTicker(s.pollingInterval).C
 
 	go func(ctx context.Context) {
 		for {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR removes different hardcoded polling intervals used for different services that query the blockchain periodically. Examples include `gasPriceMonitor`, `blockWatcher`,  `rewardService`, ... 
**Specific updates (required)**
- added a new flag `blockPollingInterval` that takes in an integer to indicate the polling interval in seconds
- remove all seperate hardcoded polling intervals in livepeer.go
- add a `pollingInterval` field to `RewardService` and set it to the `blockPollingInterval` when invoking the constructor

**How did you test each of these updates (required)**
Ran test-harness
Ran unit tests


**Does this pull request close any open issues?**
Fixes #1128 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
