### PR TITLE
db, discovery: select active Os from DB

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -417,6 +417,14 @@ func main() {
 		go orchWatcher.Watch()
 		defer orchWatcher.Stop()
 
+		serviceRegistryWatcher, err := watchers.NewServiceRegistryWatcher(addrMap["ServiceRegistry"], blockWatcher, dbh, n.Eth)
+		if err != nil {
+			glog.Errorf("Failed to set up service registry watcher: %v", err)
+			return
+		}
+		go serviceRegistryWatcher.Watch()
+		defer serviceRegistryWatcher.Stop()
+
 		blockWatchCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -409,6 +409,14 @@ func main() {
 		go senderWatcher.Watch()
 		defer senderWatcher.Stop()
 
+		orchWatcher, err := watchers.NewOrchestratorWatcher(addrMap["BondingManager"], blockWatcher, dbh, n.Eth)
+		if err != nil {
+			glog.Errorf("Failed to setup orchestrator watcher: %v", err)
+			return
+		}
+		go orchWatcher.Watch()
+		defer orchWatcher.Stop()
+
 		blockWatchCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 

--- a/common/db.go
+++ b/common/db.go
@@ -19,11 +19,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+// DB is an initialized DB driver with prepared statements
 type DB struct {
 	dbh *sql.DB
 
 	// prepared statements
-	selectOrchs                      *sql.Stmt
 	updateOrch                       *sql.Stmt
 	selectKV                         *sql.Stmt
 	updateKV                         *sql.Stmt
@@ -39,12 +39,16 @@ type DB struct {
 	deleteMiniHeader                 *sql.Stmt
 }
 
+// DBOrch is the type binding for a row result from the orchestrators table
 type DBOrch struct {
-	ServiceURI    string
-	EthereumAddr  string
-	PricePerPixel int64
+	ServiceURI        string
+	EthereumAddr      string
+	PricePerPixel     int64
+	ActivationRound   int64
+	DeactivationRound int64
 }
 
+// DBOrch is the type binding for a row result from the unbondingLocks table
 type DBUnbondingLock struct {
 	ID            int64
 	Delegator     ethcommon.Address
@@ -52,8 +56,10 @@ type DBUnbondingLock struct {
 	WithdrawRound int64
 }
 
+// DBOrchFilter is an object used to attach a filter to a selectOrch query
 type DBOrchFilter struct {
-	MaxPrice *big.Rat
+	MaxPrice     *big.Rat
+	CurrentRound *big.Int
 }
 
 var LivepeerDBVersion = 1
@@ -73,7 +79,9 @@ var schema = `
 		createdAt STRING DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		updatedAt STRING DEFAULT CURRENT_TIMESTAMP NOT NULL,
 		serviceURI STRING,
-		pricePerPixel int64
+		pricePerPixel int64,
+		activationRound int64,
+		deactivationRound int64
 	);
 
 	CREATE TABLE IF NOT EXISTS unbondingLocks (
@@ -113,8 +121,14 @@ var schema = `
 	CREATE INDEX IF NOT EXISTS idx_blockheaders_number ON blockheaders(number);
 `
 
-func NewDBOrch(serviceURI string, orchAddr string) *DBOrch {
-	return &DBOrch{ServiceURI: serviceURI, EthereumAddr: orchAddr}
+func NewDBOrch(ethereumAddr string, serviceURI string, pricePerPixel int64, activationRound int64, deactivationRound int64) *DBOrch {
+	return &DBOrch{
+		ServiceURI:        serviceURI,
+		EthereumAddr:      ethereumAddr,
+		PricePerPixel:     pricePerPixel,
+		ActivationRound:   activationRound,
+		DeactivationRound: deactivationRound,
+	}
 }
 
 func InitDB(dbPath string) (*DB, error) {
@@ -161,17 +175,8 @@ func InitDB(dbPath string) (*DB, error) {
 		// all good; nothing to do
 	}
 
-	// updateOrchestrators statement
-	stmt, err := db.Prepare("INSERT OR REPLACE INTO orchestrators(updatedAt, serviceURI, ethereumAddr, pricePerPixel, createdAt) VALUES(datetime(), ?1, ?2, ?3, (SELECT createdAt FROM orchestrators WHERE ethereumAddr = ?2))")
-	if err != nil {
-		glog.Error("Unable to prepare updateOrchestrators stmt ", err)
-		d.Close()
-		return nil, err
-	}
-	d.updateOrch = stmt
-
 	// selectKV prepared statement
-	stmt, err = db.Prepare("SELECT value FROM kv WHERE key=?")
+	stmt, err := db.Prepare("SELECT value FROM kv WHERE key=?")
 	if err != nil {
 		glog.Error("Unable to prepare selectKV stmt", err)
 		d.Close()
@@ -187,6 +192,31 @@ func InitDB(dbPath string) (*DB, error) {
 		return nil, err
 	}
 	d.updateKV = stmt
+
+	// updateOrch prepared statement
+	stmt, err = db.Prepare(`
+	INSERT INTO orchestrators(updatedAt, ethereumAddr, serviceURI, pricePerPixel, activationRound, deactivationRound, createdAt) 
+	VALUES(datetime(), :ethereumAddr, :serviceURI, :pricePerPixel, :activationRound, :deactivationRound, datetime()) 
+	ON CONFLICT(ethereumAddr) DO UPDATE SET 
+	updatedAt = excluded.updatedAt,
+	serviceURI =
+  		CASE WHEN trim(excluded.serviceURI) == ""
+  		THEN orchestrators.serviceURI
+		ELSE trim(excluded.serviceURI) END, 
+	pricePerPixel = 
+		CASE WHEN excluded.pricePerPixel == 0
+		THEN orchestrators.pricePerPixel
+		ELSE excluded.pricePerPixel END, 
+	activationRound = 
+		CASE WHEN excluded.activationRound == 0
+		THEN orchestrators.activationRound
+		ELSE excluded.activationRound END, 
+	deactivationRound = 
+		CASE WHEN excluded.deactivationRound == 0
+		THEN orchestrators.deactivationRound
+		ELSE excluded.deactivationRound END 
+	`)
+	d.updateOrch = stmt
 
 	// Unbonding locks prepared statements
 	stmt, err = db.Prepare("INSERT INTO unbondingLocks(id, delegator, amount, withdrawRound) VALUES(?, ?, ?, ?)")
@@ -276,17 +306,14 @@ func InitDB(dbPath string) (*DB, error) {
 
 func (db *DB) Close() {
 	glog.V(DEBUG).Info("Closing DB")
-	if db.updateOrch != nil {
-		db.updateOrch.Close()
-	}
-	if db.selectOrchs != nil {
-		db.selectOrchs.Close()
-	}
 	if db.selectKV != nil {
 		db.selectKV.Close()
 	}
 	if db.updateKV != nil {
 		db.updateKV.Close()
+	}
+	if db.updateOrch != nil {
+		db.updateOrch.Close()
 	}
 	if db.insertUnbondingLock != nil {
 		db.insertUnbondingLock.Close()
@@ -383,11 +410,18 @@ func (db *DB) updateKVStore(key, value string) error {
 }
 
 func (db *DB) UpdateOrch(orch *DBOrch) error {
-	if db == nil || orch == nil || orch.ServiceURI == "" || orch.EthereumAddr == "" {
+	if db == nil || orch == nil || orch.EthereumAddr == "" {
 		return nil
 	}
 
-	_, err := db.updateOrch.Exec(orch.ServiceURI, orch.EthereumAddr, orch.PricePerPixel)
+	_, err := db.updateOrch.Exec(
+		sql.Named("ethereumAddr", orch.EthereumAddr),
+		sql.Named("serviceURI", orch.ServiceURI),
+		sql.Named("pricePerPixel", orch.PricePerPixel),
+		sql.Named("activationRound", orch.ActivationRound),
+		sql.Named("deactivationRound", orch.DeactivationRound),
+	)
+
 	if err != nil {
 		glog.Error("db: Unable to update orchestrator ", err)
 	}
@@ -408,16 +442,18 @@ func (db *DB) SelectOrchs(filter *DBOrchFilter) ([]*DBOrch, error) {
 	}
 	orchs := []*DBOrch{}
 	for rows.Next() {
-		var orch DBOrch
-		var serviceURI string
-		var ethereumAddr string
-		if err := rows.Scan(&serviceURI, &ethereumAddr); err != nil {
+		var (
+			serviceURI        string
+			ethereumAddr      string
+			pricePerPixel     int64
+			activationRound   int64
+			deactivationRound int64
+		)
+		if err := rows.Scan(&serviceURI, &ethereumAddr, &pricePerPixel, &activationRound, &deactivationRound); err != nil {
 			glog.Error("db: Unable to fetch orchestrator ", err)
 			continue
 		}
-		orch.ServiceURI = serviceURI
-		orch.EthereumAddr = ethereumAddr
-		orchs = append(orchs, &orch)
+		orchs = append(orchs, NewDBOrch(serviceURI, ethereumAddr, pricePerPixel, activationRound, deactivationRound))
 	}
 	return orchs, nil
 }
@@ -599,15 +635,31 @@ func buildWinningTicketsQuery(sessionIDs []string) string {
 }
 
 func buildSelectOrchsQuery(filter *DBOrchFilter) (string, error) {
-	query := "SELECT serviceURI, ethereumAddr FROM orchestrators WHERE updatedAt >= datetime('now','-1 day')"
-	if filter != nil && filter.MaxPrice != nil {
-		fixedPrice, err := PriceToFixed(filter.MaxPrice)
-		if err != nil {
-			return "", err
-		}
-		query = query + " AND pricePerPixel <= " + strconv.FormatInt(fixedPrice, 10)
+	query := "SELECT ethereumAddr, serviceURI, pricePerPixel, activationRound, deactivationRound FROM orchestrators "
+	fil, err := buildFilterOrchsQuery(filter)
+	if err != nil {
+		return "", err
 	}
-	return query, nil
+	return query + fil, nil
+}
+
+func buildFilterOrchsQuery(filter *DBOrchFilter) (string, error) {
+	qry := "WHERE updatedAt >= datetime('now','-1 day')"
+	if filter != nil {
+		if filter.MaxPrice != nil {
+			fixedPrice, err := PriceToFixed(filter.MaxPrice)
+			if err != nil {
+				return "", err
+			}
+			qry += " AND pricePerPixel <= " + strconv.FormatInt(fixedPrice, 10)
+		}
+
+		if filter.CurrentRound != nil {
+			currentRound := filter.CurrentRound.Int64()
+			qry += fmt.Sprintf(" AND activationRound <= %v AND %v < deactivationRound", currentRound, currentRound)
+		}
+	}
+	return qry, nil
 }
 
 // FindLatestMiniHeader returns the MiniHeader with the highest blocknumber in the DB

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -193,7 +193,10 @@ func ethOrchToDBOrch(orch *lpTypes.Transcoder) *common.DBOrch {
 	if orch == nil {
 		return nil
 	}
-	return common.NewDBOrch(orch.ServiceURI, orch.Address.String())
+	return &common.DBOrch{
+		ServiceURI:   orch.ServiceURI,
+		EthereumAddr: orch.Address.String(),
+	}
 }
 
 func pmTicketParams(params *net.TicketParams) *pm.TicketParams {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -265,10 +265,14 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 	orchs, err := node.Database.SelectOrchs(nil)
 	require.Nil(err)
 	assert.Len(orchs, 3)
+	orchsTest := make([]orchTest, 1)
+	for _, o := range orchs {
+		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
+	}
 	for _, o := range orchestrators {
-		dbO := ethOrchToDBOrch(o)
+		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
 
-		assert.Contains(orchs, dbO)
+		assert.Contains(orchsTest, dbO)
 	}
 
 	// creating new OrchestratorPoolCache
@@ -456,21 +460,28 @@ func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) 
 	cachedOrchs, err := cacheDBOrchs(node, orchestrators)
 	require.Nil(err)
 	assert.Len(cachedOrchs, 50)
+	orchsTest := make([]orchTest, 1)
+	for _, o := range cachedOrchs {
+		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
+	}
 	for _, o := range orchestrators {
-		dbO := ethOrchToDBOrch(o)
-		dbO.PricePerPixel, _ = common.PriceToFixed(big.NewRat(999, 1))
+		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
 
-		assert.Contains(cachedOrchs, dbO)
+		assert.Contains(orchsTest, dbO)
 	}
 
 	// ensuring orchs exist in DB
 	orchs, err := node.Database.SelectOrchs(nil)
 	require.Nil(err)
 	assert.Len(orchs, 50)
+	orchsTest = make([]orchTest, 1)
+	for _, o := range orchs {
+		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
+	}
 	for _, o := range orchestrators {
-		dbO := ethOrchToDBOrch(o)
+		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
 
-		assert.Contains(orchs, dbO)
+		assert.Contains(orchsTest, dbO)
 	}
 
 	// creating new OrchestratorPoolCache
@@ -537,21 +548,28 @@ func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
 	cachedOrchs, err := cacheDBOrchs(node, orchestrators)
 	require.Nil(err)
 	assert.Len(cachedOrchs, 50)
+	orchsTest := make([]orchTest, 1)
+	for _, o := range cachedOrchs {
+		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
+	}
 	for _, o := range orchestrators {
-		dbO := ethOrchToDBOrch(o)
-		dbO.PricePerPixel, _ = common.PriceToFixed(big.NewRat(999, 1))
+		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
 
-		assert.Contains(cachedOrchs, dbO)
+		assert.Contains(orchsTest, dbO)
 	}
 
 	// ensuring orchs exist in DB
 	orchs, err := node.Database.SelectOrchs(nil)
 	require.Nil(err)
 	assert.Len(orchs, 50)
+	orchsTest = make([]orchTest, 1)
+	for _, o := range orchs {
+		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
+	}
 	for _, o := range orchestrators {
-		dbO := ethOrchToDBOrch(o)
+		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
 
-		assert.Contains(orchs, dbO)
+		assert.Contains(orchsTest, dbO)
 	}
 
 	// creating new OrchestratorPoolCache
@@ -644,18 +662,26 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 	require.Nil(err)
 	assert.Len(orchs, 50)
 
-	for _, o := range orchestrators {
-		dbO := ethOrchToDBOrch(o)
-
-		assert.Contains(orchs, dbO)
+	orchsTest := make([]orchTest, 1)
+	for _, o := range orchs {
+		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
 	}
-	orchs, err = node.Database.SelectOrchs(&common.DBOrchFilter{server.BroadcastCfg.MaxPrice()})
+	for _, o := range orchestrators {
+		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
+
+		assert.Contains(orchsTest, dbO)
+	}
+	orchs, err = node.Database.SelectOrchs(&common.DBOrchFilter{MaxPrice: server.BroadcastCfg.MaxPrice()})
 	require.Nil(err)
 	assert.Len(orchs, 25)
+	orchsTest = make([]orchTest, 1)
+	for _, o := range orchs {
+		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
+	}
 	for _, o := range orchestrators[25:] {
-		dbO := ethOrchToDBOrch(o)
+		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
 
-		assert.Contains(orchs, dbO)
+		assert.Contains(orchsTest, dbO)
 	}
 
 	// creating new OrchestratorPoolCache
@@ -878,4 +904,13 @@ func TestDeserializeWebhookJSON(t *testing.T) {
 	urls, err = deserializeWebhookJSON([]byte(`1112`))
 	assert.Contains(err.Error(), "cannot unmarshal number")
 	assert.Empty(urls)
+}
+
+type orchTest struct {
+	EthereumAddr string
+	ServiceURI   string
+}
+
+func toOrchTest(addr, serviceURI string) orchTest {
+	return orchTest{EthereumAddr: addr, ServiceURI: serviceURI}
 }

--- a/eth/client.go
+++ b/eth/client.go
@@ -584,14 +584,16 @@ func (c *client) GetTranscoder(addr ethcommon.Address) (*lpTypes.Transcoder, err
 	}
 
 	return &lpTypes.Transcoder{
-		Address:         addr,
-		ServiceURI:      serviceURI,
-		LastRewardRound: tInfo.LastRewardRound,
-		RewardCut:       tInfo.RewardCut,
-		FeeShare:        tInfo.FeeShare,
-		DelegatedStake:  delegatedStake,
-		Active:          active,
-		Status:          status,
+		Address:           addr,
+		ServiceURI:        serviceURI,
+		LastRewardRound:   tInfo.LastRewardRound,
+		RewardCut:         tInfo.RewardCut,
+		FeeShare:          tInfo.FeeShare,
+		DelegatedStake:    delegatedStake,
+		ActivationRound:   tInfo.ActivationRound,
+		DeactivationRound: tInfo.DeactivationRound,
+		Active:            active,
+		Status:            status,
 	}, nil
 }
 

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -204,7 +204,7 @@ func (e *StubClient) TotalSupply() (*big.Int, error)                  { return b
 // Service Registry
 
 func (e *StubClient) SetServiceURI(serviceURI string) (*types.Transaction, error) { return nil, nil }
-func (e *StubClient) GetServiceURI(addr common.Address) (string, error)           { return "", nil }
+func (e *StubClient) GetServiceURI(addr common.Address) (string, error)           { return e.Orch.ServiceURI, nil }
 
 // Staking
 

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -170,6 +170,7 @@ type StubClient struct {
 	PoolSize                     *big.Int
 	ClaimedAmount                *big.Int
 	ClaimedReserveError          error
+	Orch                         *lpTypes.Transcoder
 }
 
 type stubTranscoder struct {
@@ -226,8 +227,10 @@ func (e *StubClient) WithdrawFees() (*types.Transaction, error) { return nil, ni
 func (e *StubClient) ClaimEarnings(endRound *big.Int) error {
 	return nil
 }
-func (e *StubClient) GetTranscoder(addr common.Address) (*lpTypes.Transcoder, error) { return nil, nil }
-func (e *StubClient) GetDelegator(addr common.Address) (*lpTypes.Delegator, error)   { return nil, nil }
+func (e *StubClient) GetTranscoder(addr common.Address) (*lpTypes.Transcoder, error) {
+	return e.Orch, nil
+}
+func (e *StubClient) GetDelegator(addr common.Address) (*lpTypes.Delegator, error) { return nil, nil }
 func (e *StubClient) GetDelegatorUnbondingLock(addr common.Address, unbondingLockId *big.Int) (*lpTypes.UnbondingLock, error) {
 	return nil, nil
 }

--- a/eth/types/contracts.go
+++ b/eth/types/contracts.go
@@ -13,14 +13,16 @@ var (
 )
 
 type Transcoder struct {
-	Address         common.Address
-	ServiceURI      string
-	LastRewardRound *big.Int
-	RewardCut       *big.Int
-	FeeShare        *big.Int
-	DelegatedStake  *big.Int
-	Active          bool
-	Status          string
+	Address           common.Address
+	ServiceURI        string
+	LastRewardRound   *big.Int
+	RewardCut         *big.Int
+	FeeShare          *big.Int
+	DelegatedStake    *big.Int
+	ActivationRound   *big.Int
+	DeactivationRound *big.Int
+	Active            bool
+	Status            string
 }
 
 func ParseTranscoderStatus(s uint8) (string, error) {

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -1,0 +1,146 @@
+package watchers
+
+import (
+	"math"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	"github.com/livepeer/go-livepeer/eth/contracts"
+)
+
+const maxFutureRound = int64(math.MaxInt64)
+
+type OrchestratorWatcher struct {
+	store   orchestratorStore
+	dec     *EventDecoder
+	watcher BlockWatcher
+	lpEth   eth.LivepeerEthClient
+	quit    chan struct{}
+}
+
+func NewOrchestratorWatcher(bondingManagerAddr ethcommon.Address, watcher BlockWatcher, store orchestratorStore, lpEth eth.LivepeerEthClient) (*OrchestratorWatcher, error) {
+	dec, err := NewEventDecoder(bondingManagerAddr, contracts.BondingManagerABI)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OrchestratorWatcher{
+		store:   store,
+		dec:     dec,
+		watcher: watcher,
+		lpEth:   lpEth,
+		quit:    make(chan struct{}),
+	}, nil
+}
+
+// Watch starts the event watching loop
+func (ow *OrchestratorWatcher) Watch() {
+	events := make(chan []*blockwatch.Event, 10)
+	sub := ow.watcher.Subscribe(events)
+	defer sub.Unsubscribe()
+
+	for {
+		select {
+		case <-ow.quit:
+			return
+		case err := <-sub.Err():
+			glog.Error(err)
+		case events := <-events:
+			ow.handleBlockEvents(events)
+		}
+	}
+}
+
+// Stop watching for events
+func (ow *OrchestratorWatcher) Stop() {
+	close(ow.quit)
+}
+
+func (ow *OrchestratorWatcher) handleBlockEvents(events []*blockwatch.Event) {
+	for _, event := range events {
+		for _, log := range event.BlockHeader.Logs {
+			if event.Type == blockwatch.Removed {
+				log.Removed = true
+			}
+			if err := ow.handleLog(log); err != nil {
+				glog.Error(err)
+			}
+		}
+	}
+}
+
+func (ow *OrchestratorWatcher) handleLog(log types.Log) error {
+	eventName, err := ow.dec.FindEventName(log)
+	if err != nil {
+		// Noop if we cannot find the event name
+		return nil
+	}
+
+	switch eventName {
+	case "TranscoderActivated":
+		return ow.handleTranscoderActivated(log)
+	case "TranscoderDeactivated":
+		return ow.handleTranscoderDeactivated(log)
+	default:
+		return nil
+	}
+}
+
+func (ow *OrchestratorWatcher) handleTranscoderActivated(log types.Log) error {
+	var transcoderActivated contracts.BondingManagerTranscoderActivated
+	if err := ow.dec.Decode("TranscoderActivated", log, &transcoderActivated); err != nil {
+		return err
+	}
+
+	if !log.Removed {
+		return ow.store.UpdateOrch(
+			&common.DBOrch{
+				EthereumAddr:      transcoderActivated.Transcoder.String(),
+				ActivationRound:   transcoderActivated.ActivationRound.Int64(),
+				DeactivationRound: maxFutureRound,
+			},
+		)
+	}
+	t, err := ow.lpEth.GetTranscoder(transcoderActivated.Transcoder)
+	if err != nil {
+		return err
+	}
+	return ow.store.UpdateOrch(
+		&common.DBOrch{
+			EthereumAddr:      t.Address.String(),
+			ActivationRound:   t.ActivationRound.Int64(),
+			DeactivationRound: t.DeactivationRound.Int64(),
+		},
+	)
+}
+
+func (ow *OrchestratorWatcher) handleTranscoderDeactivated(log types.Log) error {
+	var transcoderDeactivated contracts.BondingManagerTranscoderDeactivated
+	if err := ow.dec.Decode("TranscoderDeactivated", log, &transcoderDeactivated); err != nil {
+		return err
+	}
+
+	if !log.Removed {
+		return ow.store.UpdateOrch(
+			&common.DBOrch{
+				EthereumAddr:      transcoderDeactivated.Transcoder.String(),
+				DeactivationRound: transcoderDeactivated.DeactivationRound.Int64(),
+			},
+		)
+	}
+	t, err := ow.lpEth.GetTranscoder(transcoderDeactivated.Transcoder)
+	if err != nil {
+		return err
+	}
+	return ow.store.UpdateOrch(
+		&common.DBOrch{
+			EthereumAddr:      t.Address.String(),
+			ActivationRound:   t.ActivationRound.Int64(),
+			DeactivationRound: t.DeactivationRound.Int64(),
+		},
+	)
+}

--- a/eth/watchers/orchestratorwatcher_test.go
+++ b/eth/watchers/orchestratorwatcher_test.go
@@ -1,0 +1,109 @@
+package watchers
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	lpTypes "github.com/livepeer/go-livepeer/eth/types"
+	"github.com/livepeer/go-livepeer/pm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrchWatcher_WatchAndStop(t *testing.T) {
+	assert := assert.New(t)
+	watcher := &stubBlockWatcher{}
+	stubStore := &stubOrchestratorStore{}
+	lpEth := &eth.StubClient{}
+	ow, err := NewOrchestratorWatcher(stubBondingManagerAddr, watcher, stubStore, lpEth)
+	assert.Nil(err)
+
+	go ow.Watch()
+	time.Sleep(2 * time.Millisecond)
+
+	// Test Stop
+	ow.Stop()
+	time.Sleep(2 * time.Millisecond)
+	assert.True(watcher.sub.unsubscribed)
+}
+
+func TestOrchWatcher_HandleLog_TranscoderActivated(t *testing.T) {
+	assert := assert.New(t)
+	watcher := &stubBlockWatcher{}
+	stubStore := &stubOrchestratorStore{}
+	lpEth := &eth.StubClient{
+		Orch: &lpTypes.Transcoder{
+			Address:           pm.RandAddress(),
+			ActivationRound:   big.NewInt(5),
+			DeactivationRound: big.NewInt(100),
+		},
+	}
+	ow, err := NewOrchestratorWatcher(stubBondingManagerAddr, watcher, stubStore, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	header.Logs = append(header.Logs, newStubTranscoderActivatedLog())
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go ow.Watch()
+	defer ow.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	assert.Equal(stubActivationRound.Int64(), stubStore.activationRound)
+	assert.Equal(stubStore.deactivationRound, maxFutureRound)
+	assert.Equal(stubStore.ethereumAddr, stubTranscoder.String())
+
+	blockEvent.Type = blockwatch.Removed
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	assert.Equal(stubStore.activationRound, int64(5))
+	assert.Equal(stubStore.deactivationRound, int64(100))
+	assert.Equal(stubStore.ethereumAddr, lpEth.Orch.Address.String())
+}
+
+func TestOrchWatcher_HandleLog_TranscoderDeactivated(t *testing.T) {
+	assert := assert.New(t)
+	watcher := &stubBlockWatcher{}
+	stubStore := &stubOrchestratorStore{}
+	lpEth := &eth.StubClient{
+		Orch: &lpTypes.Transcoder{
+			Address:           pm.RandAddress(),
+			ActivationRound:   big.NewInt(5),
+			DeactivationRound: big.NewInt(10),
+		},
+	}
+	ow, err := NewOrchestratorWatcher(stubBondingManagerAddr, watcher, stubStore, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	header.Logs = append(header.Logs, newStubTranscoderDeactivatedLog())
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go ow.Watch()
+	defer ow.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	assert.Equal(stubDeactivationRound.Int64(), stubStore.deactivationRound)
+	assert.Equal(stubStore.ethereumAddr, stubTranscoder.String())
+
+	blockEvent.Type = blockwatch.Removed
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	assert.Equal(stubStore.deactivationRound, int64(10))
+	assert.Equal(stubStore.activationRound, int64(5))
+	assert.Equal(stubStore.ethereumAddr, lpEth.Orch.Address.String())
+}

--- a/eth/watchers/serviceRegistryWatcher.go
+++ b/eth/watchers/serviceRegistryWatcher.go
@@ -1,0 +1,111 @@
+package watchers
+
+import (
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	"github.com/livepeer/go-livepeer/eth/contracts"
+)
+
+type ServiceRegistryWatcher struct {
+	store   orchestratorStore
+	dec     *EventDecoder
+	watcher BlockWatcher
+	lpEth   eth.LivepeerEthClient
+	quit    chan struct{}
+}
+
+func NewServiceRegistryWatcher(serviceRegistryAddr ethcommon.Address, watcher BlockWatcher, store orchestratorStore, lpEth eth.LivepeerEthClient) (*ServiceRegistryWatcher, error) {
+	dec, err := NewEventDecoder(serviceRegistryAddr, contracts.ServiceRegistryABI)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServiceRegistryWatcher{
+		store:   store,
+		dec:     dec,
+		watcher: watcher,
+		lpEth:   lpEth,
+		quit:    make(chan struct{}),
+	}, nil
+}
+
+// Watch starts the event watching loop
+func (srw *ServiceRegistryWatcher) Watch() {
+	events := make(chan []*blockwatch.Event, 10)
+	sub := srw.watcher.Subscribe(events)
+	defer sub.Unsubscribe()
+
+	for {
+		select {
+		case <-srw.quit:
+			return
+		case err := <-sub.Err():
+			glog.Error(err)
+		case events := <-events:
+			srw.handleBlockEvents(events)
+		}
+	}
+}
+
+// Stop watching for events
+func (srw *ServiceRegistryWatcher) Stop() {
+	close(srw.quit)
+}
+
+func (srw *ServiceRegistryWatcher) handleBlockEvents(events []*blockwatch.Event) {
+	for _, event := range events {
+		for _, log := range event.BlockHeader.Logs {
+			if event.Type == blockwatch.Removed {
+				log.Removed = true
+			}
+			if err := srw.handleLog(log); err != nil {
+				glog.Error(err)
+			}
+		}
+	}
+}
+
+func (srw *ServiceRegistryWatcher) handleLog(log types.Log) error {
+	eventName, err := srw.dec.FindEventName(log)
+	if err != nil {
+		// Noop if we cannot find the event name
+		return nil
+	}
+
+	switch eventName {
+	case "ServiceURIUpdate":
+		return srw.handleServiceURIUpdate(log)
+	default:
+		return nil
+	}
+}
+
+func (srw *ServiceRegistryWatcher) handleServiceURIUpdate(log types.Log) error {
+	var serviceURIUpdate contracts.ServiceRegistryServiceURIUpdate
+	if err := srw.dec.Decode("ServiceURIUpdate", log, &serviceURIUpdate); err != nil {
+		return err
+	}
+
+	if !log.Removed {
+		return srw.store.UpdateOrch(
+			&common.DBOrch{
+				EthereumAddr: serviceURIUpdate.Addr.String(),
+				ServiceURI:   serviceURIUpdate.ServiceURI,
+			},
+		)
+	}
+	uri, err := srw.lpEth.GetServiceURI(serviceURIUpdate.Addr)
+	if err != nil {
+		return err
+	}
+	return srw.store.UpdateOrch(
+		&common.DBOrch{
+			EthereumAddr: serviceURIUpdate.Addr.String(),
+			ServiceURI:   uri,
+		},
+	)
+}

--- a/eth/watchers/serviceRegistryWatcher_test.go
+++ b/eth/watchers/serviceRegistryWatcher_test.go
@@ -1,0 +1,66 @@
+package watchers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	lpTypes "github.com/livepeer/go-livepeer/eth/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceRegistryWatcher_WatchAndStop(t *testing.T) {
+	assert := assert.New(t)
+	watcher := &stubBlockWatcher{}
+	stubStore := &stubOrchestratorStore{}
+	lpEth := &eth.StubClient{}
+	srw, err := NewServiceRegistryWatcher(stubServiceRegistryAddr, watcher, stubStore, lpEth)
+	assert.Nil(err)
+
+	go srw.Watch()
+	time.Sleep(2 * time.Millisecond)
+
+	// Test Stop
+	srw.Stop()
+	time.Sleep(2 * time.Millisecond)
+	assert.True(watcher.sub.unsubscribed)
+}
+
+func TestServiceRegistryWatcher_HandleLog_HandleServiceURIUpdate(t *testing.T) {
+	assert := assert.New(t)
+	watcher := &stubBlockWatcher{}
+	stubStore := &stubOrchestratorStore{}
+	lpEth := &eth.StubClient{
+		Orch: &lpTypes.Transcoder{
+			Address:    stubTranscoder,
+			ServiceURI: "http://127.0.0.1:1337",
+		},
+	}
+	srw, err := NewServiceRegistryWatcher(stubServiceRegistryAddr, watcher, stubStore, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	header.Logs = append(header.Logs, newStubServiceURIUpdateLog())
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go srw.Watch()
+	defer srw.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	assert.Equal(stubUpdatedServiceURI, stubStore.serviceURI)
+	assert.Equal(stubStore.ethereumAddr, stubTranscoder.String())
+
+	// Test log removed
+	blockEvent.Type = blockwatch.Removed
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	assert.Equal(lpEth.Orch.ServiceURI, stubStore.serviceURI)
+	assert.Equal(lpEth.Orch.Address.String(), stubStore.ethereumAddr)
+}

--- a/eth/watchers/stub.go
+++ b/eth/watchers/stub.go
@@ -3,29 +3,34 @@ package watchers
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
 	"github.com/livepeer/go-livepeer/pm"
 )
 
 var stubSender = pm.RandAddress()
 var stubClaimant = pm.RandAddress()
+var stubTranscoder = pm.RandAddress()
 
-var stubBondingManagerAddr = common.HexToAddress("0x511bc4556d823ae99630ae8de28b9b80df90ea2e")
-var stubRoundsManagerAddr = common.HexToAddress("0xc1F9BB72216E5ecDc97e248F65E14df1fE46600a")
+var stubActivationRound = big.NewInt(99)
+var stubDeactivationRound = big.NewInt(77)
 
-var stubTicketBrokerAddr = common.HexToAddress("0x9d6d492bD500DA5B33cf95A5d610a73360FcaAa0")
+var stubBondingManagerAddr = ethcommon.HexToAddress("0x511bc4556d823ae99630ae8de28b9b80df90ea2e")
+var stubRoundsManagerAddr = ethcommon.HexToAddress("0xc1F9BB72216E5ecDc97e248F65E14df1fE46600a")
+
+var stubTicketBrokerAddr = ethcommon.HexToAddress("0x9d6d492bD500DA5B33cf95A5d610a73360FcaAa0")
 
 func newStubBaseLog() types.Log {
 	return types.Log{
 		BlockNumber: uint64(30),
-		TxHash:      common.HexToHash("0xd9bb5f9e888ee6f74bedcda811c2461230f247c205849d6f83cb6c3925e54586"),
+		TxHash:      ethcommon.HexToHash("0xd9bb5f9e888ee6f74bedcda811c2461230f247c205849d6f83cb6c3925e54586"),
 		TxIndex:     uint(0),
-		BlockHash:   common.HexToHash("0x6bbf9b6e836207ab25379c20e517a89090cbbaf8877746f6ed7fb6820770816b"),
+		BlockHash:   ethcommon.HexToHash("0x6bbf9b6e836207ab25379c20e517a89090cbbaf8877746f6ed7fb6820770816b"),
 		Index:       uint(0),
 		Removed:     false,
 	}
@@ -34,17 +39,17 @@ func newStubBaseLog() types.Log {
 func newStubUnbondLog() types.Log {
 	log := newStubBaseLog()
 	log.Address = stubBondingManagerAddr
-	log.Topics = []common.Hash{
-		common.HexToHash("0x2d5d98d189bee5496a08db2a5948cb7e5e786f09d17d0c3f228eb41776c24a06"),
+	log.Topics = []ethcommon.Hash{
+		ethcommon.HexToHash("0x2d5d98d189bee5496a08db2a5948cb7e5e786f09d17d0c3f228eb41776c24a06"),
 		// delegate = 0x525419FF5707190389bfb5C87c375D710F5fCb0E
-		common.HexToHash("0x000000000000000000000000525419ff5707190389bfb5c87c375d710f5fcb0e"),
+		ethcommon.HexToHash("0x000000000000000000000000525419ff5707190389bfb5c87c375d710f5fcb0e"),
 		// delegator = 0xF75b78571F6563e8Acf1899F682Fb10A9248CCE8
-		common.HexToHash("0x000000000000000000000000f75b78571f6563e8acf1899f682fb10a9248cce8"),
+		ethcommon.HexToHash("0x000000000000000000000000f75b78571f6563e8acf1899f682fb10a9248cce8"),
 	}
 	// unbondingLockId = 1
 	// amount = 11111000000000000000
 	// withdrawRound = 1457
-	log.Data = common.Hex2Bytes("00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000009a3233a1a35d800000000000000000000000000000000000000000000000000000000000000005b1")
+	log.Data = ethcommon.Hex2Bytes("00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000009a3233a1a35d800000000000000000000000000000000000000000000000000000000000000005b1")
 
 	return log
 }
@@ -52,16 +57,16 @@ func newStubUnbondLog() types.Log {
 func newStubRebondLog() types.Log {
 	log := newStubBaseLog()
 	log.Address = stubBondingManagerAddr
-	log.Topics = []common.Hash{
-		common.HexToHash("0x9f5b64cc71e1e26ff178caaa7877a04d8ce66fde989251870e80e6fbee690c17"),
+	log.Topics = []ethcommon.Hash{
+		ethcommon.HexToHash("0x9f5b64cc71e1e26ff178caaa7877a04d8ce66fde989251870e80e6fbee690c17"),
 		// delegate = 0x525419FF5707190389bfb5C87c375D710F5fCb0E
-		common.HexToHash("0x000000000000000000000000525419ff5707190389bfb5c87c375d710f5fcb0e"),
+		ethcommon.HexToHash("0x000000000000000000000000525419ff5707190389bfb5c87c375d710f5fcb0e"),
 		// delegator = 0xF75b78571F6563e8Acf1899F682Fb10A9248CCE8
-		common.HexToHash("0x000000000000000000000000f75b78571f6563e8acf1899f682fb10a9248cce8"),
+		ethcommon.HexToHash("0x000000000000000000000000f75b78571f6563e8acf1899f682fb10a9248cce8"),
 	}
 	// unbondingLockId = 1
 	// amount = 57000000000000000000
-	log.Data = common.Hex2Bytes("00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000031708ae0045440000")
+	log.Data = ethcommon.Hex2Bytes("00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000031708ae0045440000")
 
 	return log
 }
@@ -69,15 +74,15 @@ func newStubRebondLog() types.Log {
 func newStubWithdrawStakeLog() types.Log {
 	log := newStubBaseLog()
 	log.Address = stubBondingManagerAddr
-	log.Topics = []common.Hash{
-		common.HexToHash("0x1340f1a8f3d456a649e1a12071dfa15655e3d09252131d0f980c3b405cc8dd2e"),
+	log.Topics = []ethcommon.Hash{
+		ethcommon.HexToHash("0x1340f1a8f3d456a649e1a12071dfa15655e3d09252131d0f980c3b405cc8dd2e"),
 		// delegator = 0xF75b78571F6563e8Acf1899F682Fb10A9248CCE8
-		common.HexToHash("0x000000000000000000000000f75b78571f6563e8acf1899f682fb10a9248cce8"),
+		ethcommon.HexToHash("0x000000000000000000000000f75b78571f6563e8acf1899f682fb10a9248cce8"),
 	}
 	// unbondingLockId = 1
 	// amount = 7343158980137288000
 	// withdrawRound = 1450
-	log.Data = common.Hex2Bytes("000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000065e8242fcc4d81b100000000000000000000000000000000000000000000000000000000000005aa")
+	log.Data = ethcommon.Hex2Bytes("000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000065e8242fcc4d81b100000000000000000000000000000000000000000000000000000000000005aa")
 
 	return log
 }
@@ -87,8 +92,8 @@ func newStubNewRoundLog() types.Log {
 	log.Address = stubRoundsManagerAddr
 	topic := crypto.Keccak256Hash([]byte("NewRound(uint256,bytes32)"))
 	round := big.NewInt(8)
-	roundBytes := common.BytesToHash(common.LeftPadBytes(round.Bytes(), 32))
-	log.Topics = []common.Hash{topic, roundBytes}
+	roundBytes := ethcommon.BytesToHash(ethcommon.LeftPadBytes(round.Bytes(), 32))
+	log.Topics = []ethcommon.Hash{topic, roundBytes}
 	log.Data, _ = hexutil.Decode("0x15063b24c3dfd390370cd13eaf27fd0b079c60f31bf1414c574f865e906a8964")
 	return log
 }
@@ -97,11 +102,11 @@ func newStubDepositFundedLog() types.Log {
 	log := newStubBaseLog()
 	log.Address = stubTicketBrokerAddr
 	amount, _ := new(big.Int).SetString("5000000000000000000", 10)
-	amountData := common.LeftPadBytes(amount.Bytes(), 32)
-	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
-	var senderTopic common.Hash
+	amountData := ethcommon.LeftPadBytes(amount.Bytes(), 32)
+	sender := ethcommon.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic ethcommon.Hash
 	copy(senderTopic[:], sender[:])
-	log.Topics = []common.Hash{
+	log.Topics = []ethcommon.Hash{
 		crypto.Keccak256Hash([]byte("DepositFunded(address,uint256)")),
 		senderTopic,
 	}
@@ -113,11 +118,11 @@ func newStubReserveFundedLog() types.Log {
 	log := newStubBaseLog()
 	log.Address = stubTicketBrokerAddr
 	amount, _ := new(big.Int).SetString("5000000000000000000", 10)
-	amountData := common.LeftPadBytes(amount.Bytes(), 32)
-	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
-	var senderTopic common.Hash
+	amountData := ethcommon.LeftPadBytes(amount.Bytes(), 32)
+	sender := ethcommon.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic ethcommon.Hash
 	copy(senderTopic[:], sender[:])
-	log.Topics = []common.Hash{
+	log.Topics = []ethcommon.Hash{
 		crypto.Keccak256Hash([]byte("ReserveFunded(address,uint256)")),
 		senderTopic,
 	}
@@ -128,18 +133,18 @@ func newStubReserveFundedLog() types.Log {
 func newStubWithdrawalLog() types.Log {
 	log := newStubBaseLog()
 	log.Address = stubTicketBrokerAddr
-	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
-	var senderTopic common.Hash
+	sender := ethcommon.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic ethcommon.Hash
 	copy(senderTopic[:], sender[:])
-	log.Topics = []common.Hash{
+	log.Topics = []ethcommon.Hash{
 		crypto.Keccak256Hash([]byte("Withdrawal(address,uint256,uint256)")),
 		senderTopic,
 	}
 
 	deposit, _ := new(big.Int).SetString("5000000000000000000", 10)
 	reserve, _ := new(big.Int).SetString("1000000000000000000", 10)
-	depositData := common.LeftPadBytes(deposit.Bytes(), 32)
-	reserveData := common.LeftPadBytes(reserve.Bytes(), 32)
+	depositData := ethcommon.LeftPadBytes(deposit.Bytes(), 32)
+	reserveData := ethcommon.LeftPadBytes(reserve.Bytes(), 32)
 	var data []byte
 	data = append(data, depositData...)
 	data = append(data, reserveData...)
@@ -150,19 +155,19 @@ func newStubWithdrawalLog() types.Log {
 func newStubWinningTicketLog() types.Log {
 	log := newStubBaseLog()
 	log.Address = stubTicketBrokerAddr
-	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
+	sender := ethcommon.LeftPadBytes(stubSender.Bytes(), 32)
 	var senderTopic [32]byte
 	copy(senderTopic[:], sender[:])
-	recipient := common.LeftPadBytes(stubClaimant.Bytes(), 32)
+	recipient := ethcommon.LeftPadBytes(stubClaimant.Bytes(), 32)
 	var recipientTopic [32]byte
 	copy(recipientTopic[:], recipient[:])
-	log.Topics = []common.Hash{
+	log.Topics = []ethcommon.Hash{
 		crypto.Keccak256Hash([]byte("WinningTicketTransfer(address,address,uint256)")),
 		senderTopic,
 		recipientTopic,
 	}
 	amount, _ := new(big.Int).SetString("200000000000", 10)
-	amountData := common.LeftPadBytes(amount.Bytes(), 32)
+	amountData := ethcommon.LeftPadBytes(amount.Bytes(), 32)
 	log.Data = amountData
 	return log
 }
@@ -170,16 +175,16 @@ func newStubWinningTicketLog() types.Log {
 func newStubUnlockLog() types.Log {
 	log := newStubBaseLog()
 	log.Address = stubTicketBrokerAddr
-	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
-	var senderTopic common.Hash
+	sender := ethcommon.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic ethcommon.Hash
 	copy(senderTopic[:], sender[:])
-	log.Topics = []common.Hash{
+	log.Topics = []ethcommon.Hash{
 		crypto.Keccak256Hash([]byte("Unlock(address,uint256,uint256)")),
 		senderTopic,
 	}
 	var data []byte
-	data = append(data, common.LeftPadBytes(big.NewInt(100).Bytes(), 32)...)
-	data = append(data, common.LeftPadBytes(big.NewInt(150).Bytes(), 32)...)
+	data = append(data, ethcommon.LeftPadBytes(big.NewInt(100).Bytes(), 32)...)
+	data = append(data, ethcommon.LeftPadBytes(big.NewInt(150).Bytes(), 32)...)
 	log.Data = data
 	return log
 }
@@ -187,14 +192,42 @@ func newStubUnlockLog() types.Log {
 func newStubUnlockCancelledLog() types.Log {
 	log := newStubBaseLog()
 	log.Address = stubTicketBrokerAddr
-	sender := common.LeftPadBytes(stubSender.Bytes(), 32)
-	var senderTopic common.Hash
+	sender := ethcommon.LeftPadBytes(stubSender.Bytes(), 32)
+	var senderTopic ethcommon.Hash
 	copy(senderTopic[:], sender[:])
-	log.Topics = []common.Hash{
+	log.Topics = []ethcommon.Hash{
 		crypto.Keccak256Hash([]byte("UnlockCancelled(address)")),
 		senderTopic,
 	}
 	log.Data = []byte{}
+	return log
+}
+
+func newStubTranscoderActivatedLog() types.Log {
+	log := newStubBaseLog()
+	log.Address = stubBondingManagerAddr
+	transcoder := ethcommon.LeftPadBytes(stubTranscoder.Bytes(), 32)
+	var transcoderTopic ethcommon.Hash
+	copy(transcoderTopic[:], transcoder[:])
+	log.Topics = []ethcommon.Hash{
+		crypto.Keccak256Hash([]byte("TranscoderActivated(address,uint256)")),
+		transcoderTopic,
+	}
+	log.Data = ethcommon.LeftPadBytes(stubActivationRound.Bytes(), 32)
+	return log
+}
+
+func newStubTranscoderDeactivatedLog() types.Log {
+	log := newStubBaseLog()
+	log.Address = stubBondingManagerAddr
+	transcoder := ethcommon.LeftPadBytes(stubTranscoder.Bytes(), 32)
+	var transcoderTopic ethcommon.Hash
+	copy(transcoderTopic[:], transcoder[:])
+	log.Topics = []ethcommon.Hash{
+		crypto.Keccak256Hash([]byte("TranscoderDeactivated(address,uint256)")),
+		transcoderTopic,
+	}
+	log.Data = ethcommon.LeftPadBytes(stubDeactivationRound.Bytes(), 32)
 	return log
 }
 
@@ -223,7 +256,7 @@ func (bw *stubBlockWatcher) Subscribe(sink chan<- []*blockwatch.Event) event.Sub
 }
 
 type stubUnbondingLock struct {
-	Delegator     common.Address
+	Delegator     ethcommon.Address
 	Amount        *big.Int
 	WithdrawRound *big.Int
 	UsedBlock     *big.Int
@@ -242,7 +275,7 @@ func newStubUnbondingLockStore() *stubUnbondingLockStore {
 	}
 }
 
-func (s *stubUnbondingLockStore) InsertUnbondingLock(id *big.Int, delegator common.Address, amount, withdrawRound *big.Int) error {
+func (s *stubUnbondingLockStore) InsertUnbondingLock(id *big.Int, delegator ethcommon.Address, amount, withdrawRound *big.Int) error {
 	if s.insertErr != nil {
 		return s.insertErr
 	}
@@ -256,7 +289,7 @@ func (s *stubUnbondingLockStore) InsertUnbondingLock(id *big.Int, delegator comm
 	return nil
 }
 
-func (s *stubUnbondingLockStore) DeleteUnbondingLock(id *big.Int, delegator common.Address) error {
+func (s *stubUnbondingLockStore) DeleteUnbondingLock(id *big.Int, delegator ethcommon.Address) error {
 	if s.deleteErr != nil {
 		return s.deleteErr
 	}
@@ -266,7 +299,7 @@ func (s *stubUnbondingLockStore) DeleteUnbondingLock(id *big.Int, delegator comm
 	return nil
 }
 
-func (s *stubUnbondingLockStore) UseUnbondingLock(id *big.Int, delegator common.Address, usedBlock *big.Int) error {
+func (s *stubUnbondingLockStore) UseUnbondingLock(id *big.Int, delegator ethcommon.Address, usedBlock *big.Int) error {
 	if s.useErr != nil {
 		return s.useErr
 	}
@@ -287,7 +320,7 @@ func defaultMiniHeader() *blockwatch.MiniHeader {
 		Hash:   pm.RandHash(),
 	}
 	log := types.Log{
-		Topics:    []common.Hash{pm.RandHash(), pm.RandHash()},
+		Topics:    []ethcommon.Hash{pm.RandHash(), pm.RandHash()},
 		Data:      pm.RandBytes(32),
 		BlockHash: block.Hash,
 	}
@@ -304,4 +337,17 @@ func (rw *stubRoundsWatcher) Subscribe(sink chan<- types.Log) event.Subscription
 	rw.sink = sink
 	rw.sub = &stubSubscription{errCh: make(<-chan error)}
 	return rw.sub
+}
+
+type stubOrchestratorStore struct {
+	activationRound   int64
+	deactivationRound int64
+	ethereumAddr      string
+}
+
+func (s *stubOrchestratorStore) UpdateOrch(orch *common.DBOrch) error {
+	s.activationRound = orch.ActivationRound
+	s.deactivationRound = orch.DeactivationRound
+	s.ethereumAddr = orch.EthereumAddr
+	return nil
 }

--- a/eth/watchers/topics.go
+++ b/eth/watchers/topics.go
@@ -19,6 +19,7 @@ var eventSignatures = []string{
 	"UnlockCancelled(address)",
 	"TranscoderActivated(address,uint256)",
 	"TranscoderDeactivated(address,uint256)",
+	"ServiceURIUpdate(address,string)",
 }
 
 // FilterTopics returns a list of topics to be used when filtering logs

--- a/eth/watchers/topics.go
+++ b/eth/watchers/topics.go
@@ -17,6 +17,8 @@ var eventSignatures = []string{
 	"ReserveFrozen(address,address,uint256,uint256)",
 	"Unlock(address,uint256,uint256)",
 	"UnlockCancelled(address)",
+	"TranscoderActivated(address,uint256)",
+	"TranscoderDeactivated(address,uint256)",
 }
 
 // FilterTopics returns a list of topics to be used when filtering logs

--- a/eth/watchers/types.go
+++ b/eth/watchers/types.go
@@ -3,6 +3,7 @@ package watchers
 import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
 )
 
@@ -12,4 +13,8 @@ type BlockWatcher interface {
 
 type EventWatcher interface {
 	Subscribe(sink chan<- types.Log) event.Subscription
+}
+
+type orchestratorStore interface {
+	UpdateOrch(*common.DBOrch) error
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
 This PR makes the necessary updates to `common/db` for tracking updates to the active orchestrator set. Primarily it adds `activationRound` and `deactivationRound` columns to the `orchestrators` table and allows for a `currentRound` filter to be passed in to the orchestrator selection query. 

**Specific updates (required)**
- Added `activationRound` and `deactivationRound` columns to the `orchestrators` table
- Added a `currentRound` filter to `DBOrchFilter`
- Changed `updateOrch` query to use `UPSERT` instead of `INSERT OR REPLACE` , the idea behind this is that we don't have to fetch the entire `DBOrch` for an object when updating single fields in event watchers (serviceURI, activation/deactivation rounds)
- Added a filter to `selectOrchs` that filters for active orchestrators whenever `DBOrchFilter.CurrentRound` is defined
- Updated `NewDBOrch` to return a `DBOrch` instance with all values initiated
- Extracted generating the filter part of `selectOrch` query into a seperate helper that can be re-used for the `OrchCount` query
- Changed some tests in discovery to use the same underlying type when using `assert.Contains`

**How did you test each of these updates (required)**
Ran unit tests


**Does this pull request close any open issues?**
Fixes #1152 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
