### PR TITLE
Discovery timeout + logging updates

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -16,7 +16,7 @@ import (
 	"github.com/golang/glog"
 )
 
-const getOrchestratorsTimeoutLoop = 1 * time.Hour
+const getOrchestratorsTimeoutLoop = 3 * time.Second
 
 var serverGetOrchInfo = server.GetOrchestratorInfo
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -52,6 +52,7 @@ type BroadcastSessionsManager struct {
 	// Accessing or changing any of the below requires ownership of this mutex
 	sessLock *sync.Mutex
 
+	mid      core.ManifestID
 	sel      BroadcastSessionsSelector
 	sessMap  map[string]*BroadcastSession
 	numOrchs int // how many orchs to request at once
@@ -114,8 +115,8 @@ func (bsm *BroadcastSessionsManager) completeSession(sess *BroadcastSession) {
 
 func (bsm *BroadcastSessionsManager) refreshSessions() {
 
-	glog.V(common.DEBUG).Info("Starting session refresh")
-	defer glog.V(common.DEBUG).Info("Ending session refresh")
+	glog.V(common.DEBUG).Info("Starting session refresh manifestID=", bsm.mid)
+	defer glog.V(common.DEBUG).Info("Ending session refresh manifestID=", bsm.mid)
 	bsm.sessLock.Lock()
 	if bsm.finished || bsm.refreshing {
 		bsm.sessLock.Unlock()
@@ -176,6 +177,7 @@ func NewSessionManager(node *core.LivepeerNode, params *streamParameters, pl cor
 	maxInflight := common.HTTPTimeout.Seconds() / SegLen.Seconds()
 	numOrchs := int(math.Min(poolSize, maxInflight*2))
 	bsm := &BroadcastSessionsManager{
+		mid:            params.mid,
 		sel:            sel,
 		sessMap:        make(map[string]*BroadcastSession),
 		createSessions: func() ([]*BroadcastSession, error) { return selectOrchestrator(node, params, pl, numOrchs) },

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -226,8 +226,8 @@ func startOrchestratorClient(uri *url.URL) (net.OrchestratorClient, *grpc.Client
 		grpc.WithBlock(),
 		grpc.WithTimeout(GRPCConnectTimeout))
 	if err != nil {
-		glog.Error("Did not connect: ", err)
-		return nil, nil, errors.New("Did not connect: " + err.Error())
+		glog.Errorf("Did not connect to orch=%v err=%v", uri, err)
+		return nil, nil, fmt.Errorf("Did not connect to orch=%v err=%v", uri, err)
 	}
 	c := net.NewOrchestratorClient(conn)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the orch discovery timeout to 3 seconds (this was the previous value before it was accidentally changed to 1 hour in a previous PR) and adds additional information to session refresh and orch connection logging.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates the orch discovery timeout to 3 seconds
- Includes the manifestID in logs for session fresh start and end 
- Includes the URI in logs for a timeout when trying to connect to an orch

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Haven't tested this yet.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
