### PR TITLE
db: close db when updateOrch prepared statement can not be created

### DIFF
--- a/common/db.go
+++ b/common/db.go
@@ -216,6 +216,11 @@ func InitDB(dbPath string) (*DB, error) {
 		THEN orchestrators.deactivationRound
 		ELSE excluded.deactivationRound END 
 	`)
+	if err != nil {
+		glog.Error("Unable to prepare updateOrch ", err)
+		d.Close()
+		return nil, err
+	}
 	d.updateOrch = stmt
 
 	// Unbonding locks prepared statements


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

correctly close db and return error if the prepared statement for `updateOrch` fails to be bootstrapped. 

**Specific updates (required)**
- handle error for updateOrch prepared statement


**How did you test each of these updates (required)**
ran node in on-chain discovery mode


**Does this pull request close any open issues?**


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
