### PR TITLE
cmd, common, eth: cache orchestrator stake

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -429,7 +429,7 @@ func main() {
 		go senderWatcher.Watch()
 		defer senderWatcher.Stop()
 
-		orchWatcher, err := watchers.NewOrchestratorWatcher(addrMap["BondingManager"], blockWatcher, dbh, n.Eth)
+		orchWatcher, err := watchers.NewOrchestratorWatcher(addrMap["BondingManager"], blockWatcher, dbh, n.Eth, roundsWatcher)
 		if err != nil {
 			glog.Errorf("Failed to setup orchestrator watcher: %v", err)
 			return

--- a/common/db.go
+++ b/common/db.go
@@ -46,6 +46,7 @@ type DBOrch struct {
 	PricePerPixel     int64
 	ActivationRound   int64
 	DeactivationRound int64
+	Stake             string
 }
 
 // DBOrch is the type binding for a row result from the unbondingLocks table
@@ -81,7 +82,8 @@ var schema = `
 		serviceURI STRING,
 		pricePerPixel int64,
 		activationRound int64,
-		deactivationRound int64
+		deactivationRound int64,
+		stake STRING
 	);
 
 	CREATE TABLE IF NOT EXISTS unbondingLocks (
@@ -121,13 +123,14 @@ var schema = `
 	CREATE INDEX IF NOT EXISTS idx_blockheaders_number ON blockheaders(number);
 `
 
-func NewDBOrch(ethereumAddr string, serviceURI string, pricePerPixel int64, activationRound int64, deactivationRound int64) *DBOrch {
+func NewDBOrch(ethereumAddr string, serviceURI string, pricePerPixel int64, activationRound int64, deactivationRound int64, stake string) *DBOrch {
 	return &DBOrch{
 		ServiceURI:        serviceURI,
 		EthereumAddr:      ethereumAddr,
 		PricePerPixel:     pricePerPixel,
 		ActivationRound:   activationRound,
 		DeactivationRound: deactivationRound,
+		Stake:             stake,
 	}
 }
 
@@ -195,8 +198,8 @@ func InitDB(dbPath string) (*DB, error) {
 
 	// updateOrch prepared statement
 	stmt, err = db.Prepare(`
-	INSERT INTO orchestrators(updatedAt, ethereumAddr, serviceURI, pricePerPixel, activationRound, deactivationRound, createdAt) 
-	VALUES(datetime(), :ethereumAddr, :serviceURI, :pricePerPixel, :activationRound, :deactivationRound, datetime()) 
+	INSERT INTO orchestrators(updatedAt, ethereumAddr, serviceURI, pricePerPixel, activationRound, deactivationRound, stake, createdAt) 
+	VALUES(datetime(), :ethereumAddr, :serviceURI, :pricePerPixel, :activationRound, :deactivationRound, :stake, datetime()) 
 	ON CONFLICT(ethereumAddr) DO UPDATE SET 
 	updatedAt = excluded.updatedAt,
 	serviceURI =
@@ -214,7 +217,11 @@ func InitDB(dbPath string) (*DB, error) {
 	deactivationRound = 
 		CASE WHEN excluded.deactivationRound == 0
 		THEN orchestrators.deactivationRound
-		ELSE excluded.deactivationRound END 
+		ELSE excluded.deactivationRound END,
+	stake = 
+		CASE WHEN excluded.stake == ""
+		THEN orchestrators.stake
+		ELSE excluded.stake END 
 	`)
 	d.updateOrch = stmt
 
@@ -420,6 +427,7 @@ func (db *DB) UpdateOrch(orch *DBOrch) error {
 		sql.Named("pricePerPixel", orch.PricePerPixel),
 		sql.Named("activationRound", orch.ActivationRound),
 		sql.Named("deactivationRound", orch.DeactivationRound),
+		sql.Named("stake", orch.Stake),
 	)
 
 	if err != nil {
@@ -448,12 +456,18 @@ func (db *DB) SelectOrchs(filter *DBOrchFilter) ([]*DBOrch, error) {
 			pricePerPixel     int64
 			activationRound   int64
 			deactivationRound int64
+			stake             sql.NullString
 		)
-		if err := rows.Scan(&serviceURI, &ethereumAddr, &pricePerPixel, &activationRound, &deactivationRound); err != nil {
+		if err := rows.Scan(&serviceURI, &ethereumAddr, &pricePerPixel, &activationRound, &deactivationRound, &stake); err != nil {
 			glog.Error("db: Unable to fetch orchestrator ", err)
 			continue
 		}
-		orchs = append(orchs, NewDBOrch(serviceURI, ethereumAddr, pricePerPixel, activationRound, deactivationRound))
+
+		totalStake := "0"
+		if stake.Valid {
+			totalStake = stake.String
+		}
+		orchs = append(orchs, NewDBOrch(serviceURI, ethereumAddr, pricePerPixel, activationRound, deactivationRound, totalStake))
 	}
 	return orchs, nil
 }
@@ -655,7 +669,7 @@ func buildWinningTicketsQuery(sessionIDs []string) string {
 }
 
 func buildSelectOrchsQuery(filter *DBOrchFilter) (string, error) {
-	query := "SELECT ethereumAddr, serviceURI, pricePerPixel, activationRound, deactivationRound FROM orchestrators "
+	query := "SELECT ethereumAddr, serviceURI, pricePerPixel, activationRound, deactivationRound, stake FROM orchestrators "
 	fil, err := buildFilterOrchsQuery(filter)
 	if err != nil {
 		return "", err

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -222,7 +222,7 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 
 	// adding row
 	orchAddress := pm.RandAddress().String()
-	orch := NewDBOrch(orchAddress, "127.0.0.1:8936", 1, 0, 0)
+	orch := NewDBOrch(orchAddress, "127.0.0.1:8936", 1, 0, 0, "")
 
 	err = dbh.UpdateOrch(orch)
 	require.Nil(err)
@@ -233,7 +233,7 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 	assert.Equal(orchs[0].ServiceURI, orch.ServiceURI)
 
 	// updating row with same orchAddress
-	orchUpdate := NewDBOrch(orchAddress, "127.0.0.1:8937", 1000, 5, 10)
+	orchUpdate := NewDBOrch(orchAddress, "127.0.0.1:8937", 1000, 5, 10, "50")
 	err = dbh.UpdateOrch(orchUpdate)
 	require.Nil(err)
 
@@ -243,6 +243,7 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 	assert.Equal(updatedOrch[0].ActivationRound, orchUpdate.ActivationRound)
 	assert.Equal(updatedOrch[0].DeactivationRound, orchUpdate.DeactivationRound)
 	assert.Equal(updatedOrch[0].PricePerPixel, orchUpdate.PricePerPixel)
+	assert.Equal(updatedOrch[0].Stake, orchUpdate.Stake)
 
 	// updating only serviceURI
 	serviceURIUpdate := &DBOrch{
@@ -258,6 +259,7 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 	assert.Equal(updatedOrch[0].ActivationRound, orchUpdate.ActivationRound)
 	assert.Equal(updatedOrch[0].DeactivationRound, orchUpdate.DeactivationRound)
 	assert.Equal(updatedOrch[0].PricePerPixel, orchUpdate.PricePerPixel)
+	assert.Equal(updatedOrch[0].Stake, orchUpdate.Stake)
 
 	// udpating only pricePerPixel
 	priceUpdate := &DBOrch{
@@ -273,6 +275,7 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 	assert.Equal(updatedOrch[0].ActivationRound, orchUpdate.ActivationRound)
 	assert.Equal(updatedOrch[0].DeactivationRound, orchUpdate.DeactivationRound)
 	assert.Equal(updatedOrch[0].PricePerPixel, priceUpdate.PricePerPixel)
+	assert.Equal(updatedOrch[0].Stake, orchUpdate.Stake)
 
 	// updating only activationRound
 	activationRoundUpdate := &DBOrch{
@@ -288,6 +291,7 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 	assert.Equal(updatedOrch[0].ActivationRound, activationRoundUpdate.ActivationRound)
 	assert.Equal(updatedOrch[0].DeactivationRound, orchUpdate.DeactivationRound)
 	assert.Equal(updatedOrch[0].PricePerPixel, priceUpdate.PricePerPixel)
+	assert.Equal(updatedOrch[0].Stake, orchUpdate.Stake)
 
 	// updating only deactivationRound
 	deactivationRoundUpdate := &DBOrch{
@@ -303,6 +307,24 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 	assert.Equal(updatedOrch[0].ActivationRound, activationRoundUpdate.ActivationRound)
 	assert.Equal(updatedOrch[0].DeactivationRound, deactivationRoundUpdate.DeactivationRound)
 	assert.Equal(updatedOrch[0].PricePerPixel, priceUpdate.PricePerPixel)
+	assert.Equal(updatedOrch[0].Stake, orchUpdate.Stake)
+
+	// Updating only stake
+	stakeUpdate := &DBOrch{
+		EthereumAddr: orchAddress,
+		Stake:        "1000",
+	}
+	err = dbh.UpdateOrch(stakeUpdate)
+	require.Nil(err)
+
+	updatedOrch, err = dbh.SelectOrchs(nil)
+	assert.Len(updatedOrch, 1)
+	assert.NoError(err)
+	assert.Equal(updatedOrch[0].ServiceURI, serviceURIUpdate.ServiceURI)
+	assert.Equal(updatedOrch[0].ActivationRound, activationRoundUpdate.ActivationRound)
+	assert.Equal(updatedOrch[0].DeactivationRound, deactivationRoundUpdate.DeactivationRound)
+	assert.Equal(updatedOrch[0].PricePerPixel, priceUpdate.PricePerPixel)
+	assert.Equal(updatedOrch[0].Stake, stakeUpdate.Stake)
 }
 
 func TestSelectUpdateOrchs_AddingMultipleRows_NoError(t *testing.T) {
@@ -316,7 +338,7 @@ func TestSelectUpdateOrchs_AddingMultipleRows_NoError(t *testing.T) {
 	// adding one row
 	orchAddress := pm.RandAddress().String()
 
-	orch := NewDBOrch(orchAddress, "127.0.0.1:8936", 1, 0, 0)
+	orch := NewDBOrch(orchAddress, "127.0.0.1:8936", 1, 0, 0, "0")
 	err = dbh.UpdateOrch(orch)
 	require.Nil(err)
 
@@ -328,7 +350,7 @@ func TestSelectUpdateOrchs_AddingMultipleRows_NoError(t *testing.T) {
 	// adding second row
 	orchAddress = pm.RandAddress().String()
 
-	orchAdd := NewDBOrch(orchAddress, "127.0.0.1:8938", 1, 0, 0)
+	orchAdd := NewDBOrch(orchAddress, "127.0.0.1:8938", 1, 0, 0, "0")
 	err = dbh.UpdateOrch(orchAdd)
 	require.Nil(err)
 
@@ -353,7 +375,7 @@ func TestOrchCount(t *testing.T) {
 	require.Nil(err)
 
 	for i := 0; i < 10; i++ {
-		orch := NewDBOrch("https://127.0.0.1:"+strconv.Itoa(8936+i), pm.RandAddress().String(), 1, int64(i), int64(5+i))
+		orch := NewDBOrch("https://127.0.0.1:"+strconv.Itoa(8936+i), pm.RandAddress().String(), 1, int64(i), int64(5+i), "0")
 		orch.PricePerPixel, err = PriceToFixed(big.NewRat(1, int64(5+i)))
 		require.Nil(err)
 		err = dbh.UpdateOrch(orch)
@@ -408,7 +430,7 @@ func TestDBFilterOrchs(t *testing.T) {
 	require.Nil(err)
 
 	for i := 0; i < 10; i++ {
-		orch := NewDBOrch(pm.RandAddress().String(), "https://127.0.0.1:"+strconv.Itoa(8936+i), 1, int64(i), int64(5+i))
+		orch := NewDBOrch(pm.RandAddress().String(), "https://127.0.0.1:"+strconv.Itoa(8936+i), 1, int64(i), int64(5+i), "0")
 		orch.PricePerPixel, err = PriceToFixed(big.NewRat(1, int64(5+i)))
 		require.Nil(err)
 		err = dbh.UpdateOrch(orch)

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -211,6 +211,7 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 		Database: dbh,
 		Eth: &eth.StubClient{
 			Orchestrators: orchestrators,
+			TotalStake:    big.NewInt(5000),
 		},
 		Sender: sender,
 	}
@@ -235,6 +236,7 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 	for _, o := range dbOrchs {
 		test := toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel)
 		assert.Contains(testOrchs, test)
+		assert.Equal(o.Stake, big.NewInt(5000).String())
 	}
 
 	urls := pool.GetURLs()

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -172,6 +172,8 @@ type StubClient struct {
 	ClaimedReserveError          error
 	Orch                         *lpTypes.Transcoder
 	Err                          error
+	TotalStake                   *big.Int
+	TranscoderPoolError          error
 }
 
 type stubTranscoder struct {
@@ -244,7 +246,10 @@ func (e *StubClient) GetDelegatorUnbondingLock(addr common.Address, unbondingLoc
 	return nil, nil
 }
 func (e *StubClient) GetTranscoderEarningsPoolForRound(addr common.Address, round *big.Int) (*lpTypes.TokenPools, error) {
-	return nil, nil
+	if e.TranscoderPoolError != nil {
+		return &lpTypes.TokenPools{}, e.TranscoderPoolError
+	}
+	return &lpTypes.TokenPools{TotalStake: e.TotalStake}, nil
 }
 func (e *StubClient) TranscoderPool() ([]*lpTypes.Transcoder, error) {
 	return e.Orchestrators, nil

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -2,6 +2,7 @@ package watchers
 
 import (
 	"math"
+	"math/big"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -19,10 +20,11 @@ type OrchestratorWatcher struct {
 	dec     *EventDecoder
 	watcher BlockWatcher
 	lpEth   eth.LivepeerEthClient
+	rw      EventWatcher
 	quit    chan struct{}
 }
 
-func NewOrchestratorWatcher(bondingManagerAddr ethcommon.Address, watcher BlockWatcher, store common.OrchestratorStore, lpEth eth.LivepeerEthClient) (*OrchestratorWatcher, error) {
+func NewOrchestratorWatcher(bondingManagerAddr ethcommon.Address, watcher BlockWatcher, store common.OrchestratorStore, lpEth eth.LivepeerEthClient, rw EventWatcher) (*OrchestratorWatcher, error) {
 	dec, err := NewEventDecoder(bondingManagerAddr, contracts.BondingManagerABI)
 	if err != nil {
 		return nil, err
@@ -33,12 +35,17 @@ func NewOrchestratorWatcher(bondingManagerAddr ethcommon.Address, watcher BlockW
 		dec:     dec,
 		watcher: watcher,
 		lpEth:   lpEth,
+		rw:      rw,
 		quit:    make(chan struct{}),
 	}, nil
 }
 
 // Watch starts the event watching loop
 func (ow *OrchestratorWatcher) Watch() {
+	roundEvents := make(chan types.Log, 10)
+	roundSub := ow.rw.Subscribe(roundEvents)
+	defer roundSub.Unsubscribe()
+
 	events := make(chan []*blockwatch.Event, 10)
 	sub := ow.watcher.Subscribe(events)
 	defer sub.Unsubscribe()
@@ -51,6 +58,10 @@ func (ow *OrchestratorWatcher) Watch() {
 			glog.Error(err)
 		case events := <-events:
 			ow.handleBlockEvents(events)
+		case roundEvent := <-roundEvents:
+			if err := ow.handleRoundEvent(roundEvent); err != nil {
+				glog.Errorf("error handling new round event: %v", err)
+			}
 		}
 	}
 }
@@ -150,4 +161,42 @@ func (ow *OrchestratorWatcher) handleTranscoderDeactivated(log types.Log) error 
 			DeactivationRound: t.DeactivationRound.Int64(),
 		},
 	)
+}
+
+func (ow *OrchestratorWatcher) handleRoundEvent(log types.Log) error {
+	round, err := ow.lpEth.CurrentRound()
+	if err != nil {
+		return err
+	}
+
+	orchs, err := ow.store.SelectOrchs(&common.DBOrchFilter{CurrentRound: round})
+	if err != nil {
+		return err
+	}
+
+	for _, o := range orchs {
+		if err := ow.cacheOrchestratorStake(ethcommon.HexToAddress(o.EthereumAddr), round); err != nil {
+			glog.Errorf("could not cache stake update for orchestrator %v and round %v", o.EthereumAddr, round)
+		}
+	}
+
+	return nil
+}
+
+func (ow *OrchestratorWatcher) cacheOrchestratorStake(addr ethcommon.Address, round *big.Int) error {
+	ep, err := ow.lpEth.GetTranscoderEarningsPoolForRound(addr, round)
+	if err != nil {
+		return err
+	}
+
+	if err := ow.store.UpdateOrch(
+		&common.DBOrch{
+			EthereumAddr: addr.Hex(),
+			Stake:        ep.TotalStake.String(),
+		},
+	); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/eth/watchers/senderwatcher.go
+++ b/eth/watchers/senderwatcher.go
@@ -104,7 +104,9 @@ func (sw *SenderWatcher) Watch() {
 		case events := <-events:
 			sw.handleBlockEvents(events)
 		case roundEvent := <-roundEvents:
-			sw.handleRoundEvent(roundEvent)
+			if err := sw.handleRoundEvent(roundEvent); err != nil {
+				glog.Errorf("error handling new round event: %v", err)
+			}
 		}
 	}
 }

--- a/eth/watchers/stub.go
+++ b/eth/watchers/stub.go
@@ -365,17 +365,29 @@ type stubOrchestratorStore struct {
 	deactivationRound int64
 	serviceURI        string
 	ethereumAddr      string
+	stake             string
+	selectErr         error
+	updateErr         error
 }
 
 func (s *stubOrchestratorStore) UpdateOrch(orch *common.DBOrch) error {
+	if s.updateErr != nil {
+		return s.updateErr
+	}
 	s.activationRound = orch.ActivationRound
 	s.deactivationRound = orch.DeactivationRound
 	s.ethereumAddr = orch.EthereumAddr
 	s.serviceURI = orch.ServiceURI
+	s.stake = orch.Stake
 	return nil
 }
 
 func (s *stubOrchestratorStore) OrchCount(filter *common.DBOrchFilter) (int, error) { return 0, nil }
 func (s *stubOrchestratorStore) SelectOrchs(filter *common.DBOrchFilter) ([]*common.DBOrch, error) {
-	return nil, nil
+	if s.selectErr != nil {
+		return []*common.DBOrch{}, s.selectErr
+	}
+	return []*common.DBOrch{
+		common.NewDBOrch(s.ethereumAddr, s.serviceURI, 0, s.activationRound, s.deactivationRound, s.stake),
+	}, nil
 }

--- a/eth/watchers/types.go
+++ b/eth/watchers/types.go
@@ -3,7 +3,6 @@ package watchers
 import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
 )
 
@@ -13,8 +12,4 @@ type BlockWatcher interface {
 
 type EventWatcher interface {
 	Subscribe(sink chan<- types.Log) event.Subscription
-}
-
-type orchestratorStore interface {
-	UpdateOrch(*common.DBOrch) error
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR caches the stake for orchestrators in the active set whenever a new round event is emitted. 

This can be both a removed log (re-org) or an added log (new round), in both cases we make an RPC call for the current round number and a subsequent RPC call for each O to fetch its stake for that specific round. We then update the orchestrator in the DB with the new stake. 

**Specific updates (required)**
- Added a `stake` column to the  `orchestrators` table and updated `UpdateOrch` and `SelectOrchs` methods accordingly 
- Added a `RoundsWatcher` subscription to `OrchestratorWatcher`
- Added internal helper methods `handleRoundEvent` and `cacheOrchestratorStake` to `OrchestratorWatcher`
- updated `StubEthClient.GetTranscoderPoolForRound`
- Cache stake for orchestrators when `DBOrchestratorPoolCache` is created

**How did you test each of these updates (required)**
ran unit tests


**Does this pull request close any open issues?**
Fixes #1213 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
