### PR TITLE
server: Close pixel verification tmpfile after use.

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -604,6 +604,7 @@ func verifyPixels(fname string, bos drivers.OSSession, reportedPixels int64) err
 			return fmt.Errorf("error creating temp file for pixels verification: %v", err)
 		}
 		defer os.Remove(tempfile.Name())
+		defer tempfile.Close()
 
 		data := memOS.GetData(fname)
 		if data == nil {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

When we do pixel verification, we create a handle to a temp file. However, this handle is not closed, eventually exhausting the file handles allowed by the system. This PR closes the handle.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Closes the tempfile handle

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Did not test, not even manually!

Also looked at how to unit-test this, but didn't see any easy solutions since there are two sources of randomness: the tmpfile itself, and `common.RandName` . We can easily change the `RandName` to use an overridable `common.RandomIDGenerator` for testing, but controlling the tmpfile name itself is harder. Then there is the question of how to verify it's actually created and removed within the verifyPixels function itself.  I guess we could pass a Tempfile-like interface into `verifyPixels` but that seems painful just for testing this one case.


**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes https://github.com/livepeer/go-livepeer/issues/1311

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
