### PR TITLE
Reuse existing context.Context where available

### DIFF
--- a/eth/eventservices/rewardservice.go
+++ b/eth/eventservices/rewardservice.go
@@ -35,7 +35,7 @@ func (s *RewardService) Start(ctx context.Context) error {
 		return ErrRewardServiceStarted
 	}
 
-	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancelCtx, cancel := context.WithCancel(ctx)
 	s.cancelWorker = cancel
 
 	tickCh := time.NewTicker(s.pollingInterval).C

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -158,6 +158,7 @@ func InitCensus(nodeType, nodeID, version string) {
 		success:     make(map[uint64]*segmentsAverager),
 	}
 	var err error
+	ctx := context.Background()
 	census.kNodeType = tag.MustNewKey("node_type")
 	census.kNodeID = tag.MustNewKey("node_id")
 	census.kProfile = tag.MustNewKey("profile")
@@ -167,7 +168,7 @@ func InitCensus(nodeType, nodeID, version string) {
 	census.kSender = tag.MustNewKey("sender")
 	census.kRecipient = tag.MustNewKey("recipient")
 	census.kManifestID = tag.MustNewKey("manifestID")
-	census.ctx, err = tag.New(context.Background(), tag.Insert(census.kNodeType, nodeType), tag.Insert(census.kNodeID, nodeID))
+	census.ctx, err = tag.New(ctx, tag.Insert(census.kNodeType, nodeType), tag.Insert(census.kNodeID, nodeID))
 	if err != nil {
 		glog.Fatal("Error creating context", err)
 	}
@@ -226,7 +227,7 @@ func InitCensus(nodeType, nodeID, version string) {
 	goos := tag.MustNewKey("goos")
 	goversion := tag.MustNewKey("goversion")
 	livepeerversion := tag.MustNewKey("livepeerversion")
-	ctx, err := tag.New(context.Background(), tag.Insert(census.kNodeType, nodeType), tag.Insert(census.kNodeID, nodeID),
+	ctx, err = tag.New(ctx, tag.Insert(census.kNodeType, nodeType), tag.Insert(census.kNodeID, nodeID),
 		tag.Insert(compiler, runtime.Compiler), tag.Insert(goarch, runtime.GOARCH), tag.Insert(goos, runtime.GOOS),
 		tag.Insert(goversion, runtime.Version()), tag.Insert(livepeerversion, version))
 	if err != nil {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -148,7 +148,7 @@ func (s *LivepeerServer) StartMediaServer(ctx context.Context, transcodingOption
 	s.LPMS.HandleHLSPlay(getHLSMasterPlaylistHandler(s), getHLSMediaPlaylistHandler(s), getHLSSegmentHandler(s))
 
 	//Start the LPMS server
-	lpmsCtx, cancel := context.WithCancel(context.Background())
+	lpmsCtx, cancel := context.WithCancel(ctx)
 
 	ec := make(chan error, 2)
 	go func() {

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -895,7 +894,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 				return
 			}
 
-			balance, err := b.BalanceAt(context.Background(), s.LivepeerNode.Eth.Account().Address, nil)
+			balance, err := b.BalanceAt(r.Context(), s.LivepeerNode.Eth.Account().Address, nil)
 			if err != nil {
 				glog.Error(err)
 				w.Write([]byte(""))
@@ -1000,7 +999,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 				return
 			}
 
-			blk, err := backend.BlockByNumber(context.Background(), nil)
+			blk, err := backend.BlockByNumber(r.Context(), nil)
 			if err != nil {
 				glog.Errorf("Unable to get latest block")
 				return
@@ -1043,7 +1042,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		chainID, err := be.ChainID(context.Background())
+		chainID, err := be.ChainID(r.Context())
 		if err != nil {
 			glog.Errorf("Error getting eth network ID: %v", err)
 		}


### PR DESCRIPTION
Pass context down the function hierarchy rather than abusing `context.Background()`

This is a "best practices / coding style" cleanup.  This compiles down to zero change in the resulting binary, except for the changes to `server/webserver.go`, which is optimized to now use context from the incoming http request rather than the global context retrieved from `context.Background()`.

This specific change has zero impact on any structures or function signatures.  Because of this, I see it as "low hanging fruit" that can be reviewed easily and separately from any other more drastic changes relating to context usage.

see #1332