### PR TITLE
cmd: format eth and lpt balances in CLI

### DIFF
--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -42,6 +42,9 @@ func (w *wizard) stats(showOrchestrator bool) {
 	fmt.Println("|NODE STATS|")
 	fmt.Println("+-----------+")
 
+	lptBal, _ := new(big.Int).SetString(w.getTokenBalance(), 10)
+	ethBal, _ := new(big.Int).SetString(w.getEthBalance(), 10)
+
 	table := tablewriter.NewWriter(os.Stdout)
 	data := [][]string{
 		[]string{"Node's version", status.Version},
@@ -53,8 +56,8 @@ func (w *wizard) stats(showOrchestrator bool) {
 		[]string{"LivepeerToken Address", addrMap["LivepeerToken"].Hex()},
 		[]string{"LivepeerTokenFaucet Address", addrMap["LivepeerTokenFaucet"].Hex()},
 		[]string{"ETH Account", w.getEthAddr()},
-		[]string{"LPT Balance", w.getTokenBalance()},
-		[]string{"ETH Balance", w.getEthBalance()},
+		[]string{"LPT Balance", eth.FormatUnits(lptBal, "LPT")},
+		[]string{"ETH Balance", eth.FormatUnits(ethBal, "ETH")},
 	}
 
 	for _, v := range data {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR formats the balances for ETH and LPT displayed in the CLI, previously the wei string returned from the webserver was displayed directly. 


Previously: 

```
*-----------------------------*--------------------------------------------*
|                 ETH Account | 0x13d3C3bdDD3531d11F92884bC49cb98255D51370 |
*-----------------------------*--------------------------------------------*
|                 LPT Balance |                       40000000000000000000 |
*-----------------------------*--------------------------------------------*
|                 ETH Balance |                       22247628928100213819
*-----------------------------*--------------------------------------------*
```

Now: 
```
*-----------------------------*--------------------------------------------*
|                 ETH Account | 0x13d3C3bdDD3531d11F92884bC49cb98255D51370 |
*-----------------------------*--------------------------------------------*
|                 LPT Balance |                                     40 LPT |
*-----------------------------*--------------------------------------------*
|                 ETH Balance |                  22.247628928100213819 ETH |
*-----------------------------*--------------------------------------------*
```

**Specific updates (required)**
- Wrapped the values printed in console in an `eth.FormatUnits` call


**How did you test each of these updates (required)**
Ran CLI

**Does this pull request close any open issues?**


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
