### PR TITLE
Remove unneeded locking in LB transcode function

### DIFF
--- a/core/lb.go
+++ b/core/lb.go
@@ -198,8 +198,11 @@ func (sess *transcoderSession) Transcode(job string, fname string, profiles []ff
 			*TranscodeData
 			error
 		})}
+	sess.mu.Lock()
+	sender := sess.sender
+	sess.mu.Unlock()
 	select {
-	case sess.sender <- params:
+	case sender <- params:
 		glog.V(common.DEBUG).Info("LB: Transcode submitted for ", sess.key, fname)
 	default:
 		glog.V(common.DEBUG).Info("LB: Transcoder was busy; exiting ", sess.key, fname)

--- a/core/lb.go
+++ b/core/lb.go
@@ -198,13 +198,11 @@ func (sess *transcoderSession) Transcode(job string, fname string, profiles []ff
 			*TranscodeData
 			error
 		})}
-	sess.mu.Lock()
-	defer sess.mu.Unlock()
 	select {
 	case sess.sender <- params:
-		glog.V(common.DEBUG).Info("LB: Transcode submitted for ", sess.key)
+		glog.V(common.DEBUG).Info("LB: Transcode submitted for ", sess.key, fname)
 	default:
-		glog.V(common.DEBUG).Info("LB: Transcoder was busy; exiting ", sess.key)
+		glog.V(common.DEBUG).Info("LB: Transcoder was busy; exiting ", sess.key, fname)
 		return nil, ErrTranscoderBusy
 	}
 	res := <-params.res

--- a/core/lb.go
+++ b/core/lb.go
@@ -199,15 +199,15 @@ func (sess *transcoderSession) Transcode(job string, fname string, profiles []ff
 			error
 		})}
 	sess.mu.Lock()
-	sender := sess.sender
-	sess.mu.Unlock()
 	select {
-	case sender <- params:
+	case sess.sender <- params:
 		glog.V(common.DEBUG).Info("LB: Transcode submitted for ", sess.key, fname)
 	default:
 		glog.V(common.DEBUG).Info("LB: Transcoder was busy; exiting ", sess.key, fname)
+		sess.mu.Unlock()
 		return nil, ErrTranscoderBusy
 	}
+	sess.mu.Unlock()
 	res := <-params.res
 	return res.TranscodeData, res.error
 }

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -24,6 +24,7 @@ type StubTranscoder struct {
 	FailWait      time.Duration
 	TranscodeWait time.Duration
 	Started       chan interface{}
+	TranscodeFn   func()
 }
 
 func newStubTranscoder(d string, workDir string) TranscoderSession {
@@ -51,6 +52,10 @@ func (t *StubTranscoder) Transcode(job string, fname string, profiles []ffmpeg.V
 
 	if t.TranscodeWait > 0 {
 		time.Sleep(t.TranscodeWait)
+	}
+
+	if t.TranscodeFn != nil {
+		t.TranscodeFn()
 	}
 
 	t.SegCount++


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Locking in `transcoderSession::Transcode` function kills `one segment in flight` rule.

**Specific updates (required)**
Removed unneeded locking in LB transcode function.
Add unit tests for "Transcoder Busy" and "Transcoder Stopped" errors

**How did you test each of these updates (required)**
Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
