### PR TITLE
cmd, core, eth/watchers: O checks that it is active in ProcessPayment

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -745,7 +745,7 @@ func main() {
 			return
 		}
 
-		orch := core.NewOrchestrator(s.LivepeerNode)
+		orch := core.NewOrchestrator(s.LivepeerNode, roundsWatcher)
 
 		go func() {
 			server.StartTranscodeServer(orch, *httpAddr, s.HTTPMux, n.WorkDir, n.TranscoderManager != nil)

--- a/common/types.go
+++ b/common/types.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"math/big"
 	"net/url"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -22,4 +23,8 @@ type OrchestratorStore interface {
 	OrchCount(filter *DBOrchFilter) (int, error)
 	SelectOrchs(filter *DBOrchFilter) ([]*DBOrch, error)
 	UpdateOrch(orch *DBOrch) error
+}
+
+type RoundsManager interface {
+	LastInitializedRound() *big.Int
 }

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -32,19 +32,15 @@ type ticketParamsValidator interface {
 	ValidateTicketParams(ticketParams *pm.TicketParams) error
 }
 
-type roundsManager interface {
-	LastInitializedRound() *big.Int
-}
-
 type DBOrchestratorPoolCache struct {
 	store                 common.OrchestratorStore
 	lpEth                 eth.LivepeerEthClient
 	ticketParamsValidator ticketParamsValidator
-	rm                    roundsManager
+	rm                    common.RoundsManager
 	bcast                 common.Broadcaster
 }
 
-func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm roundsManager) (*DBOrchestratorPoolCache, error) {
+func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm common.RoundsManager) (*DBOrchestratorPoolCache, error) {
 	if node.Eth == nil {
 		return nil, fmt.Errorf("could not create DBOrchestratorPoolCache: LivepeerEthClient is nil")
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This PR adds the necessary functionality for an O to check whether it is active before accepting payments/segments. 

**Specific updates (required)**
- Added an `AddressFilter` to `OrchestratorWatcher` which allows the `OrchestratorWatcher` implementation to only populate the DB for O itself when running in orchestrator mode
- Now starting `OrchestratorDBPoolCache` in on-chain mode for both O and B, in orchestrator mode the pool will only have one entry , the orchestrator itself. And `OrchestratorPool.Size()` will return 0 if the orchestrator is inactive and 1 if it is active
- Added a helper method `orchestrator.isActive() bool` that checks whether `OrchestratorPool.Size() > 0`
- Added a call to `orchestrator.isActive()` in `orchestrator.ProcessPayment()`, if the orchestrator is inactive we'll return an error. 

**How did you test each of these updates (required)**
Updated & ran unit tests

**Does this pull request close any open issues?**
Fixes #1202 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
