### PR TITLE
Download segment data only once for verification

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -428,8 +428,6 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 			name := fmt.Sprintf("%s/%d.ts", sess.Profiles[i].Name, seg.SeqNo)
 			newURL, err := bos.SaveData(name, data)
 			if err != nil {
-				segHashLock.Lock()
-				segHashLock.Unlock()
 				switch err.Error() {
 				case "Session ended":
 					errFunc(monitor.SegmentTranscodeErrorSessionEnded, url, err)

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -1084,53 +1084,12 @@ func TestVerifier_HLSInsertion(t *testing.T) {
 	drivers.S3BUCKET = "livepeer"
 	mem := drivers.NewS3Driver("", drivers.S3BUCKET, "", "").NewSession(string(mid))
 	assert.NotNil(mem)
-	genBcastSess := func(url string) *BroadcastSession {
-		segData := []*net.TranscodedSegmentData{
-			{Url: url, Pixels: 100},
-		}
-
-		buf, err := proto.Marshal(&net.TranscodeResult{
-			Result: &net.TranscodeResult_Data{
-				Data: &net.TranscodeData{Segments: segData},
-			},
-		})
-		assert.Nil(err, fmt.Sprintf("Could not marshal results for %s", url))
-		ts, mux := stubTLSServer()
-		mux.HandleFunc("/segment", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			w.Write(buf)
-		})
-		defer func() {
-			// Work around a weird timing issue. Tests fail if the server closes
-			// in-scope (prob leads to something like the client being unable
-			// to read the response?), so we delay the close for a little bit
-			go func() {
-				// We assume this test doesn't take more than 1s
-				// But if it does (eg, we get a POST error), then bump this up
-				time.Sleep(1 * time.Second)
-				ts.Close()
-			}()
-		}()
-		return &BroadcastSession{
-			Broadcaster:   stubBroadcaster2(),
-			ManifestID:    mid,
-			Profiles:      []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9},
-			BroadcasterOS: mem,
-			OrchestratorInfo: &net.OrchestratorInfo{
-				Transcoder: ts.URL,
-				PriceInfo: &net.PriceInfo{
-					PricePerUnit:  1,
-					PixelsPerUnit: 1,
-				},
-			},
-		}
-	}
 
 	baseURL := "https://livepeer.s3.amazonaws.com"
 	bsm := bsmWithSessList([]*BroadcastSession{
-		genBcastSess(baseURL + "/resp1"),
-		genBcastSess(baseURL + "/resp2"),
-		genBcastSess(baseURL + "/resp3"),
+		genBcastSess(t, baseURL+"/resp1", mem, mid),
+		genBcastSess(t, baseURL+"/resp2", mem, mid),
+		genBcastSess(t, baseURL+"/resp3", mem, mid),
 	})
 	cxn := &rtmpConnection{
 		mid:         mid,
@@ -1148,6 +1107,10 @@ func TestVerifier_HLSInsertion(t *testing.T) {
 			{Score: 1, Pixels: []int64{100}},
 		},
 	})
+
+	oldDownloadSeg := downloadSeg
+	defer func() { downloadSeg = oldDownloadSeg }()
+	downloadSeg = func(url string) ([]byte, error) { return []byte("foo"), nil }
 
 	_, err := transcodeSegment(cxn, seg, "dummy", verifier)
 	assert.Equal(verification.ErrTampered, err)
