### PR TITLE
cmd, eth: fix floating point math for eth<=>wei conversions

### DIFF
--- a/cmd/livepeer_cli/wizard_ticketbroker.go
+++ b/cmd/livepeer_cli/wizard_ticketbroker.go
@@ -46,20 +46,18 @@ func (w *wizard) deposit() {
 		return
 	}
 
-	fmt.Printf("Current Deposit: %v\n", sender.Deposit)
-	fmt.Printf("Current Reserve: %v\n", sender.Reserve.FundsRemaining)
+	fmt.Printf("Current Deposit: %v\n", eth.FormatUnits(sender.Deposit, "ETH"))
+	fmt.Printf("Current Reserve: %v\n", eth.FormatUnits(sender.Reserve.FundsRemaining, "ETH"))
 
 	fmt.Printf("Enter deposit amount in ETH - ")
-
-	depositAmount := w.readPositiveFloat()
+	depositAmount := w.readPositiveBaseAmount()
 
 	fmt.Printf("Enter reserve amount in ETH - ")
-
-	reserveAmount := w.readPositiveFloat()
+	reserveAmount := w.readPositiveBaseAmount()
 
 	form := url.Values{
-		"depositAmount": {eth.ToBaseAmount(depositAmount).String()},
-		"reserveAmount": {eth.ToBaseAmount(reserveAmount).String()},
+		"depositAmount": {depositAmount.String()},
+		"reserveAmount": {reserveAmount.String()},
 	}
 	fmt.Println(httpPostWithParams(fmt.Sprintf("http://%v:%v/fundDepositAndReserve", w.host, w.httpPort), form))
 

--- a/cmd/livepeer_cli/wizard_ticketbroker.go
+++ b/cmd/livepeer_cli/wizard_ticketbroker.go
@@ -58,8 +58,8 @@ func (w *wizard) deposit() {
 	reserveAmount := w.readPositiveFloat()
 
 	form := url.Values{
-		"depositAmount": {eth.ToBaseUnit(big.NewFloat(depositAmount)).String()},
-		"reserveAmount": {eth.ToBaseUnit(big.NewFloat(reserveAmount)).String()},
+		"depositAmount": {eth.ToBaseAmount(depositAmount).String()},
+		"reserveAmount": {eth.ToBaseAmount(reserveAmount).String()},
 	}
 	fmt.Println(httpPostWithParams(fmt.Sprintf("http://%v:%v/fundDepositAndReserve", w.host, w.httpPort), form))
 

--- a/eth/helpers_test.go
+++ b/eth/helpers_test.go
@@ -33,3 +33,53 @@ func TestFromPercOfUint256_Given50Percent_ResultWithinEpsilon(t *testing.T) {
 func TestFromPercOfUint256_Given0Percent_ReturnsZero(t *testing.T) {
 	assert.Equal(t, int64(0), FromPercOfUint256(0.0).Int64())
 }
+
+func TestToBaseAmount(t *testing.T) {
+	exp := "100000000000000000" // 0.1 eth
+	wei, err := ToBaseAmount("0.1")
+	assert.Nil(t, err)
+	assert.Equal(t, wei.String(), exp)
+
+	exp = "20000000000000000" // 0.02 eth
+	wei, err = ToBaseAmount("0.02")
+	assert.Nil(t, err)
+	assert.Equal(t, wei.String(), exp)
+
+	exp = "1250000000000000000" // 1.25 eth
+	wei, err = ToBaseAmount("1.25")
+	assert.Nil(t, err)
+	assert.Equal(t, wei.String(), exp)
+
+	exp = "3333333333333333" // 0.003333333333333333 eth
+	wei, err = ToBaseAmount("0.003333333333333333")
+	assert.Nil(t, err)
+	assert.Equal(t, wei.String(), exp)
+
+	// return an error if value has more than 18 decimals
+	wei, err = ToBaseAmount("0.111111111111111111111111111111111")
+	assert.Nil(t, wei)
+	assert.EqualError(t, err, "submitted value has more than 18 decimals")
+}
+
+func TestFromBaseAmount(t *testing.T) {
+	wei, _ := new(big.Int).SetString("100000000000000000", 10)
+	ethVal := FromBaseAmount(wei) // 0.1 eth
+	assert.Equal(t, ethVal, "0.1")
+
+	wei, _ = new(big.Int).SetString("20000000000000000", 10)
+	ethVal = FromBaseAmount(wei) // 0.02 eth
+	assert.Equal(t, ethVal, "0.02")
+
+	wei, _ = new(big.Int).SetString("1250000000000000000", 10)
+	ethVal = FromBaseAmount(wei) // 1.25 eth
+	assert.Equal(t, ethVal, "1.25")
+
+	wei, _ = new(big.Int).SetString("3333333333333333", 10) // 0.003333333333333333 eth
+	ethVal = FromBaseAmount(wei)
+	assert.Equal(t, ethVal, "0.003333333333333333")
+
+	// test that no decimals return no trailing "."
+	wei, _ = new(big.Int).SetString("1000000000000000000", 10)
+	ethVal = FromBaseAmount(wei) // 1 eth
+	assert.Equal(t, ethVal, "1")
+}

--- a/go.sum
+++ b/go.sum
@@ -121,12 +121,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=
-github.com/livepeer/joy4 v0.1.1/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cOQee+WqmaDOgGtP2oDMhcVvR4L0yA=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
-github.com/livepeer/lpms v0.0.0-20191004153601-83352b59757e h1:g1JCA8Fja6P55D6SxLZe+dkfo9+bSx1Yjf01SwnC4t0=
-github.com/livepeer/lpms v0.0.0-20191004153601-83352b59757e/go.mod h1:U9OaF8OI1Golj6bOqXBv9LGIFsyX5kHk/mv3zjSndQc=
 github.com/livepeer/lpms v0.0.0-20191121223052-fdbf27c7cfbf h1:E/R36VasXIimPSgqpq4nBPEqzwMj4rlk7UpFB4Yaqvk=
 github.com/livepeer/lpms v0.0.0-20191121223052-fdbf27c7cfbf/go.mod h1:Vd2O4BVQI/Yj2hzjnNcyTj+qib8zb0hh7GunKP6KJc8=
 github.com/livepeer/m3u8 v0.11.0 h1:aI2hLXV5h5VqxjjmAOs55TpUR35KzNL2XWLkbETql5g=


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This PR attempts to fix floating point math rounding errors caused when depositing broadcasting funds with the CLI. To fix this we are no longer using floating point math but arbitrary-precision fixed-point decimal numbers instead (up to 2^31 decimals). 

**Specific updates (required)**
- removed `eth.FromBaseUnit` and `eth.ToBaseUnit`
- added `github.com/shopspring/decimal` third-party library 
- introduce `eth.WeiToEth(interface{}) decimal.Decimal` and `eth.EthToWei(interface{}) *big.Int`

**How did you test each of these updates (required)**
- Added unit tests with different tests cases and ran unit tests 
- Ran #1211 reproduction steps and see that when adding `0.1 ETH` to reserve it no longer results in `0.100000000000000005 ETH` being taken.

**Does this pull request close any open issues?**
Fixes #1211

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
