### PR TITLE
Accept Ethereum passphrase via file on disk rather than command line

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -349,13 +349,7 @@ func main() {
 			bigGasPrice = big.NewInt(int64(*gasPrice))
 		}
 
-		ethPw, err := common.GetPass(*ethPassword)
-		if err != nil {
-			glog.Errorf("Failed to read ethPassword: %v", err)
-			return
-		}
-
-		err = client.Setup(ethPw, uint64(*gasLimit), bigGasPrice)
+		err = client.Setup(*ethPassword, uint64(*gasLimit), bigGasPrice)
 		if err != nil {
 			glog.Errorf("Failed to setup client: %v", err)
 			return

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -349,7 +349,7 @@ func main() {
 			bigGasPrice = big.NewInt(int64(*gasPrice))
 		}
 
-		ethPw, err := common.GetPass(*ethPassword, 0)
+		ethPw, err := common.GetPass(*ethPassword)
 		if err != nil {
 			glog.Errorf("Failed to read ethPassword: %v", err)
 			return

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -349,7 +349,13 @@ func main() {
 			bigGasPrice = big.NewInt(int64(*gasPrice))
 		}
 
-		err = client.Setup(*ethPassword, uint64(*gasLimit), bigGasPrice)
+		ethPw, err := common.GetPass(*ethPassword, 0)
+		if err != nil {
+			glog.Errorf("Failed to read ethPassword: %v", err)
+			return
+		}
+
+		err = client.Setup(ethPw, uint64(*gasLimit), bigGasPrice)
 		if err != nil {
 			glog.Errorf("Failed to setup client: %v", err)
 			return

--- a/common/getpass.go
+++ b/common/getpass.go
@@ -8,12 +8,19 @@ import (
 
 // GetPass attempts to read a file for a password at the supplied location.
 // If it fails, then the original supplied string will be returned to the caller.
+// A valid string will always be returned, regardless of whether an error occurred.
 func GetPass(s string, idx int) (string, error) {
 	info, err := os.Stat(s)
-	if os.IsNotExist(err) || info.IsDir() {
-		// If the supplied string is a directory or it is not a
-		// path to a file, assume it is the pass and return it
+	if os.IsNotExist(err) {
+		// If the supplied string is not a path to a file,
+		// assume it is the pass and return it
 		return s, nil
+	}
+	if os.IsNotExist(err) || info.IsDir() {
+		// If the supplied string is a directory,
+		// assume it is the pass and return it
+		// along with an approptiate error.
+		return s, fmt.Errorf("supplied path is a directory")
 	}
 	file, err := os.Open(s)
 	if err != nil {

--- a/common/getpass.go
+++ b/common/getpass.go
@@ -16,7 +16,7 @@ func GetPass(s string) (string, error) {
 		// assume it is the pass and return it
 		return s, nil
 	}
-	if os.IsNotExist(err) || info.IsDir() {
+	if info.IsDir() {
 		// If the supplied string is a directory,
 		// assume it is the pass and return it
 		// along with an approptiate error.

--- a/common/getpass.go
+++ b/common/getpass.go
@@ -9,7 +9,7 @@ import (
 // GetPass attempts to read a file for a password at the supplied location.
 // If it fails, then the original supplied string will be returned to the caller.
 // A valid string will always be returned, regardless of whether an error occurred.
-func GetPass(s string, idx int) (string, error) {
+func GetPass(s string) (string, error) {
 	info, err := os.Stat(s)
 	if os.IsNotExist(err) {
 		// If the supplied string is not a path to a file,
@@ -28,19 +28,14 @@ func GetPass(s string, idx int) (string, error) {
 	}
 	scanner := bufio.NewScanner(file)
 	scanner.Split(bufio.ScanLines)
-	var txtlines []string
 
-	for scanner.Scan() {
-		txtlines = append(txtlines, scanner.Text())
-		if len(txtlines)-idx == 1 {
-			break
-		}
-	}
+	scanner.Scan()
+	txtline := scanner.Text()
 	file.Close()
 
-	if len(txtlines) <= idx {
-		return s, fmt.Errorf("requested pass index not present in file: %s", s)
+	if len(txtline) == 0 {
+		return s, fmt.Errorf("supplied file is empty")
 	}
 
-	return txtlines[idx], nil
+	return txtline, nil
 }

--- a/common/getpass.go
+++ b/common/getpass.go
@@ -6,6 +6,8 @@ import (
 	"os"
 )
 
+// GetPass attempts to read a file for a password at the supplied location.
+// If it fails, then the original supplied string will be returned to the caller.
 func GetPass(s string, idx int) (string, error) {
 	info, err := os.Stat(s)
 	if os.IsNotExist(err) || info.IsDir() {

--- a/common/getpass.go
+++ b/common/getpass.go
@@ -1,0 +1,37 @@
+package common
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func GetPass(s string, idx int) (string, error) {
+	info, err := os.Stat(s)
+	if os.IsNotExist(err) || info.IsDir() {
+		// If the supplied string is a directory or it is not a
+		// path to a file, assume it is the pass and return it
+		return s, nil
+	}
+	file, err := os.Open(s)
+	if err != nil {
+		return s, err
+	}
+	scanner := bufio.NewScanner(file)
+	scanner.Split(bufio.ScanLines)
+	var txtlines []string
+
+	for scanner.Scan() {
+		txtlines = append(txtlines, scanner.Text())
+		if len(txtlines)-idx == 1 {
+			break
+		}
+	}
+	file.Close()
+
+	if len(txtlines) <= idx {
+		return s, fmt.Errorf("requested pass index not present in file: %s", s)
+	}
+
+	return txtlines[idx], nil
+}

--- a/common/getpass_test.go
+++ b/common/getpass_test.go
@@ -1,0 +1,115 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPassNoFileExtsts(t *testing.T) {
+	assert := assert.New(t)
+
+	input := "/tmp/../../.."
+	expectedOutput := "/tmp/../../.."
+
+	// GetPass should return the string it was supplied
+	output, err := GetPass(input, 0)
+
+	assert.Nil(err)
+	assert.Equal(expectedOutput, output)
+}
+
+func TestGetPassDirectoryExtsts(t *testing.T) {
+	assert := assert.New(t)
+
+	input := "/tmp"
+	expectedOutput := "/tmp"
+
+	// GetPass should return the string it was supplied
+	output, err := GetPass(input, 0)
+
+	assert.Nil(err)
+	assert.Equal(expectedOutput, output)
+}
+
+func TestGetPassEmptyFileExists(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	tmpFile := "TestGetPassEmptyFileExists.txt"
+
+	emptyFile, err := os.Create(tmpFile)
+	emptyFile.Close()
+	require.Nil(err)
+
+	defer func() {
+		err := os.Remove(tmpFile)
+		require.Nil(err)
+	}()
+
+	// GetPass should return an error
+	_, err = GetPass(tmpFile, 0)
+
+	assert.NotNil(err)
+}
+
+func TestGetPassFileExistsIndex0(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	input :=
+		`something
+somethingelse`
+	expectedOutput := "something"
+
+	tmpFile := "TestGetPassFileExistsIndex0.txt"
+
+	file, err := os.Create(tmpFile)
+	require.Nil(err)
+	_, err = file.WriteString(fmt.Sprintf("%s\n", input))
+	file.Close()
+	require.Nil(err)
+
+	defer func() {
+		err := os.Remove(tmpFile)
+		require.Nil(err)
+	}()
+
+	output, err := GetPass(tmpFile, 0)
+
+	assert.Nil(err)
+	// GetPass should the first line of the text file
+	assert.Equal(expectedOutput, output)
+}
+
+func TestGetPassFileExistsIndex1(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	input :=
+		`something
+somethingelse`
+	expectedOutput := "somethingelse"
+
+	tmpFile := "TestGetPassFileExistsIndex1.txt"
+
+	file, err := os.Create(tmpFile)
+	require.Nil(err)
+	_, err = file.WriteString(fmt.Sprintf("%s\n", input))
+	file.Close()
+	require.Nil(err)
+
+	defer func() {
+		err := os.Remove(tmpFile)
+		require.Nil(err)
+	}()
+
+	output, err := GetPass(tmpFile, 1)
+
+	assert.Nil(err)
+	// GetPass should the second line of the text file
+	assert.Equal(expectedOutput, output)
+}

--- a/common/getpass_test.go
+++ b/common/getpass_test.go
@@ -12,13 +12,14 @@ import (
 func TestGetPassNoFileExtsts(t *testing.T) {
 	assert := assert.New(t)
 
-	input := "/tmp/../../.."
-	expectedOutput := "/tmp/../../.."
+	input := "/tmp/../../../nothing"
+	expectedOutput := "/tmp/../../../nothing"
 
 	// GetPass should return the string it was supplied
 	output, err := GetPass(input, 0)
 
 	assert.Nil(err)
+	// GetPass should return the originaly supplied string
 	assert.Equal(expectedOutput, output)
 }
 
@@ -31,7 +32,8 @@ func TestGetPassDirectoryExtsts(t *testing.T) {
 	// GetPass should return the string it was supplied
 	output, err := GetPass(input, 0)
 
-	assert.Nil(err)
+	assert.NotNil(err)
+	// GetPass should return the originaly supplied string
 	assert.Equal(expectedOutput, output)
 }
 
@@ -40,6 +42,7 @@ func TestGetPassEmptyFileExists(t *testing.T) {
 	require := require.New(t)
 
 	tmpFile := "TestGetPassEmptyFileExists.txt"
+	expectedOutput := "TestGetPassEmptyFileExists.txt"
 
 	emptyFile, err := os.Create(tmpFile)
 	emptyFile.Close()
@@ -51,9 +54,11 @@ func TestGetPassEmptyFileExists(t *testing.T) {
 	}()
 
 	// GetPass should return an error
-	_, err = GetPass(tmpFile, 0)
+	output, err := GetPass(tmpFile, 0)
 
 	assert.NotNil(err)
+	// GetPass should return the originaly supplied string
+	assert.Equal(expectedOutput, output)
 }
 
 func TestGetPassFileExistsIndex0(t *testing.T) {

--- a/common/getpass_test.go
+++ b/common/getpass_test.go
@@ -61,7 +61,34 @@ func TestGetPassEmptyFileExists(t *testing.T) {
 	assert.Equal(expectedOutput, output)
 }
 
-func TestGetPassFileExists(t *testing.T) {
+func TestGetPassFileExistsOneLine(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	input := `something`
+	expectedOutput := "something"
+
+	tmpFile := "TestGetPassFileExistsOneLine.txt"
+
+	file, err := os.Create(tmpFile)
+	require.Nil(err)
+	_, err = file.WriteString(fmt.Sprintf("%s\n", input))
+	file.Close()
+	require.Nil(err)
+
+	defer func() {
+		err := os.Remove(tmpFile)
+		require.Nil(err)
+	}()
+
+	output, err := GetPass(tmpFile)
+
+	assert.Nil(err)
+	// GetPass should the first line of the text file
+	assert.Equal(expectedOutput, output)
+}
+
+func TestGetPassFileExistsMultiline(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -70,7 +97,7 @@ func TestGetPassFileExists(t *testing.T) {
 somethingelse`
 	expectedOutput := "something"
 
-	tmpFile := "TestGetPassFileExistsIndex0.txt"
+	tmpFile := "TestGetPassFileExistsMultiline.txt"
 
 	file, err := os.Create(tmpFile)
 	require.Nil(err)

--- a/common/getpass_test.go
+++ b/common/getpass_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetPassNoFileExtsts(t *testing.T) {
+func TestGetPassNoFileExists(t *testing.T) {
 	assert := assert.New(t)
 
 	input := "/tmp/../../../nothing"
@@ -23,7 +23,7 @@ func TestGetPassNoFileExtsts(t *testing.T) {
 	assert.Equal(expectedOutput, output)
 }
 
-func TestGetPassDirectoryExtsts(t *testing.T) {
+func TestGetPassDirectoryExists(t *testing.T) {
 	assert := assert.New(t)
 
 	input := "/tmp"

--- a/common/getpass_test.go
+++ b/common/getpass_test.go
@@ -16,7 +16,7 @@ func TestGetPassNoFileExists(t *testing.T) {
 	expectedOutput := "/tmp/../../../nothing"
 
 	// GetPass should return the string it was supplied
-	output, err := GetPass(input, 0)
+	output, err := GetPass(input)
 
 	assert.Nil(err)
 	// GetPass should return the originaly supplied string
@@ -30,7 +30,7 @@ func TestGetPassDirectoryExists(t *testing.T) {
 	expectedOutput := "/tmp"
 
 	// GetPass should return the string it was supplied
-	output, err := GetPass(input, 0)
+	output, err := GetPass(input)
 
 	assert.NotNil(err)
 	// GetPass should return the originaly supplied string
@@ -54,14 +54,14 @@ func TestGetPassEmptyFileExists(t *testing.T) {
 	}()
 
 	// GetPass should return an error
-	output, err := GetPass(tmpFile, 0)
+	output, err := GetPass(tmpFile)
 
 	assert.NotNil(err)
 	// GetPass should return the originaly supplied string
 	assert.Equal(expectedOutput, output)
 }
 
-func TestGetPassFileExistsIndex0(t *testing.T) {
+func TestGetPassFileExists(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
@@ -83,38 +83,9 @@ somethingelse`
 		require.Nil(err)
 	}()
 
-	output, err := GetPass(tmpFile, 0)
+	output, err := GetPass(tmpFile)
 
 	assert.Nil(err)
 	// GetPass should the first line of the text file
-	assert.Equal(expectedOutput, output)
-}
-
-func TestGetPassFileExistsIndex1(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-
-	input :=
-		`something
-somethingelse`
-	expectedOutput := "somethingelse"
-
-	tmpFile := "TestGetPassFileExistsIndex1.txt"
-
-	file, err := os.Create(tmpFile)
-	require.Nil(err)
-	_, err = file.WriteString(fmt.Sprintf("%s\n", input))
-	file.Close()
-	require.Nil(err)
-
-	defer func() {
-		err := os.Remove(tmpFile)
-		require.Nil(err)
-	}()
-
-	output, err := GetPass(tmpFile, 1)
-
-	assert.Nil(err)
-	// GetPass should the second line of the text file
 	assert.Equal(expectedOutput, output)
 }

--- a/eth/accountmanager.go
+++ b/eth/accountmanager.go
@@ -78,8 +78,12 @@ func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string, signer
 }
 
 // Unlock account indefinitely using underlying keystore
-func (am *accountManager) Unlock(passphrase string) error {
+func (am *accountManager) Unlock(pass string) error {
 	var err error
+
+	// We don't care if GetPass() returns an error.
+	// The string it returns will always be valid.
+	passphrase, _ := common.GetPass(pass)
 
 	err = am.keyStore.Unlock(am.account, passphrase)
 	if err != nil {


### PR DESCRIPTION
When bringing up nodes on an actual network, `-ethPassword` can be
specified on the command line to supply the Ethereum account's
passphrase and allow unattended startup and operations. This works
for now, but it is very insecure. A attacker can compromise a system,
run `ps aux` and then see all command lines, including the go-livepeer
command line containing the Ethereum passphrase in clear text.

This adds the ability for the user to supply a filepath rather than a
cleartext password to the `-ethPassword` parameter. If the supplied
string is a valid file path, the passphrase will be read from the file,
otherwise the supplied string will be used as-is.

closes #1256

- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