@@ -1233,5 +1196,120 @@ func defaultTicketBatch() *pm.TicketBatch {
 		SenderParams: []*pm.TicketSenderParams{
 			&pm.TicketSenderParams{SenderNonce: 777, Sig: pm.RandBytes(42)},
 		},
+	}
+}
+
+func TestVerifier_SegDownload(t *testing.T) {
+	assert := assert.New(t)
+
+	mid := core.ManifestID("foo")
+
+	drivers.S3BUCKET = "livepeer"
+	externalOS := &stubOSSession{}
+	bsm := bsmWithSessList([]*BroadcastSession{})
+	cxn := &rtmpConnection{
+		mid:         mid,
+		pl:          &stubPlaylistManager{manifestID: mid},
+		profile:     &ffmpeg.P240p30fps16x9,
+		sessManager: bsm,
+	}
+	seg := &stream.HLSSegment{}
+
+	oldDownloadSeg := downloadSeg
+	defer func() { downloadSeg = oldDownloadSeg }()
+
+	downloaded := make(map[string]bool)
+	downloadSeg = func(url string) ([]byte, error) {
+		downloaded[url] = true
+
+		return []byte("foo"), nil
+	}
+
+	//
+	// Tests when there is no verification policy
+	//
+
+	// When there is no broadcaster OS, segments should not be downloaded
+	url := "somewhere1"
+	cxn.sessManager = bsmWithSessList([]*BroadcastSession{genBcastSess(t, url, nil, mid)})
+	_, err := transcodeSegment(cxn, seg, "dummy", nil)
+	assert.Nil(err)
+	assert.False(downloaded[url])
+
+	// When segments are in the broadcaster's external OS, segments should not be downloaded
+	url = "https://livepeer.s3.amazonaws.com/resp1"
+	cxn.sessManager = bsmWithSessList([]*BroadcastSession{genBcastSess(t, url, externalOS, mid)})
+	_, err = transcodeSegment(cxn, seg, "dummy", nil)
+	assert.Nil(err)
+	assert.False(downloaded[url])
+
+	// When segments are not in the broadcaster's external OS, segments should be downloaded
+	url = "somewhere2"
+	cxn.sessManager = bsmWithSessList([]*BroadcastSession{genBcastSess(t, url, externalOS, mid)})
+	_, err = transcodeSegment(cxn, seg, "dummy", nil)
+	assert.Nil(err)
+	assert.True(downloaded[url])
+
+	//
+	// Tests when there is a verification policy
+	//
+
+	verifier := newStubSegmentVerifier(&stubVerifier{retries: 100})
+
+	// When there is no broadcaster OS, segments should be downloaded
+	url = "somewhere3"
+	cxn.sessManager = bsmWithSessList([]*BroadcastSession{genBcastSess(t, url, nil, mid)})
+	_, err = transcodeSegment(cxn, seg, "dummy", verifier)
+	assert.Nil(err)
+	assert.True(downloaded[url])
+
+	// When segments are in the broadcaster's external OS, segments should be downloaded
+	url = "https://livepeer.s3.amazonaws.com/resp2"
+	cxn.sessManager = bsmWithSessList([]*BroadcastSession{genBcastSess(t, url, externalOS, mid)})
+	_, err = transcodeSegment(cxn, seg, "dummy", verifier)
+	assert.Nil(err)
+	assert.True(downloaded[url])
+
+	// When segments are not in the broadcaster's exernal OS, segments should be downloaded
+	url = "somewhere4"
+	cxn.sessManager = bsmWithSessList([]*BroadcastSession{genBcastSess(t, url, externalOS, mid)})
+	_, err = transcodeSegment(cxn, seg, "dummy", verifier)
+	assert.Nil(err)
+	assert.True(downloaded[url])
+}
+
+func genBcastSess(t *testing.T, url string, os drivers.OSSession, mid core.ManifestID) *BroadcastSession {
+	segData := []*net.TranscodedSegmentData{
+		{Url: url, Pixels: 100},
+	}
+
+	buf, err := proto.Marshal(&net.TranscodeResult{
+		Result: &net.TranscodeResult_Data{
+			Data: &net.TranscodeData{Segments: segData},
+		},
+	})
+	require.Nil(t, err, fmt.Sprintf("Could not marshal results for %s", url))
+	ts, mux := stubTLSServer()
+	mux.HandleFunc("/segment", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write(buf)
+	})
+	defer func() {
+		// Work around a weird timing issue. Tests fail if the server closes
+		// in-scope (prob leads to something like the client being unable
+		// to read the response?), so we delay the close for a little bit
+		go func() {
+			// We assume this test doesn't take more than 1s
+			// But if it does (eg, we get a POST error), then bump this up
+			time.Sleep(1 * time.Second)
+			ts.Close()
+		}()
+	}()
+	return &BroadcastSession{
+		Broadcaster:      stubBroadcaster2(),
+		ManifestID:       mid,
+		Profiles:         []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9},
+		BroadcasterOS:    os,
+		OrchestratorInfo: &net.OrchestratorInfo{Transcoder: ts.URL},
 	}
 }

--- a/verification/verify.go
+++ b/verification/verify.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"sort"
 
