### PR TITLE
eth/watchers: store serviceURI on TranscoderActivated event

### DIFF
--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -171,6 +171,7 @@ type StubClient struct {
 	ClaimedAmount                *big.Int
 	ClaimedReserveError          error
 	Orch                         *lpTypes.Transcoder
+	Err                          error
 }
 
 type stubTranscoder struct {
@@ -204,7 +205,12 @@ func (e *StubClient) TotalSupply() (*big.Int, error)                  { return b
 // Service Registry
 
 func (e *StubClient) SetServiceURI(serviceURI string) (*types.Transaction, error) { return nil, nil }
-func (e *StubClient) GetServiceURI(addr common.Address) (string, error)           { return e.Orch.ServiceURI, nil }
+func (e *StubClient) GetServiceURI(addr common.Address) (string, error) {
+	if e.Err != nil {
+		return "", e.Err
+	}
+	return e.Orch.ServiceURI, nil
+}
 
 // Staking
 
@@ -228,6 +234,9 @@ func (e *StubClient) ClaimEarnings(endRound *big.Int) error {
 	return nil
 }
 func (e *StubClient) GetTranscoder(addr common.Address) (*lpTypes.Transcoder, error) {
+	if e.Err != nil {
+		return nil, e.Err
+	}
 	return e.Orch, nil
 }
 func (e *StubClient) GetDelegator(addr common.Address) (*lpTypes.Delegator, error) { return nil, nil }

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -97,9 +97,15 @@ func (ow *OrchestratorWatcher) handleTranscoderActivated(log types.Log) error {
 	}
 
 	if !log.Removed {
+		uri, err := ow.lpEth.GetServiceURI(transcoderActivated.Transcoder)
+		if err != nil {
+			return err
+		}
+
 		return ow.store.UpdateOrch(
 			&common.DBOrch{
 				EthereumAddr:      transcoderActivated.Transcoder.String(),
+				ServiceURI:        uri,
 				ActivationRound:   transcoderActivated.ActivationRound.Int64(),
 				DeactivationRound: maxFutureRound,
 			},
@@ -112,6 +118,7 @@ func (ow *OrchestratorWatcher) handleTranscoderActivated(log types.Log) error {
 	return ow.store.UpdateOrch(
 		&common.DBOrch{
 			EthereumAddr:      t.Address.String(),
+			ServiceURI:        t.ServiceURI,
 			ActivationRound:   t.ActivationRound.Int64(),
 			DeactivationRound: t.DeactivationRound.Int64(),
 		},

--- a/eth/watchers/orchestratorwatcher_test.go
+++ b/eth/watchers/orchestratorwatcher_test.go
@@ -1,10 +1,12 @@
 package watchers
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
@@ -38,6 +40,7 @@ func TestOrchWatcher_HandleLog_TranscoderActivated(t *testing.T) {
 			Address:           pm.RandAddress(),
 			ActivationRound:   big.NewInt(5),
 			DeactivationRound: big.NewInt(100),
+			ServiceURI:        "http://mytranscoder.lpt:1337",
 		},
 	}
 	ow, err := NewOrchestratorWatcher(stubBondingManagerAddr, watcher, stubStore, lpEth)
@@ -60,13 +63,34 @@ func TestOrchWatcher_HandleLog_TranscoderActivated(t *testing.T) {
 	assert.Equal(stubActivationRound.Int64(), stubStore.activationRound)
 	assert.Equal(stubStore.deactivationRound, maxFutureRound)
 	assert.Equal(stubStore.ethereumAddr, stubTranscoder.String())
+	assert.Equal(stubStore.serviceURI, "http://mytranscoder.lpt:1337")
+
+	// test GetServiceURI error
+	errorLogsBefore := glog.Stats.Error.Lines()
+	lpEth.Err = errors.New("GetServiceURI error")
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	errorLogsAfter := glog.Stats.Error.Lines()
+	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
+	lpEth.Err = nil
 
 	blockEvent.Type = blockwatch.Removed
+	lpEth.Orch.ServiceURI = "http://mytranscoder.lpt:0000"
 	watcher.sink <- []*blockwatch.Event{blockEvent}
 	time.Sleep(2 * time.Millisecond)
 	assert.Equal(stubStore.activationRound, int64(5))
 	assert.Equal(stubStore.deactivationRound, int64(100))
 	assert.Equal(stubStore.ethereumAddr, lpEth.Orch.Address.String())
+	assert.Equal(stubStore.serviceURI, "http://mytranscoder.lpt:0000")
+
+	// test GetTranscoder error
+	errorLogsBefore = glog.Stats.Error.Lines()
+	lpEth.Err = errors.New("GetTranscoder error")
+	watcher.sink <- []*blockwatch.Event{blockEvent}
+	time.Sleep(2 * time.Millisecond)
+	errorLogsAfter = glog.Stats.Error.Lines()
+	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
+	lpEth.Err = nil
 }
 
 func TestOrchWatcher_HandleLog_TranscoderDeactivated(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fetches and stores an O's `ServiceURI` when handling a `TranscoderActivated` event. 
Since we're no longer backfilling from a block far in the past, which would synchronize all historical URI updates, we will end up never saving a URI for orchestrators that are added through the DB by emitted TranscoderActivated events.

Because there is no URI for these transcoders they will never be included in the working set as we can't retrieve off-chain info for them.

**Specific updates (required)**
- Added a call to `LivepeerEthClient.GetServiceURI` when a `TranscoderActivated` event is added and populate the `ServiceURI` field on the `DBOrch` struct that's passed into `OrchestratorStore.UpdateOrch`
- In case a `TranscoderActivated` event is removed we already have access to an O's `ServiceURI` because we call `LivepeerEthClient.GetTranscoder` , now we also propagate `ServiceURI` into the BD


**How did you test each of these updates (required)**
ran unit tests

**Does this pull request close any open issues?**
Fixes #1217 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
