### PR TITLE
server: Add manifestID to more log lines.

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -245,7 +245,7 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) error {
 	mid := cxn.mid
 	vProfile := cxn.profile
 
-	glog.V(common.DEBUG).Infof("Processing segment nonce=%d seqNo=%d", nonce, seg.SeqNo)
+	glog.V(common.DEBUG).Infof("Processing segment nonce=%d manifestID=%s seqNo=%d dur=%v", nonce, mid, seg.SeqNo, seg.Duration)
 	if monitor.Enabled {
 		monitor.SegmentEmerged(nonce, seg.SeqNo, len(BroadcastJobVideoProfiles))
 	}
@@ -294,7 +294,7 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string) 
 		if monitor.Enabled {
 			monitor.SegmentTranscodeFailed(monitor.SegmentTranscodeErrorNoOrchestrators, nonce, seg.SeqNo, errNoOrchs, true)
 		}
-		glog.Infof("No sessions available for segment nonce=%d seqNo=%d", nonce, seg.SeqNo)
+		glog.Infof("No sessions available for segment nonce=%d manifestID=%s seqNo=%d", nonce, cxn.mid, seg.SeqNo)
 		// We may want to introduce a "non-retryable" error type here
 		// would help error propagation for live ingest.
 		// similar to the orchestrator's RemoteTranscoderFatalError
@@ -322,7 +322,7 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string) 
 		}
 
 		// send segment to the orchestrator
-		glog.V(common.DEBUG).Infof("Submitting segment nonce=%d seqNo=%d orch=%s", nonce, seg.SeqNo, sess.OrchestratorInfo.Transcoder)
+		glog.V(common.DEBUG).Infof("Submitting segment nonce=%d manifestID=%s seqNo=%d orch=%s", nonce, cxn.mid, seg.SeqNo, sess.OrchestratorInfo.Transcoder)
 
 		res, err := SubmitSegment(sess, seg, nonce)
 		if err != nil || res == nil {

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -162,7 +162,7 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 	// construct the response
 	var result net.TranscodeResult
 	if err != nil {
-		glog.Errorf("Could not transcode seqNo=%d mid=%s err=%v", segData.Seq, segData.ManifestID, err)
+		glog.Errorf("Could not transcode manifestID=%s seqNo=%d err=%v", segData.ManifestID, segData.Seq, err)
 		result = net.TranscodeResult{Result: &net.TranscodeResult_Error{Error: err.Error()}}
 	} else {
 		result = net.TranscodeResult{Result: &net.TranscodeResult_Data{
@@ -378,7 +378,7 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 	switch res := tr.Result.(type) {
 	case *net.TranscodeResult_Error:
 		err = fmt.Errorf(res.Error)
-		glog.Errorf("Transcode failed for segment nonce=%d seqNo=%d: %v", nonce, seg.SeqNo, err)
+		glog.Errorf("Transcode failed for segment nonce=%d manifestID=%s seqNo=%d:%v", nonce, sess.ManifestID, seg.SeqNo, err)
 		if err.Error() == "MediaStats Failure" {
 			glog.Info("Ensure the keyframe interval is 4 seconds or less")
 		}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Add manifestID to more log lines. Helps with log analysis / grep.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds the `manifestID=` to more log lines
- Makes use of `manifestID` more consistent in a few places (eg, rather than `mid=`)
- Adds a duration value `dur=` to one place that I've found useful in the past (loglevel debug)

**How did you test each of these updates (required)**
Manually
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
