### PR TITLE
cmd, common, eth, server: show price per pixel in CLI

### DIFF
--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -34,7 +34,7 @@ func (w *wizard) registeredOrchestratorStats() map[int]common.Address {
 	fmt.Println("+------------------------+")
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"ID", "Address", "Active", "Delegated Stake", "Reward Cut (%)", "Fee Share (%)", "Service URI"})
+	table.SetHeader([]string{"ID", "Address", "Active", "Delegated Stake", "Reward Cut (%)", "Fee Share (%)", "Service URI", "Price Per Pixel"})
 
 	for _, t := range orchestrators {
 		table.Append([]string{
@@ -45,6 +45,7 @@ func (w *wizard) registeredOrchestratorStats() map[int]common.Address {
 			eth.FormatPerc(t.RewardCut),
 			eth.FormatPerc(t.FeeShare),
 			t.ServiceURI,
+			t.PricePerPixel.FloatString(3),
 		})
 
 		orchestratorIDs[nextId] = t.Address

--- a/common/util.go
+++ b/common/util.go
@@ -26,6 +26,10 @@ const HTTPTimeout = 8 * time.Second
 
 const maxInt64 = int64(math.MaxInt64)
 
+// using a scaleFactor of 1000 for orchestrator prices
+// resulting in max decimal places of 3
+const priceScalingFactor = int64(1000)
+
 var (
 	ErrParseBigInt = fmt.Errorf("failed to parse big integer")
 	ErrProfile     = fmt.Errorf("failed to parse profile")
@@ -207,7 +211,12 @@ func GenErrRegex(errStrings []string) *regexp.Regexp {
 // PriceToFixed converts a big.Rat into a fixed point number represented as int64
 // using a scaleFactor of 1000 resulting in max decimal places of 3
 func PriceToFixed(price *big.Rat) (int64, error) {
-	return ratToFixed(price, 1000)
+	return ratToFixed(price, priceScalingFactor)
+}
+
+// FixedToPrice converts an fixed point number with 3 decimal places represented as in int64 into a big.Rat
+func FixedToPrice(price int64) *big.Rat {
+	return big.NewRat(price, priceScalingFactor)
 }
 
 // BaseTokenAmountToFixed converts the base amount of a token (i.e. ETH/LPT) represented as a big.Int into a fixed point number represented

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -257,7 +257,7 @@ func (e *StubClient) GetTranscoderEarningsPoolForRound(addr common.Address, roun
 	return &lpTypes.TokenPools{TotalStake: totalStake}, nil
 }
 func (e *StubClient) TranscoderPool() ([]*lpTypes.Transcoder, error) {
-	return e.Orchestrators, nil
+	return e.Orchestrators, e.TranscoderPoolError
 }
 func (e *StubClient) IsActiveTranscoder() (bool, error)        { return false, nil }
 func (e *StubClient) GetTotalBonded() (*big.Int, error)        { return big.NewInt(0), nil }

--- a/eth/types/contracts.go
+++ b/eth/types/contracts.go
@@ -23,6 +23,7 @@ type Transcoder struct {
 	DeactivationRound *big.Int
 	Active            bool
 	Status            string
+	PricePerPixel     *big.Rat
 }
 
 func ParseTranscoderStatus(s uint8) (string, error) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Show price per pixel in CLI when picking `3. Show registered orchestrators`.

The price per pixel is queried from the database so it actually includes the transaction cost overhead of 1%. 

**How did you test each of these updates (required)**
Checked that the pricing of my mainnet orch is shown correctly (45+45/100)

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
