### PR TITLE
new release process for 'rinkeby' and 'mainnet' branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,17 @@ jobs:
               export HIGHEST_CHAIN_TAG=$branch
             fi
           done
+
+          # Disallow non-tagged mainnet releases
+          generatedVersion=$(./print_version.sh)
+          definedVersion=$(cat VERSION)
+          if [[ $HIGHEST_CHAIN_TAG == "mainnet" ]]; then
+            if [[ $generatedVersion != $definedVesion ]]; then
+              echo "disallowing mainnet release without semver tag; $generatedVersion != $definedVersion"
+              exit 1
+            fi
+          fi
+
           echo "building with support for network: $HIGHEST_CHAIN_TAG"
           docker build --build-arg HIGHEST_CHAIN_TAG -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
       - run: docker push livepeerci/build:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,6 @@ jobs:
       PKG_CONFIG_PATH: /root/compiled/lib/pkgconfig
       GOPATH: /go
       DOCKER_CLI_EXPERIMENTAL: enabled
-      # If we want to build with branch --> network support for any other networks, add them here!
-      NETWORK_BRANCHES: rinkeby mainnet
 
     steps:
       - checkout
@@ -38,24 +36,7 @@ jobs:
       # Then, build the actual app in a container shared between Linux and Windows
       - run: docker pull livepeerci/build:latest || echo 'no pre-existing cache found'
       - run: |-
-          export HIGHEST_CHAIN_TAG=dev
-          for branch in $NETWORK_BRANCHES; do
-            if [[ $CIRCLE_BRANCH == "$branch" ]]; then
-              export HIGHEST_CHAIN_TAG=$branch
-            fi
-          done
-
-          # Disallow non-tagged mainnet releases
-          generatedVersion=$(./print_version.sh)
-          definedVersion=$(cat VERSION)
-          if [[ $HIGHEST_CHAIN_TAG == "mainnet" ]]; then
-            if [[ $generatedVersion != $definedVesion ]]; then
-              echo "disallowing mainnet release without semver tag; $generatedVersion != $definedVersion"
-              exit 1
-            fi
-          fi
-
-          echo "building with support for network: $HIGHEST_CHAIN_TAG"
+          source ./ci_env.sh
           docker build --build-arg HIGHEST_CHAIN_TAG -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
       - run: docker push livepeerci/build:latest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
       # If we want to build with branch --> network support for any other networks, add them here!
       NETWORK_BRANCHES: rinkeby mainnet
 
-
     steps:
       - checkout
       - setup_remote_docker:
@@ -38,7 +37,15 @@ jobs:
 
       # Then, build the actual app in a container shared between Linux and Windows
       - run: docker pull livepeerci/build:latest || echo 'no pre-existing cache found'
-      - run: docker build --build-arg HIGHEST_CHAIN_TAG -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
+      - run: |-
+          export HIGHEST_CHAIN_TAG=dev
+          for branch in $NETWORK_BRANCHES; do
+            if [[ $CIRCLE_BRANCH == "$branch" ]]; then
+              export HIGHEST_CHAIN_TAG=$branch
+            fi
+          done
+          echo "building with support for network: $HIGHEST_CHAIN_TAG"
+          docker build --build-arg HIGHEST_CHAIN_TAG -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
       - run: docker push livepeerci/build:latest
 
       # Finally, build the minimal go-livepeer distributable. We publish two tags for each build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,9 @@ jobs:
       PKG_CONFIG_PATH: /root/compiled/lib/pkgconfig
       GOPATH: /go
       DOCKER_CLI_EXPERIMENTAL: enabled
-      HIGHEST_CHAIN_TAG: rinkeby
+      # If we want to build with branch --> network support for any other networks, add them here!
+      NETWORK_BRANCHES: rinkeby mainnet
+
 
     steps:
       - checkout
@@ -39,15 +41,21 @@ jobs:
       - run: docker build --build-arg HIGHEST_CHAIN_TAG -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
       - run: docker push livepeerci/build:latest
 
-      # Finally, build the minimal go-livepeer distributable
+      # Finally, build the minimal go-livepeer distributable. We publish two tags for each build:
+      # livepeer/go-livepeer:BRANCH_NAME and livepeer/go-livepeer:VERSION_STRING. Both are useful
+      # to pull from in different contexts.
       - run: |-
           # Our Docker tag name should be our branch name with just alphanums
