### PR TITLE
livepeer: Add option to enable pprof.

### DIFF
--- a/server/webserver.go
+++ b/server/webserver.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"time"
 
+	// pprof adds handlers to default mux via `init()`
+	_ "net/http/pprof"
+
 	"github.com/cenkalti/backoff"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -67,7 +70,11 @@ func (s *LivepeerServer) StartCliWebserver(bindAddr string) {
 }
 
 func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
-	mux := http.NewServeMux()
+	// Override default mux because pprof only uses the default mux
+	// We really don't want to accidentally pull pprof into other listeners.
+	// Pprof, like the CLI, is a strictly private API!
+	mux := http.DefaultServeMux
+	http.DefaultServeMux = http.NewServeMux()
 
 	//Set the broadcast config for creating onchain jobs.
 	mux.HandleFunc("/setBroadcastConfig", func(w http.ResponseWriter, r *http.Request) {

--- a/test_args.sh
+++ b/test_args.sh
@@ -165,4 +165,9 @@ res=0
 ./livepeer -broadcaster -maxSessions 0 || res=$?
 [ $res -ne 0 ]
 
+# Check that pprof is running on CLI port
+run_lp -broadcaster
+curl -sI http://127.0.0.1:7935/debug/pprof/allocs | grep "200 OK"
+kill $pid
+
 rm -rf "$TMPDIR"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
pprof is a neat profiling tool that's built into golang. In addition to tracking the usual suspects (CPU, allocations, mutexes) this allows us to generate neat flame graphs such as those shown here: https://github.com/livepeer/go-livepeer/issues/1155

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Sets up the pprof web handlers on the CLI port
- Moves the CLI handler to use the default HTTP mux, then reset the pointer to the default HTTP mux. We have to do this because unfortunately the default mux is the only thing that pprof works with, and we don't want to take the risk of some other public listener inadvertently pulling in the default HTTP mux, and pprof endpoints along with it. This is the same reason we run the CLI webserver on its own mux.
- Adds a simple args test

**How did you test each of these updates (required)**
- Manually
- Args unit test

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass