### PR TITLE
core, pm: validate payment sender

### DIFF
--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -138,6 +138,11 @@ func (r *recipient) Stop() {
 func (r *recipient) ReceiveTicket(ticket *Ticket, sig []byte, seed *big.Int) (string, bool, error) {
 	recipientRand := r.rand(seed, ticket.Sender)
 
+	// If sender validation check fails, abort
+	if err := r.sm.ValidateSender(ticket.Sender); err != nil {
+		return "", false, err
+	}
+
 	// If any of the basic ticket validity checks fail, abort
 	if err := r.val.ValidateTicket(r.addr, ticket, sig, recipientRand); err != nil {
 		return "", false, err

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -260,6 +260,23 @@ func TestReceiveTicket_InvalidWinProb_AcceptableError(t *testing.T) {
 
 }
 
+func TestReceiveTicket_InvalidSender(t *testing.T) {
+	assert := assert.New(t)
+	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
+	sm.validateSenderErr = errors.New("Invalid Sender")
+	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)
+
+	params, err := r.TicketParams(sender)
+	require.Nil(t, err)
+
+	// Test valid non-winning ticket
+	newSenderNonce := uint32(3)
+	ticket := newTicket(sender, params, newSenderNonce)
+
+	_, _, err = r.ReceiveTicket(ticket, sig, params.Seed)
+	assert.EqualError(err, "Invalid Sender")
+}
+
 func TestReceiveTicket_InvalidTicket(t *testing.T) {
 	sender, b, v, ts, gm, sm, em, cfg, sig := newRecipientFixtureOrFatal(t)
 	r := newRecipientOrFatal(t, RandAddress(), b, v, ts, gm, sm, em, cfg)

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -277,12 +277,13 @@ func (s *stubGasPriceMonitor) GasPrice() *big.Int {
 }
 
 type stubSenderMonitor struct {
-	maxFloat    *big.Int
-	redeemable  chan *SignedTicket
-	queued      []*SignedTicket
-	acceptable  bool
-	addFloatErr error
-	maxFloatErr error
+	maxFloat          *big.Int
+	redeemable        chan *SignedTicket
+	queued            []*SignedTicket
+	acceptable        bool
+	addFloatErr       error
+	maxFloatErr       error
+	validateSenderErr error
 }
 
 func newStubSenderMonitor() *stubSenderMonitor {
@@ -323,6 +324,8 @@ func (s *stubSenderMonitor) MaxFloat(addr ethcommon.Address) (*big.Int, error) {
 
 	return s.maxFloat, nil
 }
+
+func (s *stubSenderMonitor) ValidateSender(addr ethcommon.Address) error { return s.validateSenderErr }
 
 // MockRecipient is useful for testing components that depend on pm.Recipient
 type MockRecipient struct {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds functionality that allows an orchestrator to check whether a broadcaster is coming near to the end of its unlock period. If this is the case the orchestrator will not accept segments nor payments from that broadcaster. 

This is accomplished by a `recipient.ValidateSender(sender ethcommon.Address) error` method that is called in `Orchestrator.ProcessPayment()`. This method currently does a single check against an unlock period but can be extended with other functionality if needed. 

This structure allows us to leverage a `RoundsWatcher` and `SenderWatcher` instance that is already active on `SenderMonitor`. The methods for `SenderMonitor` are (for good reason) not directly accessible on the `Recipient` interface that `Orchestrator` uses, therefore the call graph is `core.Orchestrator.ProcessPayment -> Recipient.ValidateSender -> SenderMonitor.IsLocked`.

Alternatively, we could have added a method to `Orchestrator` that accomplishes the same thing, but we would have had to add `SenderWatcher` and `RoundsWatcher` instances to `LivepeerNode` specifically for this. It thus seems a cleaner tradeoff to have a "wrapper/forwarding" function in `Recipient`.

**Specific updates (required)**
- Added a new method `Recipient.ValidateSender(sender ethcommon.Address) error`
- Added a new method `SenderMonitor.IsLocked(sender ethcommon.Address) error`
- Call `Recipient.ValidateSender` in `Orchestrator.ProcessPayment` , short circuit if the sender is nearing its unlock period
- Added the above methods to stubs

**How did you test each of these updates (required)**
Ran unit tests

**Does this pull request close any open issues?**
Fixes #1183 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
