### PR TITLE
ci: network branch name in upload URL + exit 0 for duplicate uploads

### DIFF
--- a/upload_build.sh
+++ b/upload_build.sh
@@ -70,7 +70,7 @@ fullUrl="https://storage.googleapis.com${resource}"
 # Failsafe - don't overwrite existing uploads!
 if curl --head --fail $fullUrl 2>/dev/null; then
   echo "$fullUrl already exists, not overwriting!"
-  exit 1
+  exit 0
 fi
 
 curl -X PUT -T "${FILE}" \

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -23,6 +23,17 @@ if echo $VERSION | grep dirty; then
   exit 1
 fi
 
+# If we want to build with branch --> network support for any other networks, add them here!
+NETWORK_BRANCHES="rinkeby mainnet"
+# If the binaries are built off a network branch then the resource path should include the network branch name i.e. X.Y.Z/rinkeby or X.Y.Z/mainnet
+# If the binaries are not built off a network then the resource path should only include the version i.e. X.Y.Z
+VERSION_AND_NETWORK=$VERSION
+for networkBranch in $NETWORK_BRANCHES; do
+  if [[ $BRANCH == "$networkBranch" ]]; then
+    VERSION_AND_NETWORK="$VERSION/$BRANCH"
+  fi
+done
+
 mkdir $BASE
 cp ./livepeer${EXT} $BASE
 cp ./livepeer_cli${EXT} $BASE
@@ -49,7 +60,7 @@ fi
 
 # https://stackoverflow.com/a/44751929/990590
 bucket=build.livepeer.live
-resource="/${bucket}/${VERSION}/${FILE}"
+resource="/${bucket}/${VERSION_AND_NETWORK}/${FILE}"
 contentType="application/x-compressed-tar"
 dateValue=`date -R`
 stringToSign="PUT\n\n${contentType}\n${dateValue}\n${resource}"
@@ -69,5 +80,5 @@ curl -X PUT -T "${FILE}" \
   -H "Authorization: AWS ${GCLOUD_KEY}:${signature}" \
   $fullUrl
 
-curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION/${FILE}\"}" $DISCORD_URL 2>/dev/null
+curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION_AND_NETWORK/${FILE}\"}" $DISCORD_URL 2>/dev/null
 echo "done"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the upload URL for binaries built by CI to follow these rules:

- If the branch is `rinkeby`, the upload URL is `build.livepeer.live/X.Y.Z/rinkeby/<FILE>`
- If the branch is `mainnet`, the upload URL is `build.livepeer.live/X.Y.Z/mainnet/<FILE>`
- If the branch is neither `rinkeby` nor `mainnet`, the upload URL is `build.livepeer.live/X.Y.Z/<FILE>`

The current problem is that all builds with the same version `i.e. X.Y.Z-<COMMIT-SHA>` will have the same upload URL. So, if we merge a PR into `master` and then fast-forward merge `master` into `rinkeby`, the upload URL used in CI will be the same for both `master` and `rinkeby`. This is a problem because if the CI for `master` finishes first, then the CI for `rinkeby` will detect that a build for the version was already uploaded and thus will not upload the build. As a result, the upload URL will contain binaries that only connect to private networks, but not binaries that connect to Rinkeby. We want a unique upload URL for the `rinkeby` build even if it shares the same version as the `master` build to ensure that we can upload a set of binaries that only connect to private networks AND a set of binaries that connect to Rinkeby.

This PR also updates `upload_build.sh` to return exit code 0 when the build already exists.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 592b9af: Add network branch name in upload URL
- 3c73495: Return exit code 0 in `upload_build.sh`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Created a [test branch](https://github.com/livepeer/go-livepeer/commits/test-ci-upload) with the name `test-ci-upload`. I added `test-ci-upload` to the list of network branches and confirmed that the build was uploaded to a URL containing `X.Y.Z/test-ci-upload`.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1342 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
