### PR TITLE
Stake related selection bug fixes

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -76,6 +76,11 @@ func (bsm *BroadcastSessionsManager) selectSession() *BroadcastSession {
 	}
 	for checkSessions(bsm) {
 		sess := bsm.sel.Select()
+		// Handle the case where there is an error during selection and Select() returns nil when session list length > 0
+		if sess == nil {
+			return nil
+		}
+
 		if _, ok := bsm.sessMap[sess.OrchestratorInfo.Transcoder]; ok {
 			return sess
 		}

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -126,6 +126,17 @@ func (pm *stubPlaylistManager) GetOSSession() drivers.OSSession {
 
 func (pm *stubPlaylistManager) Cleanup() {}
 
+type stubSelector struct {
+	sess *BroadcastSession
+	size int
+}
+
+func (s *stubSelector) Add(sessions []*BroadcastSession) {}
+func (s *stubSelector) Complete(sess *BroadcastSession)  {}
+func (s *stubSelector) Select() *BroadcastSession        { return s.sess }
+func (s *stubSelector) Size() int                        { return s.size }
+func (s *stubSelector) Clear()                           {}
+
 func TestStopSessionErrors(t *testing.T) {
 
 	// check error cases
@@ -258,6 +269,14 @@ func TestSelectSession(t *testing.T) {
 	assert.Len(bsm.sessMap, 1)
 
 	// XXX check refresh condition more precisely - currently numOrchs / 2
+}
+
+func TestSelectSession_NilSession(t *testing.T) {
+	bsm := StubBroadcastSessionsManager()
+	// Replace selector with stubSelector that will return nil for Select(), but 1 for Size()
+	bsm.sel = &stubSelector{size: 1}
+
+	assert.Nil(t, bsm.selectSession())
 }
 
 func TestRemoveSession(t *testing.T) {

--- a/server/selection.go
+++ b/server/selection.go
@@ -190,12 +190,7 @@ func (s *MinLSSelector) selectUnknownSession() *BroadcastSession {
 	// The greater the stake weight of a session, the more likely that it will be selected because subtracting its stake weight from r
 	// will result in a value <= 0
 	for i, sess := range s.unknownSessions {
-		// If we could not fetch the stake weight for addrs[i] then skip and remove its session
-		if _, ok := stakes[addrs[i]]; !ok {
-			s.removeUnknownSession(i)
-			continue
-		}
-
+		// If we could not fetch the stake weight for addrs[i] then its stake weight defaults to 0
 		r -= stakes[addrs[i]]
 
 		if r <= 0 {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes a nil pointer bug and index out of range bug during selection. Both of these bugs are caused by a failure to read stake weights for sessions during selection.

The nil pointer bug occurs when `Select()` returns nil despite a non-zero session list length. This can happen either when the selector fails to fetch a list of stake weights or when all of the unknown sessions are missing stake weights. #1304 results from the latter scenario.

The index out of range bug occurs when a session is removed from the unknown session list in the middle of the for loop (due to missing stake weight) and then the last session in the list is selected. Suppose the length of the list was `N` at the start of selection. The index used to access the last session in the list will be `N - 1`, but the length of the list will be `N - 2` because a session was removed in the middle of the for loop. Note that removing a session from the unknown list in the middle of the for loop is problematic even if the last session in the list is selected because while an index out of range error will not be triggered, the session returned by `Select()` will be off by one (i.e. we would return the `m + 1`th session when we actually should return the `m`th session).

The solutions implemented in this PR are:

- Instead of removing unknown sessions in the middle of the for loop during selection if they are missing stake weights, we default their stake weight to 0. These sessions can still be selected, but they will always be selected after other unknown sessions that are not missing stake weights. This eliminates the indexing issue that caused the index out of range bug because the only time we mutate the unknown session list is when we are returning the selected session (and exiting the for loop). An alternative would be to remove unknown sessions that are missing stake weights after the for loop completes. I opted not to use this approach because there would be a discrepancy between the state of the `sessMap` maintained by `BroadcastSessionsManager`, which is supposed to track unique sessions, and the internal state of the selector - the session would be removed from the selector, but there would still be an entry in `sessMap`
- Add a nil check in `selectSession()` to make sure we never try to access a field of a session if the session is nil. Usually, this should never happen because we check that the list length is non-zero before calling `Select()`. It can happen if an error is encountered during selection that prevents a session from being selected despite a non-zero list length - currently, this would happen if the selector fails to fetch a list of stake weights (i.e. a DB error) during selection. An alternative would be to make sure that the selector will only ever return nil if the list is empty. I opted not to use this approach because a) when a DB error occurs such that the selector cannot fetch a list of stake weights this feels like a scenario where something is really wrong internally with the node and we should not proceed [1] b) having the caller do a nil check is a safer/more defensive approach that doesn't make assumptions about the implementation of the selector interface.
- Always cache on-chain orchs and poll for updates when the node is in on-chain mode regardless of the discovery mechanism (i.e. hardcoded list, webhook, on-chain active set). This allows a broadcaster to specify a subset of the on-chain active set via a hardcoded list or webhook for stake/latency based selection.  

[1] I think the case where the selector cannot fetch a list of stake weights due to a DB error is different from the case where the stake weights are missing for certain sessions (but the selector still fetched a list with *some* stake weights from the DB). The former is likely the result of some internal node issue. The latter is likely the result of an issue external to the node i.e. a misconfigured orch that is advertising a recipient address that is different from its on-chain address.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 9fc68e3: Sets the default stake weight of a session to 0 if the selector successfully fetched a list of stake weights for a list of sessions, but some of the stake weights are missing
- 1e62115: Adds a nil check for the session returned by `Select()`
- 9b30acd: Use DBOrchestratorPoolCache constructor to always cache orchs and poll for updates when in on-chain mode

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1304 
Fixes #1317 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
