### PR TITLE
eth/blockwatch: remove block header not found info statement

### DIFF
--- a/eth/blockwatch/block_watcher.go
+++ b/eth/blockwatch/block_watcher.go
@@ -164,7 +164,6 @@ func (w *Watcher) pollNextBlock() error {
 	nextHeader, err := w.client.HeaderByNumber(nextBlockNumber)
 	if err != nil {
 		if err == ethereum.NotFound {
-			glog.Infof("block header not found blockNumber=%v", nextBlockNumber)
 			return nil // Noop and wait next polling interval
 		}
 		return err


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Removes the `glog.Info` statement in the `blockwatch` package for when the next block header is not available yet when `blockPollingInterval` polls quicker than the rate of blocks. Just no-op instead.

**Specific updates (required)**
- removed the log statement in blockwatch/blockwatch_client.go L167

**Checklist:**
- [ ] README and other documentation updated
- [X] Node runs in OSX and devenv
- [X] All tests in `./test.sh` pass
