### PR TITLE
server: log info about generated payments when using high verbosity

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/drivers"
+	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/pm"
@@ -175,7 +176,7 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 			tsp.SenderNonce,
 		)
 
-		glog.V(common.DEBUG).Infof("Receiving ticket manifestID=%v faceValue=%v winProb=%v ev=%v", manifestID, ticket.FaceValue, ticket.WinProbRat().FloatString(10), ticket.EV().FloatString(2))
+		glog.V(common.DEBUG).Infof("Receiving ticket manifestID=%v faceValue=%v winProb=%v ev=%v", manifestID, eth.FormatUnits(ticket.FaceValue, "ETH"), ticket.WinProbRat().FloatString(10), ticket.EV().FloatString(2))
 
 		_, won, err := orch.node.Recipient.ReceiveTicket(
 			ticket,

--- a/pm/ticket.go
+++ b/pm/ticket.go
@@ -43,6 +43,11 @@ type TicketParams struct {
 	Seed *big.Int
 }
 
+// WinProbRat returns the ticket WinProb as a percentage represented as a big.Rat
+func (p *TicketParams) WinProbRat() *big.Rat {
+	return winProbRat(p.WinProb)
+}
+
 // TicketExpirationParams indicates when/how a ticket expires
 type TicketExpirationParams struct {
 	CreationRound int64
@@ -142,7 +147,7 @@ func (t *Ticket) EV() *big.Rat {
 
 // WinProbRat returns the ticket WinProb as a percentage represented as a big.Rat
 func (t *Ticket) WinProbRat() *big.Rat {
-	return new(big.Rat).SetFrac(t.WinProb, maxWinProb)
+	return winProbRat(t.WinProb)
 }
 
 // Hash returns the keccak-256 hash of the ticket's fields as tightly packed
@@ -188,4 +193,8 @@ func (t *Ticket) flatten() []byte {
 
 func ticketEV(faceValue *big.Int, winProb *big.Int) *big.Rat {
 	return new(big.Rat).Mul(new(big.Rat).SetInt(faceValue), new(big.Rat).SetFrac(winProb, maxWinProb))
+}
+
+func winProbRat(winProb *big.Int) *big.Rat {
+	return new(big.Rat).SetFrac(winProb, maxWinProb)
 }

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/drivers"
+	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/lpms/ffmpeg"
@@ -634,6 +635,16 @@ func genPayment(sess *BroadcastSession, numTickets int) (string, error) {
 		}
 
 		protoPayment.TicketSenderParams = senderParams
+
+		ratPrice, _ := ratPriceInfo(protoPayment.ExpectedPrice)
+		glog.V(common.VERBOSE).Infof("Created new payment - manifestID=%v recipient=%v faceValue=%v winProb=%v price=%v numTickets=%v",
+			sess.ManifestID,
+			batch.Recipient.Hex(),
+			eth.FormatUnits(batch.FaceValue, "ETH"),
+			batch.WinProbRat().FloatString(10),
+			ratPrice.FloatString(3)+" wei/pixel",
+			numTickets,
+		)
 	}
 
 	data, err := proto.Marshal(protoPayment)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds a log message for logging information regarding generated ticket batches that gets logged when starting the broadcaster node with `-v 6`. 

While declaring some of the params of the log statement as variables is unnecessary as most return a single value, I do find it improves code readability. 

- Added log statement in `SubmitSegment` that logs the payment generated by `genPayment()`
- Exported `pm.maxWinProb` so that we can calculate the winprob in the log statement as a floatstring

eg. 
```
"Created new payment -  recipient=0xe426ad6DDF3905de9D798f49cb19d6E9A6a3335f  faceValue=0.05 ETH  winProb=0.0000005 %  price=50 wei/pixel  numTickets=500"
```

**Does this pull request close any open issues?**
Fixes #1307 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
