### PR TITLE
eth/blockwatch: BackfillStartBlock option

### DIFF
--- a/eth/blockwatch/block_watcher.go
+++ b/eth/blockwatch/block_watcher.go
@@ -301,12 +301,12 @@ func (w *Watcher) getMissedEventsToBackfill(ctx context.Context) ([]*Event, erro
 	}
 	latestBlockNum := int(latestBlock.Number.Int64())
 
-	if latestRetainedBlock != nil {
+	if w.backfillStartBlock != nil {
+		startBlockNum = int(w.backfillStartBlock.Int64())
+	} else if latestRetainedBlock != nil {
 		latestRetainedBlockNum = int(latestRetainedBlock.Number.Int64())
 		// Events for latestRetainedBlock already processed, start at latestRetainedBlock + 1
 		startBlockNum = latestRetainedBlockNum + 1
-	} else if w.backfillStartBlock != nil {
-		startBlockNum = int(w.backfillStartBlock.Int64())
 	} else {
 		return events, nil
 	}
@@ -318,8 +318,7 @@ func (w *Watcher) getMissedEventsToBackfill(ctx context.Context) ([]*Event, erro
 	glog.Infof("Backfilling block events (this can take a while)...\n")
 	glog.Infof("Start block: %v		 End block: %v		Blocks elapsed: %v\n", startBlockNum, startBlockNum+blocksElapsed, blocksElapsed)
 
-	endBlockNum := startBlockNum + blocksElapsed
-	logs, furthestBlockProcessed := w.getLogsInBlockRange(ctx, startBlockNum, endBlockNum)
+	logs, furthestBlockProcessed := w.getLogsInBlockRange(ctx, startBlockNum, latestBlockNum)
 	if furthestBlockProcessed > latestRetainedBlockNum {
 		// If we have processed blocks further then the latestRetainedBlock in the DB, we
 		// want to remove all blocks from the DB and insert the furthestBlockProcessed


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR updates the `blockwatch` package with a config option to start backfilling missed events from a certain block height, whereas previously backfilling would happen from the last retained block on the stack (in the DB in our case), if present. 

1. If there is a last retained block on the blockwatch stack, start backfilling from there. This should lead to an up to date view for the node
2. If there is no last retained block, start backfilling from the hardcoded `blockwatchBackfillStartBlock` defined in `livepeer.go` this is currently set to `0` and should lead to an up to date view for the node
3. If neither is defined return zero value and no error 

_**The one caveat is that this strategy makes some of the bash tests that use mainnet/rinkeby take quite a while since it starts backfilling from genesis...**_

**Specific updates (required)**
- Added a `BackFillStartBlock *big.Int` field to `blockwatch.Config`
- Changed `watcher.getMissedEventsToBackfill()` to start backfilling from `watcher.backFillStartBlock` if defined, otherwise continue operating as before the changes this PR makes
- Added a unit test for backfilling when `config.BackfillStartBlock` is defined
- Moved around `SenderWatcher` to not process events when backfilling because it will just lead to no-ops anyway (mapping is empty when starting the node)

**How did you test each of these updates (required)**
Ran unit tests


**Does this pull request close any open issues?**
Fixes #1149 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
