### PR TITLE
Add Intel Transcoding support

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -97,6 +97,7 @@ func main() {
 	maxSessions := flag.Int("maxSessions", 10, "Maximum number of concurrent transcoding sessions for Orchestrator, maximum number or RTMP streams for Broadcaster, or maximum capacity for transcoder")
 	currentManifest := flag.Bool("currentManifest", false, "Expose the currently active ManifestID as \"/stream/current.m3u8\"")
 	nvidia := flag.String("nvidia", "", "Comma-separated list of Nvidia GPU device IDs to use for transcoding")
+	intel := flag.String("intel", "", "Comma-separated list of Intel GPU device IDs to use for transcoding")
 
 	// Onchain:
 	ethAcctAddr := flag.String("ethAcctAddr", "", "Existing Eth account address")
@@ -237,6 +238,8 @@ func main() {
 	if *transcoder {
 		if *nvidia != "" {
 			n.Transcoder = core.NewNvidiaTranscoder(*nvidia, *datadir)
+		} else if *intel != "" {
+			n.Transcoder = core.NewIntelTranscoder(*intel, *datadir)
 		} else {
 			n.Transcoder = core.NewLocalTranscoder(*datadir)
 		}

--- a/doc/intel_gpu.md
+++ b/doc/intel_gpu.md
@@ -1,0 +1,38 @@
+# Intel GPU Support
+
+Livepeer supports decoding and encoding on Intel GPUs on Linux. GPU
+transcoding can be enabled by starting Livepeer in `-transcoder` mode with the
+`-intel <device-list>` flag. The `<device-list>` is a comma-separated list of Intel GPU device ID that you wish to use for transcoding. If you are
+unsure of your GPU device, use the `ls /dev/dri/render*` command. For example, to select
+devices /dev/dri/renderD128, and /dev/dri/renderD129:
+
+```
+./livepeer -transcoder -intel /dev/dri/renderD128,/dev/dri/renderD129
+```
+
+### Limitations
+
+Currently the following limitations are observed:
+
+* **Device validity** Ensure valid devices are selected when starting up the node. Currently there is no start-up check to ensure device validity.
+
+* **YUV 4:2:0 input format** The pixel format of the source video must be in YUV 4:2:0 format (planar or
+interleaved). Anything else will return an error.
+
+* **VAAPI Availability** If running the Livepeer binary, the VA shared libraries are expected to be installed in the system.
+
+* **Linux Only** We've only tested this on Linux. We haven't tried other platforms; if it works elsewhere, especially on Windows or OSX, let us know!
+
+### Running Tests
+
+A number of GPU unit tests are included. These may help verify your GPU setup.
+To run these tests, the Livepeer source code must be obtained; see the
+[install documentation](install.md) for details on setting up a build
+environment. Then the Livepeer unit test suite can be run with the `IN_DEVICE`
+environment variable. For example, to run the unit tests on GPU /dev/dri/renderD128:
+
+```
+IN_DEVICE=/dev/dri/renderD128 bash test.sh
+```
+
+A more intensive set of GPU tests is available in the LPMS repository, which is vendored within `go-livepeer`. Refer to the [LPMS README](https://github.com/livepeer/lpms/blob/ja/bottleneck/README.md) for details on how to run these tests.


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds intel transcoding support.

**Specific updates (required)**
- Updates LPMS to add intel transcoding (see livepeer/lpms#163)
- Adds a new IntelTranscoder type implementing the Transcoder interface
- Adds a -intel command line flag taking a list of GPU device IDs to use for transcoding.
- Updates documentation with a new doc/intel_gpu.md page with some usage details for the system.

**How did you test each of these updates (required)**
Unit testing, manual testing on Linux with Intel Corporation HD Graphics 5500

**Does this pull request close any open issues?**


**Checklist:**
- [x] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass

Depends on github.com/faeez-kadiri/lpms v0.0.0-20191220144343-ad9551a26e75