### PR TITLE
[O selection] Calculate latency scores and integrate new selection algo

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -388,6 +388,10 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 	}
 
 	playlist := core.NewBasicPlaylistManager(mid, storage)
+	var stakeRdr stakeReader
+	if s.LivepeerNode.Eth != nil {
+		stakeRdr = &storeStakeReader{store: s.LivepeerNode.Database}
+	}
 	cxn := &rtmpConnection{
 		mid:         mid,
 		nonce:       nonce,
@@ -395,7 +399,7 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 		pl:          playlist,
 		profile:     &vProfile,
 		params:      params,
-		sessManager: NewSessionManager(s.LivepeerNode, params, playlist, &LIFOSelector{}),
+		sessManager: NewSessionManager(s.LivepeerNode, params, playlist, NewMinLSSelector(stakeRdr, 1.0)),
 		lastUsed:    time.Now(),
 	}
 

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -101,6 +101,13 @@ type BroadcastSession struct {
 	LatencyScore     float64
 }
 
+// ReceivedTranscodeResult contains received transcode result data and related metadata
+type ReceivedTranscodeResult struct {
+	*net.TranscodeData
+	Info         *net.OrchestratorInfo
+	LatencyScore float64
+}
+
 type lphttp struct {
 	orchestrator Orchestrator
 	orchRPC      *grpc.Server

--- a/server/selection_test.go
+++ b/server/selection_test.go
@@ -11,9 +11,53 @@ import (
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/stretchr/testify/assert"
 )
+
+type stubOrchestratorStore struct {
+	orchs []*common.DBOrch
+	err   error
+}
+
+func (s *stubOrchestratorStore) OrchCount(filter *common.DBOrchFilter) (int, error) { return 0, nil }
+func (s *stubOrchestratorStore) UpdateOrch(orch *common.DBOrch) error               { return nil }
+func (s *stubOrchestratorStore) SelectOrchs(filter *common.DBOrchFilter) ([]*common.DBOrch, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.orchs, nil
+}
+
+func TestStoreStakeReader(t *testing.T) {
+	assert := assert.New(t)
+
+	store := &stubOrchestratorStore{}
+	rdr := &storeStakeReader{store: store}
+
+	store.err = errors.New("SelectOrchs error")
+	_, err := rdr.Stakes(nil)
+	assert.EqualError(err, store.err.Error())
+
+	store.err = nil
+	store.orchs = []*common.DBOrch{&common.DBOrch{}}
+	_, err = rdr.Stakes(nil)
+	assert.EqualError(err, "could not fetch all stake weights")
+
+	store.orchs = []*common.DBOrch{
+		&common.DBOrch{EthereumAddr: "foo", Stake: 77},
+		&common.DBOrch{EthereumAddr: "bar", Stake: 88},
+	}
+	stakes, err := rdr.Stakes([]ethcommon.Address{ethcommon.Address{}, ethcommon.Address{}})
+	assert.Nil(err)
+
+	for _, orch := range store.orchs {
+		addr := ethcommon.HexToAddress(orch.EthereumAddr)
+		assert.Contains(stakes, addr)
+		assert.Equal(stakes[addr], orch.Stake)
+	}
+}
 
 type stubStakeReader struct {
 	stakes map[ethcommon.Address]int64


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR attaches the last known latency score to a `BroadcastSession` after each successful transcode and instantiates new `BroadcastSessionsManager` with `MinLSSelector` so that B uses the stake/latency based selection strategy by default.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 1e2d81d: Copy the current session after each successful transcode, attach the last known latency score and update the session's `OrchestratorInfo` if needed. The copied session is then added back to `BroadcastSessionsManager` via `completeSession()`
- 2169657: Instantiate every new `BroadcastSessionsManager` with `MinLSSelector` which uses `storeStakeReader` (depends on the node's DB) to fetch the stake of Os when running stake weighted random selection

The default good enough latency score for `MinLSSelector` is set to 1.0 (i.e. real time). We may want to allow this to be configurable in the future, but setting this default value and not exposing the config option should be fine for now.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1231 
Fixes #961 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
