### PR TITLE
discovery: use maxInt64 deactivationRound in cacheTranscoderPool

### DIFF
--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"net/url"
 	"strings"
@@ -19,6 +20,8 @@ import (
 
 	"github.com/golang/glog"
 )
+
+const maxInt64 = int64(math.MaxInt64)
 
 var cacheRefreshInterval = 1 * time.Hour
 var getTicker = func() *time.Ticker {
@@ -243,12 +246,18 @@ func ethOrchToDBOrch(orch *lpTypes.Transcoder) *common.DBOrch {
 		return nil
 	}
 
-	return &common.DBOrch{
+	dbo := &common.DBOrch{
 		ServiceURI:        orch.ServiceURI,
 		EthereumAddr:      orch.Address.String(),
 		ActivationRound:   orch.ActivationRound.Int64(),
 		DeactivationRound: orch.DeactivationRound.Int64(),
 	}
+
+	if orch.DeactivationRound.Cmp(big.NewInt(maxInt64)) == 1 {
+		dbo.DeactivationRound = maxInt64
+	}
+
+	return dbo
 }
 
 func pmTicketParams(params *net.TicketParams) *pm.TicketParams {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

When an orchestrator becomes active it's on-chain `deactivationRound` gets set to the maximum value for `uint256`. In go-livepeer when we call `Eth.GetTranscoderPool` the value is returned as a `big.Int`, for inserting it into the database we convert it to an `int64` causing an overflow and `-1` is set as `deactivationRound` as a result, causing active O's to show as inactive (in order to be active the following must be true `currentRound < deactivationRound`). 

**Specific updates (required)**
- Check for each O if the returned `deactivationRound` from `Eth.GetTranscoders` would overflow when converted to `int64` set the max value for `int64` instead. 

Even though that this might cause issues very very very far into the future when we reach a  round where `2^63 − 1 < currentRound < 2^256` , this shouldn't be a concern now and we don't even know if the EVM will still be using 256 bit words when that time rolls around. 


**How did you test each of these updates (required)**
Ran on-chain transcoding workflow

```
I1203 00:15:08.314105   48383 discovery.go:105] Done fetching orch info for orchestrators, numResponses fetched: 5
I1203 00:15:08.314143   48383 broadcast.go:152] Ending session refresh
I1203 00:15:08.670160   48383 broadcast.go:450] Successfully validated segment nonce=8920814800456177905 seqNo=0
I1203 00:15:09.176480   48383 broadcast.go:450] Successfully validated segment nonce=8920814800456177905 seqNo=1
```

**Does this pull request close any open issues?**


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
