### PR TITLE
test_args: Update Rinkeby URL in test

### DIFF
--- a/test_args.sh
+++ b/test_args.sh
@@ -55,7 +55,7 @@ run_lp -broadcaster -network mainnet $ETH_ARGS
 [ -d "$DEFAULT_DATADIR"/mainnet ]
 kill $pid
 
-run_lp -broadcaster -network anyNetwork $ETH_ARGS -ethUrl "wss://rinkeby.infura.io/ws" -v 99
+run_lp -broadcaster -network anyNetwork $ETH_ARGS -ethUrl "https://rinkeby.infura.io/v3/09642b98164d43eb890939eb9a7ec500" -v 99
 [ -d "$DEFAULT_DATADIR"/anyNetwork ]
 kill $pid
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the Rinkeby Infura URL used in `test_args.sh` to include a missing project ID. I think this should fix the current failing CI builds.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Update Rinkeby Infura URL in `test_args.sh`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Let's see if CI passes...

I also tried running a node with `-ethUrl` set to a Rinkeby Infura URL without a project ID and encountered:

```
I0211 22:00:25.969886   18326 livepeer.go:203] ***Livepeer is running on the rinkeby network: 0xA268AEa9D048F8d3A592dD7f1821297972D4C8Ea***
I0211 22:00:25.970886   18326 db.go:316] Initialized DB node
E0211 22:00:26.072863   18326 livepeer.go:325] Failed to connect to Ethereum client: websocket: bad handshake (HTTP status 403 Forbidden)
I0211 22:00:26.072892   18326 db.go:321] Closing DB
```

I also tried running a node with `-ethUrl` set to a Rinkeby Infura URL with a project ID and did not encounter any errors.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1372 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
