### PR TITLE
doc: Document webhook specified profiles.

### DIFF
--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -26,9 +26,10 @@ The webhook may respond with an empty body.  In this case, the `manifestID` prop
 
 ```json
 {
-    "manifestID": "ManifestIDString",
+    "manifestID": "ManifestID",
     "streamKey":  "SecretKey",
-    "presets":    ["Preset", "Names"]
+    "presets":    ["Preset", "Names"],
+    "profiles":   [{"name":"ProfileName", "width":320, "height":240, "bitrate":1000000, "fps":30}]
 }
 ```
 The Livepeer node will use the returned `manifestID` for the given stream.
@@ -38,5 +39,7 @@ The `manifestID` should consist of alphanumeric characters, only.  Please avoid 
 An optional streamKey may be provided in order to protect the RTMP stream from playback. If the streamKey is omitted, a random key will be generated.
 
 Presets can be specified to override the default transcoding options. The available presets are listed [here](https://github.com/livepeer/go-livepeer/blob/master/common/videoprofile_ids.go).
+
+Custom transcoding profiles can be provided if the presets are not sufficient. Given a stream name (manifest ID) of "ManifestID" and a profile name of "ProfileName", the specific profile will be available for playback at `/stream/ManifestID/ProfileName.m3u8`. However, to take advantage of ABR features in HLS players, the top-level stream name should usually be supplied instead, eg `/stream/ManifestID.m3u8` The `bitrate` field is in bits per second. The `fps` field can be omitted to preserve the source frame rate. Both presets and profiles can be used together to specify the desired transcodes.
 
 There is simple webhook authentication server [example](https://github.com/livepeer/go-livepeer/blob/master/cmd/simple_auth_server/simple_auth_server.go).


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Documents the custom profile feature that has been available to the auth webhook since https://github.com/livepeer/go-livepeer/pull/1242 .

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates https://github.com/livepeer/go-livepeer/blob/master/doc/rtmpwebhookauth.md with information on the new `profiles` field.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Visual inspection

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes https://github.com/livepeer/go-livepeer/issues/1200
Fixes https://github.com/livepeer/go-livepeer/issues/1292

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
