### PR TITLE
server: Remove redundant log line.

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -347,8 +347,6 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 	}
 
 	// send segment to the orchestrator
-	glog.V(common.DEBUG).Infof("Submitting segment nonce=%d manifestID=%s seqNo=%d orch=%s", nonce, cxn.mid, seg.SeqNo, sess.OrchestratorInfo.Transcoder)
-
 	res, err := SubmitSegment(sess, seg, nonce)
 	if err != nil || res == nil {
 		cxn.sessManager.removeSession(sess)


### PR DESCRIPTION
There is a very [similar line](https://github.com/livepeer/go-livepeer/blob/29988579ce55e23416b06b170c7f39c2ad1f20c5/server/segment_rpc.go#L350) already in `segment_rpc.go` . This
confuses log analysis tools. Remove this particular instance.

https://github.com/livepeer/go-livepeer/blob/29988579ce55e23416b06b170c7f39c2ad1f20c5/server/segment_rpc.go#L350