### PR TITLE
eth, server: faucet rate limit error message

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -35,7 +35,7 @@ type Backend interface {
 	ethereum.GasEstimator
 	ethereum.GasPricer
 	ethereum.LogFilterer
-
+	ethereum.ChainReader
 	ChainID(ctx context.Context) (*big.Int, error)
 }
 

--- a/eth/client.go
+++ b/eth/client.go
@@ -57,6 +57,7 @@ type LivepeerEthClient interface {
 	// Token
 	Transfer(toAddr ethcommon.Address, amount *big.Int) (*types.Transaction, error)
 	Request() (*types.Transaction, error)
+	NextValidRequest(addr ethcommon.Address) (*big.Int, error)
 	BalanceOf(ethcommon.Address) (*big.Int, error)
 	TotalSupply() (*big.Int, error)
 

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -324,3 +324,6 @@ func (c *StubClient) ReplaceTransaction(tx *types.Transaction, method string, ga
 func (c *StubClient) Sign(msg []byte) ([]byte, error)   { return msg, nil }
 func (c *StubClient) GetGasInfo() (uint64, *big.Int)    { return 0, nil }
 func (c *StubClient) SetGasInfo(uint64, *big.Int) error { return nil }
+
+// Faucet
+func (c *StubClient) NextValidRequest(common.Address) (*big.Int, error) { return nil, nil }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR logs an error messages when a user tries to request LPT from the faucet while still rate limited, the error message includes the amount of minutes to wait. 

**Specific updates (required)**
- exposes `LivepeerEthClient.NextValidRequest`
- add a check if valid request is in the future

**How did you test each of these updates (required)**
Ran broadcaster node and tried requesting from the faucet multiple times on rinkeby

```
E1206 02:43:53.318493   54102 webserver.go:984] Error requesting tokens from faucet: can only request tokens once every hour, please wait 51 more minutes
```

**Does this pull request close any open issues?**
Fixes #1245

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
