### PR TITLE
cmd: fixed order for video profiles when setting broadcaster config in CLI

### DIFF
--- a/cmd/livepeer_cli/wizard_broadcast.go
+++ b/cmd/livepeer_cli/wizard_broadcast.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -35,6 +36,7 @@ func (w *wizard) allTranscodingOptions() map[int]string {
 		glog.Errorf("Error unmarshalling all transcoding options: %v", err)
 		return nil
 	}
+	sort.Strings(opts)
 
 	optIds := make(map[int]string)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Prints the video profiles list in a fixed order when setting broadcaster config through the CLI

**Specific updates (required)**
- sort result from `/getAvailableTranscodingOptions`

**How did you test each of these updates (required)**
Ran set bcast config twice, observe that output is printed in the same order

**Does this pull request close any open issues?**
Fixes #1144 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
