### PR TITLE
Fix flaky sendermonitor and gaspricemonitor tests

### DIFF
--- a/eth/gaspricemonitor_test.go
+++ b/eth/gaspricemonitor_test.go
@@ -95,7 +95,7 @@ func TestStart_Polling(t *testing.T) {
 	gasPrice3 := big.NewInt(888)
 	gpo := newStubGasPriceOracle(gasPrice1)
 
-	pollingInterval := 1 * time.Second
+	pollingInterval := 1 * time.Millisecond
 	gpm := NewGasPriceMonitor(gpo, pollingInterval)
 
 	assert := assert.New(t)
@@ -139,11 +139,10 @@ func TestStart_Polling(t *testing.T) {
 	// sync sleep finishes, the monitor
 	// should have decreased its own gas price
 	go func() {
-		time.Sleep(1 * pollingInterval)
 		gpo.SetGasPrice(gasPrice2)
 	}()
 
-	time.Sleep(2 * pollingInterval)
+	time.Sleep(100 * time.Millisecond)
 
 	assert.Greater(gpo.Queries(), 0)
 	assert.Equal(gasPrice2, gpm.GasPrice())
@@ -154,11 +153,10 @@ func TestStart_Polling(t *testing.T) {
 	// sync sleep finishes, the monitor
 	// should have increased its own gas price
 	go func() {
-		time.Sleep(1 * pollingInterval)
 		gpo.SetGasPrice(gasPrice3)
 	}()
 
-	time.Sleep(2 * pollingInterval)
+	time.Sleep(100 * time.Millisecond)
 
 	// There should be more queries now
 	assert.Greater(gpo.Queries(), queries)
@@ -184,7 +182,7 @@ func TestStart_Polling_ContextCancel(t *testing.T) {
 	// Cancel polling loop
 	cancel()
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(100 * time.Millisecond)
 
 	// Ensure there are no more queries
 	assert.Equal(t, gpo.queries, queries)
@@ -215,7 +213,7 @@ func TestStop(t *testing.T) {
 	err = gpm.Stop()
 	assert.Nil(err)
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(100 * time.Millisecond)
 
 	// Ensure there are no more queries
 	assert.Equal(queries, gpo.queries)

--- a/pm/sendermonitor_test.go
+++ b/pm/sendermonitor_test.go
@@ -231,12 +231,15 @@ func TestQueueTicketAndSignalMaxFloat(t *testing.T) {
 	qc = &queueConsumer{}
 	go qc.Wait(2, sm)
 
+	time.Sleep(10 * time.Millisecond)
+
 	err = sm.AddFloat(addr2, big.NewInt(5))
 	require.Nil(err)
 	err = sm.AddFloat(addr, big.NewInt(5))
 	require.Nil(err)
 
-	time.Sleep(time.Millisecond * 20)
+	time.Sleep(10 * time.Millisecond)
+
 	// Order of tickets should reflect order that AddFloat()
 	// was called
 	tickets = qc.Redeemable()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes two flaky tests that failed sometimes in CI: one in `eth/gaspricemonitor_test.go` and the other in `pm/sendermonitor_test.go`.


**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 29ec4a5: Fix the test in `eth/gaspricemonitor_test.go` by lowering the polling interval and adjusting the sleep time to ensure that `GasPriceMonitor` would update its own cached gas price based on the updated gas price in its `GasPriceOracle` dependency. 
- ac73eda: Fix the test in `pm/sendermonitor_test.go` by adding a sleep after starting the goroutine that waits for tickets popped from the redeemable queue in `SenderMonitor` to ensure that it receives each ticket in order.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Ran:

```
go test -v -count=200 -failfast ./pm
go test -v -race ./pm
go test -v -count=200 -failfast ./eth
go test -v -race /eth
```

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1113 
Fixes #996 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
