### PR TITLE
common, eth, logging: reduce verbosity of logs emitted by the blockwatch package

### DIFF
--- a/common/db.go
+++ b/common/db.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
+	"github.com/livepeer/go-livepeer/logging"
 	"github.com/livepeer/go-livepeer/pm"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
@@ -313,12 +314,12 @@ func InitDB(dbPath string) (*DB, error) {
 	}
 	d.deleteMiniHeader = stmt
 
-	glog.V(DEBUG).Info("Initialized DB node")
+	glog.V(logging.DEBUG).Info("Initialized DB node")
 	return &d, nil
 }
 
 func (db *DB) Close() {
-	glog.V(DEBUG).Info("Closing DB")
+	glog.V(logging.DEBUG).Info("Closing DB")
 	if db.selectKV != nil {
 		db.selectKV.Close()
 	}
@@ -495,7 +496,7 @@ func (db *DB) OrchCount(filter *DBOrchFilter) (int, error) {
 }
 
 func (db *DB) InsertUnbondingLock(id *big.Int, delegator ethcommon.Address, amount, withdrawRound *big.Int) error {
-	glog.V(DEBUG).Infof("db: Inserting unbonding lock %v for delegator %v", id, delegator.Hex())
+	glog.V(logging.DEBUG).Infof("db: Inserting unbonding lock %v for delegator %v", id, delegator.Hex())
 	_, err := db.insertUnbondingLock.Exec(id.Int64(), delegator.Hex(), amount.String(), withdrawRound.Int64())
 	if err != nil {
 		glog.Errorf("db: Error inserting unbonding lock %v for delegator %v: %v", id, delegator.Hex(), err)
@@ -507,7 +508,7 @@ func (db *DB) InsertUnbondingLock(id *big.Int, delegator ethcommon.Address, amou
 // DeleteUnbondingLock deletes an unbonding lock from the DB with the given ID and delegator address.
 // This method will return nil for non-existent unbonding locks
 func (db *DB) DeleteUnbondingLock(id *big.Int, delegator ethcommon.Address) error {
-	glog.V(DEBUG).Infof("db: Deleting unbonding lock %v for delegator %v", id, delegator.Hex())
+	glog.V(logging.DEBUG).Infof("db: Deleting unbonding lock %v for delegator %v", id, delegator.Hex())
 	_, err := db.deleteUnbondingLock.Exec(id.Int64(), delegator.Hex())
 	if err != nil {
 		glog.Errorf("db: Error deleting unbonding lock %v for delegator %v: %v", id, delegator.Hex(), err)
@@ -519,7 +520,7 @@ func (db *DB) DeleteUnbondingLock(id *big.Int, delegator ethcommon.Address) erro
 // UseUnbondingLock sets an unbonding lock in the DB as used by setting the lock's used block.
 // If usedBlock is nil this method will set the lock's used block to NULL
 func (db *DB) UseUnbondingLock(id *big.Int, delegator ethcommon.Address, usedBlock *big.Int) error {
-	glog.V(DEBUG).Infof("db: Using unbonding lock %v for delegator %v", id, delegator.Hex())
+	glog.V(logging.DEBUG).Infof("db: Using unbonding lock %v for delegator %v", id, delegator.Hex())
 
 	var err error
 	if usedBlock == nil {
@@ -535,7 +536,7 @@ func (db *DB) UseUnbondingLock(id *big.Int, delegator ethcommon.Address, usedBlo
 }
 
 func (db *DB) UnbondingLockIDs() ([]*big.Int, error) {
-	glog.V(DEBUG).Infof("db: Querying unbonding lock IDs")
+	glog.V(logging.DEBUG).Infof("db: Querying unbonding lock IDs")
 
 	rows, err := db.dbh.Query("SELECT id FROM unbondingLocks")
 	if err != nil {
@@ -559,7 +560,7 @@ func (db *DB) UnbondingLocks(currentRound *big.Int) ([]*DBUnbondingLock, error) 
 	if db == nil {
 		return []*DBUnbondingLock{}, nil
 	}
-	glog.V(DEBUG).Infof("db: Querying unbonding locks")
+	glog.V(logging.DEBUG).Infof("db: Querying unbonding locks")
 
 	var (
 		rows *sql.Rows
@@ -610,7 +611,7 @@ func (db *DB) StoreWinningTicket(sessionID string, ticket *pm.Ticket, sig []byte
 	if recipientRand == nil {
 		return errors.New("cannot store nil recipientRand")
 	}
-	glog.V(DEBUG).Infof("db: Inserting winning ticket from %v, recipientRand %d, senderNonce %d", ticket.Sender.Hex(), recipientRand, ticket.SenderNonce)
+	glog.V(logging.DEBUG).Infof("db: Inserting winning ticket from %v, recipientRand %d, senderNonce %d", ticket.Sender.Hex(), recipientRand, ticket.SenderNonce)
 
 	_, err := db.insertWinningTicket.Exec(ticket.Sender.Hex(), ticket.Recipient.Hex(), ticket.FaceValue.Bytes(), ticket.WinProb.Bytes(), ticket.SenderNonce, recipientRand.Bytes(), ticket.RecipientRandHash.Hex(), sig, sessionID)
 

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/logging"
 	"github.com/livepeer/go-livepeer/net"
 )
 
@@ -59,7 +60,7 @@ var httpc = &http.Client{
 }
 
 func getSegmentDataHTTP(uri string) ([]byte, error) {
-	glog.V(common.VERBOSE).Infof("Downloading uri=%s", uri)
+	glog.V(logging.VERBOSE).Infof("Downloading uri=%s", uri)
 	resp, err := httpc.Get(uri)
 	if err != nil {
 		glog.Errorf("Error getting HTTP uri=%s err=%v", uri, err)
@@ -75,6 +76,6 @@ func getSegmentDataHTTP(uri string) ([]byte, error) {
 		glog.Errorf("Error reading body uri=%s err=%v", uri, err)
 		return nil, err
 	}
-	glog.V(common.VERBOSE).Infof("Downloaded uri=%s", uri)
+	glog.V(logging.VERBOSE).Infof("Downloaded uri=%s", uri)
 	return body, nil
 }

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/logging"
 	"github.com/livepeer/go-livepeer/net"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -128,7 +128,7 @@ func (os *s3Session) EndSession() {
 func (os *s3Session) SaveData(name string, data []byte) (string, error) {
 	// tentativeUrl just used for logging
 	tentativeURL := path.Join(os.host, os.key, name)
-	glog.V(common.VERBOSE).Infof("Saving to S3 %s", tentativeURL)
+	glog.V(logging.VERBOSE).Infof("Saving to S3 %s", tentativeURL)
 	path, err := os.postData(name, data)
 	if err != nil {
 		// handle error
@@ -137,7 +137,7 @@ func (os *s3Session) SaveData(name string, data []byte) (string, error) {
 	}
 	url := os.getAbsURL(path)
 
-	glog.V(common.VERBOSE).Infof("Saved to S3 %s", tentativeURL)
+	glog.V(logging.VERBOSE).Infof("Saved to S3 %s", tentativeURL)
 
 	return url, err
 }

--- a/eth/accountmanager.go
+++ b/eth/accountmanager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/logging"
 )
 
 var (
@@ -58,7 +59,7 @@ func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string, signer
 			return nil, err
 		}
 	} else {
-		glog.V(common.SHORT).Infof("Found existing ETH account")
+		glog.V(logging.SHORT).Infof("Found existing ETH account")
 
 		// Account already exists or defaulting to first, load it from keystore
 		acct, err = getAccount(accountAddr, keyStore)
@@ -185,7 +186,7 @@ func getAccount(accountAddr ethcommon.Address, keyStore *keystore.KeyStore) (acc
 
 		return accounts.Account{}, ErrAccountNotFound
 	} else {
-		glog.V(common.SHORT).Infof("Defaulting to first ETH account in keystore %v", accts[0].Address.Hex())
+		glog.V(logging.SHORT).Infof("Defaulting to first ETH account in keystore %v", accts[0].Address.Hex())
 
 		// Default to first account
 		return accts[0], nil

--- a/eth/blockwatch/block_watcher.go
+++ b/eth/blockwatch/block_watcher.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/logging"
 )
 
 // maxBlocksInGetLogsQuery is the max number of blocks to fetch logs for in a single query. There is
@@ -121,7 +122,7 @@ func (w *Watcher) Watch(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			if err := w.pollNextBlock(); err != nil {
-				glog.Errorf("blockwatch.Watcher error encountered: %v", err)
+				glog.V(logging.DEBUG).Infof("blockwatch.Watcher error encountered: %v", err)
 			}
 		}
 	}
@@ -453,7 +454,7 @@ func (w *Watcher) getLogsInBlockRange(ctx context.Context, from, to int) ([]type
 
 				logs, err := w.filterLogsRecursively(b.FromBlock, b.ToBlock, []types.Log{})
 				if err != nil {
-					glog.Errorf("failed to fetch logs for range error=%v fromBlock=%v toBlock=%v", err, b.FromBlock, b.ToBlock)
+					glog.V(logging.DEBUG).Infof("failed to fetch logs for range error=%v fromBlock=%v toBlock=%v", err, b.FromBlock, b.ToBlock)
 				}
 				mu.Lock()
 				indexToLogResult[index] = logRequestResult{

--- a/eth/client.go
+++ b/eth/client.go
@@ -28,9 +28,9 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/golang/glog"
-	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/eth/contracts"
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
+	"github.com/livepeer/go-livepeer/logging"
 	"github.com/livepeer/go-livepeer/pm"
 )
 
@@ -212,7 +212,7 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 		TransactOpts: *opts,
 	}
 
-	glog.V(common.SHORT).Infof("Controller: %v", c.controllerAddr.Hex())
+	glog.V(logging.SHORT).Infof("Controller: %v", c.controllerAddr.Hex())
 
 	tokenAddr, err := c.GetContract(crypto.Keccak256Hash([]byte("LivepeerToken")))
 	if err != nil {
@@ -233,7 +233,7 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 		TransactOpts: *opts,
 	}
 
-	glog.V(common.SHORT).Infof("LivepeerToken: %v", c.tokenAddr.Hex())
+	glog.V(logging.SHORT).Infof("LivepeerToken: %v", c.tokenAddr.Hex())
 
 	serviceRegistryAddr, err := c.GetContract(crypto.Keccak256Hash([]byte("ServiceRegistry")))
 	if err != nil {
@@ -254,7 +254,7 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 		TransactOpts: *opts,
 	}
 
-	glog.V(common.SHORT).Infof("ServiceRegistry: %v", c.serviceRegistryAddr.Hex())
+	glog.V(logging.SHORT).Infof("ServiceRegistry: %v", c.serviceRegistryAddr.Hex())
 
 	bondingManagerAddr, err := c.GetContract(crypto.Keccak256Hash([]byte("BondingManager")))
 	if err != nil {
@@ -275,7 +275,7 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 		TransactOpts: *opts,
 	}
 
-	glog.V(common.SHORT).Infof("BondingManager: %v", c.bondingManagerAddr.Hex())
+	glog.V(logging.SHORT).Infof("BondingManager: %v", c.bondingManagerAddr.Hex())
 
 	brokerAddr, err := c.GetContract(crypto.Keccak256Hash([]byte("TicketBroker")))
 	if err != nil {
@@ -296,7 +296,7 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 		TransactOpts: *opts,
 	}
 
-	glog.V(common.SHORT).Infof("TicketBroker: %v", c.ticketBrokerAddr.Hex())
+	glog.V(logging.SHORT).Infof("TicketBroker: %v", c.ticketBrokerAddr.Hex())
 
 	roundsManagerAddr, err := c.GetContract(crypto.Keccak256Hash([]byte("RoundsManager")))
 	if err != nil {
@@ -317,7 +317,7 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 		TransactOpts: *opts,
 	}
 
-	glog.V(common.SHORT).Infof("RoundsManager: %v", c.roundsManagerAddr.Hex())
+	glog.V(logging.SHORT).Infof("RoundsManager: %v", c.roundsManagerAddr.Hex())
 
 	minterAddr, err := c.GetContract(crypto.Keccak256Hash([]byte("Minter")))
 	if err != nil {
@@ -338,7 +338,7 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 		Contract: minter,
 	}
 
-	glog.V(common.SHORT).Infof("Minter: %v", c.minterAddr.Hex())
+	glog.V(logging.SHORT).Infof("Minter: %v", c.minterAddr.Hex())
 
 	faucetAddr, err := c.GetContract(crypto.Keccak256Hash([]byte("LivepeerTokenFaucet")))
 	if err != nil {
@@ -359,7 +359,7 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 		TransactOpts: *opts,
 	}
 
-	glog.V(common.SHORT).Infof("LivepeerTokenFaucet: %v", c.faucetAddr.Hex())
+	glog.V(logging.SHORT).Infof("LivepeerTokenFaucet: %v", c.faucetAddr.Hex())
 
 	return nil
 }
@@ -383,7 +383,7 @@ func (c *client) InitializeRound() (*types.Transaction, error) {
 		return nil, err
 	}
 	if i {
-		glog.V(common.SHORT).Infof("Round already initialized")
+		glog.V(logging.SHORT).Infof("Round already initialized")
 		return nil, errors.New("ErrRoundInitialized")
 	} else {
 		return c.RoundsManagerSession.InitializeRound()
@@ -530,7 +530,7 @@ func (c *client) autoClaimEarnings(endRound *big.Int, allRounds bool) error {
 				return err
 			}
 
-			glog.V(common.SHORT).Infof("Claimed earnings from round %v through %v", lastClaimRound, currentEndRound)
+			glog.V(logging.SHORT).Infof("Claimed earnings from round %v through %v", lastClaimRound, currentEndRound)
 
 			lastClaimRound = currentEndRound
 		}
@@ -547,9 +547,9 @@ func (c *client) autoClaimEarnings(endRound *big.Int, allRounds bool) error {
 				return err
 			}
 
-			glog.V(common.SHORT).Infof("Finished claiming earnings through the end round %v", endRound)
+			glog.V(logging.SHORT).Infof("Finished claiming earnings through the end round %v", endRound)
 		} else {
-			glog.V(common.SHORT).Infof("Finished claiming earnings through round %v. Remaining rounds can be automatically claimed through a bonding action", lastClaimRound)
+			glog.V(logging.SHORT).Infof("Finished claiming earnings through round %v. Remaining rounds can be automatically claimed through a bonding action", lastClaimRound)
 		}
 	}
 

--- a/eth/gaspricemonitor.go
+++ b/eth/gaspricemonitor.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/logging"
 	"github.com/livepeer/go-livepeer/monitor"
 )
 
@@ -131,7 +131,7 @@ func (gpm *GasPriceMonitor) fetchAndUpdateGasPrice(ctx context.Context) error {
 		monitor.SuggestedGasPrice(gasPrice)
 	}
 
-	glog.V(common.DEBUG).Infof("Cached gas price: %v", gasPrice)
+	glog.V(logging.DEBUG).Infof("Cached gas price: %v", gasPrice)
 
 	return nil
 }

--- a/logging/log.go
+++ b/logging/log.go
@@ -1,4 +1,4 @@
-package common
+package logging
 
 const SHORT = 4
 const DEBUG = 5

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -19,6 +19,7 @@ import (
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/drivers"
+	"github.com/livepeer/go-livepeer/logging"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/pm"
@@ -114,8 +115,8 @@ func (bsm *BroadcastSessionsManager) completeSession(sess *BroadcastSession) {
 
 func (bsm *BroadcastSessionsManager) refreshSessions() {
 
-	glog.V(common.DEBUG).Info("Starting session refresh")
-	defer glog.V(common.DEBUG).Info("Ending session refresh")
+	glog.V(logging.DEBUG).Info("Starting session refresh")
+	defer glog.V(logging.DEBUG).Info("Ending session refresh")
 	bsm.sessLock.Lock()
 	if bsm.finished || bsm.refreshing {
 		bsm.sessLock.Unlock()
@@ -253,7 +254,7 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, erro
 	mid := cxn.mid
 	vProfile := cxn.profile
 
-	glog.V(common.DEBUG).Infof("Processing segment nonce=%d manifestID=%s seqNo=%d dur=%v", nonce, mid, seg.SeqNo, seg.Duration)
+	glog.V(logging.DEBUG).Infof("Processing segment nonce=%d manifestID=%s seqNo=%d dur=%v", nonce, mid, seg.SeqNo, seg.Duration)
 	if monitor.Enabled {
 		monitor.SegmentEmerged(nonce, seg.SeqNo, len(BroadcastJobVideoProfiles))
 	}
@@ -334,7 +335,7 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 	}
 
 	// send segment to the orchestrator
-	glog.V(common.DEBUG).Infof("Submitting segment nonce=%d manifestID=%s seqNo=%d orch=%s", nonce, cxn.mid, seg.SeqNo, sess.OrchestratorInfo.Transcoder)
+	glog.V(logging.DEBUG).Infof("Submitting segment nonce=%d manifestID=%s seqNo=%d orch=%s", nonce, cxn.mid, seg.SeqNo, sess.OrchestratorInfo.Transcoder)
 
 	res, err := SubmitSegment(sess, seg, nonce)
 	if err != nil || res == nil {
@@ -484,7 +485,7 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 		monitor.SegmentFullyTranscoded(nonce, seg.SeqNo, common.ProfilesNames(sess.Profiles), errCode)
 	}
 
-	glog.V(common.DEBUG).Infof("Successfully validated segment nonce=%d seqNo=%d", nonce, seg.SeqNo)
+	glog.V(logging.DEBUG).Infof("Successfully validated segment nonce=%d seqNo=%d", nonce, seg.SeqNo)
 	return segURLs, nil
 }
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/livepeer/go-livepeer/drivers"
+	"github.com/livepeer/go-livepeer/logging"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/net"
 
@@ -139,7 +140,7 @@ func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode) *LivepeerServ
 func (s *LivepeerServer) StartMediaServer(ctx context.Context, transcodingOptions string, httpAddr string) error {
 	BroadcastJobVideoProfiles = parsePresets(strings.Split(transcodingOptions, ","))
 
-	glog.V(common.SHORT).Infof("Transcode Job Type: %v", BroadcastJobVideoProfiles)
+	glog.V(logging.SHORT).Infof("Transcode Job Type: %v", BroadcastJobVideoProfiles)
 
 	//LPMS handlers for handling RTMP video
 	s.LPMS.HandleRTMPPublish(createRTMPStreamIDHandler(s), gotRTMPStreamHandler(s), endRTMPStreamHandler(s))

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/logging"
 	"github.com/livepeer/go-livepeer/net"
 )
 
@@ -146,7 +147,7 @@ func runTranscode(n *core.LivepeerNode, orchAddr string, httpc *http.Client, not
 	var body bytes.Buffer
 
 	tData, err := n.Transcoder.Transcode(notify.Job, notify.Url, profiles)
-	glog.V(common.VERBOSE).Infof("Transcoding done for taskId=%d url=%s err=%v", notify.TaskId, notify.Url, err)
+	glog.V(logging.VERBOSE).Infof("Transcoding done for taskId=%d url=%s err=%v", notify.TaskId, notify.Url, err)
 	if err != nil {
 		glog.Error("Unable to transcode ", err)
 		body.Write([]byte(err.Error()))
@@ -188,7 +189,7 @@ func runTranscode(n *core.LivepeerNode, orchAddr string, httpc *http.Client, not
 		ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
 	}
-	glog.V(common.VERBOSE).Infof("Transcoding done results sent for taskId=%d url=%s err=%v", notify.TaskId, notify.Url, err)
+	glog.V(logging.VERBOSE).Infof("Transcoding done results sent for taskId=%d url=%s err=%v", notify.TaskId, notify.Url, err)
 }
 
 // Orchestrator gRPC

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/drivers"
+	"github.com/livepeer/go-livepeer/logging"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/lpms/ffmpeg"
@@ -103,11 +104,11 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 	uri := ""
 	if r.Header.Get("Content-Type") == "application/vnd+livepeer.uri" {
 		uri = string(data)
-		glog.V(common.DEBUG).Infof("Start getting segment from %s", uri)
+		glog.V(logging.DEBUG).Infof("Start getting segment from %s", uri)
 		start := time.Now()
 		data, err = drivers.GetSegmentData(uri)
 		took := time.Since(start)
-		glog.V(common.DEBUG).Infof("Getting segment from %s took %s", uri, took)
+		glog.V(logging.DEBUG).Infof("Getting segment from %s took %s", uri, took)
 		if err != nil {
 			glog.Errorf("Error getting input segment %v from input OS: %v", uri, err)
 			http.Error(w, "BadRequest", http.StatusBadRequest)

--- a/verification/epic.go
+++ b/verification/epic.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/drivers"
+	"github.com/livepeer/go-livepeer/logging"
 
 	"github.com/livepeer/lpms/ffmpeg"
 )
@@ -94,7 +94,7 @@ func epicResultsToVerificationResults(er *epicResults) (*Results, error) {
 func (e *EpicClassifier) Verify(params *Params) (*Results, error) {
 	mid, source, profiles := params.ManifestID, params.Source, params.Profiles
 	orch, res := params.Orchestrator, params.Results
-	glog.V(common.DEBUG).Infof("Verifying segment manifestID=%s seqNo=%d\n",
+	glog.V(logging.DEBUG).Infof("Verifying segment manifestID=%s seqNo=%d\n",
 		mid, source.SeqNo)
 
 	// Write segments to Docker shared volume
@@ -142,7 +142,7 @@ func (e *EpicClassifier) Verify(params *Params) (*Results, error) {
 		glog.Error("Could not marshal JSON for verifier! ", err)
 		return nil, err
 	}
-	glog.V(common.DEBUG).Info("Request Body: ", string(reqData))
+	glog.V(logging.DEBUG).Info("Request Body: ", string(reqData))
 
 	// Submit request and process results
 	startTime := time.Now()
@@ -163,7 +163,7 @@ func (e *EpicClassifier) Verify(params *Params) (*Results, error) {
 	if deferErr = err; err != nil {
 		return nil, err
 	}
-	glog.V(common.DEBUG).Info("Response Body: ", string(body))
+	glog.V(logging.DEBUG).Info("Response Body: ", string(body))
 	if resp.StatusCode >= 400 {
 		deferErr = err
 		return nil, ErrVerifierStatus


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR reduces the verbosity of recoverable errors emitted by the `blockwatch` package and thus converts all `glog.Errorf(...)` statements in this package to `glog.V(...).Infof(...)`

Since the verbosity levels are declared in the `common` package and `blockwatch` is imported in `common` this would lead to a cyclical import. 

To alevatiate this the declarations of the verbosity levels have been moved into a new `logging` package. 

This seems as an over-the-top measure, but the semantics actually play out much nicer eg. `common.DEBUG` vs `logging.DEBUG`. 

Alternatively we could have moved the database implementation into it's seperate package `db` , but that would have required more changes overall. Perhaps this could be addressable in a seperate PR. 

**How did you test each of these updates (required)**
Ran a node on rinkeby

**Does this pull request close any open issues?**
Fixes #1306 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
