### PR TITLE
pm, server: broadcaster deposit & withdrawround self-check

### DIFF
--- a/pm/sender.go
+++ b/pm/sender.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ErrSenderValidation is emitted when sender.validateSender() encounters an error
+// ErrSenderValidation is returned when the sender cannot send tickets
 type ErrSenderValidation struct {
 	error
 }

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -9,6 +9,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrSenderValidation is emitted when sender.validateSender() encounters an error
+type ErrSenderValidation struct {
+	error
+}
+
 // Sender enables starting multiple probabilistic micropayment sessions with multiple recipients
 // and create tickets that adhere to each session's params and unique nonce requirements.
 type Sender interface {
@@ -78,12 +83,12 @@ func (s *sender) EV(sessionID string) (*big.Rat, error) {
 func (s *sender) validateSender() error {
 	info, err := s.senderManager.GetSenderInfo(s.signer.Account().Address)
 	if err != nil {
-		return fmt.Errorf("unable to validate sender: could not get sender info: %v", err)
+		return ErrSenderValidation{fmt.Errorf("unable to validate sender: could not get sender info: %v", err)}
 	}
 
 	maxWithdrawRound := new(big.Int).Add(s.roundsManager.LastInitializedRound(), big.NewInt(1))
 	if info.WithdrawRound.Int64() != 0 && info.WithdrawRound.Cmp(maxWithdrawRound) != 1 {
-		return fmt.Errorf("unable to validate sender: deposit and reserve is set to unlock soon")
+		return ErrSenderValidation{fmt.Errorf("unable to validate sender: deposit and reserve is set to unlock soon")}
 	}
 
 	return nil

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -131,6 +131,8 @@ func TestSender_ValidateSender(t *testing.T) {
 	sm.info[account.Address].WithdrawRound = big.NewInt(2)
 	err = s.validateSender()
 	assert.EqualError(err, "unable to validate sender: deposit and reserve is set to unlock soon")
+	_, ok = err.(ErrSenderValidation)
+	assert.True(ok)
 
 	// Not unlocked
 	sm.info[account.Address].WithdrawRound = big.NewInt(0)

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -115,12 +115,16 @@ func TestSender_ValidateSender(t *testing.T) {
 	// GetSenderInfo error
 	sm.err = errors.New("GetSenderInfo error")
 	err := s.validateSender()
+	_, ok := err.(ErrSenderValidation)
+	assert.True(ok)
 	assert.EqualError(err, "unable to validate sender: could not get sender info: GetSenderInfo error")
 	sm.err = nil
 
 	// Sender's (withdraw round + 1 = current round)
 	sm.info[account.Address].WithdrawRound = big.NewInt(4)
 	err = s.validateSender()
+	_, ok = err.(ErrSenderValidation)
+	assert.True(ok)
 	assert.EqualError(err, "unable to validate sender: deposit and reserve is set to unlock soon")
 
 	// withdrawround + 1 < current round

--- a/pm/sendermonitor_test.go
+++ b/pm/sendermonitor_test.go
@@ -470,7 +470,7 @@ func TestReserveAlloc(t *testing.T) {
 	assert.Zero(expectedAlloc.Cmp(alloc))
 }
 
-func TestValidateSender(t *testing.T) {
+func TestSenderMonitor_ValidateSender(t *testing.T) {
 	claimant, b, smgr, rm, em := senderMonitorFixture()
 	addr := RandAddress()
 	smgr.info[addr] = &SenderInfo{

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -250,6 +250,7 @@ func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core
 
 func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, error) {
 
+	rtmpStrm := cxn.stream
 	nonce := cxn.nonce
 	cpl := cxn.pl
 	mid := cxn.mid
@@ -294,6 +295,14 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, erro
 		if urls, err := transcodeSegment(cxn, seg, name, sv); err == nil {
 			return urls, nil
 		}
+
+		if shouldStopStream(err) {
+			glog.Warningf("Stopping current stream due to: %v", err)
+			rtmpStrm.Close()
+			return nil, err
+		}
+
+		// recoverable error, retry
 	}
 }
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/net"
+	"github.com/livepeer/go-livepeer/pm"
 
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/common"
@@ -801,4 +802,9 @@ func (s *LivepeerServer) LatestPlaylist() core.PlaylistManager {
 		return nil
 	}
 	return cxn.pl
+}
+
+func shouldStopStream(err error) bool {
+	_, ok := err.(pm.ErrSenderValidation)
+	return ok
 }

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/big"
 	"math/rand"
 	"mime/multipart"
 	"net/http"
@@ -374,24 +373,6 @@ func endRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 
 func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*rtmpConnection, error) {
 	nonce := rand.Uint64()
-
-	// If running in on-chain mode, check for a reasonable deposit
-	if s.LivepeerNode.Eth != nil {
-		info, err := s.LivepeerNode.Eth.GetSenderInfo(s.LivepeerNode.Eth.Account().Address)
-		if err != nil {
-			return nil, err
-		}
-
-		if info.Deposit.Cmp(big.NewInt(0)) <= 0 {
-			glog.Errorf("No deposit - cannot start broadcast session")
-
-			if monitor.Enabled {
-				monitor.StreamCreateFailed(nonce, "LowDeposit")
-			}
-
-			return nil, errLowDeposit
-		}
-	}
 
 	// Set up the connection tracking
 	params := streamParams(rtmpStrm)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -821,6 +821,14 @@ func TestCleanStreamPrefix(t *testing.T) {
 	}
 }
 
+func TestShouldStopStream(t *testing.T) {
+	assert := assert.New(t)
+	ok := shouldStopStream(fmt.Errorf("some random error string"))
+	assert.False(ok)
+	ok = shouldStopStream(pm.ErrSenderValidation{})
+	assert.True(ok)
+}
+
 func TestParseManifestID(t *testing.T) {
 	checkMid := func(inp string, exp string) {
 		mid := parseManifestID(inp)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -16,10 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts"
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/livepeer/go-livepeer/common"
-	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/pm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -697,42 +693,9 @@ func TestRegisterConnection(t *testing.T) {
 	mid := core.SplitStreamIDString(t.Name()).ManifestID
 	strm := stream.NewBasicRTMPVideoStream(&streamParameters{mid: mid})
 
-	// Switch to on-chain mode
-	c := &eth.MockClient{}
-	addr := ethcommon.Address{}
-	s.LivepeerNode.Eth = c
-
-	// Should return an error if in on-chain mode and fail to get sender deposit
-	c.On("Account").Return(accounts.Account{Address: addr})
-	c.On("GetSenderInfo", addr).Return(nil, errors.New("GetSenderInfo error")).Once()
-
-	_, err := s.registerConnection(strm)
-	assert.Equal("GetSenderInfo error", err.Error())
-
-	// Should return an error if in on-chain mode and sender deposit is 0
-	info := &pm.SenderInfo{
-		Deposit: big.NewInt(0),
-	}
-	c.On("GetSenderInfo", addr).Return(info, nil).Once()
-
-	_, err = s.registerConnection(strm)
-	assert.Equal(errLowDeposit, err)
-
-	// Remove node storage
-	drivers.NodeStorage = nil
-
-	// Should return a different error if in on-chain mode and sender deposit > 0
-	info.Deposit = big.NewInt(1)
-	c.On("GetSenderInfo", addr).Return(info, nil).Once()
-
-	_, err = s.registerConnection(strm)
-	assert.NotEqual(errLowDeposit, err)
-
-	// Switch to off-chain mode
-	s.LivepeerNode.Eth = nil
-
 	// Should return an error if missing node storage
-	_, err = s.registerConnection(strm)
+	drivers.NodeStorage = nil
+	_, err := s.registerConnection(strm)
 	assert.Equal(err, errStorage)
 	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Currently, a broadcaster in on-chain mode will alert a user that a broadcast session cannot be started if the deposit is 0, we now expand this functionality to also check whether a broadcaster has unlocked it's reserve & deposit and is nearing its `WithdrawRound`

In addition we now favor using cached values (using `SenderWatcher`) over RPC calls to a remote ethereum node to do these checks

**Specific updates (required)**
- Added a `Validate()` method to `pm.Sender` (perhaps "SelfValidate" is a better name?) 
- Call `pm.Sender.Validate` in `LivepeerServer.registerConnection()` return an error if self validation fails and prevent from sending segments to O's


**How did you test each of these updates (required)**
ran unit tests 

**Does this pull request close any open issues?**
Fixes #1184 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass

**Alternatives Considered**
- Move the validation check to `pm.Sender.StartSession` so we don't have to expand the API surface. We would have to change the signature to return an error when validation logic fails. This will result in an empty sessions list and transcoding will not happen. Harder to propagate the correct error here though. 
- Move the validation check to the constructor `pm.NewSender` and return when we hit an error, this will however shut down the node and prevents a B from re-locking or re-depositing through the CLI

