### PR TITLE
[O selection] Fetch stake from the DB

### DIFF
--- a/common/db.go
+++ b/common/db.go
@@ -61,6 +61,7 @@ type DBUnbondingLock struct {
 type DBOrchFilter struct {
 	MaxPrice     *big.Rat
 	CurrentRound *big.Int
+	Addresses    []ethcommon.Address
 }
 
 var LivepeerDBVersion = 1
@@ -701,6 +702,14 @@ func buildFilterOrchsQuery(filter *DBOrchFilter) (string, error) {
 		if filter.CurrentRound != nil {
 			currentRound := filter.CurrentRound.Int64()
 			qry += fmt.Sprintf(" AND activationRound <= %v AND %v < deactivationRound", currentRound, currentRound)
+		}
+
+		if len(filter.Addresses) > 0 {
+			hexAddrs := make([]string, len(filter.Addresses))
+			for i, addr := range filter.Addresses {
+				hexAddrs[i] = fmt.Sprintf("'%v'", addr.Hex())
+			}
+			qry += fmt.Sprintf(" AND ethereumAddr IN (%v)", strings.Join(hexAddrs, ", "))
 		}
 	}
 	return qry, nil

--- a/common/db.go
+++ b/common/db.go
@@ -46,7 +46,7 @@ type DBOrch struct {
 	PricePerPixel     int64
 	ActivationRound   int64
 	DeactivationRound int64
-	Stake             string
+	Stake             int64 // Stored as a fixed point number
 }
 
 // DBOrch is the type binding for a row result from the unbondingLocks table
@@ -83,7 +83,7 @@ var schema = `
 		pricePerPixel int64,
 		activationRound int64,
 		deactivationRound int64,
-		stake STRING
+		stake int64
 	);
 
 	CREATE TABLE IF NOT EXISTS unbondingLocks (
@@ -123,7 +123,7 @@ var schema = `
 	CREATE INDEX IF NOT EXISTS idx_blockheaders_number ON blockheaders(number);
 `
 
-func NewDBOrch(ethereumAddr string, serviceURI string, pricePerPixel int64, activationRound int64, deactivationRound int64, stake string) *DBOrch {
+func NewDBOrch(ethereumAddr string, serviceURI string, pricePerPixel int64, activationRound int64, deactivationRound int64, stake int64) *DBOrch {
 	return &DBOrch{
 		ServiceURI:        serviceURI,
 		EthereumAddr:      ethereumAddr,
@@ -219,7 +219,7 @@ func InitDB(dbPath string) (*DB, error) {
 		THEN orchestrators.deactivationRound
 		ELSE excluded.deactivationRound END,
 	stake = 
-		CASE WHEN excluded.stake == ""
+		CASE WHEN excluded.stake == 0
 		THEN orchestrators.stake
 		ELSE excluded.stake END 
 	`)
@@ -461,18 +461,14 @@ func (db *DB) SelectOrchs(filter *DBOrchFilter) ([]*DBOrch, error) {
 			pricePerPixel     int64
 			activationRound   int64
 			deactivationRound int64
-			stake             sql.NullString
+			stake             int64
 		)
 		if err := rows.Scan(&serviceURI, &ethereumAddr, &pricePerPixel, &activationRound, &deactivationRound, &stake); err != nil {
 			glog.Error("db: Unable to fetch orchestrator ", err)
 			continue
 		}
 
-		totalStake := "0"
-		if stake.Valid {
-			totalStake = stake.String
-		}
-		orchs = append(orchs, NewDBOrch(serviceURI, ethereumAddr, pricePerPixel, activationRound, deactivationRound, totalStake))
+		orchs = append(orchs, NewDBOrch(serviceURI, ethereumAddr, pricePerPixel, activationRound, deactivationRound, stake))
 	}
 	return orchs, nil
 }

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -222,7 +222,13 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 
 	// adding row
 	orchAddress := pm.RandAddress().String()
