### PR TITLE
cmd, common, discovery, eth, net: orchestrator pool active set tracking

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -288,8 +288,6 @@ func main() {
 
 	watcherErr := make(chan error)
 	var roundsWatcher *watchers.RoundsWatcher
-	var originalLastSeenBlock *big.Int
-	var currentRoundStartBlock *big.Int
 	if *network == "offchain" {
 		glog.Infof("***Livepeer is in off-chain mode***")
 
@@ -370,12 +368,12 @@ func main() {
 		topics := watchers.FilterTopics()
 
 		// Determine backfilling start block
-		originalLastSeenBlock, err = dbh.LastSeenBlock()
+		originalLastSeenBlock, err := dbh.LastSeenBlock()
 		if err != nil {
 			glog.Errorf("db: failed to retrieve latest retained block: %v", err)
 			return
 		}
-		currentRoundStartBlock, err = client.CurrentRoundStartBlock()
+		currentRoundStartBlock, err := client.CurrentRoundStartBlock()
 		if err != nil {
 			glog.Errorf("eth: failed to retrieve current round start block: %v", err)
 			return

--- a/common/types.go
+++ b/common/types.go
@@ -14,6 +14,6 @@ type Broadcaster interface {
 
 type OrchestratorPool interface {
 	GetURLs() []*url.URL
-	GetOrchestrators(int, Broadcaster) ([]*net.OrchestratorInfo, error)
+	GetOrchestrators(int) ([]*net.OrchestratorInfo, error)
 	Size() int
 }

--- a/common/types.go
+++ b/common/types.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"net/url"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/livepeer/go-livepeer/net"
+)
+
+type Broadcaster interface {
+	Address() ethcommon.Address
+	Sign([]byte) ([]byte, error)
+}
+
+type OrchestratorPool interface {
+	GetURLs() []*url.URL
+	GetOrchestrators(int, Broadcaster) ([]*net.OrchestratorInfo, error)
+	Size() int
+}

--- a/common/types.go
+++ b/common/types.go
@@ -17,3 +17,9 @@ type OrchestratorPool interface {
 	GetOrchestrators(int) ([]*net.OrchestratorInfo, error)
 	Size() int
 }
+
+type OrchestratorStore interface {
+	OrchCount(filter *DBOrchFilter) (int, error)
+	SelectOrchs(filter *DBOrchFilter) ([]*DBOrch, error)
+	UpdateOrch(orch *DBOrch) error
+}

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/eth"
-	"github.com/livepeer/go-livepeer/net"
 )
 
 var ErrTranscoderAvail = errors.New("ErrTranscoderUnavailable")
@@ -56,7 +55,7 @@ type LivepeerNode struct {
 	// Transcoder public fields
 	SegmentChans      map[ManifestID]SegmentChan
 	Recipient         pm.Recipient
-	OrchestratorPool  net.OrchestratorPool
+	OrchestratorPool  common.OrchestratorPool
 	OrchSecret        string
 	Transcoder        Transcoder
 	TranscoderManager *RemoteTranscoderManager

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -6,11 +6,11 @@ import (
 	"math/big"
 	"net/url"
 	"strings"
-	"time"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/eth"
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/pm"
@@ -19,38 +19,59 @@ import (
 	"github.com/golang/glog"
 )
 
-var cacheRefreshInterval = 1 * time.Hour
-var getTicker = func() *time.Ticker {
-	return time.NewTicker(cacheRefreshInterval)
+type ticketParamsValidator interface {
+	ValidateTicketParams(ticketParams *pm.TicketParams) error
+}
+
+type roundsManager interface {
+	LastInitializedRound() *big.Int
+}
+
+type orchestratorStore interface {
+	OrchCount(filter *common.DBOrchFilter) (int, error)
+	SelectOrchs(filter *common.DBOrchFilter) ([]*common.DBOrch, error)
+	UpdateOrch(orch *common.DBOrch) error
 }
 
 type DBOrchestratorPoolCache struct {
-	node *core.LivepeerNode
+	store                 orchestratorStore
+	lpEth                 eth.LivepeerEthClient
+	ticketParamsValidator ticketParamsValidator
+	rm                    roundsManager
+	bcast                 common.Broadcaster
 }
 
-func NewDBOrchestratorPoolCache(node *core.LivepeerNode) *DBOrchestratorPoolCache {
+func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm roundsManager) (*DBOrchestratorPoolCache, error) {
 	if node.Eth == nil {
-		glog.Error("Could not refresh DB list of orchestrators: LivepeerNode nil")
-		return nil
+		return nil, fmt.Errorf("could not create DBOrchestratorPoolCache: LivepeerEthClient is nil")
 	}
 
-	_ = cacheRegisteredTranscoders(node)
+	dbo := &DBOrchestratorPoolCache{
+		store:                 node.Database,
+		lpEth:                 node.Eth,
+		ticketParamsValidator: node.Sender,
+		rm:                    rm,
+		bcast:                 core.NewBroadcaster(node),
+	}
 
-	ticker := getTicker()
-	go func(node *core.LivepeerNode) {
-		for _ = range ticker.C {
-			err := cacheRegisteredTranscoders(node)
-			if err != nil {
-				continue
-			}
-		}
-	}(node)
+	if err := dbo.cacheTranscoderPool(); err != nil {
+		return nil, err
+	}
 
-	return &DBOrchestratorPoolCache{node: node}
+	if err := dbo.pollOrchestratorInfo(ctx); err != nil {
+		return nil, err
+	}
+
+	return dbo, nil
 }
 
 func (dbo *DBOrchestratorPoolCache) getURLs() ([]*url.URL, error) {
-	orchs, err := dbo.node.Database.SelectOrchs(&common.DBOrchFilter{MaxPrice: server.BroadcastCfg.MaxPrice()})
+	orchs, err := dbo.store.SelectOrchs(
+		&common.DBOrchFilter{
+			MaxPrice:     server.BroadcastCfg.MaxPrice(),
+			CurrentRound: dbo.rm.LastInitializedRound(),
+		},
+	)
 	if err != nil || len(orchs) <= 0 {
 		return nil, err
 	}
@@ -76,12 +97,12 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int) ([]*n
 	}
 
 	pred := func(info *net.OrchestratorInfo) bool {
-		if dbo.node.Sender != nil {
-			if err := dbo.node.Sender.ValidateTicketParams(pmTicketParams(info.TicketParams)); err != nil {
-				return false
-			}
+
+		if err := dbo.ticketParamsValidator.ValidateTicketParams(pmTicketParams(info.TicketParams)); err != nil {
+			return false
 		}
 
+		// check if O's price is below B's max price
 		price := server.BroadcastCfg.MaxPrice()
 		if price != nil {
 			return big.NewRat(info.PriceInfo.PricePerUnit, info.PriceInfo.PixelsPerUnit).Cmp(price) <= 0
@@ -89,7 +110,7 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int) ([]*n
 		return true
 	}
 
-	orchPool := NewOrchestratorPoolWithPred(dbo.node, uris, pred)
+	orchPool := NewOrchestratorPoolWithPred(dbo.bcast, uris, pred)
 
 	orchInfos, err := orchPool.GetOrchestrators(numOrchestrators)
 	if err != nil || len(orchInfos) <= 0 {
@@ -100,29 +121,59 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int) ([]*n
 }
 
 func (dbo *DBOrchestratorPoolCache) Size() int {
-	return len(dbo.GetURLs())
+	count, _ := dbo.store.OrchCount(
+		&common.DBOrchFilter{
+			MaxPrice: server.BroadcastCfg.MaxPrice(),
+		},
+	)
+	return count
 }
 
-func cacheRegisteredTranscoders(node *core.LivepeerNode) error {
-	orchestrators, err := node.Eth.RegisteredTranscoders()
+func (dbo *DBOrchestratorPoolCache) cacheTranscoderPool() error {
+	orchestrators, err := dbo.lpEth.TranscoderPool()
 	if err != nil {
-		glog.Error("Could not refresh DB list of orchestrators: ", err)
-		return err
+		return fmt.Errorf("Could not refresh DB list of orchestrators: %v", err)
 	}
-	_, dbOrchErr := cacheDBOrchs(node, orchestrators)
-	if dbOrchErr != nil {
-		glog.Error("Could not refresh DB list of orchestrators: cacheDBOrchs err")
-		return err
+
+	for _, o := range orchestrators {
+		if err := dbo.store.UpdateOrch(ethOrchToDBOrch(o)); err != nil {
+			glog.Errorf("Unable to update orchestrator %v in DB: %v", o.Address.Hex(), err)
+		}
 	}
 
 	return nil
 }
 
-func cacheDBOrchs(node *core.LivepeerNode, orchs []*lpTypes.Transcoder) ([]*common.DBOrch, error) {
-	var dbOrchs []*common.DBOrch
-	if orchs == nil {
-		glog.Error("No new DB orchestrators created: no orchestrators found onchain")
-		return dbOrchs, nil
+func (dbo *DBOrchestratorPoolCache) pollOrchestratorInfo(ctx context.Context) error {
+	if err := dbo.cacheDBOrchs(); err != nil {
+		return err
+	}
+
+	ticker := getTicker()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if err := dbo.cacheDBOrchs(); err != nil {
+					glog.Errorf("unable to poll orchestrator info: %v", err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (dbo *DBOrchestratorPoolCache) cacheDBOrchs() error {
+	orchs, err := dbo.store.SelectOrchs(
+		&common.DBOrchFilter{
+			CurrentRound: dbo.rm.LastInitializedRound(),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("could not retrieve orchestrators from DB: %v", err)
 	}
 
 	resc, errc := make(chan *common.DBOrch), make(chan error)
@@ -135,7 +186,7 @@ func cacheDBOrchs(node *core.LivepeerNode, orchs []*lpTypes.Transcoder) ([]*comm
 			errc <- err
 			return
 		}
-		info, err := serverGetOrchInfo(ctx, core.NewBroadcaster(node), uri)
+		info, err := serverGetOrchInfo(ctx, dbo.bcast, uri)
 		if err != nil {
 			errc <- err
 			return
@@ -164,7 +215,7 @@ func cacheDBOrchs(node *core.LivepeerNode, orchs []*lpTypes.Transcoder) ([]*comm
 	for i := 0; i < numOrchs; i++ {
 		select {
 		case res := <-resc:
-			if err := node.Database.UpdateOrch(res); err != nil {
+			if err := dbo.store.UpdateOrch(res); err != nil {
 				glog.Error("Error updating Orchestrator in DB: ", err)
 			}
 			returnDBOrchs = append(returnDBOrchs, res)
@@ -175,7 +226,8 @@ func cacheDBOrchs(node *core.LivepeerNode, orchs []*lpTypes.Transcoder) ([]*comm
 			break
 		}
 	}
-	return returnDBOrchs, nil
+
+	return nil
 }
 
 func parseURI(addr string) (*url.URL, error) {
@@ -193,9 +245,12 @@ func ethOrchToDBOrch(orch *lpTypes.Transcoder) *common.DBOrch {
 	if orch == nil {
 		return nil
 	}
+
 	return &common.DBOrch{
-		ServiceURI:   orch.ServiceURI,
-		EthereumAddr: orch.Address.String(),
+		ServiceURI:        orch.ServiceURI,
+		EthereumAddr:      orch.Address.String(),
+		ActivationRound:   orch.ActivationRound.Int64(),
+		DeactivationRound: orch.DeactivationRound.Int64(),
 	}
 }
 

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -595,6 +595,7 @@ func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
 			PriceInfo:  expPriceInfo,
 		}, nil
 	}
+
 	addresses := []string{}
 	for i := 0; i < 50; i++ {
 		addresses = append(addresses, "https://127.0.0.1:"+strconv.Itoa(8936+i))
@@ -965,8 +966,6 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 		return &net.OrchestratorInfo{Transcoder: "transcoder"}, nil
 	}
 
-	// mock livepeer node
-	node, _ := core.NewLivepeerNode(nil, "", nil)
 	perm = func(len int) []int { return rand.Perm(3) }
 
 	// assert created webhook pool is correct length

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1078,13 +1078,3 @@ func TestDeserializeWebhookJSON(t *testing.T) {
 	assert.Contains(err.Error(), "cannot unmarshal number")
 	assert.Empty(urls)
 }
-
-type orchTest struct {
-	EthereumAddr  string
-	ServiceURI    string
-	PricePerPixel int64
-}
-
-func toOrchTest(addr, serviceURI string, pricePerPixel int64) orchTest {
-	return orchTest{EthereumAddr: addr, ServiceURI: serviceURI, PricePerPixel: pricePerPixel}
-}

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -13,12 +13,10 @@ import (
 	"testing"
 	"time"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/eth"
-	lpTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/go-livepeer/server"
@@ -27,59 +25,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type stubOrchestratorPool struct {
-	uris  []*url.URL
-	bcast server.Broadcaster
-}
-
-func stringsToURIs(addresses []string) []*url.URL {
-	var uris []*url.URL
-
-	for _, addr := range addresses {
-		uri, err := url.ParseRequestURI(addr)
-		if err == nil {
-			uris = append(uris, uri)
-		}
+func TestNewDBOrchestratorPoolCache_NilEthClient_ReturnsError(t *testing.T) {
+	assert := assert.New(t)
+	dbh, dbraw, err := common.TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	require := require.New(t)
+	require.Nil(err)
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth:      nil,
+		Sender:   &pm.MockSender{},
 	}
-	return uris
-}
-
-func StubOrchestratorPool(addresses []string) *stubOrchestratorPool {
-	uris := stringsToURIs(addresses)
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	bcast := core.NewBroadcaster(node)
-
-	return &stubOrchestratorPool{bcast: bcast, uris: uris}
-}
-
-func StubOrchestrators(addresses []string) []*lpTypes.Transcoder {
-	var orchestrators []*lpTypes.Transcoder
-
-	for _, addr := range addresses {
-		address := ethcommon.BytesToAddress([]byte(addr))
-		transc := &lpTypes.Transcoder{ServiceURI: addr, Address: address}
-		orchestrators = append(orchestrators, transc)
-	}
-
-	return orchestrators
-}
-
-func TestNewOrchestratorPoolWithPred_NilEthClient_ReturnsNil_LogsError(t *testing.T) {
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	errorLogsBefore := glog.Stats.Error.Lines()
-	pool := NewOrchestratorPoolWithPred(node, nil, nil)
-	errorLogsAfter := glog.Stats.Error.Lines()
-	assert.NotZero(t, errorLogsAfter-errorLogsBefore)
-	assert.Nil(t, pool)
-}
-
-func TestNewDBOrchestratorPoolCache_NilEthClient_ReturnsNil_LogsError(t *testing.T) {
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	errorLogsBefore := glog.Stats.Error.Lines()
-	poolCache := NewDBOrchestratorPoolCache(node)
-	errorLogsAfter := glog.Stats.Error.Lines()
-	assert.NotZero(t, errorLogsAfter-errorLogsBefore)
-	assert.Nil(t, poolCache)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	assert.Nil(pool)
+	assert.EqualError(err, "could not create DBOrchestratorPoolCache: LivepeerEthClient is nil")
 }
 
 func TestDeadLock(t *testing.T) {
@@ -87,7 +49,7 @@ func TestDeadLock(t *testing.T) {
 	defer runtime.GOMAXPROCS(gmp)
 	var mu sync.Mutex
 	first := true
-	serverGetOrchInfo = func(ctx context.Context, bcast server.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
 		mu.Lock()
 		if first {
 			time.Sleep(100 * time.Millisecond)
@@ -114,7 +76,7 @@ func TestDeadLock_NewOrchestratorPoolWithPred(t *testing.T) {
 	defer runtime.GOMAXPROCS(gmp)
 	var mu sync.Mutex
 	first := true
-	serverGetOrchInfo = func(ctx context.Context, bcast server.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
 		mu.Lock()
 		if first {
 			time.Sleep(100 * time.Millisecond)
@@ -144,12 +106,7 @@ func TestDeadLock_NewOrchestratorPoolWithPred(t *testing.T) {
 		return true
 	}
 
-	orchestrators := StubOrchestrators(addresses)
-
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
-
-	pool := NewOrchestratorPoolWithPred(node, uris, pred)
+	pool := NewOrchestratorPoolWithPred(nil, uris, pred)
 	infos, err := pool.GetOrchestrators(1)
 
 	assert.Nil(err, "Should not be error")
@@ -172,55 +129,50 @@ func TestPoolSize(t *testing.T) {
 	assert.NotZero(t, errorLogsAfter-errorLogsBefore)
 }
 
-func TestDbOrchestratorPoolCacheSize(t *testing.T) {
+func TestDBOrchestratorPoolCacheSize(t *testing.T) {
+	assert := assert.New(t)
 	dbh, dbraw, err := common.TempDB(t)
 	defer dbh.Close()
 	defer dbraw.Close()
 	require := require.New(t)
 	require.Nil(err)
 
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Database = dbh
-	node.Eth = &eth.StubClient{}
+	sender := &pm.MockSender{}
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth:      &eth.StubClient{},
+		Sender:   sender,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	errorLogsBefore := glog.Stats.Error.Lines()
-	// No orchestrators on eth.Stubclient will result in no registered orchs found on chain
-	emptyPool := NewDBOrchestratorPoolCache(node)
-	errorLogsAfter := glog.Stats.Error.Lines()
+	emptyPool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	require.NoError(err)
 	require.NotNil(emptyPool)
-	assert.Equal(t, 0, emptyPool.Size())
-	assert.NotZero(t, errorLogsAfter-errorLogsBefore)
+	assert.Equal(0, emptyPool.Size())
 
 	addresses := []string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"}
 	orchestrators := StubOrchestrators(addresses)
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
-	nonEmptyPool := NewDBOrchestratorPoolCache(node)
+	for _, o := range orchestrators {
+		dbh.UpdateOrch(ethOrchToDBOrch(o))
+	}
+
+	nonEmptyPool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	require.NoError(err)
 	require.NotNil(nonEmptyPool)
-	assert.Equal(t, len(addresses), emptyPool.Size())
-}
-
-func TestCacheRegisteredTranscoders_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *testing.T) {
-	dbh, dbraw, err := common.TempDB(t)
-	defer dbh.Close()
-	defer dbraw.Close()
-	require := require.New(t)
-	require.Nil(err)
-
-	addresses := []string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"}
-	orchestrators := StubOrchestrators(addresses)
-
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Database = dbh
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
-
-	err = cacheRegisteredTranscoders(node)
-	require.Nil(err)
+	assert.Equal(len(addresses), nonEmptyPool.Size())
 }
 
 func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *testing.T) {
+	expPriceInfo := &net.PriceInfo{
+		PricePerUnit:  999,
+		PixelsPerUnit: 1,
+	}
+	expTranscoder := "transcoderFromTest"
+	expPricePerPixel, _ := common.PriceToFixed(big.NewRat(999, 1))
 	var mu sync.Mutex
 	first := true
-	serverGetOrchInfo = func(ctx context.Context, bcast server.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
 		mu.Lock()
 		if first {
 			time.Sleep(100 * time.Millisecond)
@@ -228,11 +180,8 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 		}
 		mu.Unlock()
 		return &net.OrchestratorInfo{
-			Transcoder: "transcoderfromtestserver",
-			PriceInfo: &net.PriceInfo{
-				PricePerUnit:  999,
-				PixelsPerUnit: 1,
-			},
+			Transcoder: expTranscoder,
+			PriceInfo:  expPriceInfo,
 		}, nil
 	}
 
@@ -242,54 +191,77 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 	require := require.New(t)
 	assert := assert.New(t)
 	require.Nil(err)
-
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Database = dbh
 
 	// adding orchestrators to DB
 	addresses := []string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"}
 	orchestrators := StubOrchestrators(addresses)
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
 
-	cachedOrchs, err := cacheDBOrchs(node, orchestrators)
-	require.Nil(err)
-	assert.Len(cachedOrchs, 3)
+	testOrchs := make([]orchTest, 0)
 	for _, o := range orchestrators {
-		dbO := ethOrchToDBOrch(o)
-		dbO.PricePerPixel, _ = common.PriceToFixed(big.NewRat(999, 1))
+		to := orchTest{
+			EthereumAddr:  o.Address.String(),
+			ServiceURI:    o.ServiceURI,
+			PricePerPixel: expPricePerPixel,
+		}
+		testOrchs = append(testOrchs, to)
+	}
 
-		assert.Contains(cachedOrchs, dbO)
+	sender := &pm.MockSender{}
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth: &eth.StubClient{
+			Orchestrators: orchestrators,
+		},
+		Sender: sender,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sender.On("ValidateTicketParams", mock.Anything).Return(nil).Times(3)
+
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	require.NoError(err)
+	assert.Equal(pool.Size(), 3)
+	orchs, err := pool.GetOrchestrators(pool.Size())
+	for _, o := range orchs {
+		assert.Equal(o.PriceInfo, expPriceInfo)
+		assert.Equal(o.Transcoder, expTranscoder)
 	}
 
 	// ensuring orchs exist in DB
-	orchs, err := node.Database.SelectOrchs(nil)
+	dbOrchs, err := pool.store.SelectOrchs(nil)
 	require.Nil(err)
-	assert.Len(orchs, 3)
-	orchsTest := make([]orchTest, 1)
-	for _, o := range orchs {
-		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
-	}
-	for _, o := range orchestrators {
-		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
-
-		assert.Contains(orchsTest, dbO)
+	assert.Len(dbOrchs, 3)
+	for _, o := range dbOrchs {
+		test := toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel)
+		assert.Contains(testOrchs, test)
 	}
 
-	// creating new OrchestratorPoolCache
-	dbOrch := NewDBOrchestratorPoolCache(node)
-	require.NotNil(dbOrch)
-
-	// check size
-	assert.Equal(3, dbOrch.Size())
-
-	urls := dbOrch.GetURLs()
+	urls := pool.GetURLs()
 	assert.Len(urls, 3)
+	for _, url := range urls {
+		assert.Contains(addresses, url.String())
+	}
 }
 
 func TestNewDBOrchestratorPoolCache_TestURLs(t *testing.T) {
+	dbh, dbraw, err := common.TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	require := require.New(t)
+	assert := assert.New(t)
+	require.Nil(err)
+
+	addresses := []string{"badUrl\\://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"}
+	orchestrators := StubOrchestrators(addresses)
+	orchs := make([]*common.DBOrch, 0)
+	for _, o := range orchestrators {
+		orchs = append(orchs, ethOrchToDBOrch(o))
+	}
+
 	var mu sync.Mutex
 	first := true
-	serverGetOrchInfo = func(ctx context.Context, bcast server.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
 		mu.Lock()
 		if first {
 			time.Sleep(100 * time.Millisecond)
@@ -299,31 +271,29 @@ func TestNewDBOrchestratorPoolCache_TestURLs(t *testing.T) {
 		return &net.OrchestratorInfo{
 			Transcoder: "transcoderfromtestserver",
 			PriceInfo: &net.PriceInfo{
-				PricePerUnit:  999,
+				PricePerUnit:  1,
 				PixelsPerUnit: 1,
 			},
 		}, nil
 	}
 
-	dbh, dbraw, err := common.TempDB(t)
-	defer dbh.Close()
-	defer dbraw.Close()
-	require := require.New(t)
-	assert := assert.New(t)
-	require.Nil(err)
+	sender := &pm.MockSender{}
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth: &eth.StubClient{
+			Orchestrators: orchestrators,
+		},
+		Sender: sender,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Database = dbh
-
-	addresses := []string{"badUrl\\://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"}
-	orchestrators := StubOrchestrators(addresses)
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
-	dbOrch := NewDBOrchestratorPoolCache(node)
-	require.NotNil(dbOrch)
-	// Not inserting bad URLs in database anymore, as there is no returnable query for getting their priceInfo
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	require.NoError(err)
+	// bad URLs are inserted in the database but are not included in the working set, as there is no returnable query for getting their priceInfo
 	// And if URL is updated it won't be picked up until next cache update
-	assert.Equal(2, dbOrch.Size())
-	urls := dbOrch.GetURLs()
+	assert.Equal(3, pool.Size())
+	urls := pool.GetURLs()
 	assert.Len(urls, 2)
 }
 
@@ -335,26 +305,126 @@ func TestNewDBOrchestratorPoolCache_TestURLs_Empty(t *testing.T) {
 	assert := assert.New(t)
 	require.Nil(err)
 
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Database = dbh
-
 	addresses := []string{}
 	// Addresses is empty slice -> No orchestrators
 	orchestrators := StubOrchestrators(addresses)
-	// Contains empty orchestrator slice -> No registered orchs found on chain error
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
-	errorLogsBefore := glog.Stats.Error.Lines()
-	dbOrch := NewDBOrchestratorPoolCache(node)
-	errorLogsAfter := glog.Stats.Error.Lines()
-	require.NotNil(dbOrch)
-	assert.Equal(0, dbOrch.Size())
-	assert.NotZero(t, errorLogsAfter-errorLogsBefore)
-	urls := dbOrch.GetURLs()
+	for _, o := range orchestrators {
+		dbh.UpdateOrch(ethOrchToDBOrch(o))
+	}
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth: &eth.StubClient{
+			Orchestrators: orchestrators,
+		},
+		Sender: &pm.MockSender{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	require.NoError(err)
+	assert.Equal(0, pool.Size())
+	urls := pool.GetURLs()
 	assert.Len(urls, 0)
 }
 
+func TestNewDBOrchestorPoolCache_PollOrchestratorInfo(t *testing.T) {
+	cachedOrchInfo := &net.OrchestratorInfo{
+		Transcoder: "transcoderFromTest",
+		PriceInfo: &net.PriceInfo{
+			PricePerUnit:  999,
+			PixelsPerUnit: 1,
+		},
+	}
+	polledOrchInfo := &net.OrchestratorInfo{
+		Transcoder: "transcoderFromTest",
+		PriceInfo: &net.PriceInfo{
+			PricePerUnit:  1,
+			PixelsPerUnit: 1,
+		},
+	}
+	returnInfo := cachedOrchInfo
+
+	var mu sync.Mutex
+	callCount := 0
+	first := true
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+		mu.Lock()
+		if first {
+			time.Sleep(100 * time.Millisecond)
+			first = false
+		}
+		mu.Unlock()
+		callCount++
+		return returnInfo, nil
+	}
+
+	dbh, dbraw, err := common.TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	require := require.New(t)
+	assert := assert.New(t)
+	require.Nil(err)
+
+	// adding orchestrators to DB
+	addresses := []string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"}
+	orchestrators := StubOrchestrators(addresses)
+
+	testOrchs := make([]orchTest, 0)
+	expPrice, _ := common.PriceToFixed(big.NewRat(999, 1))
+	for _, o := range orchestrators {
+		to := orchTest{
+			EthereumAddr:  o.Address.String(),
+			ServiceURI:    o.ServiceURI,
+			PricePerPixel: expPrice,
+		}
+		testOrchs = append(testOrchs, to)
+	}
+
+	sender := &pm.MockSender{}
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth: &eth.StubClient{
+			Orchestrators: orchestrators,
+		},
+		Sender: sender,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	origCacheRefreshInterval := cacheRefreshInterval
+	cacheRefreshInterval = 200 * time.Millisecond
+	defer func() { cacheRefreshInterval = origCacheRefreshInterval }()
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	require.NoError(err)
+
+	// Ensure orchestrators exist in DB
+	require.Equal(pool.Size(), 3)
+	dbOrchs, err := pool.store.SelectOrchs(nil)
+	require.Nil(err)
+	require.Len(dbOrchs, 3)
+	for _, o := range dbOrchs {
+		test := toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel)
+		require.Contains(testOrchs, test)
+	}
+
+	// reset callCount to 0 which is now 3 after calling CacheTranscoderPool()
+	callCount = 0
+	returnInfo = polledOrchInfo
+	time.Sleep(1100 * time.Millisecond)
+	dbOrchs, err = pool.store.SelectOrchs(nil)
+	require.Nil(err)
+	require.Len(dbOrchs, 3)
+	expPrice, _ = common.PriceToFixed(big.NewRat(1, 1))
+	for _, o := range dbOrchs {
+		assert.Equal(o.PricePerPixel, expPrice)
+	}
+	// called serverGetOrchInfo 1100 / 200 * 3 = 15 times
+	assert.GreaterOrEqual(callCount, 14)
+	assert.LessOrEqual(callCount, 16)
+}
+
 func TestNewOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *testing.T) {
-	node, _ := core.NewLivepeerNode(nil, "", nil)
 	addresses := stringsToURIs([]string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"})
 	expected := stringsToURIs([]string{"https://127.0.0.1:8938", "https://127.0.0.1:8937", "https://127.0.0.1:8936"})
 	assert := assert.New(t)
@@ -363,7 +433,7 @@ func TestNewOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *
 	rand.Seed(321)
 	perm = func(len int) []int { return rand.Perm(3) }
 
-	offchainOrch := NewOrchestratorPool(node, addresses)
+	offchainOrch := NewOrchestratorPool(nil, addresses)
 
 	for i, uri := range offchainOrch.uris {
 		assert.Equal(uri, expected[i])
@@ -383,13 +453,9 @@ func TestNewOrchestratorPoolWithPred_TestPredicate(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		addresses = append(addresses, "https://127.0.0.1:8936")
 	}
-	orchestrators := StubOrchestrators(addresses)
 	uris := stringsToURIs(addresses)
 
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
-
-	pool := NewOrchestratorPoolWithPred(node, uris, pred)
+	pool := NewOrchestratorPoolWithPred(nil, uris, pred)
 
 	oInfo := &net.OrchestratorInfo{
 		PriceInfo: &net.PriceInfo{
@@ -412,15 +478,22 @@ func TestNewOrchestratorPoolWithPred_TestPredicate(t *testing.T) {
 
 func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) {
 	// Test setup
+	expPriceInfo := &net.PriceInfo{
+		PricePerUnit:  999,
+		PixelsPerUnit: 1,
+	}
+	expTranscoder := "transcoderFromTest"
+	expPricePerPixel, _ := common.PriceToFixed(big.NewRat(999, 1))
+
 	rand.Seed(321)
 	perm = func(len int) []int { return rand.Perm(50) }
 
-	server.BroadcastCfg.SetMaxPrice(big.NewRat(10, 1))
+	server.BroadcastCfg.SetMaxPrice(big.NewRat(1, 1))
 	gmp := runtime.GOMAXPROCS(50)
 	defer runtime.GOMAXPROCS(gmp)
 	var mu sync.Mutex
 	first := true
-	serverGetOrchInfo = func(ctx context.Context, bcast server.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
 		mu.Lock()
 		if first {
 			time.Sleep(100 * time.Millisecond)
@@ -428,11 +501,8 @@ func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) 
 		}
 		mu.Unlock()
 		return &net.OrchestratorInfo{
-			Transcoder: "transcoderfromtestserver",
-			PriceInfo: &net.PriceInfo{
-				PricePerUnit:  999,
-				PixelsPerUnit: 1,
-			},
+			Transcoder: expTranscoder,
+			PriceInfo:  expPriceInfo,
 		}, nil
 	}
 	addresses := []string{}
@@ -450,50 +520,47 @@ func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) 
 	require.Nil(err)
 
 	orchestrators := StubOrchestrators(addresses)
-
-	// Create node
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Database = dbh
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
-
-	// Add orchs to DB
-	cachedOrchs, err := cacheDBOrchs(node, orchestrators)
-	require.Nil(err)
-	assert.Len(cachedOrchs, 50)
-	orchsTest := make([]orchTest, 1)
-	for _, o := range cachedOrchs {
-		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
-	}
+	testOrchs := make([]orchTest, 0)
 	for _, o := range orchestrators {
-		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
-
-		assert.Contains(orchsTest, dbO)
+		to := orchTest{
+			EthereumAddr:  o.Address.String(),
+			ServiceURI:    o.ServiceURI,
+			PricePerPixel: expPricePerPixel,
+		}
+		testOrchs = append(testOrchs, to)
 	}
+
+	sender := &pm.MockSender{}
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth: &eth.StubClient{
+			Orchestrators: orchestrators,
+		},
+		Sender: sender,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
+
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	require.NoError(err)
 
 	// ensuring orchs exist in DB
-	orchs, err := node.Database.SelectOrchs(nil)
+	orchs, err := dbh.SelectOrchs(nil)
 	require.Nil(err)
 	assert.Len(orchs, 50)
-	orchsTest = make([]orchTest, 1)
 	for _, o := range orchs {
-		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
+		test := toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel)
+		assert.Contains(testOrchs, test)
 	}
-	for _, o := range orchestrators {
-		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
-
-		assert.Contains(orchsTest, dbO)
-	}
-
-	// creating new OrchestratorPoolCache
-	dbOrch := NewDBOrchestratorPoolCache(node)
-	require.NotNil(dbOrch)
 
 	// check size
-	assert.Equal(0, dbOrch.Size())
+	assert.Equal(0, pool.Size())
 
-	urls := dbOrch.GetURLs()
+	urls := pool.GetURLs()
 	assert.Len(urls, 0)
-	infos, err := dbOrch.GetOrchestrators(len(addresses))
+	infos, err := pool.GetOrchestrators(len(addresses))
 
 	assert.Nil(err, "Should not be error")
 	assert.Len(infos, 0)
@@ -501,14 +568,22 @@ func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) 
 
 func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
 	// Test setup
-	server.BroadcastCfg.SetMaxPrice(nil)
+	expPriceInfo := &net.PriceInfo{
+		PricePerUnit:  999,
+		PixelsPerUnit: 1,
+	}
+	expTranscoder := "transcoderFromTest"
+	expPricePerPixel, _ := common.PriceToFixed(big.NewRat(999, 1))
+
+	rand.Seed(321)
 	perm = func(len int) []int { return rand.Perm(50) }
 
+	server.BroadcastCfg.SetMaxPrice(nil)
 	gmp := runtime.GOMAXPROCS(50)
 	defer runtime.GOMAXPROCS(gmp)
 	var mu sync.Mutex
 	first := true
-	serverGetOrchInfo = func(ctx context.Context, bcast server.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
 		mu.Lock()
 		if first {
 			time.Sleep(100 * time.Millisecond)
@@ -516,11 +591,8 @@ func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
 		}
 		mu.Unlock()
 		return &net.OrchestratorInfo{
-			Transcoder: "transcoderfromtestserver",
-			PriceInfo: &net.PriceInfo{
-				PricePerUnit:  999,
-				PixelsPerUnit: 1,
-			},
+			Transcoder: expTranscoder,
+			PriceInfo:  expPriceInfo,
 		}, nil
 	}
 	addresses := []string{}
@@ -538,50 +610,54 @@ func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
 	require.Nil(err)
 
 	orchestrators := StubOrchestrators(addresses)
-
-	// Create node
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Database = dbh
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
-
-	// Add orchs to DB
-	cachedOrchs, err := cacheDBOrchs(node, orchestrators)
-	require.Nil(err)
-	assert.Len(cachedOrchs, 50)
-	orchsTest := make([]orchTest, 1)
-	for _, o := range cachedOrchs {
-		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
-	}
+	testOrchs := make([]orchTest, 0)
 	for _, o := range orchestrators {
-		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
-
-		assert.Contains(orchsTest, dbO)
+		to := orchTest{
+			EthereumAddr:  o.Address.String(),
+			ServiceURI:    o.ServiceURI,
+			PricePerPixel: expPricePerPixel,
+		}
+		testOrchs = append(testOrchs, to)
 	}
+
+	sender := &pm.MockSender{}
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth: &eth.StubClient{
+			Orchestrators: orchestrators,
+		},
+		Sender: sender,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
+
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	require.NoError(err)
 
 	// ensuring orchs exist in DB
-	orchs, err := node.Database.SelectOrchs(nil)
+	orchs, err := dbh.SelectOrchs(nil)
 	require.Nil(err)
 	assert.Len(orchs, 50)
-	orchsTest = make([]orchTest, 1)
 	for _, o := range orchs {
-		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
+		test := toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel)
+		assert.Contains(testOrchs, test)
 	}
-	for _, o := range orchestrators {
-		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
-
-		assert.Contains(orchsTest, dbO)
-	}
-
-	// creating new OrchestratorPoolCache
-	dbOrch := NewDBOrchestratorPoolCache(node)
-	require.NotNil(dbOrch)
 
 	// check size
-	assert.Equal(50, dbOrch.Size())
+	assert.Equal(50, pool.Size())
 
-	urls := dbOrch.GetURLs()
+	urls := pool.GetURLs()
 	assert.Len(urls, 50)
-	infos, err := dbOrch.GetOrchestrators(50)
+	for _, url := range urls {
+		assert.Contains(addresses, url.String())
+	}
+	infos, err := pool.GetOrchestrators(50)
+	for _, info := range infos {
+		assert.Equal(info.PriceInfo, expPriceInfo)
+		assert.Equal(info.Transcoder, expTranscoder)
+	}
 
 	assert.Nil(err, "Should not be error")
 	assert.Len(infos, 50)
@@ -589,6 +665,20 @@ func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
 
 func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.T) {
 	// Test setup
+	goodTranscoder := &net.OrchestratorInfo{
+		Transcoder: "goodPriceTranscoder",
+		PriceInfo: &net.PriceInfo{
+			PricePerUnit:  1,
+			PixelsPerUnit: 1,
+		},
+	}
+	badTranscoder := &net.OrchestratorInfo{
+		Transcoder: "badPriceTranscoder",
+		PriceInfo: &net.PriceInfo{
+			PricePerUnit:  999,
+			PixelsPerUnit: 1,
+		},
+	}
 	perm = func(len int) []int { return rand.Perm(25) }
 
 	server.BroadcastCfg.SetMaxPrice(big.NewRat(10, 1))
@@ -596,7 +686,7 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 	defer runtime.GOMAXPROCS(gmp)
 	var mu sync.Mutex
 	first := true
-	serverGetOrchInfo = func(ctx context.Context, bcast server.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
 		mu.Lock()
 		if first {
 			time.Sleep(100 * time.Millisecond)
@@ -605,22 +695,10 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 		mu.Unlock()
 		if i, _ := strconv.Atoi(orchestratorServer.Port()); i > 8960 {
 			// Return valid pricing
-			return &net.OrchestratorInfo{
-				Transcoder: "goodPriceTranscoder",
-				PriceInfo: &net.PriceInfo{
-					PricePerUnit:  1,
-					PixelsPerUnit: 1,
-				},
-			}, nil
+			return goodTranscoder, nil
 		}
 		// Return invalid pricing
-		return &net.OrchestratorInfo{
-			Transcoder: "badPriceTranscoder",
-			PriceInfo: &net.PriceInfo{
-				PricePerUnit:  999,
-				PixelsPerUnit: 1,
-			},
-		}, nil
+		return badTranscoder, nil
 	}
 	addresses := []string{}
 	for i := 0; i < 50; i++ {
@@ -637,63 +715,58 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 	require.Nil(err)
 
 	orchestrators := StubOrchestrators(addresses)
-
-	// Create node
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Database = dbh
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
-
-	// Add orchs to DB
-	cachedOrchs, err := cacheDBOrchs(node, orchestrators)
-	require.Nil(err)
-	assert.Len(cachedOrchs, 50)
+	testOrchs := make([]orchTest, 0)
 	for _, o := range orchestrators[:25] {
-		dbO := ethOrchToDBOrch(o)
-		dbO.PricePerPixel, _ = common.PriceToFixed(big.NewRat(999, 1))
-		assert.Contains(cachedOrchs, dbO)
+		price, _ := common.PriceToFixed(big.NewRat(999, 1))
+		testOrchs = append(testOrchs, toOrchTest(o.Address.String(), o.ServiceURI, price))
 	}
 	for _, o := range orchestrators[25:] {
-		dbO := ethOrchToDBOrch(o)
-		dbO.PricePerPixel, _ = common.PriceToFixed(big.NewRat(1, 1))
-		assert.Contains(cachedOrchs, dbO)
+		price, _ := common.PriceToFixed(big.NewRat(1, 1))
+		testOrchs = append(testOrchs, toOrchTest(o.Address.String(), o.ServiceURI, price))
 	}
+
+	sender := &pm.MockSender{}
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth: &eth.StubClient{
+			Orchestrators: orchestrators,
+		},
+		Sender: sender,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
+
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	require.NoError(err)
+
 	// ensuring orchs exist in DB
-	orchs, err := node.Database.SelectOrchs(nil)
+	orchs, err := dbh.SelectOrchs(nil)
 	require.Nil(err)
 	assert.Len(orchs, 50)
 
-	orchsTest := make([]orchTest, 1)
 	for _, o := range orchs {
-		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
+		assert.Contains(testOrchs, toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel))
 	}
-	for _, o := range orchestrators {
-		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
 
-		assert.Contains(orchsTest, dbO)
-	}
-	orchs, err = node.Database.SelectOrchs(&common.DBOrchFilter{MaxPrice: server.BroadcastCfg.MaxPrice()})
+	orchs, err = dbh.SelectOrchs(&common.DBOrchFilter{MaxPrice: server.BroadcastCfg.MaxPrice()})
 	require.Nil(err)
 	assert.Len(orchs, 25)
-	orchsTest = make([]orchTest, 1)
 	for _, o := range orchs {
-		orchsTest = append(orchsTest, orchTest{EthereumAddr: o.EthereumAddr, ServiceURI: o.ServiceURI})
+		assert.Contains(testOrchs[25:], toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel))
 	}
-	for _, o := range orchestrators[25:] {
-		dbO := toOrchTest(o.Address.String(), o.ServiceURI)
-
-		assert.Contains(orchsTest, dbO)
-	}
-
-	// creating new OrchestratorPoolCache
-	dbOrch := NewDBOrchestratorPoolCache(node)
-	require.NotNil(dbOrch)
 
 	// check size
-	assert.Equal(25, dbOrch.Size())
+	assert.Equal(25, pool.Size())
 
-	urls := dbOrch.GetURLs()
+	urls := pool.GetURLs()
 	assert.Len(urls, 25)
-	infos, err := dbOrch.GetOrchestrators(len(orchestrators))
+	for _, url := range urls {
+		assert.Contains(addresses[25:], url.String())
+	}
+
+	infos, err := pool.GetOrchestrators(len(orchestrators))
 
 	assert.Nil(err, "Should not be error")
 	assert.Len(infos, 25)
@@ -711,7 +784,7 @@ func TestCachedPool_GetOrchestrators_TicketParamsValidation(t *testing.T) {
 
 	server.BroadcastCfg.SetMaxPrice(nil)
 
-	serverGetOrchInfo = func(ctx context.Context, bcast server.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
 		return &net.OrchestratorInfo{
 			Transcoder:   "transcoder",
 			TicketParams: &net.TicketParams{},
@@ -738,38 +811,139 @@ func TestCachedPool_GetOrchestrators_TicketParamsValidation(t *testing.T) {
 
 	orchestrators := StubOrchestrators(addresses)
 
-	// Create node
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.Database = dbh
-	node.Eth = &eth.StubClient{Orchestrators: orchestrators}
 	sender := &pm.MockSender{}
-	node.Sender = sender
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth: &eth.StubClient{
+			Orchestrators: orchestrators,
+		},
+		Sender: sender,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	// Add orchs to DB
-	cachedOrchs, err := cacheDBOrchs(node, orchestrators)
-	require.Nil(err)
-	assert.Len(cachedOrchs, 50)
-
-	dbOrch := NewDBOrchestratorPoolCache(node)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	require.NoError(err)
 
 	// Test 25 out of 50 orchs pass ticket params validation
 	sender.On("ValidateTicketParams", mock.Anything).Return(errors.New("ValidateTicketParams error")).Times(25)
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil).Times(25)
 
-	infos, err := dbOrch.GetOrchestrators(len(addresses))
+	infos, err := pool.GetOrchestrators(len(addresses))
 	assert.Nil(err)
 	assert.Len(infos, 25)
 	sender.AssertNumberOfCalls(t, "ValidateTicketParams", 50)
 
 	// Test 0 out of 50 orchs pass ticket params validation
-	sender = &pm.MockSender{}
-	node.Sender = sender
 	sender.On("ValidateTicketParams", mock.Anything).Return(errors.New("ValidateTicketParams error")).Times(50)
 
-	infos, err = dbOrch.GetOrchestrators(len(addresses))
+	infos, err = pool.GetOrchestrators(len(addresses))
 	assert.Nil(err)
 	assert.Len(infos, 0)
-	sender.AssertNumberOfCalls(t, "ValidateTicketParams", 50)
+	sender.AssertNumberOfCalls(t, "ValidateTicketParams", 100)
+}
+
+func TestCachedPool_GetOrchestrators_OnlyActiveOrchestrators(t *testing.T) {
+	// Test setup
+	perm = func(len int) []int { return rand.Perm(25) }
+	expPriceInfo := &net.PriceInfo{
+		PricePerUnit:  1,
+		PixelsPerUnit: 1,
+	}
+	expTranscoder := "transcoderFromTest"
+	expPricePricePixel, _ := common.PriceToFixed(big.NewRat(1, 1))
+
+	server.BroadcastCfg.SetMaxPrice(nil)
+	gmp := runtime.GOMAXPROCS(50)
+	defer runtime.GOMAXPROCS(gmp)
+	var mu sync.Mutex
+	first := true
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+		mu.Lock()
+		if first {
+			time.Sleep(100 * time.Millisecond)
+			first = false
+		}
+		mu.Unlock()
+		return &net.OrchestratorInfo{
+			Transcoder: expTranscoder,
+			PriceInfo:  expPriceInfo,
+		}, nil
+	}
+
+	addresses := []string{}
+	for i := 0; i < 50; i++ {
+		addresses = append(addresses, "https://127.0.0.1:"+strconv.Itoa(8936+i))
+	}
+
+	assert := assert.New(t)
+
+	// Create Database
+	dbh, dbraw, err := common.TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	require := require.New(t)
+	require.Nil(err)
+
+	orchestrators := StubOrchestrators(addresses)
+	testOrchs := make([]orchTest, 0)
+	for i, o := range orchestrators {
+		to := orchTest{
+			EthereumAddr:  o.Address.String(),
+			ServiceURI:    o.ServiceURI,
+			PricePerPixel: expPricePricePixel,
+		}
+		// Active O's will be addresses[:25]
+		o.ActivationRound = big.NewInt(int64(i))
+		o.DeactivationRound = big.NewInt(int64(i + 26))
+		testOrchs = append(testOrchs, to)
+
+		dbO := ethOrchToDBOrch(o)
+		dbO.PricePerPixel = expPricePricePixel
+		dbh.UpdateOrch(dbO)
+	}
+
+	sender := &pm.MockSender{}
+	node := &core.LivepeerNode{
+		Database: dbh,
+		Eth: &eth.StubClient{
+			Orchestrators: orchestrators,
+		},
+		Sender: sender,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
+
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{round: big.NewInt(24)})
+	require.NoError(err)
+
+	// ensuring orchs exist in DB
+	orchs, err := dbh.SelectOrchs(nil)
+	require.Nil(err)
+	assert.Len(orchs, 50)
+	for _, o := range orchs {
+		test := toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel)
+		assert.Contains(testOrchs, test)
+	}
+
+	// check size
+	assert.Equal(25, pool.Size())
+
+	urls := pool.GetURLs()
+	assert.Len(urls, 25)
+	for _, url := range urls {
+		assert.Contains(addresses[:25], url.String())
+	}
+	infos, err := pool.GetOrchestrators(50)
+	for _, info := range infos {
+		assert.Equal(info.PriceInfo, expPriceInfo)
+		assert.Equal(info.Transcoder, expTranscoder)
+	}
+
+	assert.Nil(err, "Should not be error")
+	assert.Len(infos, 25)
 }
 
 func TestNewWHOrchestratorPoolCache(t *testing.T) {
@@ -787,7 +961,7 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 		return json.Marshal(&wh)
 	}
 
-	serverGetOrchInfo = func(c context.Context, b server.Broadcaster, s *url.URL) (*net.OrchestratorInfo, error) {
+	serverGetOrchInfo = func(c context.Context, b common.Broadcaster, s *url.URL) (*net.OrchestratorInfo, error) {
 		return &net.OrchestratorInfo{Transcoder: "transcoder"}, nil
 	}
 
@@ -797,7 +971,7 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 
 	// assert created webhook pool is correct length
 	whURL, _ := url.ParseRequestURI("https://livepeer.live/api/orchestrator")
-	whpool := NewWebhookPool(node, whURL)
+	whpool := NewWebhookPool(nil, whURL)
 	assert.Equal(3, whpool.Size())
 
 	// assert that list is not refreshed if lastRequest is less than 1 min ago and hash is the same
@@ -907,10 +1081,11 @@ func TestDeserializeWebhookJSON(t *testing.T) {
 }
 
 type orchTest struct {
-	EthereumAddr string
-	ServiceURI   string
+	EthereumAddr  string
+	ServiceURI    string
+	PricePerPixel int64
 }
 
-func toOrchTest(addr, serviceURI string) orchTest {
-	return orchTest{EthereumAddr: addr, ServiceURI: serviceURI}
+func toOrchTest(addr, serviceURI string, pricePerPixel int64) orchTest {
+	return orchTest{EthereumAddr: addr, ServiceURI: serviceURI, PricePerPixel: pricePerPixel}
 }

--- a/discovery/stub.go
+++ b/discovery/stub.go
@@ -41,7 +41,12 @@ func StubOrchestrators(addresses []string) []*lpTypes.Transcoder {
 
 	for _, addr := range addresses {
 		address := ethcommon.BytesToAddress([]byte(addr))
-		transc := &lpTypes.Transcoder{ServiceURI: addr, Address: address}
+		transc := &lpTypes.Transcoder{
+			ServiceURI:        addr,
+			Address:           address,
+			ActivationRound:   big.NewInt(0),
+			DeactivationRound: big.NewInt(0),
+		}
 		orchestrators = append(orchestrators, transc)
 	}
 

--- a/discovery/stub.go
+++ b/discovery/stub.go
@@ -1,0 +1,71 @@
+package discovery
+
+import (
+	"math/big"
+	"net/url"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/core"
+	lpTypes "github.com/livepeer/go-livepeer/eth/types"
+	"github.com/livepeer/go-livepeer/pm"
+)
+
+type stubOrchestratorPool struct {
+	uris  []*url.URL
+	bcast common.Broadcaster
+}
+
+func stringsToURIs(addresses []string) []*url.URL {
+	var uris []*url.URL
+
+	for _, addr := range addresses {
+		uri, err := url.ParseRequestURI(addr)
+		if err == nil {
+			uris = append(uris, uri)
+		}
+	}
+	return uris
+}
+
+func StubOrchestratorPool(addresses []string) *stubOrchestratorPool {
+	uris := stringsToURIs(addresses)
+	node, _ := core.NewLivepeerNode(nil, "", nil)
+	bcast := core.NewBroadcaster(node)
+
+	return &stubOrchestratorPool{bcast: bcast, uris: uris}
+}
+
+func StubOrchestrators(addresses []string) []*lpTypes.Transcoder {
+	var orchestrators []*lpTypes.Transcoder
+
+	for _, addr := range addresses {
+		address := ethcommon.BytesToAddress([]byte(addr))
+		transc := &lpTypes.Transcoder{ServiceURI: addr, Address: address}
+		orchestrators = append(orchestrators, transc)
+	}
+
+	return orchestrators
+}
+
+type stubTicketParamsValidator struct {
+	err error
+}
+
+func (s *stubTicketParamsValidator) ValidateTicketParams(params *pm.TicketParams) error { return s.err }
+
+type stubRoundsManager struct {
+	round *big.Int
+}
+
+func (s *stubRoundsManager) LastInitializedRound() *big.Int { return s.round }
+
+type orchTest struct {
+	EthereumAddr  string
+	ServiceURI    string
+	PricePerPixel int64
+}
+
+func toOrchTest(addr, serviceURI string, pricePerPixel int64) orchTest {
+	return orchTest{EthereumAddr: addr, ServiceURI: serviceURI, PricePerPixel: pricePerPixel}
+}

--- a/discovery/wh_discovery.go
+++ b/discovery/wh_discovery.go
@@ -10,6 +10,7 @@ import (
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/net"
 
@@ -70,7 +71,7 @@ func (w *webhookPool) getURLs() ([]*url.URL, error) {
 		return nil, err
 	}
 
-	pool := NewOrchestratorPool(w.node, addrs)
+	pool := NewOrchestratorPool(addrs)
 
 	w.mu.Lock()
 	w.responseHash = hash
@@ -90,7 +91,7 @@ func (w *webhookPool) Size() int {
 	return len(w.GetURLs())
 }
 
-func (w *webhookPool) GetOrchestrators(numOrchestrators int) ([]*net.OrchestratorInfo, error) {
+func (w *webhookPool) GetOrchestrators(numOrchestrators int, bcast common.Broadcaster) ([]*net.OrchestratorInfo, error) {
 	_, err := w.getURLs()
 	if err != nil {
 		return nil, err
@@ -99,7 +100,7 @@ func (w *webhookPool) GetOrchestrators(numOrchestrators int) ([]*net.Orchestrato
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
-	return w.pool.GetOrchestrators(numOrchestrators)
+	return w.pool.GetOrchestrators(numOrchestrators, bcast)
 }
 
 var getURLsfromWebhook = func(cbUrl *url.URL) ([]byte, error) {

--- a/discovery/wh_discovery.go
+++ b/discovery/wh_discovery.go
@@ -33,7 +33,6 @@ type webhookPool struct {
 
 func NewWebhookPool(bcast common.Broadcaster, callback *url.URL) *webhookPool {
 	p := &webhookPool{
-		node:     node,
 		callback: callback,
 		mu:       &sync.RWMutex{},
 		bcast:    bcast,

--- a/eth/client.go
+++ b/eth/client.go
@@ -78,7 +78,7 @@ type LivepeerEthClient interface {
 	GetDelegator(addr ethcommon.Address) (*lpTypes.Delegator, error)
 	GetDelegatorUnbondingLock(addr ethcommon.Address, unbondingLockId *big.Int) (*lpTypes.UnbondingLock, error)
 	GetTranscoderEarningsPoolForRound(addr ethcommon.Address, round *big.Int) (*lpTypes.TokenPools, error)
-	RegisteredTranscoders() ([]*lpTypes.Transcoder, error)
+	TranscoderPool() ([]*lpTypes.Transcoder, error)
 	IsActiveTranscoder() (bool, error)
 	GetTotalBonded() (*big.Int, error)
 	GetTranscoderPoolSize() (*big.Int, error)
@@ -687,7 +687,7 @@ func (c *client) Paused() (bool, error) {
 	return c.ControllerSession.Paused()
 }
 
-func (c *client) RegisteredTranscoders() ([]*lpTypes.Transcoder, error) {
+func (c *client) TranscoderPool() ([]*lpTypes.Transcoder, error) {
 	var transcoders []*lpTypes.Transcoder
 
 	tAddr, err := c.GetFirstTranscoderInPool()

--- a/eth/roundinitializer.go
+++ b/eth/roundinitializer.go
@@ -122,7 +122,7 @@ func (r *RoundInitializer) tryInitialize() error {
 }
 
 func (r *RoundInitializer) shouldInitialize(epochSeed *big.Int) (bool, error) {
-	transcoders, err := r.client.RegisteredTranscoders()
+	transcoders, err := r.client.TranscoderPool()
 	if err != nil {
 		return false, err
 	}

--- a/eth/roundinitializer_test.go
+++ b/eth/roundinitializer_test.go
@@ -87,8 +87,8 @@ func TestRoundInitializer_ShouldInitialize(t *testing.T) {
 	assert := assert.New(t)
 
 	// Test error getting transcoders
-	expErr := errors.New("RegisteredTranscoders error")
-	client.On("RegisteredTranscoders").Return(nil, expErr).Once()
+	expErr := errors.New("TranscoderPool error")
+	client.On("TranscoderPool").Return(nil, expErr).Once()
 
 	ok, err := initializer.shouldInitialize(nil)
 	assert.EqualError(err, expErr.Error())
@@ -96,7 +96,7 @@ func TestRoundInitializer_ShouldInitialize(t *testing.T) {
 
 	// Test error getting max active set size
 	expErr = errors.New("GetTranscoderPoolMaxSize error")
-	client.On("RegisteredTranscoders").Return(nil, nil).Once()
+	client.On("TranscoderPool").Return(nil, nil).Once()
 	client.On("GetTranscoderPoolMaxSize").Return(nil, expErr).Once()
 
 	ok, err = initializer.shouldInitialize(nil)
@@ -104,7 +104,7 @@ func TestRoundInitializer_ShouldInitialize(t *testing.T) {
 	assert.False(ok)
 
 	// Test active set is empty because no registered transcoders
-	client.On("RegisteredTranscoders").Return([]*lpTypes.Transcoder{}, nil).Once()
+	client.On("TranscoderPool").Return([]*lpTypes.Transcoder{}, nil).Once()
 	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(2), nil).Once()
 
 	ok, err = initializer.shouldInitialize(nil)
@@ -115,7 +115,7 @@ func TestRoundInitializer_ShouldInitialize(t *testing.T) {
 	registered := []*lpTypes.Transcoder{
 		&lpTypes.Transcoder{},
 	}
-	client.On("RegisteredTranscoders").Return(registered, nil).Once()
+	client.On("TranscoderPool").Return(registered, nil).Once()
 	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(0), nil).Once()
 
 	ok, err = initializer.shouldInitialize(nil)
@@ -130,7 +130,7 @@ func TestRoundInitializer_ShouldInitialize(t *testing.T) {
 		&lpTypes.Transcoder{Address: ethcommon.BytesToAddress([]byte("jar"))},
 		&lpTypes.Transcoder{Address: ethcommon.BytesToAddress([]byte("bar"))},
 	}
-	client.On("RegisteredTranscoders").Return(registered, nil).Once()
+	client.On("TranscoderPool").Return(registered, nil).Once()
 	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(2), nil).Once()
 
 	ok, err = initializer.shouldInitialize(nil)
@@ -139,7 +139,7 @@ func TestRoundInitializer_ShouldInitialize(t *testing.T) {
 
 	// Test that caller is not in active set but it is registered
 	registered = append(registered, &lpTypes.Transcoder{Address: caller})
-	client.On("RegisteredTranscoders").Return(registered, nil)
+	client.On("TranscoderPool").Return(registered, nil)
 	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(2), nil).Once()
 
 	ok, err = initializer.shouldInitialize(nil)
@@ -201,7 +201,7 @@ func TestRoundInitializer_TryInitialize(t *testing.T) {
 
 	// Test error checking should initialize
 	expErr = errors.New("shouldInitialize error")
-	client.On("RegisteredTranscoders").Return(nil, expErr).Once()
+	client.On("TranscoderPool").Return(nil, expErr).Once()
 	blkNumRdr.err = nil
 	blkNumRdr.blkNum = big.NewInt(5)
 
@@ -215,7 +215,7 @@ func TestRoundInitializer_TryInitialize(t *testing.T) {
 	registered := []*lpTypes.Transcoder{
 		&lpTypes.Transcoder{Address: ethcommon.BytesToAddress([]byte("jar"))},
 	}
-	client.On("RegisteredTranscoders").Return(registered, nil).Once()
+	client.On("TranscoderPool").Return(registered, nil).Once()
 	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(2), nil)
 
 	err = initializer.tryInitialize()
@@ -227,7 +227,7 @@ func TestRoundInitializer_TryInitialize(t *testing.T) {
 	expErr = errors.New("CurrentRound error")
 	client.On("CurrentRound").Return(nil, expErr).Once()
 	registered = append([]*lpTypes.Transcoder{&lpTypes.Transcoder{Address: caller}}, registered...)
-	client.On("RegisteredTranscoders").Return(registered, nil)
+	client.On("TranscoderPool").Return(registered, nil)
 
 	err = initializer.tryInitialize()
 	assert.EqualError(err, expErr.Error())

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -43,8 +43,8 @@ type MockClient struct {
 
 // BondingManager
 
-// RegisteredTranscoders returns a list of registered transcoders
-func (m *MockClient) RegisteredTranscoders() ([]*lpTypes.Transcoder, error) {
+// TranscoderPool returns a list of registered transcoders
+func (m *MockClient) TranscoderPool() ([]*lpTypes.Transcoder, error) {
 	args := m.Called()
 
 	if args.Get(0) == nil {
@@ -246,7 +246,7 @@ func (e *StubClient) GetDelegatorUnbondingLock(addr common.Address, unbondingLoc
 func (e *StubClient) GetTranscoderEarningsPoolForRound(addr common.Address, round *big.Int) (*lpTypes.TokenPools, error) {
 	return nil, nil
 }
-func (e *StubClient) RegisteredTranscoders() ([]*lpTypes.Transcoder, error) {
+func (e *StubClient) TranscoderPool() ([]*lpTypes.Transcoder, error) {
 	return e.Orchestrators, nil
 }
 func (e *StubClient) IsActiveTranscoder() (bool, error)        { return false, nil }

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -15,14 +15,14 @@ import (
 const maxFutureRound = int64(math.MaxInt64)
 
 type OrchestratorWatcher struct {
-	store   orchestratorStore
+	store   common.OrchestratorStore
 	dec     *EventDecoder
 	watcher BlockWatcher
 	lpEth   eth.LivepeerEthClient
 	quit    chan struct{}
 }
 
-func NewOrchestratorWatcher(bondingManagerAddr ethcommon.Address, watcher BlockWatcher, store orchestratorStore, lpEth eth.LivepeerEthClient) (*OrchestratorWatcher, error) {
+func NewOrchestratorWatcher(bondingManagerAddr ethcommon.Address, watcher BlockWatcher, store common.OrchestratorStore, lpEth eth.LivepeerEthClient) (*OrchestratorWatcher, error) {
 	dec, err := NewEventDecoder(bondingManagerAddr, contracts.BondingManagerABI)
 	if err != nil {
 		return nil, err

--- a/eth/watchers/serviceRegistryWatcher.go
+++ b/eth/watchers/serviceRegistryWatcher.go
@@ -11,14 +11,14 @@ import (
 )
 
 type ServiceRegistryWatcher struct {
-	store   orchestratorStore
+	store   common.OrchestratorStore
 	dec     *EventDecoder
 	watcher BlockWatcher
 	lpEth   eth.LivepeerEthClient
 	quit    chan struct{}
 }
 
-func NewServiceRegistryWatcher(serviceRegistryAddr ethcommon.Address, watcher BlockWatcher, store orchestratorStore, lpEth eth.LivepeerEthClient) (*ServiceRegistryWatcher, error) {
+func NewServiceRegistryWatcher(serviceRegistryAddr ethcommon.Address, watcher BlockWatcher, store common.OrchestratorStore, lpEth eth.LivepeerEthClient) (*ServiceRegistryWatcher, error) {
 	dec, err := NewEventDecoder(serviceRegistryAddr, contracts.ServiceRegistryABI)
 	if err != nil {
 		return nil, err

--- a/eth/watchers/stub.go
+++ b/eth/watchers/stub.go
@@ -374,3 +374,8 @@ func (s *stubOrchestratorStore) UpdateOrch(orch *common.DBOrch) error {
 	s.serviceURI = orch.ServiceURI
 	return nil
 }
+
+func (s *stubOrchestratorStore) OrchCount(filter *common.DBOrchFilter) (int, error) { return 0, nil }
+func (s *stubOrchestratorStore) SelectOrchs(filter *common.DBOrchFilter) ([]*common.DBOrch, error) {
+	return nil, nil
+}

--- a/net/interface.go
+++ b/net/interface.go
@@ -1,16 +1,8 @@
 package net
 
 import (
-	"net/url"
-
 	"github.com/livepeer/m3u8"
 )
-
-type OrchestratorPool interface {
-	GetURLs() []*url.URL
-	GetOrchestrators(int) ([]*OrchestratorInfo, error)
-	Size() int
-}
 
 type RemoteTranscoderInfo struct {
 	Address  string

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -182,9 +182,7 @@ func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core
 		return nil, errDiscovery
 	}
 
-	rpcBcast := core.NewBroadcaster(n)
-
-	tinfos, err := n.OrchestratorPool.GetOrchestrators(count, rpcBcast)
+	tinfos, err := n.OrchestratorPool.GetOrchestrators(count)
 	if len(tinfos) <= 0 {
 		glog.Info("No orchestrators found; not transcoding. Error: ", err)
 		return nil, errNoOrchs
@@ -222,7 +220,7 @@ func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core
 		}
 
 		session := &BroadcastSession{
-			Broadcaster:      rpcBcast,
+			Broadcaster:      core.NewBroadcaster(n),
 			ManifestID:       params.mid,
 			Profiles:         params.profiles,
 			OrchestratorInfo: tinfo,

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -184,7 +184,7 @@ func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core
 
 	rpcBcast := core.NewBroadcaster(n)
 
-	tinfos, err := n.OrchestratorPool.GetOrchestrators(count)
+	tinfos, err := n.OrchestratorPool.GetOrchestrators(count, rpcBcast)
 	if len(tinfos) <= 0 {
 		glog.Info("No orchestrators found; not transcoding. Error: ", err)
 		return nil, errNoOrchs

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -61,7 +61,7 @@ func (d *stubDiscovery) GetURLs() []*url.URL {
 	return nil
 }
 
-func (d *stubDiscovery) GetOrchestrators(num int) ([]*net.OrchestratorInfo, error) {
+func (d *stubDiscovery) GetOrchestrators(num int, bcast common.Broadcaster) ([]*net.OrchestratorInfo, error) {
 	if d.waitGetOrch != nil {
 		<-d.waitGetOrch
 	}

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -61,7 +61,7 @@ func (d *stubDiscovery) GetURLs() []*url.URL {
 	return nil
 }
 
-func (d *stubDiscovery) GetOrchestrators(num int, bcast common.Broadcaster) ([]*net.OrchestratorInfo, error) {
+func (d *stubDiscovery) GetOrchestrators(num int) ([]*net.OrchestratorInfo, error) {
 	if d.waitGetOrch != nil {
 		<-d.waitGetOrch
 	}

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/net"
@@ -45,11 +46,6 @@ type Orchestrator interface {
 	PriceInfo(sender ethcommon.Address) (*net.PriceInfo, error)
 	SufficientBalance(addr ethcommon.Address, manifestID core.ManifestID) bool
 	DebitFees(addr ethcommon.Address, manifestID core.ManifestID, price *net.PriceInfo, pixels int64)
-}
-
-type Broadcaster interface {
-	Address() ethcommon.Address
-	Sign([]byte) ([]byte, error)
 }
 
 // Balance describes methods for a session's balance maintenance
@@ -93,7 +89,7 @@ type BalanceUpdate struct {
 
 // BroadcastSession - session-specific state for broadcasters
 type BroadcastSession struct {
-	Broadcaster      Broadcaster
+	Broadcaster      common.Broadcaster
 	ManifestID       core.ManifestID
 	Profiles         []ffmpeg.VideoProfile
 	OrchestratorInfo *net.OrchestratorInfo
@@ -198,7 +194,7 @@ func ping(context context.Context, req *net.PingPong, orch Orchestrator) (*net.P
 }
 
 // GetOrchestratorInfo - the broadcaster calls GetOrchestratorInfo which invokes GetOrchestrator on the orchestrator
-func GetOrchestratorInfo(ctx context.Context, bcast Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
+func GetOrchestratorInfo(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {
 	c, conn, err := startOrchestratorClient(orchestratorServer)
 	if err != nil {
 		return nil, err
@@ -230,7 +226,7 @@ func startOrchestratorClient(uri *url.URL) (net.OrchestratorClient, *grpc.Client
 	return c, conn, nil
 }
 
-func genOrchestratorReq(b Broadcaster) (*net.OrchestratorRequest, error) {
+func genOrchestratorReq(b common.Broadcaster) (*net.OrchestratorRequest, error) {
 	sig, err := b.Sign([]byte(fmt.Sprintf("%v", b.Address().Hex())))
 	if err != nil {
 		return nil, err

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -903,7 +903,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 
 	mux.HandleFunc("/registeredOrchestrators", func(w http.ResponseWriter, r *http.Request) {
 		if s.LivepeerNode.Eth != nil {
-			orchestrators, err := s.LivepeerNode.Eth.RegisteredTranscoders()
+			orchestrators, err := s.LivepeerNode.Eth.TranscoderPool()
 			if err != nil {
 				glog.Error(err)
 				return


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR updates the `discovery` package to accomodate for the changes in #1157 #1171 #1173 #1180 and #1181 

From a high level it implements following features:
- Update `DBOrchestratorPoolCache` to filter for active orchestrators as well as a max price
- Remove `LivepeerNode` as a dependency
- Expose a method `DBOrchestratorPoolCache.CacheTranscoderPool()` that updates the database with the transcoders currently in the pool
- Facilitate caching the transcoder pool on node startup when the node's view of the active set is out of date
- Introduce a `common/types.go` file where types commonly used by packages can exist

**Specific updates (required)**

- 8555283 & 9c5fe43 : adds `Broadcaster` (previously `server.Broadcaster`), `OrchestratorPool` (previously `net.OrchestratorPool` and `OrchestratorStore` (previously unexported from eth/watchers`) to `common/types.go`

- 9f17042  : In `eth/client` renamed `LivepeerEthClient.RegisteredTranscoders()` to `LivepeerEthClient.TranscoderPool()` to better reflect the functionality of the method after the streamflow update

- bf0cbf5 : Adds a `stub.go` file to the `discovery` package for test helpers, stubs and mocks

- 430062d : Adds `common.Broadcaster` (interface for `core.Broadcaster`)  as a function argument to `OrchestratorPool.GetOrchestrators` rather than creating a new instance in the function body since `LivepeerNode` is no longer a dependency of the `discovery` package

- 17c63a5 : Fixes up the different `OrchestratorPool` implementations' constructors to reflect the updated dependencies

- b625830 : Adds the necessary updates to `DBOrchestratorPoolCache` to facilitate filtering active orchestrators 

- 2583ccd : calls `DBOrchestratorPoolCache.CacheTranscoderPool` on node startup when `lastRetainedBlock.Number < currentRoundStartBlock.Number`

**How did you test each of these updates (required)**
ran unit tests

**Does this pull request close any open issues?**
Fixes #1154 
Fixes #1123

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
