### PR TITLE
[O selection] server: Use BroadcastSessionsSelector in BroadcastSessionsManager

### DIFF
--- a/common/db.go
+++ b/common/db.go
@@ -61,6 +61,7 @@ type DBUnbondingLock struct {
 type DBOrchFilter struct {
 	MaxPrice     *big.Rat
 	CurrentRound *big.Int
+	Addresses    []ethcommon.Address
 }
 
 var LivepeerDBVersion = 1
@@ -701,6 +702,14 @@ func buildFilterOrchsQuery(filter *DBOrchFilter) (string, error) {
 		if filter.CurrentRound != nil {
 			currentRound := filter.CurrentRound.Int64()
 			qry += fmt.Sprintf(" AND activationRound <= %v AND %v < deactivationRound", currentRound, currentRound)
+		}
+
+		if len(filter.Addresses) > 0 {
+			hexAddrs := make([]string, len(filter.Addresses))
+			for i, addr := range filter.Addresses {
+				hexAddrs[i] = fmt.Sprintf("'%v'", addr.Hex())
+			}
+			qry += fmt.Sprintf(" AND ethereumAddr IN (%v)", strings.Join(hexAddrs, ", "))
 		}
 	}
 	return qry, nil

--- a/common/db.go
+++ b/common/db.go
@@ -46,7 +46,7 @@ type DBOrch struct {
 	PricePerPixel     int64
 	ActivationRound   int64
 	DeactivationRound int64
-	Stake             string
+	Stake             int64 // Stored as a fixed point number
 }
 
 // DBOrch is the type binding for a row result from the unbondingLocks table
@@ -83,7 +83,7 @@ var schema = `
 		pricePerPixel int64,
 		activationRound int64,
 		deactivationRound int64,
-		stake STRING
+		stake int64
 	);
 
 	CREATE TABLE IF NOT EXISTS unbondingLocks (
@@ -123,7 +123,7 @@ var schema = `
 	CREATE INDEX IF NOT EXISTS idx_blockheaders_number ON blockheaders(number);
 `
 
-func NewDBOrch(ethereumAddr string, serviceURI string, pricePerPixel int64, activationRound int64, deactivationRound int64, stake string) *DBOrch {
+func NewDBOrch(ethereumAddr string, serviceURI string, pricePerPixel int64, activationRound int64, deactivationRound int64, stake int64) *DBOrch {
 	return &DBOrch{
 		ServiceURI:        serviceURI,
 		EthereumAddr:      ethereumAddr,
@@ -219,7 +219,7 @@ func InitDB(dbPath string) (*DB, error) {
 		THEN orchestrators.deactivationRound
 		ELSE excluded.deactivationRound END,
 	stake = 
-		CASE WHEN excluded.stake == ""
+		CASE WHEN excluded.stake == 0
 		THEN orchestrators.stake
 		ELSE excluded.stake END 
 	`)
@@ -461,18 +461,14 @@ func (db *DB) SelectOrchs(filter *DBOrchFilter) ([]*DBOrch, error) {
 			pricePerPixel     int64
 			activationRound   int64
 			deactivationRound int64
-			stake             sql.NullString
+			stake             int64
 		)
 		if err := rows.Scan(&serviceURI, &ethereumAddr, &pricePerPixel, &activationRound, &deactivationRound, &stake); err != nil {
 			glog.Error("db: Unable to fetch orchestrator ", err)
 			continue
 		}
 
-		totalStake := "0"
-		if stake.Valid {
-			totalStake = stake.String
-		}
-		orchs = append(orchs, NewDBOrch(serviceURI, ethereumAddr, pricePerPixel, activationRound, deactivationRound, totalStake))
+		orchs = append(orchs, NewDBOrch(serviceURI, ethereumAddr, pricePerPixel, activationRound, deactivationRound, stake))
 	}
 	return orchs, nil
 }

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -222,7 +222,13 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 
 	// adding row
 	orchAddress := pm.RandAddress().String()
-	orch := NewDBOrch(orchAddress, "127.0.0.1:8936", 1, 0, 0, "")
+	orch := &DBOrch{
+		EthereumAddr:      orchAddress,
+		ServiceURI:        "127.0.0.1:8936",
+		PricePerPixel:     1,
+		ActivationRound:   0,
+		DeactivationRound: 0,
+	}
 
 	err = dbh.UpdateOrch(orch)
 	require.Nil(err)
@@ -231,9 +237,11 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 	require.Nil(err)
 	assert.Len(orchs, 1)
 	assert.Equal(orchs[0].ServiceURI, orch.ServiceURI)
+	// Default value for stake should be 0
+	assert.Equal(orchs[0].Stake, int64(0))
 
 	// updating row with same orchAddress
-	orchUpdate := NewDBOrch(orchAddress, "127.0.0.1:8937", 1000, 5, 10, "50")
+	orchUpdate := NewDBOrch(orchAddress, "127.0.0.1:8937", 1000, 5, 10, 50)
 	err = dbh.UpdateOrch(orchUpdate)
 	require.Nil(err)
 
@@ -312,7 +320,7 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 	// Updating only stake
 	stakeUpdate := &DBOrch{
 		EthereumAddr: orchAddress,
-		Stake:        "1000",
+		Stake:        1000,
 	}
 	err = dbh.UpdateOrch(stakeUpdate)
 	require.Nil(err)
