### PR TITLE
Explicitly use HTTP2 transport

### DIFF
--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"
 	"github.com/livepeer/lpms/ffmpeg"
+	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -112,7 +113,7 @@ func runTranscoder(n *core.LivepeerNode, orchAddr string, capacity int) error {
 		}
 	}()
 
-	httpc := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
+	httpc := &http.Client{Transport: &http2.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
 	var wg sync.WaitGroup
 	for {
 		notify, err := r.Recv()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Explicitly use HTTP2 transport in communication between
orchestrator and transcoder.
Mitigates issue in the golang's implementation of HTTP2
https://github.com/golang/go/issues/32441


**How did you test each of these updates (required)**
unit tests passes

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
