### PR TITLE
ci: Compute md5 and sha256 hashes for builds

### DIFF
--- a/upload_build.sh
+++ b/upload_build.sh
@@ -34,9 +34,17 @@ for networkBranch in $NETWORK_BRANCHES; do
   fi
 done
 
+NODE="./livepeer${EXT}"
+CLI="./livepeer_cli${EXT}"
+
 mkdir $BASE
-cp ./livepeer${EXT} $BASE
-cp ./livepeer_cli${EXT} $BASE
+cp $NODE $BASE
+cp $CLI $BASE
+
+NODE_MD5=`md5sum ${NODE}`
+CLI_MD5=`md5sum ${CLI}`
+NODE_SHA256=`shasum -a 256 ${NODE}`
+CLI_SHA256=`shasum -a 256 ${CLI}`
 
 # do a basic upload so we know if stuff's working prior to doing everything else
 if [[ $ARCH == "windows" ]]; then
@@ -80,5 +88,5 @@ curl -X PUT -T "${FILE}" \
   -H "Authorization: AWS ${GCLOUD_KEY}:${signature}" \
   $fullUrl
 
-curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION_AND_NETWORK/${FILE}\"}" $DISCORD_URL 2>/dev/null
+curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION_AND_NETWORK/${FILE}\nMD5:\n${NODE_MD5}\n${CLI_MD5}\nSHA256:\n${NODE_SHA256}\n${CLI_SHA256}\"}" $DISCORD_URL 2>/dev/null
 echo "done"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates CI to compute the md5 and sha256 hashes of the `livepeer` and `livepeer_cli` binaries. These hashes are included in a message that is posted to Discord when the binaries are uploaded to a storage bucket.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Compute md5 and sha256 hashes of `livepeer` and `livepeer_cli` binaries
- Include hashes in message posted to Discord

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Checked the md5 and sha256 hashes computed locally from uploaded binaries against the hashes reported in Discord.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1354 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
