### PR TITLE
discovery: Shuffle orchestrators prior to OrchestratorInfo

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -26,8 +26,6 @@ type orchestratorPool struct {
 	bcast common.Broadcaster
 }
 
-var perm = func(len int) []int { return rand.Perm(len) }
-
 func NewOrchestratorPool(bcast common.Broadcaster, uris []*url.URL) *orchestratorPool {
 	if len(uris) <= 0 {
 		// Should we return here?

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -34,13 +34,7 @@ func NewOrchestratorPool(bcast common.Broadcaster, uris []*url.URL) *orchestrato
 		glog.Error("Orchestrator pool does not have any URIs")
 	}
 
-	var randomizedUris []*url.URL
-	for _, i := range perm(len(uris)) {
-		uri := uris[i]
-		randomizedUris = append(randomizedUris, uri)
-	}
-
-	return &orchestratorPool{uris: randomizedUris, bcast: bcast}
+	return &orchestratorPool{uris: uris, bcast: bcast}
 }
 
 func NewOrchestratorPoolWithPred(bcast common.Broadcaster, addresses []*url.URL, pred func(*net.OrchestratorInfo) bool) *orchestratorPool {
@@ -80,7 +74,13 @@ func (o *orchestratorPool) GetOrchestrators(numOrchestrators int) ([]*net.Orches
 		}
 	}
 
-	for _, uri := range o.uris {
+	// Shuffle into new slice to avoid mutating underlying data
+	uris := make([]*url.URL, len(o.uris))
+	for i, j := range rand.Perm(len(o.uris)) {
+		uris[i] = o.uris[j]
+	}
+
+	for _, uri := range uris {
 		go getOrchInfo(uri)
 	}
 

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1052,7 +1052,7 @@ func TestDeserializeWebhookJSON(t *testing.T) {
 	assert := assert.New(t)
 
 	// assert input of webhookResponse address object returns correct address
-	resp, _ := json.Marshal(&[]webhookResponse{webhookResponse{Address: "https://127.0.0.1:8936"}})
+	resp, _ := json.Marshal(&[]webhookResponse{{Address: "https://127.0.0.1:8936"}})
 	urls, err := deserializeWebhookJSON(resp)
 	assert.Nil(err)
 	assert.Equal("https://127.0.0.1:8936", urls[0].String())
@@ -1063,7 +1063,7 @@ func TestDeserializeWebhookJSON(t *testing.T) {
 	assert.Nil(urls)
 
 	// assert input of empty byte array returns empty object
-	resp, _ = json.Marshal(&[]webhookResponse{webhookResponse{}})
+	resp, _ = json.Marshal(&[]webhookResponse{{}})
 	urls, err = deserializeWebhookJSON(resp)
 	assert.Nil(err)
 	assert.Empty(urls)
@@ -1106,5 +1106,5 @@ func TestEthOrchToDBOrch(t *testing.T) {
 	assert.Equal(dbo.ServiceURI, o.ServiceURI)
 	assert.Equal(dbo.EthereumAddr, o.Address.Hex())
 	assert.Equal(dbo.ActivationRound, o.ActivationRound.Int64())
-	assert.Equal(dbo.DeactivationRound,  int64(math.MaxInt64))
+	assert.Equal(dbo.DeactivationRound, int64(math.MaxInt64))
 }

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"math"
 	"math/big"
-	"math/rand"
 	"net/url"
 	"runtime"
 	"strconv"
@@ -434,9 +433,6 @@ func TestNewOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *
 	assert := assert.New(t)
 
 	// creating NewOrchestratorPool with orch addresses
-	rand.Seed(321)
-	perm = func(len int) []int { return rand.Perm(3) }
-
 	offchainOrch := NewOrchestratorPool(nil, addresses)
 
 	for i, uri := range offchainOrch.uris {
@@ -488,9 +484,6 @@ func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) 
 	}
 	expTranscoder := "transcoderFromTest"
 	expPricePerPixel, _ := common.PriceToFixed(big.NewRat(999, 1))
-
-	rand.Seed(321)
-	perm = func(len int) []int { return rand.Perm(50) }
 
 	server.BroadcastCfg.SetMaxPrice(big.NewRat(1, 1))
 	gmp := runtime.GOMAXPROCS(50)
@@ -578,9 +571,6 @@ func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
 	}
 	expTranscoder := "transcoderFromTest"
 	expPricePerPixel, _ := common.PriceToFixed(big.NewRat(999, 1))
-
-	rand.Seed(321)
-	perm = func(len int) []int { return rand.Perm(50) }
 
 	server.BroadcastCfg.SetMaxPrice(nil)
 	gmp := runtime.GOMAXPROCS(50)
@@ -684,7 +674,6 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 			PixelsPerUnit: 1,
 		},
 	}
-	perm = func(len int) []int { return rand.Perm(25) }
 
 	server.BroadcastCfg.SetMaxPrice(big.NewRat(10, 1))
 	gmp := runtime.GOMAXPROCS(50)
@@ -782,7 +771,6 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 
 func TestCachedPool_GetOrchestrators_TicketParamsValidation(t *testing.T) {
 	// Test setup
-	perm = func(len int) []int { return rand.Perm(50) }
 
 	gmp := runtime.GOMAXPROCS(50)
 	defer runtime.GOMAXPROCS(gmp)
@@ -850,7 +838,6 @@ func TestCachedPool_GetOrchestrators_TicketParamsValidation(t *testing.T) {
 
 func TestCachedPool_GetOrchestrators_OnlyActiveOrchestrators(t *testing.T) {
 	// Test setup
-	perm = func(len int) []int { return rand.Perm(25) }
 	expPriceInfo := &net.PriceInfo{
 		PricePerUnit:  1,
 		PixelsPerUnit: 1,
@@ -969,8 +956,6 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 	serverGetOrchInfo = func(c context.Context, b common.Broadcaster, s *url.URL) (*net.OrchestratorInfo, error) {
 		return &net.OrchestratorInfo{Transcoder: "transcoder"}, nil
 	}
-
-	perm = func(len int) []int { return rand.Perm(3) }
 
 	// assert created webhook pool is correct length
 	whURL, _ := url.ParseRequestURI("https://livepeer.live/api/orchestrator")


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Shuffle orchestrators each time GetOrchestratorInfo is invoked, rather than just once at the beginning. This improves success rates by a few percent if the O list is static.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Randomize orchestrators prior to GetOrchestratorInfo
- Tests around randomization
- Gofmt / lint fixes for tests
- More test cleanup, removing the `perm` helper which is no longer needed. Other tests don't rely on randomization and the uncertainty involved with goroutine scheduling around GetOrchestratorInfo (one goroutine per request) means there isn't a need to make the `perm` reproducible.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Manual testing, unit tests.


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
