### PR TITLE
server: Fix /currentRound handler

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -68,6 +68,24 @@ func currentBlockHandler(getter BlockGetter) http.Handler {
 	})
 }
 
+func currentRoundHandler(client eth.LivepeerEthClient) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if client == nil {
+			respondWith500(w, "missing ETH client")
+			return
+		}
+
+		currentRound, err := client.CurrentRound()
+		if err != nil {
+			respondWith500(w, fmt.Sprintf("could not query current round: %v", err))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(currentRound.Bytes())
+	})
+}
+
 func fundDepositAndReserveHandler(client eth.LivepeerEthClient) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if client == nil {

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -163,17 +163,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 		w.Write(data)
 	})
 
-	mux.HandleFunc("/currentRound", func(w http.ResponseWriter, r *http.Request) {
-		if s.LivepeerNode.Eth != nil {
-			currentRound, err := s.LivepeerNode.Eth.CurrentRound()
-			if err != nil {
-				glog.Error(err)
-				return
-			}
-
-			w.Write([]byte(currentRound.String()))
-		}
-	})
+	mux.Handle("/currentRound", currentRoundHandler(s.LivepeerNode.Eth))
 
 	mux.HandleFunc("/initializeRound", func(w http.ResponseWriter, r *http.Request) {
 		if s.LivepeerNode.Eth != nil {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes the `/currentRound` handler in the webserver. Previously, it was converting a `big.Int` into a `string` and then casting it into a `[]byte`. Then, `livepeer_cli` would use those bytes to create `big.Int`. The act of converting the `big.Int` into a `string` and *then* casting it into a `[]byte` results in a different `[]byte` representation and as a result, when `livepeer_cli` converts the response from the server into a `big.Int`, we end up with an incorrect value for current round.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Directly return the byte representation of the current round in the `/currentRound` handler
- Refactor the `/currentRound` handler so it is easier to write unit tests for
- Add unit tests for the `currentRoundHandler()`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests. Ran the a node using the devtool script to confirm that `livepeer_cli` prints the correct current round.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
