### PR TITLE
lb: Reduce the number of concurrent goroutines under test.

### DIFF
--- a/core/lb_test.go
+++ b/core/lb_test.go
@@ -147,8 +147,8 @@ func TestLB_ConcurrentSessionErrors(t *testing.T) {
 	// Race detector is sometimes slow enough to trigger timeouts
 	// These numbers may need tweaking
 	// (Or a separate non-race test with higher numbers)
-	mainIter := 500
-	innerIters := 50
+	mainIter := 200
+	innerIters := 40
 	innerTimeout := 10 * time.Second
 	mainTimeout := 20 * time.Second
 


### PR DESCRIPTION
Minimize hitting the goroutine limit under `-race`.

Fixes https://github.com/livepeer/go-livepeer/issues/1296

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
