### PR TITLE
Broadcaster encoding fee estimation

### DIFF
--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -588,18 +588,17 @@ func TestValidatePrice(t *testing.T) {
 	// B MaxPrice < O Price
 	BroadcastCfg.SetMaxPrice(big.NewRat(1, 5))
 	err = validatePrice(s)
-	assert.Errorf(err, err.Error(), "Orchestrator price higher than the set maximum price of %v wei per %v pixels", int64(1), int64(5))
+	assert.EqualError(err, fmt.Sprintf("Orchestrator price higher than the set maximum price of %v wei per %v pixels", int64(1), int64(5)))
 
 	// O.PriceInfo is nil
 	s.OrchestratorInfo.PriceInfo = nil
 	err = validatePrice(s)
-	assert.EqualError(err, err.Error(), "Invalid orchestrator price")
+	assert.EqualError(err, "missing orchestrator price")
 
 	// O.PriceInfo.PixelsPerUnit is 0
 	s.OrchestratorInfo.PriceInfo = &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 0}
 	err = validatePrice(s)
-	assert.EqualError(err, err.Error(), "Invalid orchestrator price")
-
+	assert.EqualError(err, "invalid priceInfo.pixelsPerUnit")
 }
 
 func TestGetPayment_GivenInvalidBase64_ReturnsError(t *testing.T) {

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -626,10 +626,14 @@ func genPayment(sess *BroadcastSession, numTickets int) (string, error) {
 }
 
 func validatePrice(sess *BroadcastSession) error {
-	if sess.OrchestratorInfo.PriceInfo.GetPixelsPerUnit() == 0 {
-		return fmt.Errorf("Invalid orchestrator price")
+	oPrice, err := ratPriceInfo(sess.OrchestratorInfo.GetPriceInfo())
+	if err != nil {
+		return err
 	}
-	oPrice := big.NewRat(sess.OrchestratorInfo.PriceInfo.GetPricePerUnit(), sess.OrchestratorInfo.PriceInfo.GetPixelsPerUnit())
+	if oPrice == nil {
+		return errors.New("missing orchestrator price")
+	}
+
 	maxPrice := BroadcastCfg.MaxPrice()
 	if maxPrice != nil && oPrice.Cmp(maxPrice) == 1 {
 		return fmt.Errorf("Orchestrator price higher than the set maximum price of %v wei per %v pixels", maxPrice.Num().Int64(), maxPrice.Denom().Int64())

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -541,7 +541,14 @@ func newBalanceUpdate(sess *BroadcastSession, minCredit *big.Rat) (*BalanceUpdat
 		return nil, err
 	}
 
-	update.NumTickets, update.NewCredit, update.ExistingCredit = sess.Balance.StageUpdate(minCredit, ev)
+	// The orchestrator requires the broadcaster's balance to be at least the EV of a single ticket
+	// Use the ticket EV when creating the balance update if the passed in minCredit is less than the ticket EV
+	safeMinCredit := minCredit
+	if ev.Cmp(safeMinCredit) > 0 {
+		safeMinCredit = ev
+	}
+
+	update.NumTickets, update.NewCredit, update.ExistingCredit = sess.Balance.StageUpdate(safeMinCredit, ev)
 
 	return update, nil
 }

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -831,7 +831,7 @@ func TestSubmitSegment_NewBalanceUpdateError(t *testing.T) {
 	b := stubBroadcaster2()
 	sender := &pm.MockSender{}
 	expErr := errors.New("EV error")
-	sender.On("EV", mock.Anything).Return(nil, expErr)
+	sender.On("EV", mock.Anything).Return(big.NewRat(0, 1), expErr)
 
 	s := &BroadcastSession{
 		Broadcaster: b,
@@ -855,7 +855,7 @@ func TestSubmitSegment_GenPaymentError_CreateTicketBatchError(t *testing.T) {
 	balance.On("StageUpdate", mock.Anything, mock.Anything).Return(1, nil, existingCredit)
 	balance.On("Credit", existingCredit)
 	sender := &pm.MockSender{}
-	sender.On("EV", mock.Anything).Return(nil, nil)
+	sender.On("EV", mock.Anything).Return(big.NewRat(0, 1), nil)
 	expErr := errors.New("CreateTicketBatch error")
 	sender.On("CreateTicketBatch", mock.Anything, mock.Anything).Return(nil, expErr)
 
@@ -937,7 +937,7 @@ func TestSubmitSegment_HttpPostError(t *testing.T) {
 	balance.On("StageUpdate", mock.Anything, mock.Anything).Return(0, nil, existingCredit)
 	balance.On("Credit", existingCredit)
 	sender := &pm.MockSender{}
-	sender.On("EV", mock.Anything).Return(nil, nil)
+	sender.On("EV", mock.Anything).Return(big.NewRat(0, 1), nil)
 	s.Balance = balance
 	s.Sender = sender
 
@@ -976,7 +976,7 @@ func TestSubmitSegment_Non200StatusCode(t *testing.T) {
 	balance := &mockBalance{}
 	balance.On("StageUpdate", mock.Anything, mock.Anything).Return(0, newCredit, existingCredit)
 	sender := &pm.MockSender{}
-	sender.On("EV", mock.Anything).Return(nil, nil)
+	sender.On("EV", mock.Anything).Return(big.NewRat(0, 1), nil)
 	s.Balance = balance
 	s.Sender = sender
 
@@ -1016,7 +1016,7 @@ func TestSubmitSegment_ProtoUnmarshalError(t *testing.T) {
 	balance := &mockBalance{}
 	balance.On("StageUpdate", mock.Anything, mock.Anything).Return(0, newCredit, existingCredit)
 	sender := &pm.MockSender{}
-	sender.On("EV", mock.Anything).Return(nil, nil)
+	sender.On("EV", mock.Anything).Return(big.NewRat(0, 1), nil)
 	s.Balance = balance
 	s.Sender = sender
 
@@ -1062,7 +1062,7 @@ func TestSubmitSegment_TranscodeResultError(t *testing.T) {
 	balance := &mockBalance{}
 	balance.On("StageUpdate", mock.Anything, mock.Anything).Return(0, newCredit, existingCredit)
 	sender := &pm.MockSender{}
-	sender.On("EV", mock.Anything).Return(nil, nil)
+	sender.On("EV", mock.Anything).Return(big.NewRat(0, 1), nil)
 	s.Balance = balance
 	s.Sender = sender
 
@@ -1163,7 +1163,7 @@ func TestSubmitSegment_Success(t *testing.T) {
 	balance.On("StageUpdate", mock.Anything, mock.Anything).Return(0, newCredit, big.NewRat(0, 1)).Once()
 	balance.On("Credit", ratMatcher(newCredit)).Once()
 	sender := &pm.MockSender{}
-	sender.On("EV", mock.Anything).Return(nil, nil)
+	sender.On("EV", mock.Anything).Return(big.NewRat(0, 1), nil)
 	s.Balance = balance
 	s.Sender = sender
 
@@ -1353,7 +1353,7 @@ func TestSubmitSegment_UpdateOrchestratorInfo(t *testing.T) {
 	balance.On("StageUpdate", mock.Anything, mock.Anything).Return(0, big.NewRat(0, 1), existingCredit)
 	balance.On("Credit", ratMatcher(change))
 	sender = &pm.MockSender{}
-	sender.On("EV", mock.Anything).Return(nil, nil)
+	sender.On("EV", mock.Anything).Return(big.NewRat(0, 1), nil)
 	sender.On("StartSession", params).Return("foobar")
 	s = newSess()
 	s.Balance = balance


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR implements encoding fee estimation for the broadcaster.

Prior to generating a balance update (which is used to determine the # of tickets to include in a payment), the broadcaster will estimate the transcoding fee for the source segment (at the moment, the broadcaster only estimates the encoding fee, but does not estimate the decoding fee). If the estimated fee is greater than the ticket EV, the broadcaster will use the estimated fee as the "safe minimum credit". If the estimated fee is less than the ticket EV, the broadcaster will use the ticket EV as the "safe minimum credit". We calculate the safe minimum credit in this manner because the orchestrator still requires a minimum credit (EV of a single ticket) - we can remove this safe minimum credit calculation if we implement short circuited transcoding in the future which would allow us to remove minimum credit requirements.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 7495ea6: Add the `estimateFee()` helper
- 1171e35: Reuse a helper for converting `*net.PriceInfo` into `*big.Rat` 
- 5e31f8d: Add safe minimum credit calculation

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests. 

Replicated the scenario described in #1174 by streaming into the broadcaster, immediately shutting it down after submitting the first segment and before it receives a response and then reconnecting to the same orchestrator after rebooting the broadcaster.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1174

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
