### PR TITLE
ci: build gmp with --enable-fat

### DIFF
--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -63,7 +63,7 @@ if [[ $(uname) != *"MSYS"* ]]; then
     tar xf gmp-6.1.2.tar
     rm gmp-6.1.2.tar
     cd "$HOME/gmp-6.1.2"
-    ./configure --prefix="$HOME/compiled" --disable-shared  --with-pic
+    ./configure --prefix="$HOME/compiled" --disable-shared  --with-pic --enable-fat
     make
     make install
   fi


### PR DESCRIPTION
fixes https://github.com/livepeer/go-livepeer/issues/1385

our GMP was not fat enough, apparently

tested and working on previously-broken AC instances