### PR TITLE
Accept orchSecret password via file on disk rather than command line

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -231,7 +231,7 @@ func main() {
 	}
 
 	if *orchSecret != "" {
-		n.OrchSecret = *orchSecret
+		n.OrchSecret, _ = common.GetPass(*orchSecret)
 	}
 
 	if *transcoder {


### PR DESCRIPTION
When bringing up livepeer nodes, -orchSecret can be specified on
the command line to supply the Orchestrator's password. This works
for now, but it is insecure. A attacker can compromise a system,
run ps aux and then see all command lines, including the
go-livepeer command line containing the password in clear text.

This adds the ability to read the secret from a text file. A text
file can have permissions set to only allow the appropriate user
access to it.

closes https://github.com/livepeer/go-livepeer/issues/1259