@@ -338,7 +346,7 @@ func TestSelectUpdateOrchs_AddingMultipleRows_NoError(t *testing.T) {
 	// adding one row
 	orchAddress := pm.RandAddress().String()
 
-	orch := NewDBOrch(orchAddress, "127.0.0.1:8936", 1, 0, 0, "0")
+	orch := NewDBOrch(orchAddress, "127.0.0.1:8936", 1, 0, 0, 0)
 	err = dbh.UpdateOrch(orch)
 	require.Nil(err)
 
@@ -350,7 +358,7 @@ func TestSelectUpdateOrchs_AddingMultipleRows_NoError(t *testing.T) {
 	// adding second row
 	orchAddress = pm.RandAddress().String()
 
-	orchAdd := NewDBOrch(orchAddress, "127.0.0.1:8938", 1, 0, 0, "0")
+	orchAdd := NewDBOrch(orchAddress, "127.0.0.1:8938", 1, 0, 0, 0)
 	err = dbh.UpdateOrch(orchAdd)
 	require.Nil(err)
 
@@ -375,7 +383,7 @@ func TestOrchCount(t *testing.T) {
 	require.Nil(err)
 
 	for i := 0; i < 10; i++ {
-		orch := NewDBOrch("https://127.0.0.1:"+strconv.Itoa(8936+i), pm.RandAddress().String(), 1, int64(i), int64(5+i), "0")
+		orch := NewDBOrch("https://127.0.0.1:"+strconv.Itoa(8936+i), pm.RandAddress().String(), 1, int64(i), int64(5+i), 0)
 		orch.PricePerPixel, err = PriceToFixed(big.NewRat(1, int64(5+i)))
 		require.Nil(err)
 		err = dbh.UpdateOrch(orch)
@@ -430,7 +438,7 @@ func TestDBFilterOrchs(t *testing.T) {
 	require.Nil(err)
 
 	for i := 0; i < 10; i++ {
-		orch := NewDBOrch(pm.RandAddress().String(), "https://127.0.0.1:"+strconv.Itoa(8936+i), 1, int64(i), int64(5+i), "0")
+		orch := NewDBOrch(pm.RandAddress().String(), "https://127.0.0.1:"+strconv.Itoa(8936+i), 1, int64(i), int64(5+i), 0)
 		orch.PricePerPixel, err = PriceToFixed(big.NewRat(1, int64(5+i)))
 		require.Nil(err)
 		err = dbh.UpdateOrch(orch)

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -426,6 +426,7 @@ func TestOrchCount(t *testing.T) {
 func TestDBFilterOrchs(t *testing.T) {
 	assert := assert.New(t)
 	var orchList []string
+	var orchAddrList []string
 	var nilDb *DB
 	nilOrchs, nilErr := nilDb.SelectOrchs(&DBOrchFilter{MaxPrice: big.NewRat(1, 1)})
 	assert.Nil(nilOrchs)
@@ -444,6 +445,7 @@ func TestDBFilterOrchs(t *testing.T) {
 		err = dbh.UpdateOrch(orch)
 		require.Nil(err)
 		orchList = append(orchList, orch.ServiceURI)
+		orchAddrList = append(orchAddrList, orch.EthereumAddr)
 	}
 
 	//URI - MaxPrice - ActivationRound - DeactivationRound
@@ -491,7 +493,7 @@ func TestDBFilterOrchs(t *testing.T) {
 		assert.Contains(orchList[1:6], o.ServiceURI)
 	}
 
-	// select only active orchs and orchs that pass price filter
+	// Select only active orchs and orchs that pass price filter
 	orchsFiltered, err = dbh.SelectOrchs(&DBOrchFilter{MaxPrice: big.NewRat(1, 8), CurrentRound: big.NewInt(5)})
 	assert.Nil(err)
 	// Should return 3 results, index 3 to 5
@@ -499,6 +501,40 @@ func TestDBFilterOrchs(t *testing.T) {
 	for _, o := range orchsFiltered {
 		assert.Contains(orchList[3:6], o.ServiceURI)
 	}
+
+	// Select only active orchs that pass price filter and that are included in Addresses list
+	filterAddrs := []ethcommon.Address{ethcommon.HexToAddress(orchAddrList[3]), ethcommon.HexToAddress(orchAddrList[4])}
+	orchsFiltered, err = dbh.SelectOrchs(&DBOrchFilter{MaxPrice: big.NewRat(1, 8), CurrentRound: big.NewInt(5), Addresses: filterAddrs})
+	assert.Nil(err)
+	assert.Len(orchsFiltered, 2)
+	for _, o := range orchsFiltered {
+		assert.Contains(orchList[3:5], o.ServiceURI)
+		assert.Contains(orchAddrList[3:5], o.EthereumAddr)
+	}
+
+	// Select orchs that are included in Addresses list when list length > 1
+	filterAddrs = []ethcommon.Address{ethcommon.HexToAddress(orchAddrList[0]), ethcommon.HexToAddress(orchAddrList[1])}
+	orchsFiltered, err = dbh.SelectOrchs(&DBOrchFilter{Addresses: filterAddrs})
+	assert.Nil(err)
+	assert.Len(orchsFiltered, 2)
+	for _, o := range orchsFiltered {
+		assert.Contains(orchList[0:2], o.ServiceURI)
+		assert.Contains(orchAddrList[0:2], o.EthereumAddr)
+	}
+
+	// Select orchs that are included in Addresses list when list length = 0
+	filterAddrs = []ethcommon.Address{ethcommon.HexToAddress(orchAddrList[1])}
+	orchsFiltered, err = dbh.SelectOrchs(&DBOrchFilter{Addresses: filterAddrs})
+	assert.Nil(err)
+	assert.Len(orchsFiltered, 1)
+	assert.Equal(orchList[1], orchsFiltered[0].ServiceURI)
+	assert.Equal(orchAddrList[1], orchsFiltered[0].EthereumAddr)
+
+	// Empty result when no orchs match Addresses list
+	filterAddrs = []ethcommon.Address{ethcommon.BytesToAddress([]byte("foobarbaz"))}
+	orchsFiltered, err = dbh.SelectOrchs(&DBOrchFilter{Addresses: filterAddrs})
+	assert.Nil(err)
+	assert.Len(orchsFiltered, 0)
 }
 
 func TestDBUnbondingLocks(t *testing.T) {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 	"strings"
@@ -144,6 +145,65 @@ func TestPriceToFixed(t *testing.T) {
 
 	// rat smaller than 1/1000 returns 0
 	fp, err = PriceToFixed(big.NewRat(1, 5000))
+	assert.Nil(err)
+	assert.Zero(fp)
+}
+
+func TestBaseTokenAmountToFixed(t *testing.T) {
+	assert := assert.New(t)
+
+	// Check when nil is passed in
+	fp, err := BaseTokenAmountToFixed(nil)
+	assert.EqualError(err, "reference to rat is nil")
+	assert.Zero(fp)
+
+	baseTokenAmount, _ := new(big.Int).SetString("1844486980754712220549592", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(184448698075), fp)
+
+	baseTokenAmount, _ = new(big.Int).SetString("1238827039830161692185743", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(123882703983), fp)
+
+	baseTokenAmount, _ = new(big.Int).SetString("451288400383394091574336", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(45128840038), fp)
+
+	// math.MaxInt64 = 9223372036854775807 is the largest fixed point number that can be represented as a int64
+	// This corresponds to 92233720368547.75807 tokens or 92233720368547.75807 * (10 ** 18) base token units
+	baseTokenAmount, _ = new(big.Int).SetString("92233720368547758070000000000000", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(math.MaxInt64), fp)
+
+	// Base token amount = 92233720368547.75808 * (10 ** 18). This is 1 more than the largest base token amount that can be represented as a fixed point number
+	// Should return math.MaxInt64
+	baseTokenAmount, _ = new(big.Int).SetString("92233720368547758080000000000000", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(math.MaxInt64), fp)
+
+	// Base token amount = 92233720368547.75808 * (10 ** 18). This is a magnitude greater than the largest base token amount that can be represented as a fixed point number
+	// Should return math.MaxInt64
+	baseTokenAmount, _ = new(big.Int).SetString("922337203685477580700000000000000", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(math.MaxInt64), fp)
+
+	// Base token amount = .00001 * (10 ** 18). This is the smallest base token amount that can be represented as a fixed point number
+	// Should return 1
+	baseTokenAmount, _ = new(big.Int).SetString("10000000000000", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(1), fp)
+
+	// Base token amount = .000009 * (10 ** 18). This is smaller than the minimum base token amount for fixed point number conversion
+	// Should return 0
+	baseTokenAmount, _ = new(big.Int).SetString("9000000000000", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
 	assert.Nil(err)
 	assert.Zero(fp)
 }

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -174,7 +174,14 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchestratorStake() error {
 			errc <- err
 			return
 		}
-		o.Stake = ep.TotalStake.String()
+
+		stakeFp, err := common.BaseTokenAmountToFixed(ep.TotalStake)
+		if err != nil {
+			errc <- err
+			return
+		}
+		o.Stake = stakeFp
+
 		resc <- o
 	}
 

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -213,7 +213,7 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 		Database: dbh,
 		Eth: &eth.StubClient{
 			Orchestrators: orchestrators,
-			TotalStake:    big.NewInt(5000),
+			TotalStake:    new(big.Int).Mul(big.NewInt(5000), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)),
 		},
 		Sender: sender,
 	}
@@ -238,7 +238,7 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 	for _, o := range dbOrchs {
 		test := toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel)
 		assert.Contains(testOrchs, test)
-		assert.Equal(o.Stake, big.NewInt(5000).String())
+		assert.Equal(o.Stake, int64(500000000))
 	}
 
 	urls := pool.GetURLs()

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -249,7 +249,12 @@ func (e *StubClient) GetTranscoderEarningsPoolForRound(addr common.Address, roun
 	if e.TranscoderPoolError != nil {
 		return &lpTypes.TokenPools{}, e.TranscoderPoolError
 	}
-	return &lpTypes.TokenPools{TotalStake: e.TotalStake}, nil
+
+	totalStake := big.NewInt(0)
+	if e.TotalStake != nil {
+		totalStake = e.TotalStake
+	}
+	return &lpTypes.TokenPools{TotalStake: totalStake}, nil
 }
 func (e *StubClient) TranscoderPool() ([]*lpTypes.Transcoder, error) {
 	return e.Orchestrators, nil

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -189,10 +189,15 @@ func (ow *OrchestratorWatcher) cacheOrchestratorStake(addr ethcommon.Address, ro
 		return err
 	}
 
+	stakeFp, err := common.BaseTokenAmountToFixed(ep.TotalStake)
+	if err != nil {
+		return err
+	}
+
 	if err := ow.store.UpdateOrch(
 		&common.DBOrch{
 			EthereumAddr: addr.Hex(),
-			Stake:        ep.TotalStake.String(),
+			Stake:        stakeFp,
 		},
 	); err != nil {
 		return err

--- a/eth/watchers/orchestratorwatcher_test.go
+++ b/eth/watchers/orchestratorwatcher_test.go
@@ -167,7 +167,7 @@ func TestOrchWatcher_HandleRoundEvent_CacheOrchestratorStake(t *testing.T) {
 	rw.sink <- newRoundEvent
 	time.Sleep(2 * time.Millisecond)
 
-	assert.Equal(stubStore.stake, expStake.String())
+	assert.Equal(stubStore.stake, int64(500000000))
 
 	// LivepeerEthClient.CurrentRound() error
 	lpEth.RoundsErr = errors.New("CurrentRound error")

--- a/eth/watchers/stub.go
+++ b/eth/watchers/stub.go
@@ -365,7 +365,7 @@ type stubOrchestratorStore struct {
 	deactivationRound int64
 	serviceURI        string
 	ethereumAddr      string
-	stake             string
+	stake             int64
 	selectErr         error
 	updateErr         error
 }

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -48,7 +48,7 @@ type BroadcastSessionsManager struct {
 	// Accessing or changing any of the below requires ownership of this mutex
 	sessLock *sync.Mutex
 
-	sessList []*BroadcastSession
+	sel      BroadcastSessionsSelector
 	sessMap  map[string]*BroadcastSession
 	numOrchs int // how many orchs to request at once
 
@@ -63,16 +63,14 @@ func (bsm *BroadcastSessionsManager) selectSession() *BroadcastSession {
 	defer bsm.sessLock.Unlock()
 
 	checkSessions := func(m *BroadcastSessionsManager) bool {
-		numSess := len(m.sessList)
+		numSess := m.sel.Size()
 		if numSess < int(math.Ceil(float64(m.numOrchs)/2.0)) {
 			go m.refreshSessions()
 		}
 		return numSess > 0
 	}
 	for checkSessions(bsm) {
-		last := len(bsm.sessList) - 1
-		sess, sessions := bsm.sessList[last], bsm.sessList[:last]
-		bsm.sessList = sessions
+		sess := bsm.sel.Select()
 		if _, ok := bsm.sessMap[sess.OrchestratorInfo.Transcoder]; ok {
 			return sess
 		}
@@ -100,7 +98,7 @@ func (bsm *BroadcastSessionsManager) completeSession(sess *BroadcastSession) {
 	defer bsm.sessLock.Unlock()
 
 	if _, ok := bsm.sessMap[sess.OrchestratorInfo.Transcoder]; ok {
-		bsm.sessList = append(bsm.sessList, sess)
+		bsm.sel.Complete(sess)
 	}
 }
 
@@ -148,18 +146,19 @@ func (bsm *BroadcastSessionsManager) refreshSessions() {
 		uniqueSessions = append(uniqueSessions, sess)
 		bsm.sessMap[sess.OrchestratorInfo.Transcoder] = sess
 	}
-	bsm.sessList = append(uniqueSessions, bsm.sessList...)
+
+	bsm.sel.Add(uniqueSessions)
 }
 
 func (bsm *BroadcastSessionsManager) cleanup() {
 	bsm.sessLock.Lock()
 	defer bsm.sessLock.Unlock()
 	bsm.finished = true
-	bsm.sessList = nil
+	bsm.sel.Clear()
 	bsm.sessMap = make(map[string]*BroadcastSession) // prevent segfaults
 }
 
-func NewSessionManager(node *core.LivepeerNode, params *streamParameters, pl core.PlaylistManager) *BroadcastSessionsManager {
+func NewSessionManager(node *core.LivepeerNode, params *streamParameters, pl core.PlaylistManager, sel BroadcastSessionsSelector) *BroadcastSessionsManager {
 	var poolSize float64
 	if node.OrchestratorPool != nil {
 		poolSize = float64(node.OrchestratorPool.Size())
@@ -167,6 +166,7 @@ func NewSessionManager(node *core.LivepeerNode, params *streamParameters, pl cor
 	maxInflight := common.HTTPTimeout.Seconds() / SegLen.Seconds()
 	numOrchs := int(math.Min(poolSize, maxInflight*2))
 	bsm := &BroadcastSessionsManager{
+		sel:            sel,
 		sessMap:        make(map[string]*BroadcastSession),
 		createSessions: func() ([]*BroadcastSession, error) { return selectOrchestrator(node, params, pl, numOrchs) },
 		sessLock:       &sync.Mutex{},

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -419,6 +419,10 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 	}
 
 	playlist := core.NewBasicPlaylistManager(mid, storage)
+	var stakeRdr stakeReader
+	if s.LivepeerNode.Eth != nil {
+		stakeRdr = &storeStakeReader{store: s.LivepeerNode.Database}
+	}
 	cxn := &rtmpConnection{
 		mid:         mid,
 		nonce:       nonce,
@@ -426,7 +430,7 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 		pl:          playlist,
 		profile:     &vProfile,
 		params:      params,
-		sessManager: NewSessionManager(s.LivepeerNode, params, playlist, &LIFOSelector{}),
+		sessManager: NewSessionManager(s.LivepeerNode, params, playlist, NewMinLSSelector(stakeRdr, 1.0)),
 		lastUsed:    time.Now(),
 	}
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -426,7 +426,7 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 		pl:          playlist,
 		profile:     &vProfile,
 		params:      params,
-		sessManager: NewSessionManager(s.LivepeerNode, params, playlist),
+		sessManager: NewSessionManager(s.LivepeerNode, params, playlist, &LIFOSelector{}),
 		lastUsed:    time.Now(),
 	}
 

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -810,7 +810,7 @@ func TestBroadcastSessionManagerWithStreamStartStop(t *testing.T) {
 	cxn, exists := s.rtmpConnections[mid]
 	assert.Equal(exists, true)
 	assert.Equal(cxn.sessManager.finished, false)
-	assert.Len(cxn.sessManager.sessList, 2)
+	assert.Equal(cxn.sessManager.sel.Size(), 2)
 	assert.Len(cxn.sessManager.sessMap, 2)
 
 	// assert stream ends successfully
@@ -821,7 +821,7 @@ func TestBroadcastSessionManagerWithStreamStartStop(t *testing.T) {
 	_, exists = s.rtmpConnections[mid]
 	assert.Equal(exists, false)
 	assert.Equal(cxn.sessManager.finished, true)
-	assert.Len(cxn.sessManager.sessList, 0)
+	assert.Equal(cxn.sessManager.sel.Size(), 0)
 	assert.Len(cxn.sessManager.sessMap, 0)
 
 	// assert stream starts successfully again
@@ -832,7 +832,7 @@ func TestBroadcastSessionManagerWithStreamStartStop(t *testing.T) {
 	cxn, exists = s.rtmpConnections[mid]
 	assert.Equal(exists, true)
 	assert.Equal(cxn.sessManager.finished, false)
-	assert.Len(cxn.sessManager.sessList, 2)
+	assert.Equal(cxn.sessManager.sel.Size(), 2)
 	assert.Len(cxn.sessManager.sessMap, 2)
 }
 

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -98,6 +98,7 @@ type BroadcastSession struct {
 	Sender           pm.Sender
 	PMSessionID      string
 	Balance          Balance
+	LatencyScore     float64
 }
 
 type lphttp struct {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -101,6 +101,13 @@ type BroadcastSession struct {
 	LatencyScore     float64
 }
 
+// ReceivedTranscodeResult contains received transcode result data and related metadata
+type ReceivedTranscodeResult struct {
+	*net.TranscodeData
+	Info         *net.OrchestratorInfo
+	LatencyScore float64
+}
+
 type lphttp struct {
 	orchestrator Orchestrator
 	orchRPC      *grpc.Server

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -280,7 +280,7 @@ func verifySegCreds(orch Orchestrator, segCreds string, broadcaster ethcommon.Ad
 	return md, nil
 }
 
-func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64) (*net.TranscodeData, error) {
+func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64) (*ReceivedTranscodeResult, error) {
 	uploaded := seg.Name != "" // hijack seg.Name to convey the uploaded URI
 
 	segCreds, err := genSegCreds(sess, seg)
@@ -407,11 +407,6 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 		return nil, err
 	}
 
-	// update OrchestratorInfo if necessary
-	if tr.Info != nil {
-		defer updateOrchestratorInfo(sess, tr.Info)
-	}
-
 	// check for errors and exit early if there's anything unusual
 	var tdata *net.TranscodeData
 	switch res := tr.Result.(type) {
@@ -464,24 +459,11 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 
 	glog.Infof("Successfully transcoded segment nonce=%d manifestID=%s segName=%s seqNo=%d", nonce, string(sess.ManifestID), seg.Name, seg.SeqNo)
 
-	return tdata, nil
-}
-
-func updateOrchestratorInfo(sess *BroadcastSession, oInfo *net.OrchestratorInfo) {
-	sess.OrchestratorInfo = oInfo
-
-	if len(oInfo.Storage) > 0 {
-		sess.OrchestratorOS = drivers.NewSession(oInfo.Storage[0])
-	}
-
-	if sess.Sender != nil && oInfo.TicketParams != nil {
-		// Note: We do not validate the ticket params included in the OrchestratorInfo
-		// message here. Instead, we store the ticket params with the current BroadcastSession
-		// and the next time this BroadcastSession is used, the ticket params will be validated
-		// during ticket creation in genPayment(). If ticket params validation during ticket
-		// creation fails, then this BroadcastSession will be removed
-		sess.PMSessionID = sess.Sender.StartSession(*pmTicketParams(oInfo.TicketParams))
-	}
+	return &ReceivedTranscodeResult{
+		TranscodeData: tdata,
+		Info:          tr.Info,
+		LatencyScore:  transcodeDur.Seconds() / seg.Duration,
+	}, nil
 }
 
 func genSegCreds(sess *BroadcastSession, seg *stream.HLSSegment) (string, error) {

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -1304,12 +1304,44 @@ func TestSubmitSegment_Success(t *testing.T) {
 		assert.Equal([]byte("dummy"), data)
 	}
 
-	tdata, err := SubmitSegment(s, &stream.HLSSegment{Data: []byte("dummy")}, 0)
+	noNameSeg := &stream.HLSSegment{Data: []byte("dummy")}
+	tdata, err := SubmitSegment(s, noNameSeg, 0)
 
 	assert.Nil(err)
 	assert.Equal(1, len(tdata.Segments))
 	assert.Equal("foo", tdata.Segments[0].Url)
 	assert.Equal([]byte("bar"), tdata.Sig)
+	assert.Nil(tdata.Info)
+
+	// Check that latency score calculation is different for different segment durations
+	// The transcode duration calculated in SubmitSegment should be about the same across all calls
+	noNameSeg.Duration = 5.0
+	tdata, err = SubmitSegment(s, noNameSeg, 0)
+	assert.Nil(err)
+	latencyScore1 := tdata.LatencyScore
+
+	noNameSeg.Duration = 10.0
+	tdata, err = SubmitSegment(s, noNameSeg, 0)
+	assert.Nil(err)
+	latencyScore2 := tdata.LatencyScore
+
+	noNameSeg.Duration = .5
+	tdata, err = SubmitSegment(s, noNameSeg, 0)
+	assert.Nil(err)
+	latencyScore3 := tdata.LatencyScore
+
+	assert.Less(latencyScore1, latencyScore3)
+	assert.Less(latencyScore2, latencyScore1)
+
+	// Check that a new OrchestratorInfo is returned from SubmitSegment()
+	tr.Info = &net.OrchestratorInfo{}
+	buf, err = proto.Marshal(tr)
+	require.Nil(err)
+
+	tdata, err = SubmitSegment(s, noNameSeg, 0)
+	assert.Nil(err)
+	assert.NotEqual(tdata.Info, s.OrchestratorInfo)
+	assert.Equal(tdata.Info, tr.Info)
 
 	// Test when input data is uploaded
 	runChecks = func(r *http.Request) {
@@ -1406,183 +1438,6 @@ func TestSubmitSegment_Success(t *testing.T) {
 	SubmitSegment(s, seg, 0)
 
 	balance.AssertCalled(t, "Credit", ratMatcher(change))
-}
-
-func TestSubmitSegment_UpdateOrchestratorInfo(t *testing.T) {
-	require := require.New(t)
-
-	params := pm.TicketParams{
-		Recipient:         ethcommon.Address{},
-		FaceValue:         big.NewInt(100),
-		WinProb:           big.NewInt(100),
-		RecipientRandHash: pm.RandHash(),
-		Seed:              big.NewInt(100),
-	}
-
-	tr := &net.TranscodeResult{
-		Result: &net.TranscodeResult_Data{
-			Data: &net.TranscodeData{
-				Segments: []*net.TranscodedSegmentData{
-					&net.TranscodedSegmentData{Url: "foo", Pixels: 10},
-				},
-				Sig: []byte("bar"),
-			},
-		},
-		Info: &net.OrchestratorInfo{
-			Transcoder: "http://google.com",
-			PriceInfo: &net.PriceInfo{
-				PricePerUnit:  1,
-				PixelsPerUnit: 1,
-			},
-			TicketParams: &net.TicketParams{
-				Recipient:         params.Recipient.Bytes(),
-				FaceValue:         params.FaceValue.Bytes(),
-				WinProb:           params.WinProb.Bytes(),
-				RecipientRandHash: params.RecipientRandHash.Bytes(),
-				Seed:              params.Seed.Bytes(),
-			},
-		},
-	}
-	buf, err := proto.Marshal(tr)
-	require.Nil(err)
-
-	ts, mux := stubTLSServer()
-	defer ts.Close()
-	mux.HandleFunc("/segment", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write(buf)
-	})
-
-	// Test with no pm.Sender in BroadcastSession
-
-	newSess := func() *BroadcastSession {
-		return &BroadcastSession{
-			Broadcaster: stubBroadcaster2(),
-			ManifestID:  core.RandomManifestID(),
-			OrchestratorInfo: &net.OrchestratorInfo{
-				Transcoder: ts.URL,
-				PriceInfo: &net.PriceInfo{
-					PricePerUnit:  2,
-					PixelsPerUnit: 1,
-				},
-			},
-		}
-	}
-
-	s := newSess()
-
-	assert := assert.New(t)
-
-	_, err = SubmitSegment(s, &stream.HLSSegment{Data: []byte("dummy")}, 0)
-
-	assert.Nil(err)
-	assert.Equal("http://google.com", s.OrchestratorInfo.Transcoder)
-	assert.Equal(tr.Info.TicketParams.Recipient, s.OrchestratorInfo.TicketParams.Recipient)
-	assert.Equal(tr.Info.TicketParams.FaceValue, s.OrchestratorInfo.TicketParams.FaceValue)
-	assert.Equal(tr.Info.TicketParams.WinProb, s.OrchestratorInfo.TicketParams.WinProb)
-	assert.Equal(tr.Info.TicketParams.RecipientRandHash, s.OrchestratorInfo.TicketParams.RecipientRandHash)
-	assert.Equal(tr.Info.TicketParams.Seed, s.OrchestratorInfo.TicketParams.Seed)
-
-	// Test with pm.Sender in BroadcastSession
-
-	sender := &pm.MockSender{}
-	s = newSess()
-	s.Sender = sender
-
-	batch := &pm.TicketBatch{
-		TicketParams: &pm.TicketParams{
-			Recipient: pm.RandAddress(),
-			FaceValue: big.NewInt(1234),
-			WinProb:   big.NewInt(5678),
-			Seed:      big.NewInt(7777),
-		},
-		TicketExpirationParams: &pm.TicketExpirationParams{},
-		Sender:                 pm.RandAddress(),
-		SenderParams: []*pm.TicketSenderParams{
-			&pm.TicketSenderParams{SenderNonce: 777, Sig: pm.RandBytes(42)},
-		},
-	}
-
-	sender.On("CreateTicketBatch", mock.Anything, mock.Anything).Return(batch, nil)
-	sender.On("StartSession", params).Return("foobar")
-
-	_, err = SubmitSegment(s, &stream.HLSSegment{Data: []byte("dummy")}, 0)
-
-	assert.Nil(err)
-	assert.Equal("foobar", s.PMSessionID)
-	sender.AssertCalled(t, "StartSession", params)
-
-	// Test balance update completion with last known price and NOT the price
-	// included in an updated OrchestratorInfo message
-
-	ratMatcher := func(rat *big.Rat) interface{} {
-		return mock.MatchedBy(func(x *big.Rat) bool { return x.Cmp(rat) == 0 })
-	}
-
-	existingCredit := big.NewRat(100, 1)
-	// change = existingCredit - (pixelCount * price) = 100 - (10 * 2) = 80
-	// Note that price = 2 which is the last known price and not the price = 1 included in the
-	// updated OrchestratorInfo message
-	change := big.NewRat(80, 1)
-	balance := &mockBalance{}
-	balance.On("StageUpdate", mock.Anything, mock.Anything).Return(0, big.NewRat(0, 1), existingCredit)
-	balance.On("Credit", ratMatcher(change))
-	sender = &pm.MockSender{}
-	sender.On("EV", mock.Anything).Return(big.NewRat(0, 1), nil)
-	sender.On("StartSession", params).Return("foobar")
-	s = newSess()
-	s.Balance = balance
-	s.Sender = sender
-
-	_, err = SubmitSegment(s, &stream.HLSSegment{Data: []byte("dummy")}, 0)
-
-	balance.AssertCalled(t, "Credit", ratMatcher(change))
-
-	// Test does not crash if OrchestratorInfo.TicketParams is nil
-
-	sender = &pm.MockSender{}
-	s = newSess()
-	s.Sender = sender
-
-	// Update stub server to return OrchestratorInfo without TicketParams
-	tr.Info = &net.OrchestratorInfo{
-		Transcoder: "http://google.com",
-	}
-	buf, err = proto.Marshal(tr)
-	require.Nil(err)
-
-	sender.On("CreateTicketBatch", mock.Anything, mock.Anything).Return(batch, nil)
-	sender.On("StartSession", mock.Anything).Return("foobar")
-
-	_, err = SubmitSegment(s, &stream.HLSSegment{Data: []byte("dummy")}, 0)
-
-	assert.Nil(err)
-	assert.Equal("http://google.com", s.OrchestratorInfo.Transcoder)
-	sender.AssertNotCalled(t, "StartSession", mock.Anything)
-
-	// Test update OrchestratorOS
-
-	s = newSess()
-
-	tr.Info = &net.OrchestratorInfo{
-		Transcoder: "http://google.com",
-		Storage: []*net.OSInfo{
-			&net.OSInfo{
-				StorageType: 1,
-				S3Info: &net.S3OSInfo{
-					Host: "http://apple.com",
-				},
-			},
-		},
-	}
-	buf, err = proto.Marshal(tr)
-	require.Nil(err)
-
-	_, err = SubmitSegment(s, &stream.HLSSegment{Data: []byte("dummy")}, 0)
-
-	assert.Nil(err)
-	assert.Equal(tr.Info.Storage[0].StorageType, s.OrchestratorOS.GetInfo().StorageType)
-	assert.Equal(tr.Info.Storage[0].S3Info.Host, s.OrchestratorOS.GetInfo().S3Info.Host)
 }
 
 func stubTLSServer() (*httptest.Server, *http.ServeMux) {

--- a/server/selection.go
+++ b/server/selection.go
@@ -1,0 +1,42 @@
+package server
+
+// BroadcastSessionsSelector selects the next BroadcastSession to use
+type BroadcastSessionsSelector interface {
+	Add(sessions []*BroadcastSession)
+	Complete(sess *BroadcastSession)
+	Select() *BroadcastSession
+	Size() int
+	Clear()
+}
+
+// LIFOSelector selects the next BroadcastSession in LIFO order
+type LIFOSelector []*BroadcastSession
+
+// Add adds the sessions to the front of the selector's list
+func (s *LIFOSelector) Add(sessions []*BroadcastSession) {
+	*s = append(sessions, *s...)
+}
+
+// Complete adds the session to the end of the selector's list
+func (s *LIFOSelector) Complete(sess *BroadcastSession) {
+	*s = append(*s, sess)
+}
+
+// Select returns the last session in the selector's list
+func (s *LIFOSelector) Select() *BroadcastSession {
+	sessList := *s
+	last := len(sessList) - 1
+	sess, sessions := sessList[last], sessList[:last]
+	*s = sessions
+	return sess
+}
+
+// Size returns the number of sessions stored by the selector
+func (s *LIFOSelector) Size() int {
+	return len(*s)
+}
+
+// Clear resets the selector's state
+func (s *LIFOSelector) Clear() {
+	*s = nil
+}

--- a/server/selection.go
+++ b/server/selection.go
@@ -1,5 +1,13 @@
 package server
 
+import (
+	"container/heap"
+	"math/rand"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/golang/glog"
+)
+
 // BroadcastSessionsSelector selects the next BroadcastSession to use
 type BroadcastSessionsSelector interface {
 	Add(sessions []*BroadcastSession)
@@ -7,6 +15,171 @@ type BroadcastSessionsSelector interface {
 	Select() *BroadcastSession
 	Size() int
 	Clear()
+}
+
+type sessHeap []*BroadcastSession
+
+func (h sessHeap) Len() int {
+	return len(h)
+}
+
+func (h sessHeap) Less(i, j int) bool {
+	return h[i].LatencyScore < h[j].LatencyScore
+}
+
+func (h sessHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *sessHeap) Push(x interface{}) {
+	sess := x.(*BroadcastSession)
+	*h = append(*h, sess)
+}
+
+func (h *sessHeap) Pop() interface{} {
+	// Pop from the end because heap.Pop() swaps the 0th index element with the last element
+	// before calling this method
+	// See https://golang.org/src/container/heap/heap.go?s=2190:2223#L50
+	old := *h
+	n := len(old)
+	sess := old[n-1]
+	old[n-1] = nil
+	*h = old[:n-1]
+
+	return sess
+}
+
+func (h *sessHeap) Peek() interface{} {
+	if h.Len() == 0 {
+		return nil
+	}
+
+	// The minimum element is at the 0th index as long as we always modify
+	// sessHeap using the heap.Push() and heap.Pop() methods
+	// See https://golang.org/pkg/container/heap/
+	return (*h)[0]
+}
+
+type stakeReader interface {
+	Stakes(addrs []ethcommon.Address) (map[ethcommon.Address]int64, error)
+}
+
+// MinLSSelector selects the next BroadcastSession with the lowest latency score if it is good enough.
+// Otherwise, it selects a session that does not have a latency score yet
+// MinLSSelector is not concurrency safe so the caller is responsible for ensuring safety for concurrent method calls
+type MinLSSelector struct {
+	unknownSessions []*BroadcastSession
+	knownSessions   *sessHeap
+
+	stakeRdr stakeReader
+
+	minLS float64
+}
+
+// NewMinLSSelector returns an instance of MinLSSelector configured with a good enough latency score
+func NewMinLSSelector(stakeRdr stakeReader, minLS float64) *MinLSSelector {
+	knownSessions := &sessHeap{}
+	heap.Init(knownSessions)
+
+	return &MinLSSelector{
+		knownSessions: knownSessions,
+		stakeRdr:      stakeRdr,
+		minLS:         minLS,
+	}
+}
+
+// Add adds the sessions to the selector's list of sessions without a latency score
+func (s *MinLSSelector) Add(sessions []*BroadcastSession) {
+	s.unknownSessions = append(s.unknownSessions, sessions...)
+}
+
+// Complete adds the session to the selector's list sessions with a latency score
+func (s *MinLSSelector) Complete(sess *BroadcastSession) {
+	heap.Push(s.knownSessions, sess)
+}
+
+// Select returns the session with the lowest latency score if it is good enough.
+// Otherwise, a session without a latency score yet is returned
+func (s *MinLSSelector) Select() *BroadcastSession {
+	sess := s.knownSessions.Peek()
+	if sess == nil {
+		return s.selectUnknownSession()
+	}
+
+	minSess := sess.(*BroadcastSession)
+	if minSess.LatencyScore > s.minLS && len(s.unknownSessions) > 0 {
+		return s.selectUnknownSession()
+	}
+
+	return heap.Pop(s.knownSessions).(*BroadcastSession)
+}
+
+// Size returns the number of sessions stored by the selector
+func (s *MinLSSelector) Size() int {
+	return len(s.unknownSessions) + s.knownSessions.Len()
+}
+
+// Clear resets the selector's state
+func (s *MinLSSelector) Clear() {
+	s.unknownSessions = nil
+	s.knownSessions = &sessHeap{}
+	s.stakeRdr = nil
+}
+
+// Use stake weighted random selection to select from unknownSessions
+func (s *MinLSSelector) selectUnknownSession() *BroadcastSession {
+	if len(s.unknownSessions) == 0 {
+		return nil
+	}
+
+	if s.stakeRdr == nil {
+		// Sessions are selected based on the order of unknownSessions in off-chain mode
+		sess := s.unknownSessions[0]
+		s.unknownSessions = s.unknownSessions[1:]
+		return sess
+	}
+
+	addrs := make([]ethcommon.Address, len(s.unknownSessions))
+	for i, sess := range s.unknownSessions {
+		addrs[i] = ethcommon.BytesToAddress(sess.OrchestratorInfo.TicketParams.Recipient)
+	}
+
+	stakes, err := s.stakeRdr.Stakes(addrs)
+	// If we fail to read stake weights of unknownSessions we should not continue with selection
+	if err != nil {
+		glog.Errorf("failed to read stake weights for selection: %v", err)
+		return nil
+	}
+
+	totalStake := int64(0)
+	for _, stake := range stakes {
+		totalStake += stake
+	}
+
+	// Generate a random stake weight between 0 and totalStake
+	r := int64(0)
+	if totalStake > 0 {
+		r = rand.Int63n(totalStake)
+	}
+
+	// Run a weighted random selection on unknownSessions
+	// We iterate through each session and subtract the stake weight for the session's orchestrator from r (initialized to a random stake weight)
+	// If subtracting the stake weight for the current session from r results in a value <= 0, we select the current session
+	// The greater the stake weight of a session, the more likely that it will be selected because subtracting its stake weight from r
+	// will result in a value <= 0
+	for i, sess := range s.unknownSessions {
+		r -= stakes[addrs[i]]
+
+		if r <= 0 {
+			n := len(s.unknownSessions)
+			s.unknownSessions[n-1], s.unknownSessions[i] = s.unknownSessions[i], s.unknownSessions[n-1]
+			s.unknownSessions = s.unknownSessions[:n-1]
+
+			return sess
+		}
+	}
+
+	return nil
 }
 
 // LIFOSelector selects the next BroadcastSession in LIFO order

--- a/server/selection_test.go
+++ b/server/selection_test.go
@@ -1,0 +1,288 @@
+package server
+
+import (
+	"container/heap"
+	"errors"
+	"math"
+	"math/big"
+	"sort"
+	"strconv"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/net"
+	"github.com/stretchr/testify/assert"
+)
+
+type stubStakeReader struct {
+	stakes map[ethcommon.Address]int64
+	err    error
+}
+
+func newStubStakeReader() *stubStakeReader {
+	return &stubStakeReader{stakes: make(map[ethcommon.Address]int64)}
+}
+
+func (r *stubStakeReader) Stakes(addrs []ethcommon.Address) (map[ethcommon.Address]int64, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.stakes, nil
+}
+
+func (r *stubStakeReader) SetStakes(stakes map[ethcommon.Address]int64) {
+	r.stakes = stakes
+}
+
+func TestSessHeap(t *testing.T) {
+	assert := assert.New(t)
+
+	h := &sessHeap{}
+	heap.Init(h)
+	assert.Zero(h.Len())
+	// Return nil for empty heap
+	assert.Nil(h.Peek())
+
+	sess1 := &BroadcastSession{LatencyScore: 1.0}
+	heap.Push(h, sess1)
+	assert.Equal(h.Len(), 1)
+	assert.Equal(h.Peek().(*BroadcastSession), sess1)
+
+	sess2 := &BroadcastSession{LatencyScore: 1.1}
+	heap.Push(h, sess2)
+	assert.Equal(h.Len(), 2)
+	assert.Equal(h.Peek().(*BroadcastSession), sess1)
+
+	sess3 := &BroadcastSession{LatencyScore: .9}
+	heap.Push(h, sess3)
+	assert.Equal(h.Len(), 3)
+	assert.Equal(h.Peek().(*BroadcastSession), sess3)
+
+	assert.Equal(heap.Pop(h).(*BroadcastSession), sess3)
+	assert.Equal(heap.Pop(h).(*BroadcastSession), sess1)
+	assert.Equal(heap.Pop(h).(*BroadcastSession), sess2)
+	assert.Zero(h.Len())
+}
+
+func TestMinLSSelector(t *testing.T) {
+	assert := assert.New(t)
+
+	sel := NewMinLSSelector(nil, 1.0)
+	assert.Zero(sel.Size())
+
+	sessions := []*BroadcastSession{
+		&BroadcastSession{},
+		&BroadcastSession{},
+		&BroadcastSession{},
+	}
+
+	// Return nil when there are no sessions
+	assert.Nil(sel.Select())
+
+	sel.Add(sessions)
+	assert.Equal(sel.Size(), 3)
+	for _, sess := range sessions {
+		assert.Contains(sel.unknownSessions, sess)
+	}
+
+	// Select from unknownSessions
+	sess1 := sel.Select()
+	assert.Equal(sel.Size(), 2)
+	assert.Equal(len(sel.unknownSessions), 2)
+
+	// Set sess1.LatencyScore to not be good enough
+	sess1.LatencyScore = 1.1
+	sel.Complete(sess1)
+	assert.Equal(sel.Size(), 3)
+	assert.Equal(len(sel.unknownSessions), 2)
+	assert.Equal(sel.knownSessions.Len(), 1)
+
+	// Select from unknownSessions
+	sess2 := sel.Select()
+	assert.Equal(sel.Size(), 2)
+	assert.Equal(len(sel.unknownSessions), 1)
+	assert.Equal(sel.knownSessions.Len(), 1)
+
+	// Set sess2.LatencyScore to be good enough
+	sess2.LatencyScore = .9
+	sel.Complete(sess2)
+	assert.Equal(sel.Size(), 3)
+	assert.Equal(len(sel.unknownSessions), 1)
+	assert.Equal(sel.knownSessions.Len(), 2)
+
+	// Select from knownSessions
+	knownSess := sel.Select()
+	assert.Equal(sel.Size(), 2)
+	assert.Equal(len(sel.unknownSessions), 1)
+	assert.Equal(sel.knownSessions.Len(), 1)
+	assert.Equal(knownSess, sess2)
+
+	// Set knownSess.LatencyScore to not be good enough
+	knownSess.LatencyScore = 1.1
+	sel.Complete(knownSess)
+	// Clear unknownSessions
+	sess := sel.Select()
+	sess.LatencyScore = 2.1
+	sel.Complete(sess)
+	assert.Equal(len(sel.unknownSessions), 0)
+	assert.Equal(sel.knownSessions.Len(), 3)
+
+	// Select from knownSessions
+	knownSess = sel.Select()
+	assert.Equal(sel.Size(), 2)
+	assert.Equal(len(sel.unknownSessions), 0)
+	assert.Equal(sel.knownSessions.Len(), 2)
+
+	sel.Clear()
+	assert.Zero(sel.Size())
+	assert.Nil(sel.unknownSessions)
+	assert.Zero(sel.knownSessions.Len())
+	assert.Nil(sel.stakeRdr)
+}
+
+func TestMinLSSelector_SelectUnknownSession_Errors(t *testing.T) {
+	assert := assert.New(t)
+
+	stakeRdr := newStubStakeReader()
+	sel := NewMinLSSelector(stakeRdr, 1.0)
+
+	sel.Add(
+		[]*BroadcastSession{
+			&BroadcastSession{
+				OrchestratorInfo: &net.OrchestratorInfo{
+					TicketParams: &net.TicketParams{Recipient: []byte("foo")},
+				},
+			},
+		},
+	)
+
+	// Test error when reading stake
+	stakeRdr.err = errors.New("Stakes error")
+	errorLogsBefore := glog.Stats.Error.Lines()
+	assert.Nil(sel.selectUnknownSession())
+	errorLogsAfter := glog.Stats.Error.Lines()
+	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
+}
+
+func TestMinLSSelector_SelectUnknownSession_UniqueWeights(t *testing.T) {
+	stakeRdr := newStubStakeReader()
+	sel := NewMinLSSelector(stakeRdr, 1.0)
+
+	sessions := make([]*BroadcastSession, 10)
+	stakes := make([]int64, 10)
+	stakeMap := make(map[ethcommon.Address]int64)
+	totalStake := int64(0)
+	for i := 0; i < 10; i++ {
+		addr := ethcommon.BytesToAddress([]byte(strconv.Itoa(i)))
+		stake := int64(1000 * (i + 1))
+		totalStake += stake
+
+		sessions[i] = &BroadcastSession{
+			OrchestratorInfo: &net.OrchestratorInfo{
+				TicketParams: &net.TicketParams{Recipient: addr.Bytes()},
+			},
+		}
+		stakes[i] = stake
+		stakeMap[addr] = stake
+	}
+
+	stakeRdr.SetStakes(stakeMap)
+	sel.Add(sessions)
+
+	// Run selectUnknownSession() x100000 and record # of times a session weight is selected
+	// Each session has a unique stake weight so we will record the # of selections per stake weight
+	stakeCount := make(map[int64]int)
+	for i := 0; i < 100000; i++ {
+		sess := sel.selectUnknownSession()
+		addr := ethcommon.BytesToAddress(sess.OrchestratorInfo.TicketParams.Recipient)
+		stake := stakeMap[addr]
+		stakeCount[stake]++
+
+		// Call Add() to add the session back to unknownSessions
+		sel.Add([]*BroadcastSession{sess})
+	}
+
+	sort.Slice(stakes, func(i, j int) bool {
+		return stakes[i] < stakes[j]
+	})
+
+	// Check that higher stake weight sessions are selected more often than lower stake weight sessions
+	for i, stake := range stakes[:len(stakes)-1] {
+		nextStake := stakes[i+1]
+		assert.Less(t, stakeCount[stake], stakeCount[nextStake])
+	}
+
+	// Check that the difference between the selection count ratio and the stake weight ratio of a session is less than some small delta
+	maxDelta := .015
+	for stake, count := range stakeCount {
+		// Selection count ratio = # times selected / total selections
+		countRat := big.NewRat(int64(count), 100000)
+		// Stake weight ratio = stake / totalStake
+		stakeRat := big.NewRat(stake, totalStake)
+		deltaRat := new(big.Rat).Sub(stakeRat, countRat)
+		deltaRat.Abs(deltaRat)
+		delta, _ := deltaRat.Float64()
+		assert.Less(t, delta, maxDelta)
+	}
+}
+
+func TestMinLSSelector_SelectUnknownSession_UniformWeights(t *testing.T) {
+	stakeRdr := newStubStakeReader()
+	sel := NewMinLSSelector(stakeRdr, 1.0)
+
+	sessions := make([]*BroadcastSession, 10)
+	stakeMap := make(map[ethcommon.Address]int64)
+	for i := 0; i < 10; i++ {
+		addr := ethcommon.BytesToAddress([]byte(strconv.Itoa(i)))
+
+		sessions[i] = &BroadcastSession{
+			OrchestratorInfo: &net.OrchestratorInfo{
+				TicketParams: &net.TicketParams{Recipient: addr.Bytes()},
+			},
+		}
+		stakeMap[addr] = 1000
+	}
+
+	stakeRdr.SetStakes(stakeMap)
+	sel.Add(sessions)
+
+	// Run selectUnknownSession() x1000000 and record # of times a session is selected
+	sessCount := make(map[*BroadcastSession]int)
+	for i := 0; i < 1000000; i++ {
+		sess := sel.selectUnknownSession()
+		sessCount[sess]++
+
+		// Call Add() to add the session back to unknownSessions
+		sel.Add([]*BroadcastSession{sess})
+	}
+
+	// Check that the difference between the selection count of each session is less than some small delta
+	maxDelta := .015
+	for i, sess := range sessions[:len(sessions)-1] {
+		nextSess := sessions[i+1]
+		diff := math.Abs(float64(sessCount[sess] - sessCount[nextSess]))
+		delta := diff / float64(sessCount[sess])
+		assert.Less(t, delta, maxDelta)
+	}
+}
+
+func TestMinLSSelector_SelectUnknownSession_NilStakeReader(t *testing.T) {
+	sel := NewMinLSSelector(nil, 1.0)
+
+	sessions := make([]*BroadcastSession, 10)
+	for i := 0; i < 10; i++ {
+		sessions[i] = &BroadcastSession{}
+	}
+
+	sel.Add(sessions)
+
+	i := 0
+	// Check that we select sessions based on the order of unknownSessions and that the size of
+	// unknownSessions decreases with each selection
+	for sel.Size() > 0 {
+		sess := sel.selectUnknownSession()
+		assert.Same(t, sess, sessions[i])
+		i++
+	}
+}

--- a/server/selection_test.go
+++ b/server/selection_test.go
@@ -11,9 +11,53 @@ import (
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/stretchr/testify/assert"
 )
+
+type stubOrchestratorStore struct {
+	orchs []*common.DBOrch
+	err   error
+}
+
+func (s *stubOrchestratorStore) OrchCount(filter *common.DBOrchFilter) (int, error) { return 0, nil }
+func (s *stubOrchestratorStore) UpdateOrch(orch *common.DBOrch) error               { return nil }
+func (s *stubOrchestratorStore) SelectOrchs(filter *common.DBOrchFilter) ([]*common.DBOrch, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.orchs, nil
+}
+
+func TestStoreStakeReader(t *testing.T) {
+	assert := assert.New(t)
+
+	store := &stubOrchestratorStore{}
+	rdr := &storeStakeReader{store: store}
+
+	store.err = errors.New("SelectOrchs error")
+	_, err := rdr.Stakes(nil)
+	assert.EqualError(err, store.err.Error())
+
+	store.err = nil
+	store.orchs = []*common.DBOrch{&common.DBOrch{}}
+	_, err = rdr.Stakes(nil)
+	assert.EqualError(err, "could not fetch all stake weights")
+
+	store.orchs = []*common.DBOrch{
+		&common.DBOrch{EthereumAddr: "foo", Stake: 77},
+		&common.DBOrch{EthereumAddr: "bar", Stake: 88},
+	}
+	stakes, err := rdr.Stakes([]ethcommon.Address{ethcommon.Address{}, ethcommon.Address{}})
+	assert.Nil(err)
+
+	for _, orch := range store.orchs {
+		addr := ethcommon.HexToAddress(orch.EthereumAddr)
+		assert.Contains(stakes, addr)
+		assert.Equal(stakes[addr], orch.Stake)
+	}
+}
 
 type stubStakeReader struct {
 	stakes map[ethcommon.Address]int64


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR moves the current LIFO O selection logic from `BroadcastSessionsManager` to `LIFOSelector` which implements the `BroadcastSessionsSelector` interface. The goals of this refactor are:

- Allow new selection logic to be implemented separately from `BroadcastSessionsManager` in follow on PRs. New selection logic can be encapsulated in a new type that implements the `BroadcastSessionsSelector` interface
- Keep the existing LIFO selection logic in `LIFOSelector` to serve as an example of an alternate selection strategy once the new selection strategy is implemented in follow on PRs

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Update `BroadcastSessionsManager` to accept the `BroadcastSessionsSelector` interface as a dependency
- Add `LIFOSelector` which implements `BroadcastSessionsSelector`

Note that `LIFOSelector` is *not* concurrency safe. The caller of `LIFOSelector` should implement locking i.e. `BroadcastSessionsManager`.

The `BroadcastSessionsSelector` API does not contain a method for removing sessions. The caller of the API should keep track of which sessions still exist. A session returned from `Select()` that no longer exists should be discarded and `Select()` should be called again. This design choice matches the existing design in `BroadcastSessionsManager` where `sessMap` is used to keep track of existing sessions and whenever a non-existent session is returned we re-select another session.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1228 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