-          TAG=$(echo $CIRCLE_BRANCH | tr -cd '[:alnum:]_')
-          docker build -t livepeer/go-livepeer:${TAG}-linux -f docker/Dockerfile.release-linux .
-          docker push livepeer/go-livepeer:${TAG}-linux
-          # Manifest step is optional in case the Windows build hasn't finished yet
-          docker manifest create livepeer/go-livepeer:${TAG} livepeer/go-livepeer:${TAG}-linux livepeer/go-livepeer:${TAG}-windows || true
-          docker manifest push livepeer/go-livepeer:${TAG} || true
+          BRANCH_TAG=$(echo $CIRCLE_BRANCH | sed 's/\//-/g' | tr -cd '[:alnum:]_-')
+          VERSION_TAG=$(./print_version.sh)
+          docker build -t current-build -f docker/Dockerfile.release-linux .
+          for TAG in $BRANCH_TAG $VERSION_TAG; do
+            docker tag current-build livepeer/go-livepeer:${TAG}-linux
+            docker push livepeer/go-livepeer:${TAG}-linux
+            # Manifest step is optional in case the Windows build hasn't finished yet
+            docker manifest create livepeer/go-livepeer:${TAG} livepeer/go-livepeer:${TAG}-linux livepeer/go-livepeer:${TAG}-windows || true
+            docker manifest push livepeer/go-livepeer:${TAG} || true
+          done
 
   build:
     docker:
@@ -60,7 +68,6 @@ jobs:
       PKG_CONFIG_PATH: /root/compiled/lib/pkgconfig
       TEST_RESULTS: /tmp/test-results
       GOPATH: /go
-      HIGHEST_CHAIN_TAG: rinkeby
 
     steps:
       - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
   - git fetch --unshallow --tags
   - ./install_ffmpeg.sh
   - go mod download
-  - make livepeer livepeer_cli
+  - source ./ci_env.sh && make livepeer livepeer_cli
   - ./upload_build.sh

--- a/ci_env.sh
+++ b/ci_env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Script to populate some environment variables in various CI processes. Should be
+# invoked with `source ci_env.sh`.
+
+set -e
+
+# If we want to build with branch --> network support for any other networks, add them here!
+NETWORK_BRANCHES="rinkeby mainnet"
+
+branch=""
+if [[ "${CIRCLE_BRANCH:-}" != "" ]]; then
+  branch="$CIRCLE_BRANCH"
+elif [[ "${TRAVIS_BRANCH:-}" != "" ]]; then
+  branch="$TRAVIS_BRANCH"
+fi
+
+export HIGHEST_CHAIN_TAG=dev
+for networkBranch in $NETWORK_BRANCHES; do
+  if [[ $branch == "$networkBranch" ]]; then
+    export HIGHEST_CHAIN_TAG=$networkBranch
+  fi
+done
+
+# Disallow non-tagged mainnet releases
+generatedVersion=$(./print_version.sh)
+definedVersion=$(cat VERSION)
+if [[ $HIGHEST_CHAIN_TAG == "mainnet" ]]; then
+  if [[ $generatedVersion != $definedVersion ]]; then
+    echo "disallowing mainnet release without semver tag; $generatedVersion != $definedVersion"
+    exit 1
+  fi
+fi

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -1,0 +1,42 @@
+# go-livepeer release process
+
+We presently use three branches for go-livepeer releases.
+
+#### master
+
+Built in CI with go build `-tags dev`, releasing binaries that may only connect to private networks. Published to Docker Hub as `livepeer/go-livepeer:master`.
+
+#### rinkeby
+
+Cut off of master periodically when we're comfortable that it's reasonably stable. Built in CI with `-tags rinkeby`, so it can connect to the Rinkeby test network. Published to Docker Hub as `livepeer/go-livepeer:rinkeby`.
+
+#### mainnet
+
+Cut off of `rinkeby` when we want to do a proper mainnet release. Built in CI with `-tags mainnet`, giving it the ability to connect to the Ethereum mainnet.
+
+This is the only branch that receives proper semver updates; all releases should have a tag of the form `vMAJOR.MINOR.PATCH`. Published to Docker Hub as `livepeer/go-livepeer:mainnet` and e.g. `livepeer/go-livepeer:0.5.3`.
+
+### Cutting a mainnet release of go-livepeer
+
+This process will vary somewhat based on the particular states of the branches, whether we're doing a hotfix, etc. But the overall steps are the same. First, merge changes into the mainnet branch and make the release commit:
+
+```bash
+git checkout mainnet
+git merge --ff-only rinkeby
+echo -n '0.5.2' > VERSION
+git commit -am 'release v0.5.2'
+git push --atomic origin mainnet v0.5.2
+```
+
+Then, merge that version bump back to rinkeby and master:
+
+```bash
+git checkout rinkeby
+git merge --ff-only mainnet
+git push origin rinkeby
+git checkout master
+git merge --ff-only mainnet
+git push origin master
+```
+
+If there's different commits on those branches then we'd omit the --ff-only flag, but the cleanest possible scenario after a mainnet release is that all three branches are pointed at the same ref.


### PR DESCRIPTION
See the new doc/releases.md for an explanation of these changes.

I did a couple dummy commits to test different functionality; [here's a successful build with support for the nonexistent `eli/new-release-process` branch](https://app.circleci.com/jobs/github/livepeer/go-livepeer/4042/parallel-runs/0/steps/0-108) and [here's a failing build illustrating the failsafe that disallows non-semver-tagged mainnet releases](https://app.circleci.com/jobs/github/livepeer/go-livepeer/4048/parallel-runs/0/steps/0-108).

https://github.com/livepeer/go-livepeer/issues/1296 has been causing these builds to fail intermittently.