-	orch := NewDBOrch(orchAddress, "127.0.0.1:8936", 1, 0, 0, "")
+	orch := &DBOrch{
+		EthereumAddr:      orchAddress,
+		ServiceURI:        "127.0.0.1:8936",
+		PricePerPixel:     1,
+		ActivationRound:   0,
+		DeactivationRound: 0,
+	}
 
 	err = dbh.UpdateOrch(orch)
 	require.Nil(err)
@@ -231,9 +237,11 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 	require.Nil(err)
 	assert.Len(orchs, 1)
 	assert.Equal(orchs[0].ServiceURI, orch.ServiceURI)
+	// Default value for stake should be 0
+	assert.Equal(orchs[0].Stake, int64(0))
 
 	// updating row with same orchAddress
-	orchUpdate := NewDBOrch(orchAddress, "127.0.0.1:8937", 1000, 5, 10, "50")
+	orchUpdate := NewDBOrch(orchAddress, "127.0.0.1:8937", 1000, 5, 10, 50)
 	err = dbh.UpdateOrch(orchUpdate)
 	require.Nil(err)
 
@@ -312,7 +320,7 @@ func TestSelectUpdateOrchs_AddingUpdatingRow_NoError(t *testing.T) {
 	// Updating only stake
 	stakeUpdate := &DBOrch{
 		EthereumAddr: orchAddress,
-		Stake:        "1000",
+		Stake:        1000,
 	}
 	err = dbh.UpdateOrch(stakeUpdate)
 	require.Nil(err)
@@ -338,7 +346,7 @@ func TestSelectUpdateOrchs_AddingMultipleRows_NoError(t *testing.T) {
 	// adding one row
 	orchAddress := pm.RandAddress().String()
 
-	orch := NewDBOrch(orchAddress, "127.0.0.1:8936", 1, 0, 0, "0")
+	orch := NewDBOrch(orchAddress, "127.0.0.1:8936", 1, 0, 0, 0)
 	err = dbh.UpdateOrch(orch)
 	require.Nil(err)
 
@@ -350,7 +358,7 @@ func TestSelectUpdateOrchs_AddingMultipleRows_NoError(t *testing.T) {
 	// adding second row
 	orchAddress = pm.RandAddress().String()
 
-	orchAdd := NewDBOrch(orchAddress, "127.0.0.1:8938", 1, 0, 0, "0")
+	orchAdd := NewDBOrch(orchAddress, "127.0.0.1:8938", 1, 0, 0, 0)
 	err = dbh.UpdateOrch(orchAdd)
 	require.Nil(err)
 
@@ -375,7 +383,7 @@ func TestOrchCount(t *testing.T) {
 	require.Nil(err)
 
 	for i := 0; i < 10; i++ {
-		orch := NewDBOrch("https://127.0.0.1:"+strconv.Itoa(8936+i), pm.RandAddress().String(), 1, int64(i), int64(5+i), "0")
+		orch := NewDBOrch("https://127.0.0.1:"+strconv.Itoa(8936+i), pm.RandAddress().String(), 1, int64(i), int64(5+i), 0)
 		orch.PricePerPixel, err = PriceToFixed(big.NewRat(1, int64(5+i)))
 		require.Nil(err)
 		err = dbh.UpdateOrch(orch)
@@ -430,7 +438,7 @@ func TestDBFilterOrchs(t *testing.T) {
 	require.Nil(err)
 
 	for i := 0; i < 10; i++ {
-		orch := NewDBOrch(pm.RandAddress().String(), "https://127.0.0.1:"+strconv.Itoa(8936+i), 1, int64(i), int64(5+i), "0")
+		orch := NewDBOrch(pm.RandAddress().String(), "https://127.0.0.1:"+strconv.Itoa(8936+i), 1, int64(i), int64(5+i), 0)
 		orch.PricePerPixel, err = PriceToFixed(big.NewRat(1, int64(5+i)))
 		require.Nil(err)
 		err = dbh.UpdateOrch(orch)

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -426,6 +426,7 @@ func TestOrchCount(t *testing.T) {
 func TestDBFilterOrchs(t *testing.T) {
 	assert := assert.New(t)
 	var orchList []string
+	var orchAddrList []string
 	var nilDb *DB
 	nilOrchs, nilErr := nilDb.SelectOrchs(&DBOrchFilter{MaxPrice: big.NewRat(1, 1)})
 	assert.Nil(nilOrchs)
@@ -444,6 +445,7 @@ func TestDBFilterOrchs(t *testing.T) {
 		err = dbh.UpdateOrch(orch)
 		require.Nil(err)
 		orchList = append(orchList, orch.ServiceURI)
+		orchAddrList = append(orchAddrList, orch.EthereumAddr)
 	}
 
 	//URI - MaxPrice - ActivationRound - DeactivationRound
@@ -491,7 +493,7 @@ func TestDBFilterOrchs(t *testing.T) {
 		assert.Contains(orchList[1:6], o.ServiceURI)
 	}
 
-	// select only active orchs and orchs that pass price filter
+	// Select only active orchs and orchs that pass price filter
 	orchsFiltered, err = dbh.SelectOrchs(&DBOrchFilter{MaxPrice: big.NewRat(1, 8), CurrentRound: big.NewInt(5)})
 	assert.Nil(err)
 	// Should return 3 results, index 3 to 5
@@ -499,6 +501,40 @@ func TestDBFilterOrchs(t *testing.T) {
 	for _, o := range orchsFiltered {
 		assert.Contains(orchList[3:6], o.ServiceURI)
 	}
+
+	// Select only active orchs that pass price filter and that are included in Addresses list
+	filterAddrs := []ethcommon.Address{ethcommon.HexToAddress(orchAddrList[3]), ethcommon.HexToAddress(orchAddrList[4])}
+	orchsFiltered, err = dbh.SelectOrchs(&DBOrchFilter{MaxPrice: big.NewRat(1, 8), CurrentRound: big.NewInt(5), Addresses: filterAddrs})
+	assert.Nil(err)
+	assert.Len(orchsFiltered, 2)
+	for _, o := range orchsFiltered {
+		assert.Contains(orchList[3:5], o.ServiceURI)
+		assert.Contains(orchAddrList[3:5], o.EthereumAddr)
+	}
+
+	// Select orchs that are included in Addresses list when list length > 1
+	filterAddrs = []ethcommon.Address{ethcommon.HexToAddress(orchAddrList[0]), ethcommon.HexToAddress(orchAddrList[1])}
+	orchsFiltered, err = dbh.SelectOrchs(&DBOrchFilter{Addresses: filterAddrs})
+	assert.Nil(err)
+	assert.Len(orchsFiltered, 2)
+	for _, o := range orchsFiltered {
+		assert.Contains(orchList[0:2], o.ServiceURI)
+		assert.Contains(orchAddrList[0:2], o.EthereumAddr)
+	}
+
+	// Select orchs that are included in Addresses list when list length = 0
+	filterAddrs = []ethcommon.Address{ethcommon.HexToAddress(orchAddrList[1])}
+	orchsFiltered, err = dbh.SelectOrchs(&DBOrchFilter{Addresses: filterAddrs})
+	assert.Nil(err)
+	assert.Len(orchsFiltered, 1)
+	assert.Equal(orchList[1], orchsFiltered[0].ServiceURI)
+	assert.Equal(orchAddrList[1], orchsFiltered[0].EthereumAddr)
+
+	// Empty result when no orchs match Addresses list
+	filterAddrs = []ethcommon.Address{ethcommon.BytesToAddress([]byte("foobarbaz"))}
+	orchsFiltered, err = dbh.SelectOrchs(&DBOrchFilter{Addresses: filterAddrs})
+	assert.Nil(err)
+	assert.Len(orchsFiltered, 0)
 }
 
 func TestDBUnbondingLocks(t *testing.T) {

--- a/common/util.go
+++ b/common/util.go
@@ -172,11 +172,30 @@ func GenErrRegex(errStrings []string) *regexp.Regexp {
 // PriceToFixed converts a big.Rat into a fixed point number represented as int64
 // using a scaleFactor of 1000 resulting in max decimal places of 3
 func PriceToFixed(price *big.Rat) (int64, error) {
-	scalingFactor := int64(1000)
-	if price == nil {
+	return ratToFixed(price, 1000)
+}
+
+// BaseTokenAmountToFixed converts the base amount of a token (i.e. ETH/LPT) represented as a big.Int into a fixed point number represented
+// as a int64 using a scalingFactor of 100000 resulting in max decimal places of 5
+func BaseTokenAmountToFixed(baseAmount *big.Int) (int64, error) {
+	// The base token amount is denominated in base units of a token
+	// Assume that there are 10 ** 18 base units for each token
+	// Convert the base token amount to a whole token amount by representing the base token amount
+	// as a fraction with the denominator set to 10 ** 18
+	var rat *big.Rat
+	if baseAmount != nil {
+		maxDecimals := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+		rat = new(big.Rat).SetFrac(baseAmount, maxDecimals)
+	}
+
+	return ratToFixed(rat, 100000)
+}
+
+func ratToFixed(rat *big.Rat, scalingFactor int64) (int64, error) {
+	if rat == nil {
 		return 0, fmt.Errorf("reference to rat is nil")
 	}
-	scaled := new(big.Rat).Mul(price, big.NewRat(scalingFactor, 1))
+	scaled := new(big.Rat).Mul(rat, big.NewRat(scalingFactor, 1))
 	fp, _ := new(big.Float).SetRat(scaled).Int64()
 	return fp, nil
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"encoding/hex"
+	"math"
 	"math/big"
 	"testing"
 
@@ -90,6 +91,65 @@ func TestPriceToFixed(t *testing.T) {
 
 	// rat smaller than 1/1000 returns 0
 	fp, err = PriceToFixed(big.NewRat(1, 5000))
+	assert.Nil(err)
+	assert.Zero(fp)
+}
+
+func TestBaseTokenAmountToFixed(t *testing.T) {
+	assert := assert.New(t)
+
+	// Check when nil is passed in
+	fp, err := BaseTokenAmountToFixed(nil)
+	assert.EqualError(err, "reference to rat is nil")
+	assert.Zero(fp)
+
+	baseTokenAmount, _ := new(big.Int).SetString("1844486980754712220549592", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(184448698075), fp)
+
+	baseTokenAmount, _ = new(big.Int).SetString("1238827039830161692185743", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(123882703983), fp)
+
+	baseTokenAmount, _ = new(big.Int).SetString("451288400383394091574336", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(45128840038), fp)
+
+	// math.MaxInt64 = 9223372036854775807 is the largest fixed point number that can be represented as a int64
+	// This corresponds to 92233720368547.75807 tokens or 92233720368547.75807 * (10 ** 18) base token units
+	baseTokenAmount, _ = new(big.Int).SetString("92233720368547758070000000000000", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(math.MaxInt64), fp)
+
+	// Base token amount = 92233720368547.75808 * (10 ** 18). This is 1 more than the largest base token amount that can be represented as a fixed point number
+	// Should return math.MaxInt64
+	baseTokenAmount, _ = new(big.Int).SetString("92233720368547758080000000000000", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(math.MaxInt64), fp)
+
+	// Base token amount = 92233720368547.75808 * (10 ** 18). This is a magnitude greater than the largest base token amount that can be represented as a fixed point number
+	// Should return math.MaxInt64
+	baseTokenAmount, _ = new(big.Int).SetString("922337203685477580700000000000000", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(math.MaxInt64), fp)
+
+	// Base token amount = .00001 * (10 ** 18). This is the smallest base token amount that can be represented as a fixed point number
+	// Should return 1
+	baseTokenAmount, _ = new(big.Int).SetString("10000000000000", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
+	assert.Nil(err)
+	assert.Equal(int64(1), fp)
+
+	// Base token amount = .000009 * (10 ** 18). This is smaller than the minimum base token amount for fixed point number conversion
+	// Should return 0
+	baseTokenAmount, _ = new(big.Int).SetString("9000000000000", 10)
+	fp, err = BaseTokenAmountToFixed(baseTokenAmount)
 	assert.Nil(err)
 	assert.Zero(fp)
 }

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -174,7 +174,14 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchestratorStake() error {
 			errc <- err
 			return
 		}
-		o.Stake = ep.TotalStake.String()
+
+		stakeFp, err := common.BaseTokenAmountToFixed(ep.TotalStake)
+		if err != nil {
+			errc <- err
+			return
+		}
+		o.Stake = stakeFp
+
 		resc <- o
 	}
 

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -213,7 +213,7 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 		Database: dbh,
 		Eth: &eth.StubClient{
 			Orchestrators: orchestrators,
-			TotalStake:    big.NewInt(5000),
+			TotalStake:    new(big.Int).Mul(big.NewInt(5000), new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)),
 		},
 		Sender: sender,
 	}
@@ -238,7 +238,7 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 	for _, o := range dbOrchs {
 		test := toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel)
 		assert.Contains(testOrchs, test)
-		assert.Equal(o.Stake, big.NewInt(5000).String())
+		assert.Equal(o.Stake, int64(500000000))
 	}
 
 	urls := pool.GetURLs()

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -249,7 +249,12 @@ func (e *StubClient) GetTranscoderEarningsPoolForRound(addr common.Address, roun
 	if e.TranscoderPoolError != nil {
 		return &lpTypes.TokenPools{}, e.TranscoderPoolError
 	}
-	return &lpTypes.TokenPools{TotalStake: e.TotalStake}, nil
+
+	totalStake := big.NewInt(0)
+	if e.TotalStake != nil {
+		totalStake = e.TotalStake
+	}
+	return &lpTypes.TokenPools{TotalStake: totalStake}, nil
 }
 func (e *StubClient) TranscoderPool() ([]*lpTypes.Transcoder, error) {
 	return e.Orchestrators, nil

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -189,10 +189,15 @@ func (ow *OrchestratorWatcher) cacheOrchestratorStake(addr ethcommon.Address, ro
 		return err
 	}
 
+	stakeFp, err := common.BaseTokenAmountToFixed(ep.TotalStake)
+	if err != nil {
+		return err
+	}
+
 	if err := ow.store.UpdateOrch(
 		&common.DBOrch{
 			EthereumAddr: addr.Hex(),
-			Stake:        ep.TotalStake.String(),
+			Stake:        stakeFp,
 		},
 	); err != nil {
 		return err

--- a/eth/watchers/orchestratorwatcher_test.go
+++ b/eth/watchers/orchestratorwatcher_test.go
@@ -167,7 +167,7 @@ func TestOrchWatcher_HandleRoundEvent_CacheOrchestratorStake(t *testing.T) {
 	rw.sink <- newRoundEvent
 	time.Sleep(2 * time.Millisecond)
 
-	assert.Equal(stubStore.stake, expStake.String())
+	assert.Equal(stubStore.stake, int64(500000000))
 
 	// LivepeerEthClient.CurrentRound() error
 	lpEth.RoundsErr = errors.New("CurrentRound error")

--- a/eth/watchers/stub.go
+++ b/eth/watchers/stub.go
@@ -365,7 +365,7 @@ type stubOrchestratorStore struct {
 	deactivationRound int64
 	serviceURI        string
 	ethereumAddr      string
-	stake             string
+	stake             int64
 	selectErr         error
 	updateErr         error
 }

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -388,6 +388,10 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 	}
 
 	playlist := core.NewBasicPlaylistManager(mid, storage)
+	var stakeRdr stakeReader
+	if s.LivepeerNode.Eth != nil {
+		stakeRdr = &storeStakeReader{store: s.LivepeerNode.Database}
+	}
 	cxn := &rtmpConnection{
 		mid:         mid,
 		nonce:       nonce,
@@ -395,7 +399,7 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 		pl:          playlist,
 		profile:     &vProfile,
 		params:      params,
-		sessManager: NewSessionManager(s.LivepeerNode, params, playlist, &LIFOSelector{}),
+		sessManager: NewSessionManager(s.LivepeerNode, params, playlist, NewMinLSSelector(stakeRdr, 1.0)),
 		lastUsed:    time.Now(),
 	}
 

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -101,6 +101,13 @@ type BroadcastSession struct {
 	LatencyScore     float64
 }
 
+// ReceivedTranscodeResult contains received transcode result data and related metadata
+type ReceivedTranscodeResult struct {
+	*net.TranscodeData
+	Info         *net.OrchestratorInfo
+	LatencyScore float64
+}
+
 type lphttp struct {
 	orchestrator Orchestrator
 	orchRPC      *grpc.Server

--- a/server/selection_test.go
+++ b/server/selection_test.go
@@ -11,9 +11,53 @@ import (
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/stretchr/testify/assert"
 )
+
+type stubOrchestratorStore struct {
+	orchs []*common.DBOrch
+	err   error
+}
+
+func (s *stubOrchestratorStore) OrchCount(filter *common.DBOrchFilter) (int, error) { return 0, nil }
+func (s *stubOrchestratorStore) UpdateOrch(orch *common.DBOrch) error               { return nil }
+func (s *stubOrchestratorStore) SelectOrchs(filter *common.DBOrchFilter) ([]*common.DBOrch, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.orchs, nil
+}
+
+func TestStoreStakeReader(t *testing.T) {
+	assert := assert.New(t)
+
+	store := &stubOrchestratorStore{}
+	rdr := &storeStakeReader{store: store}
+
+	store.err = errors.New("SelectOrchs error")
+	_, err := rdr.Stakes(nil)
+	assert.EqualError(err, store.err.Error())
+
+	store.err = nil
+	store.orchs = []*common.DBOrch{&common.DBOrch{}}
+	_, err = rdr.Stakes(nil)
+	assert.EqualError(err, "could not fetch all stake weights")
+
+	store.orchs = []*common.DBOrch{
+		&common.DBOrch{EthereumAddr: "foo", Stake: 77},
+		&common.DBOrch{EthereumAddr: "bar", Stake: 88},
+	}
+	stakes, err := rdr.Stakes([]ethcommon.Address{ethcommon.Address{}, ethcommon.Address{}})
+	assert.Nil(err)
+
+	for _, orch := range store.orchs {
+		addr := ethcommon.HexToAddress(orch.EthereumAddr)
+		assert.Contains(stakes, addr)
+		assert.Equal(stakes[addr], orch.Stake)
+	}
+}
 
 type stubStakeReader struct {
 	stakes map[ethcommon.Address]int64


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds support for fetching Os by address from the DB. This feature is a requirement for stake/latency based selection because we need to be able to fetch the stake for specific Os in B's working set.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 22c8b6a: Use the BLOB type for the stake column in the orchestrators table
- a7fef47: Add an `Addresses` field in `DBOrchFilter` that is used to filter for specific Os by `EthereumAddr` in the SQL query for `SelectOrchs()`

The main motivation behind the BLOB column type update in 22c8b6a was to avoid an additional check when converting from the DB result to a `big.Int` (`string` -> `big.Int` requires an additional check while `[]byte` -> `big.Int` does not). Happy to discuss whether the benefit of change outweighs downsides though!

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
