### PR TITLE
pm, server: close RTMP connection when sender validation fails

### DIFF
--- a/pm/sender.go
+++ b/pm/sender.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ErrSenderValidation is emitted when sender.validateSender() encounters an error
+// ErrSenderValidation is returned when the sender cannot send tickets
 type ErrSenderValidation struct {
 	error
 }

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -9,6 +9,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ErrSenderValidation is emitted when sender.validateSender() encounters an error
+type ErrSenderValidation struct {
+	error
+}
+
 // Sender enables starting multiple probabilistic micropayment sessions with multiple recipients
 // and create tickets that adhere to each session's params and unique nonce requirements.
 type Sender interface {
@@ -78,12 +83,12 @@ func (s *sender) EV(sessionID string) (*big.Rat, error) {
 func (s *sender) validateSender() error {
 	info, err := s.senderManager.GetSenderInfo(s.signer.Account().Address)
 	if err != nil {
-		return fmt.Errorf("unable to validate sender: could not get sender info: %v", err)
+		return ErrSenderValidation{fmt.Errorf("unable to validate sender: could not get sender info: %v", err)}
 	}
 
 	maxWithdrawRound := new(big.Int).Add(s.roundsManager.LastInitializedRound(), big.NewInt(1))
 	if info.WithdrawRound.Int64() != 0 && info.WithdrawRound.Cmp(maxWithdrawRound) != 1 {
-		return fmt.Errorf("unable to validate sender: deposit and reserve is set to unlock soon")
+		return ErrSenderValidation{fmt.Errorf("unable to validate sender: deposit and reserve is set to unlock soon")}
 	}
 
 	return nil

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -131,6 +131,8 @@ func TestSender_ValidateSender(t *testing.T) {
 	sm.info[account.Address].WithdrawRound = big.NewInt(2)
 	err = s.validateSender()
 	assert.EqualError(err, "unable to validate sender: deposit and reserve is set to unlock soon")
+	_, ok = err.(ErrSenderValidation)
+	assert.True(ok)
 
 	// Not unlocked
 	sm.info[account.Address].WithdrawRound = big.NewInt(0)

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -115,12 +115,16 @@ func TestSender_ValidateSender(t *testing.T) {
 	// GetSenderInfo error
 	sm.err = errors.New("GetSenderInfo error")
 	err := s.validateSender()
+	_, ok := err.(ErrSenderValidation)
+	assert.True(ok)
 	assert.EqualError(err, "unable to validate sender: could not get sender info: GetSenderInfo error")
 	sm.err = nil
 
 	// Sender's (withdraw round + 1 = current round)
 	sm.info[account.Address].WithdrawRound = big.NewInt(4)
 	err = s.validateSender()
+	_, ok = err.(ErrSenderValidation)
+	assert.True(ok)
 	assert.EqualError(err, "unable to validate sender: deposit and reserve is set to unlock soon")
 
 	// withdrawround + 1 < current round

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -250,6 +250,7 @@ func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core
 
 func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, error) {
 
+	rtmpStrm := cxn.stream
 	nonce := cxn.nonce
 	cpl := cxn.pl
 	mid := cxn.mid
@@ -294,6 +295,14 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, erro
 		if urls, err := transcodeSegment(cxn, seg, name, sv); err == nil {
 			return urls, nil
 		}
+
+		if shouldStopStream(err) {
+			glog.Warningf("Stopping current stream due to: %v", err)
+			rtmpStrm.Close()
+			return nil, err
+		}
+
+		// recoverable error, retry
 	}
 }
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/net"
+	"github.com/livepeer/go-livepeer/pm"
 
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/common"
@@ -801,4 +802,9 @@ func (s *LivepeerServer) LatestPlaylist() core.PlaylistManager {
 		return nil
 	}
 	return cxn.pl
+}
+
+func shouldStopStream(err error) bool {
+	_, ok := err.(pm.ErrSenderValidation)
+	return ok
 }

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -821,6 +821,14 @@ func TestCleanStreamPrefix(t *testing.T) {
 	}
 }
 
+func TestShouldStopStream(t *testing.T) {
+	assert := assert.New(t)
+	ok := shouldStopStream(fmt.Errorf("some random error string"))
+	assert.False(ok)
+	ok = shouldStopStream(pm.ErrSenderValidation{})
+	assert.True(ok)
+}
+
 func TestParseManifestID(t *testing.T) {
 	checkMid := func(inp string, exp string) {
 		mid := parseManifestID(inp)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
- Return a top-level error from `sender.validateSender` -> `pm.ErrSenderValidation` so that we can compare a returned error against it in the `server` package
- Introduce a `server.nonRetryableTranscodeError` type that implements the `error` interface
- Wrap `sessions == nil` and failing sender validation in `nonRetryableTranscodeError``
- Modify `server.shouldStopStream(err)` to return whether `err` is a `nonRetryableTranscodeError`
- Close RTMP stream when `server.shouldStopStream(err)` return true and break out of the loop in `server.processSegment`
 
**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
Fixes #1247

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
