### PR TITLE
support s3-compatible object stores

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -127,7 +127,7 @@ func main() {
 
 	// Storage:
 	datadir := flag.String("datadir", "", "data directory")
-	s3bucket := flag.String("s3bucket", "", "S3 region/bucket (e.g. eu-central-1/testbucket)")
+	s3bucket := flag.String("s3bucket", "", "S3 region/bucket (e.g. eu-central-1/testbucket) or url of an S3-compatible server (e.g. https://example.com:9000/testbucket)")
 	s3creds := flag.String("s3creds", "", "S3 credentials (in form ACCESSKEYID/ACCESSKEY)")
 	gsBucket := flag.String("gsbucket", "", "Google storage bucket")
 	gsKey := flag.String("gskey", "", "Google Storage private key file name (in json format)")
@@ -599,8 +599,7 @@ func main() {
 		return
 	}
 	if *s3bucket != "" {
-		s3bp := strings.Split(*s3bucket, "/")
-		drivers.S3BUCKET = s3bp[1]
+		drivers.S3CONFIG = *s3bucket
 	}
 	if *gsBucket != "" && *gsKey == "" || *gsBucket == "" && *gsKey != "" {
 		glog.Error("Should specify both gsbucket and gskey")
@@ -609,9 +608,9 @@ func main() {
 
 	// XXX get s3 credentials from local env vars?
 	if *s3bucket != "" && *s3creds != "" {
-		br := strings.Split(*s3bucket, "/")
+		// br := strings.Split(*s3bucket, "/")
 		cr := strings.Split(*s3creds, "/")
-		drivers.NodeStorage = drivers.NewS3Driver(br[0], br[1], cr[0], cr[1])
+		drivers.NodeStorage = drivers.NewS3Driver(*s3bucket, cr[0], cr[1])
 	}
 
 	if *gsBucket != "" && *gsKey != "" {

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -120,7 +120,7 @@ if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
     --disable-encoders --disable-decoders --disable-filters --disable-bsfs \
     --disable-postproc --disable-lzma \
     --enable-gnutls --enable-libx264 --enable-gpl \
-    --enable-protocol=https,rtmp,file \
+    --enable-protocol=https,http,rtmp,file \
     --enable-muxer=mpegts,hls,segment --enable-demuxer=flv,mpegts \
     --enable-bsf=h264_mp4toannexb,aac_adtstoasc,h264_metadata,h264_redundant_pps \
     --enable-parser=aac,aac_latm,h264 \


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

I hacked this together so I could play around with using [Minio](https://min.io/) as an object store, executing go-livepeer like so:

```
./livepeer -s3bucket http://localhost:9000/eli-bucket -s3creds minioadmin/minioadmin -broadcaster -transcodingOptions P240p30fps16x9
```

**What does this pull request do? Explain your changes. (required)**

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Changed some of the logic on the `-s3bucket` parameter to allow it to support both the old `-s3bucket regionname/bucketname` format as well as a fully-specified `-s3bucket https://minio.example.com/bucketname`. 
- Added `--enable-protocol=http` to the ffmpeg build so that the HLS puller can request segments from a non-https store, e.g. for a local Minio server in a secure cluster.

**How did you test each of these updates (required)**
* Tried four test cases with a local Minio server: Broadcaster OS, Orchestrator OS, Both OS, neither OS. I tried to repeat all four cases with an Amazon S3 bucket but got signature errors. Then I tried the same methodology with a build off of master and still got signature errors. Is there a current S3 bug, perhaps?
