### PR TITLE
common, db: add network id check to prevent datadir collisions

### DIFF
--- a/test_args.sh
+++ b/test_args.sh
@@ -67,6 +67,11 @@ run_lp -broadcaster -datadir "$CUSTOM_DATADIR"
 [ ! -d  "$CUSTOM_DATADIR"/offchain ] # sanity check that network isn't included
 kill $pid
 
+CUSTOM_DATADIR="$TMPDIR"/customDatadir2
+
+# sanity check that custom datadir does not exist
+[ ! -d "$CUSTOM_DATADIR" ]
+
 # check custom datadir with a network
 run_lp -broadcaster -datadir "$CUSTOM_DATADIR" -network rinkeby $ETH_ARGS
 [ ! -d  "$CUSTOM_DATADIR"/rinkeby ] # sanity check that network isn't included


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Prevents further datadir collisions by checking the chainID from the provided remote ethereum node against the chainID in the database when the datadir and node were first initiated. 

This prevents the edge case where a node operator changes network without changing the network name or connecting to a network URL that doesn't fit the name. 

**Specific updates (required)**
- Introduced db.NetworkID
- Introduced db.SelectKV
- Introduced db.UpdateKV
- save & compare chainID when starting the node

**How did you test each of these updates (required)**
unit tests

**Does this pull request close any open issues?**
Fixes #1098 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass


TODO: still uses `backend.NetworkID` , swap it out for `backend.ChainID`
