### PR TITLE
cmd/cli: ETH & LPT unit formatting for pending fees and pending stake

### DIFF
--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -224,30 +224,32 @@ func (w *wizard) delegatorStats() {
 		return
 	}
 
-	fmt.Println("+---------------+")
-	fmt.Println("|DELEGATOR STATS|")
-	fmt.Println("+---------------+")
-
 	pendingStake := ""
 	if d.PendingStake.Int64() == -1 {
 		pendingStake = "Please fetch pending stake separately"
 	} else {
-		pendingStake = d.PendingStake.String()
+		pendingStake = eth.FormatUnits(d.PendingStake, "LPT")
 	}
+
 	pendingFees := ""
 	if d.PendingFees.Int64() == -1 {
 		pendingFees = "Please fetch pending fees separately"
 	} else {
-		pendingFees = d.PendingFees.String()
+		pendingFees = eth.FormatUnits(d.PendingFees, "ETH")
 	}
+
+	fmt.Println("+---------------+")
+	fmt.Println("|DELEGATOR STATS|")
+	fmt.Println("+---------------+")
+
 	table := tablewriter.NewWriter(os.Stdout)
 	data := [][]string{
 		[]string{"Status", d.Status},
-		[]string{"Stake", d.BondedAmount.String()},
-		[]string{"Collected Fees", d.Fees.String()},
+		[]string{"Stake", eth.FormatUnits(d.BondedAmount, "LPT")},
+		[]string{"Collected Fees", eth.FormatUnits(d.Fees, "ETH")},
 		[]string{"Pending Stake", pendingStake},
 		[]string{"Pending Fees", pendingFees},
-		[]string{"Delegated Stake", d.DelegatedAmount.String()},
+		[]string{"Delegated Stake", eth.FormatUnits(d.DelegatedAmount, "LPT")},
 		[]string{"Delegate Address", d.DelegateAddress.Hex()},
 		[]string{"Last Claim Round", d.LastClaimRound.String()},
 		[]string{"Start Round", d.StartRound.String()},


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR attempts to add small improvements to the CLI by adding unit formatting and double checking if streamflow vocabulary is used ubiquitously everywhere. 

**Specific updates (required)**
- Since `pendingFees` and `pendingStake` no longer reverts I removed the need to set this to `-1` is the call reverts (empty output)
- Added `eth.FormatUnits` to the delegator stats section
- Renamed the `list registered transcoders` option to `list active transcoders`

**How did you test each of these updates (required)**
ran CLI

**Does this pull request close any open issues?**
Fixes #1301 
**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
