### PR TITLE
core: Check for nil balance in Orchestrator.SufficientBalance()

### DIFF
--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1108,8 +1108,7 @@ func TestSufficientBalance_IsSufficient_ReturnsTrue(t *testing.T) {
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", false, nil).Once()
 	assert := assert.New(t)
 
-	// Create a ticket where faceVal = EV
-	// making faceVal the expected balance increase
+	// Create a ticket where faceVal = EV so that the balance = EV
 	payment := defaultPayment(t)
 	payment.TicketParams.FaceValue = big.NewInt(100).Bytes()
 	payment.TicketParams.WinProb = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)).Bytes()
@@ -1134,8 +1133,10 @@ func TestSufficientBalance_IsNotSufficient_ReturnsFalse(t *testing.T) {
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", false, nil).Once()
 	assert := assert.New(t)
 
-	// Create a ticket where faceVal = EV
-	// making faceVal the expected balance increase
+	// Check when the balance is nil because no payment was received yet and there is no cached balance
+	assert.False(orch.SufficientBalance(ethcommon.BytesToAddress([]byte("foo")), manifestID))
+
+	// Create a ticket where faceVal < EV so that the balance < EV
 	payment := defaultPayment(t)
 	payment.TicketParams.FaceValue = big.NewInt(100).Bytes()
 	payment.TicketParams.WinProb = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)).Bytes()

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -275,7 +275,9 @@ func (orch *orchestrator) SufficientBalance(addr ethcommon.Address, manifestID M
 	if orch.node == nil || orch.node.Recipient == nil || orch.node.Balances == nil {
 		return true
 	}
-	if orch.node.Balances.Balance(addr, manifestID).Cmp(orch.node.Recipient.EV()) < 0 {
+
+	balance := orch.node.Balances.Balance(addr, manifestID)
+	if balance == nil || balance.Cmp(orch.node.Recipient.EV()) < 0 {
 		return false
 	}
 	return true


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes a bug where a nil pointer error is triggered by `Orchestrator.SufficientBalance()` when an orchestrator does not have a cached balance for a stream and does not receive a payment with a segment so it does not credit the stream's balance (the first credit operation for a stream's balance will create a cached balance if it does not already exist).

The bug can be replicated with the following steps:

1. Build the node using the latest `master`
2. Run `docker run -d -p 8545:8545 -p 8546:8546 --name geth-with-livepeer-protocol livepeer/geth-with-livepeer-protocol:streamflow
3. Setup an O using the devtool
4. Setup a B using the devtool
5. Make sure that B can connect to O
6. Stream into B and observe O start to transcode
7. Restart O
8. Stream into B again and observe O encounter errors while transcoding

After step 7, O will start without any cached balances so O's view of a stream's balance (for a particular manifestID) is out-of-sync with B's view of a stream's balance. As a result, B will not send a payment with the first segment in step 8.

This is a screenshot of the error encountered in step 8:
![Screen Shot 2019-10-28 at 10 43 39 AM](https://user-images.githubusercontent.com/5933273/67688438-33aadd80-f970-11e9-960f-e2c31972d607.png)

This PR does NOT solve the stream balance synchronization issue between B & O when either node restarts and then reconnects with each other shortly afterwords. This PR only fixes the nil pointer error that O encounters in this scenario. In the example scenario mentioned above, in step 8, B will encounter an insufficient balance error and then if reconnects with O again it afterwords it will start off with a stream balance of 0. We might be able to eventually move away from stream balance tracking if we implement short circuited transcoding (which we're already interested in implementing and have already discussed here and there) along with per segment pixel limits (will write up a separate GH issue about this with more details), but we can follow up on that separately.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Check if the balance for a stream is nil in `Orchestrator.SufficientBalance()`. If the balance is nil, return false

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added a unit test for the update.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
