### PR TITLE
ci: add failsafes for clobbering mainnet build

### DIFF
--- a/ci_env.sh
+++ b/ci_env.sh
@@ -30,4 +30,9 @@ if [[ $HIGHEST_CHAIN_TAG == "mainnet" ]]; then
     echo "disallowing mainnet release without semver tag; $generatedVersion != $definedVersion"
     exit 1
   fi
+else
+  if [[ $generatedVersion == $definedVersion ]]; then
+    echo "disallowing semver tag release $generatedVersion on branch '$branch', should be 'mainnet'"
+    exit 1
+  fi
 fi

--- a/doc/releases.md
+++ b/doc/releases.md
@@ -18,25 +18,24 @@ This is the only branch that receives proper semver updates; all releases should
 
 ### Cutting a mainnet release of go-livepeer
 
-This process will vary somewhat based on the particular states of the branches, whether we're doing a hotfix, etc. But the overall steps are the same. First, merge changes into the mainnet branch and make the release commit:
+This process will vary somewhat based on the particular states of the branches, whether we're doing a hotfix, etc. But the overall steps are the same. First, make the release commit on a branch:
 
 ```bash
-git checkout mainnet
-git merge --ff-only rinkeby
+git checkout -b v0.5.2 
 echo -n '0.5.2' > VERSION
 git commit -am 'release v0.5.2'
-git push --atomic origin mainnet v0.5.2
+git push --atomic origin v0.5.2 v0.5.2
 ```
 
-Then, merge that version bump back to rinkeby and master:
+Merge the release commit into master via PR. Then, merge the version bump into rinkeby and mainnet:
 
 ```bash
 git checkout rinkeby
-git merge --ff-only mainnet
+git merge --ff-only master 
 git push origin rinkeby
-git checkout master
-git merge --ff-only mainnet
-git push origin master
+git checkout mainnet
+git merge --ff-only rinkeby 
+git push origin mainnet 
 ```
 
 If there's different commits on those branches then we'd omit the --ff-only flag, but the cleanest possible scenario after a mainnet release is that all three branches are pointed at the same ref.

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -53,12 +53,20 @@ contentType="application/x-compressed-tar"
 dateValue=`date -R`
 stringToSign="PUT\n\n${contentType}\n${dateValue}\n${resource}"
 signature=`echo -en ${stringToSign} | openssl sha1 -hmac ${GCLOUD_SECRET} -binary | base64`
+fullUrl="https://storage.googleapis.com${resource}"
+
+# Failsafe - don't overwrite existing uploads!
+if curl --head --fail $fullUrl 2>/dev/null; then
+  echo "$fullUrl already exists, not overwriting!"
+  exit 1
+fi
+
 curl -X PUT -T "${FILE}" \
   -H "Host: storage.googleapis.com" \
   -H "Date: ${dateValue}" \
   -H "Content-Type: ${contentType}" \
   -H "Authorization: AWS ${GCLOUD_KEY}:${signature}" \
-  https://storage.googleapis.com${resource}
+  $fullUrl
 
 curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION/${FILE}\"}" $DISCORD_URL 2>/dev/null
 echo "done"


### PR DESCRIPTION
Two things to prevent what happened yesterday from happening in the future:

1. Semver-tagged builds are disallowed unless they're on the `mainnet` branch
2. We shan't overwrite existing files when uploading to build.livepeer.live.