### PR TITLE
Fix transposed units in Max Price Per Pixel

### DIFF
--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -148,7 +148,7 @@ func (w *wizard) broadcastStats() {
 	price, transcodingOptions := w.getBroadcastConfig()
 	priceString := "n/a"
 	if price != nil {
-		priceString = fmt.Sprintf("%v pixels / %v wei", price.Num().Int64(), price.Denom().Int64())
+		priceString = fmt.Sprintf("%v wei / %v pixels", price.Num().Int64(), price.Denom().Int64())
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)


### PR DESCRIPTION
This change fixes this bug: https://github.com/livepeer/go-livepeer/issues/1168

**What does this pull request do? Explain your changes. (required)**

This change fixes this bug: https://github.com/livepeer/go-livepeer/issues/1168

**Specific updates (required)**

Corrected the labelling of the units shown in the `Max Price Per Pixel` parameter shown under `BROADCASTER STATS`

**How did you test each of these updates (required)**

Not tested, as not compiled or executed.

**Does this pull request close any open issues?**

This change fixes this bug: https://github.com/livepeer/go-livepeer/issues/1168

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
