### PR TITLE
eth: use EIP155Signer

### DIFF
--- a/eth/accountmanager.go
+++ b/eth/accountmanager.go
@@ -25,19 +25,19 @@ type AccountManager interface {
 	Unlock(passphrase string) error
 	Lock() error
 	CreateTransactOpts(gasLimit uint64, gasPrice *big.Int) (*bind.TransactOpts, error)
-	SignTx(signer types.Signer, tx *types.Transaction) (*types.Transaction, error)
+	SignTx(tx *types.Transaction) (*types.Transaction, error)
 	Sign(msg []byte) ([]byte, error)
 	Account() accounts.Account
 }
 
 type accountManager struct {
-	account accounts.Account
-
+	account  accounts.Account
+	signer   types.Signer
 	unlocked bool
 	keyStore *keystore.KeyStore
 }
 
-func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string) (AccountManager, error) {
+func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string, signer types.Signer) (AccountManager, error) {
 	keyStore := keystore.NewKeyStore(keystoreDir, keystore.StandardScryptN, keystore.StandardScryptP)
 
 	acctExists := keyStore.HasAddress(accountAddr)
@@ -71,6 +71,7 @@ func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string) (Accou
 
 	return &accountManager{
 		account:  acct,
+		signer:   signer,
 		unlocked: false,
 		keyStore: keyStore,
 	}, nil
@@ -129,19 +130,19 @@ func (am *accountManager) CreateTransactOpts(gasLimit uint64, gasPrice *big.Int)
 				return nil, errors.New("not authorized to sign this account")
 			}
 
-			return am.SignTx(signer, tx)
+			return am.SignTx(tx)
 		},
 	}, nil
 }
 
 // Sign a transaction. Account must be unlocked
-func (am *accountManager) SignTx(signer types.Signer, tx *types.Transaction) (*types.Transaction, error) {
-	signature, err := am.keyStore.SignHash(am.account, signer.Hash(tx).Bytes())
+func (am *accountManager) SignTx(tx *types.Transaction) (*types.Transaction, error) {
+	signature, err := am.keyStore.SignHash(am.account, am.signer.Hash(tx).Bytes())
 	if err != nil {
 		return nil, err
 	}
 
-	return tx.WithSignature(signer, signature)
+	return tx.WithSignature(am.signer, signature)
 }
 
 // Sign byte array message. Account must be unlocked

--- a/eth/accountmanager_test.go
+++ b/eth/accountmanager_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/livepeer/go-livepeer/pm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,7 @@ func TestAccountManager(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	am, err := NewAccountManager(a.Address, dir)
+	am, err := NewAccountManager(a.Address, dir, types.EIP155Signer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +52,7 @@ func TestEmptyPassphrase(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	am, err := NewAccountManager(a.Address, dir)
+	am, err := NewAccountManager(a.Address, dir, types.EIP155Signer{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +81,7 @@ func TestSign(t *testing.T) {
 	a, err := ks.NewAccount("")
 	require.Nil(err)
 
-	am, err := NewAccountManager(a.Address, dir)
+	am, err := NewAccountManager(a.Address, dir, types.EIP155Signer{})
 	require.Nil(err)
 
 	_, err = am.Sign([]byte("foo"))

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -43,9 +43,10 @@ type backend struct {
 	*ethclient.Client
 	methods      map[string]string
 	nonceManager *NonceManager
+	signer       types.Signer
 }
 
-func NewBackend(client *ethclient.Client) (Backend, error) {
+func NewBackend(client *ethclient.Client, signer types.Signer) (Backend, error) {
 	methods, err := makeMethodsMap()
 	if err != nil {
 		return nil, err
@@ -55,6 +56,7 @@ func NewBackend(client *ethclient.Client) (Backend, error) {
 		client,
 		methods,
 		NewNonceManager(client),
+		signer,
 	}, nil
 }
 
@@ -72,7 +74,7 @@ func (b *backend) SendTransaction(ctx context.Context, tx *types.Transaction) er
 	}
 
 	// update local nonce
-	msg, err := tx.AsMessage(types.HomesteadSigner{})
+	msg, err := tx.AsMessage(b.signer)
 	if err != nil {
 		return err
 	}

--- a/eth/client.go
+++ b/eth/client.go
@@ -146,12 +146,19 @@ type client struct {
 }
 
 func NewClient(accountAddr ethcommon.Address, keystoreDir string, eth *ethclient.Client, controllerAddr ethcommon.Address, txTimeout time.Duration) (LivepeerEthClient, error) {
-	am, err := NewAccountManager(accountAddr, keystoreDir)
+	chainID, err := eth.ChainID(context.Background())
 	if err != nil {
 		return nil, err
 	}
 
-	backend, err := NewBackend(eth)
+	signer := types.NewEIP155Signer(chainID)
+
+	backend, err := NewBackend(eth, signer)
+	if err != nil {
+		return nil, err
+	}
+
+	am, err := NewAccountManager(accountAddr, keystoreDir, signer)
 	if err != nil {
 		return nil, err
 	}
@@ -795,7 +802,7 @@ func (c *client) ReplaceTransaction(tx *types.Transaction, method string, gasPri
 	// Replacement raw tx uses same fields as old tx (reusing the same nonce is crucial) except the gas price is updated
 	newRawTx := types.NewTransaction(tx.Nonce(), *tx.To(), tx.Value(), tx.Gas(), gasPrice, tx.Data())
 
-	newSignedTx, err := c.accountManager.SignTx(types.HomesteadSigner{}, newRawTx)
+	newSignedTx, err := c.accountManager.SignTx(newRawTx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Force all transactions to be signed with `EIP155Signer` instead of `HomesteadSigner` by overwriting the default signer passed in as an argument by the contract bindings

**Specific updates (required)**
- Added signer argument to `backend` constructor and type (we need a signer to get the tx as message)
- Added signer argument to `accountManager` constructor and type (we need a signer to sign tx's)
- When instantiating a new `LivepeerEthClient`, fetch the `chainID`, instantiate an `EIP155Signer` and pass it as arguments to `backend` and `accountManager`

**How did you test each of these updates (required)**
Ran unit tests, ran node making a tx

**Does this pull request close any open issues?**
Fixes #1257 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
