### PR TITLE
Distinguish between fatal and non-fatal retryable errors

### DIFF
--- a/verification/epic.go
+++ b/verification/epic.go
@@ -27,7 +27,7 @@ var VerifierPath string
 var ErrMissingSource = errors.New("MissingSource")
 var ErrVerifierStatus = errors.New("VerifierStatus")
 var ErrVideoUnavailable = errors.New("VideoUnavailable")
-var ErrAudioMismatch = Retryable{errors.New("AudioMismatch")}
+var ErrAudioMismatch = Fatal{Retryable{errors.New("AudioMismatch")}}
 var ErrTampered = Retryable{errors.New("Tampered")}
 
 type epicResolution struct {


### PR DESCRIPTION
This wraps `Retryable` errors with a new `fatal` error type and adds a check for it just like `IsRetryable()`, called `IsFatal()`

Fatal errors should not be included in the results from `verification.Verify()`
Fatal errors should not trigger a `sv.count++` in `verification.Verify()`
Rather than using `sv.count`, we can rely on the length of the results slice.

Fatal errors include:
* `ErrAudioMismatch`
* `ErrPixelMismatch`

Non-fatal:
* `ErrTampered`

closes #1327 