### PR TITLE
Set HIGHEST_CHAIN_TAG=rinkeby during docker image build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Then, build the actual app in a container shared between Linux and Windows
       - run: docker pull livepeerci/build:latest || echo 'no pre-existing cache found'
-      - run: docker build -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
+      - run: docker build --build-arg HIGHEST_CHAIN_TAG=rinkeby -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
       - run: docker push livepeerci/build:latest
 
       # Finally, build the minimal go-livepeer distributable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Then, build the actual app in a container shared between Linux and Windows
       - run: docker pull livepeerci/build:latest || echo 'no pre-existing cache found'
-      - run: docker build --build-arg HIGHEST_CHAIN_TAG=rinkeby -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
+      - run: docker build --build-arg HIGHEST_CHAIN_TAG -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
       - run: docker push livepeerci/build:latest
 
       # Finally, build the minimal go-livepeer distributable

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -5,6 +5,9 @@
 
 FROM livepeerci/build-platform:latest
 
+ARG HIGHEST_CHAIN_TAG
+ENV HIGHEST_CHAIN_TAG ${HIGHEST_CHAIN_TAG}
+
 COPY ./install_ffmpeg.sh ./install_ffmpeg.sh
 RUN ./install_ffmpeg.sh
 
@@ -17,6 +20,6 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY . .
-RUN make livepeer livepeer_cli
+RUN HIGHEST_CHAIN_TAG=${HIGHEST_CHAIN_TAG} make livepeer livepeer_cli
 
 CMD ./upload_build.sh

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -20,6 +20,6 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY . .
-RUN HIGHEST_CHAIN_TAG=${HIGHEST_CHAIN_TAG} make livepeer livepeer_cli
+RUN make livepeer livepeer_cli
 
 CMD ./upload_build.sh


### PR DESCRIPTION
closes #1246

We will be recommending that new miner / transcoder participants try out the docker-compose solution for a quick bring-up for experimenting on the Livepeer testnet. We need the image to support the Rinkeby testnet in order for this to work.