### PR TITLE
Cap transcoding attempts.

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -98,6 +98,7 @@ func main() {
 	broadcaster := flag.Bool("broadcaster", false, "Set to true to be a broadcaster")
 	orchSecret := flag.String("orchSecret", "", "Shared secret with the orchestrator as a standalone transcoder")
 	transcodingOptions := flag.String("transcodingOptions", "P240p30fps16x9,P360p30fps16x9", "Transcoding options for broadcast job")
+	maxAttempts := flag.Int("maxAttempts", 3, "Maximum transcode attempts")
 	maxSessions := flag.Int("maxSessions", 10, "Maximum number of concurrent transcoding sessions for Orchestrator, maximum number or RTMP streams for Broadcaster, or maximum capacity for transcoder")
 	currentManifest := flag.Bool("currentManifest", false, "Expose the currently active ManifestID as \"/stream/current.m3u8\"")
 	nvidia := flag.String("nvidia", "", "Comma-separated list of Nvidia GPU device IDs to use for transcoding")
@@ -700,6 +701,10 @@ func main() {
 		} else if *network != "offchain" {
 			server.Policy = &verification.Policy{Retries: 2}
 		}
+
+		// Set max transcode attempts. <=0 is OK; it just means "don't transcode"
+		server.MaxAttempts = *maxAttempts
+
 	} else if n.NodeType == core.OrchestratorNode {
 		suri, err := getServiceURI(n, *serviceAddr)
 		if err != nil {

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -25,6 +25,7 @@ import (
 
 var Policy *verification.Policy
 var BroadcastCfg = &BroadcastConfig{}
+var MaxAttempts = 3
 
 type BroadcastConfig struct {
 	maxPrice *big.Rat
@@ -290,7 +291,7 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, erro
 		sv = verification.NewSegmentVerifier(Policy)
 	}
 
-	for {
+	for i := 0; i < MaxAttempts; i++ {
 		// if fails, retry; rudimentary
 		if urls, err := transcodeSegment(cxn, seg, name, sv); err == nil {
 			return urls, nil
@@ -304,6 +305,7 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, erro
 
 		// recoverable error, retry
 	}
+	return nil, errors.New("Hit max transcode attempts")
 }
 
 func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -458,7 +458,7 @@ func TestTranscodeSegment_CompleteSession(t *testing.T) {
 	tr := &net.TranscodeResult{
 		Result: &net.TranscodeResult_Data{
 			Data: &net.TranscodeData{
-				Segments: []*net.TranscodedSegmentData{&net.TranscodedSegmentData{Url: "test.flv"}},
+				Segments: []*net.TranscodedSegmentData{{Url: "test.flv"}},
 				Sig:      []byte("bar"),
 			},
 		},
@@ -529,7 +529,7 @@ func TestTranscodeSegment_VerifyPixels(t *testing.T) {
 
 	// Create stub response with incorrect reported pixels
 	tSegData := []*net.TranscodedSegmentData{
-		&net.TranscodedSegmentData{Url: "test.flv", Pixels: 100},
+		{Url: "test.flv", Pixels: 100},
 	}
 	tr := dummyRes(tSegData)
 	buf, err := proto.Marshal(tr)
@@ -607,7 +607,7 @@ func TestUpdateSession(t *testing.T) {
 
 	info := &net.OrchestratorInfo{
 		Storage: []*net.OSInfo{
-			&net.OSInfo{
+			{
 				StorageType: 1,
 				S3Info:      &net.S3OSInfo{Host: "http://apple.com"},
 			},
@@ -662,7 +662,7 @@ func TestHLSInsertion(t *testing.T) {
 	assert := assert.New(t)
 
 	segData := []*net.TranscodedSegmentData{
-		&net.TranscodedSegmentData{Url: "/path/to/video", Pixels: 100},
+		{Url: "/path/to/video", Pixels: 100},
 	}
 
 	buf, err := proto.Marshal(&net.TranscodeResult{
@@ -843,8 +843,8 @@ func TestVerifier_Verify(t *testing.T) {
 		retries: 1,
 		err:     verification.ErrTampered,
 		results: []verification.Results{
-			verification.Results{Score: 9},
-			verification.Results{Score: 1},
+			{Score: 9},
+			{Score: 1},
 		},
 	}
 	mem, ok := drivers.NewMemoryDriver(nil).NewSession("streamName").(*drivers.MemorySession)
@@ -886,7 +886,7 @@ func TestVerifier_HLSInsertion(t *testing.T) {
 	assert.NotNil(mem)
 	genBcastSess := func(url string) *BroadcastSession {
 		segData := []*net.TranscodedSegmentData{
-			&net.TranscodedSegmentData{Url: url, Pixels: 100},
+			{Url: url, Pixels: 100},
 		}
 
 		buf, err := proto.Marshal(&net.TranscodeResult{


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Cap transcoding attempts.

Avoids thundering herd problems around repeated retries.

This will lower the success rate a bit, but is a more
realistic interpretation of satisfactory transcoding criteria.

The impact on the success rate is usually a few percent, < 5%.
When we see this type of impact, we're usually already below
99% anyway; for example going from ~95% -> ~92%. That
extra three percent would be for the segments that are retried
sometimes dozens of times. When that happens, it's also likely
that other segments are prone to be dropped, since a this point
it's a race between the O refresh and running out of Os.

The CLI flag added here is called `maxAttempts` . Originally this was `maxRetries` but this naming presented a few problems:

* When counting towards the cap, we count attempts, not just retries. So the [terminating condition](https://github.com/livepeer/go-livepeer/compare/ja/retrycap?expand=1#diff-cecc27bfe2b6b19181ce443733dfba57R294) would have to be `maxRetries+1` which felt a little unintuitive at first glance.

* Specifying attempts allows the user to configure to skip transcoding for whatever reason (eg, segmentation only), apart from specifying an empty set of orchestrators. This can be done with a value <= 0. Not sure how useful this is, but it "works" with this small semantic tweak. (A retry would mean a minimum of one transcode attempt.)

* Should we preserve the ability to do unlimited transcodes? This could probably be signaled with `-maxAttempts 0`, with the terminating condition modified accordingly. It's not here right now, but can add it in if folks feel that's important, since that's the behavior that we currently support.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds a new `maxAttempts` CLI flag. Default value of 3.
- Caps transcode attempts based on `maxAttempts`.
- Adds unit tests
- Applies some automatic changes from gofmt https://github.com/livepeer/go-livepeer/commit/590e02601ea5a02565065fdf9a49edb61c058906

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit tests, manual tests with multi-O


**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes https://github.com/livepeer/go-livepeer/issues/1057

This is simpler than the algorithm described in #1057 ; this is only a counter and doesn't take elapsed time into account.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
