### PR TITLE
pm: fix concurrent map write issue in sendermonitor.MaxFloat()

### DIFF
--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -66,7 +66,7 @@ type senderMonitor struct {
 	cleanupInterval time.Duration
 	ttl             int
 
-	mu      sync.RWMutex
+	mu      sync.Mutex
 	senders map[ethcommon.Address]*remoteSender
 
 	broker Broker
@@ -166,8 +166,8 @@ func (sm *senderMonitor) SubFloat(addr ethcommon.Address, amount *big.Int) {
 
 // MaxFloat returns a remote sender's max float
 func (sm *senderMonitor) MaxFloat(addr ethcommon.Address) (*big.Int, error) {
-	sm.mu.RLock()
-	defer sm.mu.RUnlock()
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 
 	sm.ensureCache(addr)
 

--- a/pm/sendermonitor_test.go
+++ b/pm/sendermonitor_test.go
@@ -58,6 +58,26 @@ func TestMaxFloat(t *testing.T) {
 
 	mf, err := sm.MaxFloat(addr)
 	assert.Equal(reserveAlloc, mf)
+
+	// test race conditions
+	addrs := make([]ethcommon.Address, 5)
+	for i := range addrs {
+		addr := RandAddress()
+		addrs[i] = addr
+		smgr.info[addr] = &SenderInfo{
+			Deposit:       big.NewInt(500),
+			WithdrawRound: big.NewInt(0),
+			Reserve: &ReserveInfo{
+				FundsRemaining:        big.NewInt(500),
+				ClaimedInCurrentRound: big.NewInt(0),
+			},
+		}
+		smgr.claimedReserve[addr] = big.NewInt(100)
+	}
+
+	for _, addr := range addrs {
+		go sm.MaxFloat(addr)
+	}
 }
 
 func TestSubFloat(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR makes sure that the `SenderMonitor.senders` map is correctly write locked when calling `senderMonitor.MaxFloat()` , previously only reads were locked causing concurrent write operations under certain conditions and resulting in a panic. 

**Specific updates (required)**
- Changed the mutex in `SenderMonitor` to be a simple Mutex rather than a `RWMutex`
- in `sm.MaxFloat()` change the `RLock` and `RUnlock` calls to `Lock` and `Unlock`

**How did you test each of these updates (required)**
Added a unit test per suggestion in [this comment](https://github.com/livepeer/go-livepeer/pull/1288#pullrequestreview-340614754)

**Does this pull request close any open issues?**
Fixes #1281 


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
