### PR TITLE
clean "tagged" release versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
       PKG_CONFIG_PATH: /root/compiled/lib/pkgconfig
       GOPATH: /go
       DOCKER_CLI_EXPERIMENTAL: enabled
+      HIGHEST_CHAIN_TAG: rinkeby
 
     steps:
       - checkout
@@ -59,6 +60,7 @@ jobs:
       PKG_CONFIG_PATH: /root/compiled/lib/pkgconfig
       TEST_RESULTS: /tmp/test-results
       GOPATH: /go
+      HIGHEST_CHAIN_TAG: rinkeby
 
     steps:
       - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ osx_image: xcode10.2
 env:
   global:
     - PKG_CONFIG_PATH=/Users/travis/compiled/lib/pkgconfig
+    - HIGHEST_CHAIN_TAG=rinkeby
 
 script:
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 
 script:
   - set -e
+  - git fetch --unshallow --tags
   - ./install_ffmpeg.sh
   - go mod download
   - make livepeer livepeer_cli

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ net/lp_rpc.pb.go: net/lp_rpc.proto
 
 version=$(shell cat VERSION)
 
-ldflags := -X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(version)-$(shell git describe --always --long --dirty --abbrev=8)
+ldflags := -X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(./print_version.sh)
 cgo_ldflags :=
 
 uname_s := $(shell uname -s)
@@ -25,7 +25,7 @@ livepeer_cli:
 
 .PHONY: localdocker
 localdocker:
-	git describe --always --long --dirty > .git.describe
+	./print_version.sh > .git.describe
 	# docker build -t livepeerbinary:debian -f Dockerfile.debian .
 	# Manually build our context... this is hacky but docker refuses to support symlinks
 	# or selectable .dockerignore files

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,20 +14,20 @@ jobs:
       - checkout: self
       - bash: |-
           set -e
-          # First, build/cache the platform-specific root container
-          docker login -u '$(DOCKER_USER)' -p '$(DOCKER_PASS)'
-          docker pull livepeerci/build-platform:latest-windows || echo "build cache not found."
-          docker build -m 4gb --cache-from=livepeerci/build-platform:latest-windows -t livepeerci/build-platform:latest-windows -f ./docker/Dockerfile.build-windows .
-          docker push livepeerci/build-platform:latest-windows
-          docker tag livepeerci/build-platform:latest-windows livepeerci/build-platform:latest
+          # # First, build/cache the platform-specific root container
+          # docker login -u '$(DOCKER_USER)' -p '$(DOCKER_PASS)'
+          # docker pull livepeerci/build-platform:latest-windows || echo "build cache not found."
+          # docker build -m 4gb --cache-from=livepeerci/build-platform:latest-windows -t livepeerci/build-platform:latest-windows -f ./docker/Dockerfile.build-windows .
+          # docker push livepeerci/build-platform:latest-windows
+          # docker tag livepeerci/build-platform:latest-windows livepeerci/build-platform:latest
 
-          # Then, build/cache the container shared between Windows and Linux
-          docker pull livepeerci/build:latest-windows || echo "build cache not found"
-          docker build -m 4gb --cache-from=livepeerci/build:latest-windows -t livepeerci/build:latest-windows -f ./docker/Dockerfile.build .
-          docker push livepeerci/build:latest-windows
-          docker tag livepeerci/build:latest-windows livepeerci/build:latest
+          # # Then, build/cache the container shared between Windows and Linux
+          # docker pull livepeerci/build:latest-windows || echo "build cache not found"
+          # docker build -m 4gb --cache-from=livepeerci/build:latest-windows -t livepeerci/build:latest-windows -f ./docker/Dockerfile.build .
+          # docker push livepeerci/build:latest-windows
+          # docker tag livepeerci/build:latest-windows livepeerci/build:latest
 
-          # Push the release image at the tag name with non-alphanums removed
-          docker run --rm -e GCLOUD_KEY=$(GCLOUD_KEY) -e GCLOUD_SECRET=$(GCLOUD_SECRET)  -e DISCORD_URL=$(DISCORD_URL) -e CIRCLE_BRANCH=$(Build.SourceBranchName) livepeerci/build:latest-windows
-          TAG=`echo $CIRCLE_BRANCH | tr -cd '[:alnum:]_'`
+          # # Push the release image at the tag name with non-alphanums removed
+          # docker run --rm -e GCLOUD_KEY=$(GCLOUD_KEY) -e GCLOUD_SECRET=$(GCLOUD_SECRET)  -e DISCORD_URL=$(DISCORD_URL) -e CIRCLE_BRANCH=$(Build.SourceBranchName) livepeerci/build:latest-windows
+          # TAG=`echo $CIRCLE_BRANCH | tr -cd '[:alnum:]_'`
         failOnStderr: false

--- a/docker/Dockerfile.debian.auto
+++ b/docker/Dockerfile.debian.auto
@@ -17,7 +17,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY . .
-RUN git describe --always --long --dirty > .git.describe
+RUN ./print_version.sh > .git.describe
 
 RUN go build -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(cat VERSION)-$(cat .git.describe)" -v cmd/livepeer/livepeer.go
 RUN go build -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(cat VERSION)-$(cat .git.describe)" -v cmd/livepeer_cli/*

--- a/print_version.sh
+++ b/print_version.sh
@@ -14,8 +14,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 currentTag="$(git describe --tags)"
 currentVersion="$(cat "$DIR/VERSION")"
 currentSha="$(git describe --always --long --dirty --abbrev=8)"
-if [[ "$currentTag" == "$currentVersion" ]]; then
-  echo -en "$currentTag"
+if [[ "$currentTag" == "v$currentVersion" ]]; then
+  echo -en "$currentVersion"
 else
   echo -en "$currentVersion-$currentSha"
 fi

--- a/print_version.sh
+++ b/print_version.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Prints the current build version of go-livepeer. Based on the following considerations:
+# 1. If the VERSION file matches the tag of our current commit, then we're the canonical
+#    x.y.z version, and that will be our version string.
+# 2. Otherwise, our version string is x.y.z-SHA, provided by the VERSION file and
+#    git describe --always --long --abbrev=8 --dirty
+
+set -e
+set -o nounset
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+currentTag="$(git describe --tags)"
+currentVersion="$(cat "$DIR/VERSION")"
+currentSha="$(git describe --always --long --dirty --abbrev=8)"
+if [[ "$currentTag" == "$currentVersion" ]]; then
+  echo -en "$currentTag"
+else
+  echo -en "$currentVersion-$currentSha"
+fi

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -15,7 +15,7 @@ fi
 
 BASE="livepeer-$ARCH-amd64"
 BRANCH="${TRAVIS_BRANCH:-${CIRCLE_BRANCH:-unknown}}"
-VERSION="$(cat VERSION)-$(git describe --always --long --abbrev=8 --dirty)"
+VERSION="$(./print_version.sh)"
 if echo $VERSION | grep dirty; then
   echo "Error: git state dirty, refusing to upload build"
   git diff | cat


### PR DESCRIPTION
This changeset allows us to release "named" versions of go-livepeer where the version string doesn't contain the commit SHA. Made for the upcoming v0.5.0 release.

Also cauterizes the Windows build for now as it's broken and not a priority for anything.

Also adds `HIGHEST_CHAIN_TAG` to the Linux and Mac CI processes to create binaries that support the Rinkeby chain.