### PR TITLE
Return transcoded segments as multipart/mixed in HTTP ingest

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -459,12 +459,14 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 		for i, url := range segURLs {
 			err = cpl.InsertHLSSegment(&sess.Profiles[i], seg.SeqNo, url, seg.Duration)
 			if err != nil {
-				// We assume playlist insertion is *not* recoverable for now
+				// InsertHLSSegment only returns ErrSegmentAlreadyExists error
+				// Right now InsertHLSSegment call is atomic regarding transcoded segments - we either inserting
+				// all the transcoded segments or none, so we shouldn't hit this error
+				// But report in case that InsertHLSSegment changed or something wrong is going on in other parts of workflow
 				glog.Errorf("Playlist insertion error nonce=%d manifestID=%s seqNo=%d err=%s", nonce, cxn.mid, seg.SeqNo, err)
 				if monitor.Enabled {
 					monitor.SegmentTranscodeFailed(monitor.SegmentTranscodeErrorPlaylist, nonce, seg.SeqNo, err, false)
 				}
-				return nil, err
 			}
 		}
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -299,7 +299,6 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 	verifier *verification.SegmentVerifier) error {
 
 	nonce := cxn.nonce
-	rtmpStrm := cxn.stream
 	cpl := cxn.pl
 	sess := cxn.sessManager.selectSession()
 	// Return early under a few circumstances:
@@ -343,13 +342,6 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 			cxn.sessManager.removeSession(sess)
 			if res == nil && err == nil {
 				return errors.New("Empty response")
-			}
-			if shouldStopStream(err) {
-				glog.Warningf("Stopping current stream due to: %v", err)
-				rtmpStrm.Close()
-				return err
-			}
-			if shouldStopSession(err) {
 			}
 			return err
 		}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -770,7 +770,3 @@ func (s *LivepeerServer) LatestPlaylist() core.PlaylistManager {
 	}
 	return cxn.pl
 }
-
-func shouldStopStream(err error) bool {
-	return false
-}

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -858,12 +858,6 @@ func TestCleanStreamPrefix(t *testing.T) {
 	}
 }
 
-func TestShouldStopStream(t *testing.T) {
-	if shouldStopStream(fmt.Errorf("some random error string")) {
-		t.Error("Expected shouldStopStream=false for a random error")
-	}
-}
-
 func TestParseManifestID(t *testing.T) {
 	checkMid := func(inp string, exp string) {
 		mid := parseManifestID(inp)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Returns transcoded data as using `multipart/mixed` encoding.

**Specific updates (required)**
Changed HTTP push handler to return.

**How did you test each of these updates (required)**
Will write unit test in next commits.

**Does this pull request close any open issues?**
Refs #1003 
Refs #1279 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
