### PR TITLE
readme: update install from source with env var descriptions

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -24,7 +24,11 @@ You can also build the executables from scratch.
 
 &ensp; 4\. You need to install `ffmpeg` as a dependency.  Run `./install_ffmpeg.sh`.  This will install the dependencies in `~/compiled`.  You need to have `pkg-config` installed.
 
-&ensp; 5\. You can now run `PKG_CONFIG_PATH=~/compiled/lib/pkgconfig go build ./cmd/livepeer/livepeer.go` from the project root directory. To get latest version, `git pull` from the project root directory.
+&ensp; 5\. You can now run `HIGHEST_CHAIN_TAG=<CHAIN_NAME> PKG_CONFIG_PATH=~/compiled/lib/pkgconfig make` from the project root directory. To get latest version, `git pull` from the project root directory.
+
+&ensp; &ensp; a\. `HIGHEST_CHAIN_TAG` (available values: `dev`, `rinkeby` & `mainnet`) represents the highest compatible chain to build for with an ordering of `dev < rinkeby < mainnet`, e.g. using `HIGHEST_CHAIN_TAG=rinkeby` will allow the node to run on the public Rinkeby test network but throw an error when trying to connect to the main Ethereum network.
+
+&ensp; &ensp; b\. `PKG_CONFIG_PATH` is the path where `pkg-config` files for `ffmpeg` dependencies have been installed _(see step 3 & 4)_.
 
 &ensp; 6\. To run tests locally `./test.sh`, to run in docker container run `./test_docker.sh`
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This PR adds descriptions for `HIGHEST_CHAIN_TAG` and `PKG_CONFIG_PATH` to the _Installing from source_ section of the `install.md`  docs file. 

**Does this pull request close any open issues?**
Fixes #1244 

**Checklist:**
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