@@ -215,9 +214,7 @@ func countPixelParams(params *Params) ([]int64, error) {
 	pxls := make([]int64, len(params.Results.Segments))
 
 	for i := 0; i < len(params.Results.Segments); i++ {
-		count, err := countPixels(
-			params.Results.Segments[i].Url,
-			params.Renditions[i])
+		count, err := countPixels(params.Renditions[i])
 		if err != nil {
 			return nil, err
 		}
@@ -226,30 +223,24 @@ func countPixelParams(params *Params) ([]int64, error) {
 	return pxls, nil
 }
 
-func countPixels(fname string, data []byte) (int64, error) {
-	uri, err := url.ParseRequestURI(fname)
-	// If the filename is a relative URI and the broadcaster is using local memory storage
+func countPixels(data []byte) (int64, error) {
 	// write the data to a temp file
-	if err == nil && !uri.IsAbs() && data != nil {
-		tempfile, err := ioutil.TempFile("", common.RandName())
-		if err != nil {
-			return 0, fmt.Errorf("error creating temp file for pixels verification: %w", err)
-		}
-		defer os.Remove(tempfile.Name())
+	tempfile, err := ioutil.TempFile("", common.RandName())
+	if err != nil {
+		return 0, fmt.Errorf("error creating temp file for pixels verification: %w", err)
+	}
+	defer os.Remove(tempfile.Name())
 
-		if _, err := tempfile.Write(data); err != nil {
-			tempfile.Close()
-			return 0, fmt.Errorf("error writing temp file for pixels verification: %w", err)
-		}
-
-		if err = tempfile.Close(); err != nil {
-			return 0, fmt.Errorf("error closing temp file for pixels verification: %w", err)
-		}
-
-		fname = tempfile.Name()
+	if _, err := tempfile.Write(data); err != nil {
+		tempfile.Close()
+		return 0, fmt.Errorf("error writing temp file for pixels verification: %w", err)
 	}
 
-	p, err := pixels(fname)
+	if err = tempfile.Close(); err != nil {
+		return 0, fmt.Errorf("error closing temp file for pixels verification: %w", err)
+	}
+
+	p, err := pixels(tempfile.Name())
 	if err != nil {
 		return 0, err
 	}

--- a/verification/verify_test.go
+++ b/verification/verify_test.go
@@ -123,7 +123,8 @@ func TestVerify(t *testing.T) {
 	// Check pixel count succeeds w/o external verifier
 	sv = &SegmentVerifier{policy: &Policy{Verifier: nil, Retries: 2}, verifySig: func(ethcommon.Address, []byte, []byte) bool { return true }}
 	pxls, err := pixels("../server/test.flv")
-	a := make([]byte, pxls)
+
+	a, err := ioutil.ReadFile("../server/test.flv")
 	assert.Nil(err)
 	data = &net.TranscodeData{Segments: []*net.TranscodedSegmentData{
 		{Url: "../server/test.flv", Pixels: pxls},
@@ -142,7 +143,6 @@ func TestVerify(t *testing.T) {
 		{Url: "../server/test.flv", Pixels: 123},
 		{Url: "../server/test.flv", Pixels: 456},
 	}}
-	renditions = [][]byte{{byte(pxls)}, {byte(pxls)}}
 	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{}, Renditions: renditions})
 	assert.Nil(res)
 	assert.Equal(ErrPixelMismatch, err)
@@ -297,7 +297,7 @@ func TestPixels(t *testing.T) {
 
 // helper function for TestVerifyPixels to test countPixels()
 func verifyPixels(fname string, data []byte, reportedPixels int64) error {
-	c, err := countPixels(fname, data)
+	c, err := countPixels(data)
 	if err != nil {
 		return err
 	}
@@ -327,7 +327,7 @@ func TestVerifyPixels(t *testing.T) {
 	// Test error for relative URI and no memory storage if the file does not exist on disk
 	// Will try to use the relative URI to read the file from disk and fail
 	err = verifyPixels(fname, nil, 50)
-	assert.EqualError(err, "No such file or directory")
+	assert.EqualError(err, "Invalid data found when processing input")
 
 	// Test writing temp file for relative URI and local memory storage with incorrect pixels
 	err = verifyPixels(fname, memOS.GetData(fname), 50)
@@ -340,11 +340,7 @@ func TestVerifyPixels(t *testing.T) {
 	err = verifyPixels(fname, memOS.GetData(fname), p)
 	assert.Nil(err)
 
-	// Test no writing temp file with incorrect pixels
+	// Test nil data
 	err = verifyPixels("../server/test.flv", nil, 50)
-	assert.Equal(ErrPixelMismatch, err)
-
-	// Test no writing temp file with correct pixels
-	err = verifyPixels("../server/test.flv", nil, p)
-	assert.Nil(err)
+	assert.EqualError(err, "Invalid data found when processing input")
 }


### PR DESCRIPTION
Broadcaster nodes should download segment data once for both sig verification and pixel count verification

closes #1382 