### PR TITLE
cmd, eth/watchers: ServiceRegistry event watcher

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -417,6 +417,14 @@ func main() {
 		go orchWatcher.Watch()
 		defer orchWatcher.Stop()
 
+		serviceRegistryWatcher, err := watchers.NewServiceRegistryWatcher(addrMap["ServiceRegistry"], blockWatcher, dbh, n.Eth)
+		if err != nil {
+			glog.Errorf("Failed to set up service registry watcher: %v", err)
+			return
+		}
+		go serviceRegistryWatcher.Watch()
+		defer serviceRegistryWatcher.Stop()
+
 		blockWatchCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -204,7 +204,7 @@ func (e *StubClient) TotalSupply() (*big.Int, error)                  { return b
 // Service Registry
 
 func (e *StubClient) SetServiceURI(serviceURI string) (*types.Transaction, error) { return nil, nil }
-func (e *StubClient) GetServiceURI(addr common.Address) (string, error)           { return "", nil }
+func (e *StubClient) GetServiceURI(addr common.Address) (string, error)           { return e.Orch.ServiceURI, nil }
 
 // Staking
 

--- a/eth/watchers/serviceRegistryWatcher.go
+++ b/eth/watchers/serviceRegistryWatcher.go
@@ -1,0 +1,111 @@
+package watchers
+
+import (
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	"github.com/livepeer/go-livepeer/eth/contracts"
+)
+
+type ServiceRegistryWatcher struct {
+	store   orchestratorStore
+	dec     *EventDecoder
+	watcher BlockWatcher
+	lpEth   eth.LivepeerEthClient
+	quit    chan struct{}
+}
+
+func NewServiceRegistryWatcher(serviceRegistryAddr ethcommon.Address, watcher BlockWatcher, store orchestratorStore, lpEth eth.LivepeerEthClient) (*ServiceRegistryWatcher, error) {
+	dec, err := NewEventDecoder(serviceRegistryAddr, contracts.ServiceRegistryABI)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ServiceRegistryWatcher{
+		store:   store,
+		dec:     dec,
+		watcher: watcher,
+		lpEth:   lpEth,
+		quit:    make(chan struct{}),
+	}, nil
+}
+
+// Watch starts the event watching loop
+func (srw *ServiceRegistryWatcher) Watch() {
+	events := make(chan []*blockwatch.Event, 10)
+	sub := srw.watcher.Subscribe(events)
+	defer sub.Unsubscribe()
+
+	for {
+		select {
+		case <-srw.quit:
+			return
+		case err := <-sub.Err():
+			glog.Error(err)
+		case events := <-events:
+			srw.handleBlockEvents(events)
+		}
+	}
+}
+
+// Stop watching for events
+func (srw *ServiceRegistryWatcher) Stop() {
+	close(srw.quit)
+}
+
+func (srw *ServiceRegistryWatcher) handleBlockEvents(events []*blockwatch.Event) {
+	for _, event := range events {
+		for _, log := range event.BlockHeader.Logs {
+			if event.Type == blockwatch.Removed {
+				log.Removed = true
+			}
+			if err := srw.handleLog(log); err != nil {
+				glog.Error(err)
+			}
+		}
+	}
+}
+
+func (srw *ServiceRegistryWatcher) handleLog(log types.Log) error {
+	eventName, err := srw.dec.FindEventName(log)
+	if err != nil {
+		// Noop if we cannot find the event name
+		return nil
+	}
+
+	switch eventName {
+	case "ServiceURIUpdate":
+		return srw.handleServiceURIUpdate(log)
+	default:
+		return nil
+	}
+}
+
+func (srw *ServiceRegistryWatcher) handleServiceURIUpdate(log types.Log) error {
+	var serviceURIUpdate contracts.ServiceRegistryServiceURIUpdate
+	if err := srw.dec.Decode("ServiceURIUpdate", log, &serviceURIUpdate); err != nil {
+		return err
+	}
+
+	if !log.Removed {
+		return srw.store.UpdateOrch(
+			&common.DBOrch{
+				EthereumAddr: serviceURIUpdate.Addr.String(),
+				ServiceURI:   serviceURIUpdate.ServiceURI,
+			},
+		)
+	}
+	uri, err := srw.lpEth.GetServiceURI(serviceURIUpdate.Addr)
+	if err != nil {
+		return err
+	}
+	return srw.store.UpdateOrch(
+		&common.DBOrch{
+			EthereumAddr: serviceURIUpdate.Addr.String(),
+			ServiceURI:   uri,
+		},
+	)
+}

--- a/eth/watchers/serviceRegistryWatcher_test.go
+++ b/eth/watchers/serviceRegistryWatcher_test.go
@@ -1,0 +1,66 @@
+package watchers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/livepeer/go-livepeer/eth"
+	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	lpTypes "github.com/livepeer/go-livepeer/eth/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceRegistryWatcher_WatchAndStop(t *testing.T) {
+	assert := assert.New(t)
+	watcher := &stubBlockWatcher{}
+	stubStore := &stubOrchestratorStore{}
+	lpEth := &eth.StubClient{}
+	srw, err := NewServiceRegistryWatcher(stubServiceRegistryAddr, watcher, stubStore, lpEth)
+	assert.Nil(err)
+
+	go srw.Watch()
+	time.Sleep(2 * time.Millisecond)
+
+	// Test Stop
+	srw.Stop()
+	time.Sleep(2 * time.Millisecond)
+	assert.True(watcher.sub.unsubscribed)
+}
+
+func TestServiceRegistryWatcher_HandleLog_HandleServiceURIUpdate(t *testing.T) {
+	assert := assert.New(t)
+	watcher := &stubBlockWatcher{}
+	stubStore := &stubOrchestratorStore{}
+	lpEth := &eth.StubClient{
+		Orch: &lpTypes.Transcoder{
+			Address:    stubTranscoder,
+			ServiceURI: "http://127.0.0.1:1337",
+		},
+	}
+	srw, err := NewServiceRegistryWatcher(stubServiceRegistryAddr, watcher, stubStore, lpEth)
+	assert.Nil(err)
+
+	header := defaultMiniHeader()
+	header.Logs = append(header.Logs, newStubServiceURIUpdateLog())
+
+	blockEvent := &blockwatch.Event{
+		Type:        blockwatch.Added,
+		BlockHeader: header,
+	}
+
+	go srw.Watch()
+	defer srw.Stop()
+	time.Sleep(2 * time.Millisecond)
+
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	assert.Equal(stubUpdatedServiceURI, stubStore.serviceURI)
+	assert.Equal(stubStore.ethereumAddr, stubTranscoder.String())
+
+	// Test log removed
+	blockEvent.Type = blockwatch.Removed
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	assert.Equal(lpEth.Orch.ServiceURI, stubStore.serviceURI)
+	assert.Equal(lpEth.Orch.Address.String(), stubStore.ethereumAddr)
+}

--- a/eth/watchers/topics.go
+++ b/eth/watchers/topics.go
@@ -19,6 +19,7 @@ var eventSignatures = []string{
 	"UnlockCancelled(address)",
 	"TranscoderActivated(address,uint256)",
 	"TranscoderDeactivated(address,uint256)",
+	"ServiceURIUpdate(address,string)",
 }
 
 // FilterTopics returns a list of topics to be used when filtering logs


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds an event watcher that watches the `ServiceRegistry` contract for emitted `ServiceURIUpdate` events and updates orchestrators in the database accordingly.

**Specific updates (required)**
- Added a `ServiceRegistryWatcher` type and start it when the node starts
- Added `ServiceURIUpdate` event to `eth/watchers/topics.go`
- Added a method to generate stubbed out serviceURI update events
- Change the stub eth client method `GetServiceURI` to return a stubbed out value

**How did you test each of these updates (required)**
ran unit tests

**Does this pull request close any open issues?**
Fixes #1151 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
