### PR TITLE
cmd, core, eth/watchers: O checks that it is active in ProcessPayment

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -745,7 +745,7 @@ func main() {
 			return
 		}
 
-		orch := core.NewOrchestrator(s.LivepeerNode)
+		orch := core.NewOrchestrator(s.LivepeerNode, roundsWatcher)
 
 		go func() {
 			server.StartTranscodeServer(orch, *httpAddr, s.HTTPMux, n.WorkDir, n.TranscoderManager != nil)

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -876,8 +876,8 @@ func setupOrchestrator(ctx context.Context, n *core.LivepeerNode, initializeRoun
 
 	err = n.Database.UpdateOrch(&common.DBOrch{
 		EthereumAddr:      n.Eth.Account().Address.Hex(),
-		ActivationRound:   orch.ActivationRound.Int64(),
-		DeactivationRound: orch.DeactivationRound.Int64(),
+		ActivationRound:   common.ToInt64(orch.ActivationRound),
+		DeactivationRound: common.ToInt64(orch.DeactivationRound),
 	})
 	if err != nil {
 		return err

--- a/cmd/livepeer/livepeer_test.go
+++ b/cmd/livepeer/livepeer_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/eth"
+	lpTypes "github.com/livepeer/go-livepeer/eth/types"
+	"github.com/livepeer/go-livepeer/pm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupOrchestrator(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	dbh, dbraw, err := common.TempDB(t)
+	require.Nil(err)
+
+	defer dbh.Close()
+	defer dbraw.Close()
+
+	orch := pm.RandAddress()
+
+	stubEthClient := &eth.StubClient{
+		Orch: &lpTypes.Transcoder{
+			Address:           orch,
+			ActivationRound:   big.NewInt(5),
+			DeactivationRound: big.NewInt(10),
+		},
+		TranscoderAddress: orch,
+	}
+
+	n, err := core.NewLivepeerNode(stubEthClient, "", dbh)
+	require.Nil(err)
+
+	err = setupOrchestrator(context.Background(), n, false)
+	assert.Nil(err)
+
+	orchs, err := dbh.SelectOrchs(&common.DBOrchFilter{
+		Addresses: []ethcommon.Address{orch},
+	})
+	assert.Nil(err)
+	assert.Len(orchs, 1)
+	assert.Equal(orchs[0].ActivationRound, int64(5))
+	assert.Equal(orchs[0].DeactivationRound, int64(10))
+
+	// test eth.GetTranscoder error
+	stubEthClient.Err = errors.New("GetTranscoder error")
+	err = setupOrchestrator(context.Background(), n, false)
+	assert.EqualError(err, "GetTranscoder error")
+}

--- a/common/types.go
+++ b/common/types.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"math/big"
 	"net/url"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -22,4 +23,8 @@ type OrchestratorStore interface {
 	OrchCount(filter *DBOrchFilter) (int, error)
 	SelectOrchs(filter *DBOrchFilter) ([]*DBOrch, error)
 	UpdateOrch(orch *DBOrch) error
+}
+
+type RoundsManager interface {
+	LastInitializedRound() *big.Int
 }

--- a/common/util.go
+++ b/common/util.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"math/big"
 	"math/rand"
 	"regexp"
@@ -22,6 +23,8 @@ import (
 
 // HTTPTimeout timeout used in HTTP connections between nodes
 const HTTPTimeout = 8 * time.Second
+
+const maxInt64 = int64(math.MaxInt64)
 
 var (
 	ErrParseBigInt = fmt.Errorf("failed to parse big integer")
@@ -245,4 +248,12 @@ var RandomIDGenerator = func(length uint) string {
 // RandName generates random hexadecimal string
 func RandName() string {
 	return RandomIDGenerator(10)
+}
+
+func ToInt64(val *big.Int) int64 {
+	if val.Cmp(big.NewInt(maxInt64)) > 0 {
+		return maxInt64
+	}
+
+	return val.Int64()
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -207,3 +207,11 @@ func TestBaseTokenAmountToFixed(t *testing.T) {
 	assert.Nil(err)
 	assert.Zero(fp)
 }
+
+func TestToInt64(t *testing.T) {
+	// test val > math.MaxInt64 => val = math.MaxInt64
+	val, _ := new(big.Int).SetString("9223372036854775808", 10) // 2^63
+	assert.Equal(t, int64(math.MaxInt64), ToInt64(val))
+	// test val < math.MaxInt64
+	assert.Equal(t, int64(5), ToInt64(big.NewInt(5)))
+}

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -32,19 +32,15 @@ type ticketParamsValidator interface {
 	ValidateTicketParams(ticketParams *pm.TicketParams) error
 }
 
-type roundsManager interface {
-	LastInitializedRound() *big.Int
-}
-
 type DBOrchestratorPoolCache struct {
 	store                 common.OrchestratorStore
 	lpEth                 eth.LivepeerEthClient
 	ticketParamsValidator ticketParamsValidator
-	rm                    roundsManager
+	rm                    common.RoundsManager
 	bcast                 common.Broadcaster
 }
 
-func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm roundsManager) (*DBOrchestratorPoolCache, error) {
+func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm common.RoundsManager) (*DBOrchestratorPoolCache, error) {
 	if node.Eth == nil {
 		return nil, fmt.Errorf("could not create DBOrchestratorPoolCache: LivepeerEthClient is nil")
 	}

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -3,7 +3,6 @@ package discovery
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/big"
 	"net/url"
 	"strings"
@@ -20,8 +19,6 @@ import (
 
 	"github.com/golang/glog"
 )
-
-const maxInt64 = int64(math.MaxInt64)
 
 var cacheRefreshInterval = 1 * time.Hour
 var getTicker = func() *time.Ticker {
@@ -303,12 +300,8 @@ func ethOrchToDBOrch(orch *lpTypes.Transcoder) *common.DBOrch {
 	dbo := &common.DBOrch{
 		ServiceURI:        orch.ServiceURI,
 		EthereumAddr:      orch.Address.String(),
-		ActivationRound:   orch.ActivationRound.Int64(),
-		DeactivationRound: orch.DeactivationRound.Int64(),
-	}
-
-	if orch.DeactivationRound.Cmp(big.NewInt(maxInt64)) == 1 {
-		dbo.DeactivationRound = maxInt64
+		ActivationRound:   common.ToInt64(orch.ActivationRound),
+		DeactivationRound: common.ToInt64(orch.DeactivationRound),
 	}
 
 	return dbo

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"math/big"
 	"math/rand"
 	"net/url"
@@ -1105,5 +1106,5 @@ func TestEthOrchToDBOrch(t *testing.T) {
 	assert.Equal(dbo.ServiceURI, o.ServiceURI)
 	assert.Equal(dbo.EthereumAddr, o.Address.Hex())
 	assert.Equal(dbo.ActivationRound, o.ActivationRound.Int64())
-	assert.Equal(dbo.DeactivationRound, maxInt64)
+	assert.Equal(dbo.DeactivationRound,  int64(math.MaxInt64))
 }

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -117,7 +117,7 @@ func (ow *OrchestratorWatcher) handleTranscoderActivated(log types.Log) error {
 			&common.DBOrch{
 				EthereumAddr:      transcoderActivated.Transcoder.String(),
 				ServiceURI:        uri,
-				ActivationRound:   transcoderActivated.ActivationRound.Int64(),
+				ActivationRound:   common.ToInt64(transcoderActivated.ActivationRound),
 				DeactivationRound: maxFutureRound,
 			},
 		)
@@ -130,8 +130,8 @@ func (ow *OrchestratorWatcher) handleTranscoderActivated(log types.Log) error {
 		&common.DBOrch{
 			EthereumAddr:      t.Address.String(),
 			ServiceURI:        t.ServiceURI,
-			ActivationRound:   t.ActivationRound.Int64(),
-			DeactivationRound: t.DeactivationRound.Int64(),
+			ActivationRound:   common.ToInt64(t.ActivationRound),
+			DeactivationRound: common.ToInt64(t.DeactivationRound),
 		},
 	)
 }
@@ -146,7 +146,7 @@ func (ow *OrchestratorWatcher) handleTranscoderDeactivated(log types.Log) error 
 		return ow.store.UpdateOrch(
 			&common.DBOrch{
 				EthereumAddr:      transcoderDeactivated.Transcoder.String(),
-				DeactivationRound: transcoderDeactivated.DeactivationRound.Int64(),
+				DeactivationRound: common.ToInt64(transcoderDeactivated.DeactivationRound),
 			},
 		)
 	}
@@ -157,8 +157,8 @@ func (ow *OrchestratorWatcher) handleTranscoderDeactivated(log types.Log) error 
 	return ow.store.UpdateOrch(
 		&common.DBOrch{
 			EthereumAddr:      t.Address.String(),
-			ActivationRound:   t.ActivationRound.Int64(),
-			DeactivationRound: t.DeactivationRound.Int64(),
+			ActivationRound:   common.ToInt64(t.ActivationRound),
+			DeactivationRound: common.ToInt64(t.DeactivationRound),
 		},
 	)
 }

--- a/test.sh
+++ b/test.sh
@@ -2,58 +2,63 @@
 
 #Test script to run all the tests for continuous integration
 
-cd core
+cd cmd/livepeer
 go test -logtostderr=true -v
 t1=$?
+cd ../..
+
+cd core
+go test -logtostderr=true -v
+t2=$?
 # Be more strict with load balancer tests: run with race detector enabled
 go test -logtostderr=true -run LB_ -race
-t1_lb=$?
+t2_lb=$?
 cd ..
 
 cd server
 go test -logtostderr=true -v
-t2=$?
+t3=$?
 cd ..
 
 cd monitor
 go test -logtostderr=true -v
-t3=$?
+t4=$?
 cd ..
 
 cd eth
 go test -logtostderr=true -v
-t4=$?
+t5=$?
 cd ..
 
 cd eth/watchers
 go test -logtostderr=true -v
-t5=$?
+t6=$?
 cd ../..
 
 cd common
 go test -logtostderr=true -v
-t6=$?
+t7=$?
 cd ..
 
 cd discovery
 go test -logtostderr=true -v
-t7=$?
+t8=$?
 cd ..
 
 cd pm
 go test -logtostderr=true -v
-t8=$?
+t9=$?
 cd ..
 
 cd drivers
 go test -logtostderr=true -v
-t9=$?
+t10=$?
 cd ..
 
 ./test_args.sh
 t_args=$?
 
-if (($t1!=0||$t1_lb!=0||$t2!=0||$t3!=0||$t4!=0||$t5!=0||$t6!=0||$t7!=0||$t8!=0||$t9!=0||$t_args!=0))
+if (($t1!=0||$t2!=0||$t2_lb!=0||$t3!=0||$t4!=0||$t5!=0||$t6!=0||$t7!=0||$t8!=0||$t9!=0||$t10!=0||$t_args!=0))
 then
     printf "\n\nSome Tests Failed\n\n"
     exit -1


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Reopened version of #1226.

For context, #1226 was merged, but I realized that the I missed something in the review and the feature is incomplete. So, the commit was rolled back.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1202 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
