### PR TITLE
discovery: Avoid shared state in GetOrchestratorInfo responses

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -15,7 +15,7 @@ import (
 	"github.com/golang/glog"
 )
 
-const getOrchestratorsTimeoutLoop = 3 * time.Second
+var getOrchestratorsTimeoutLoop = 3 * time.Second
 
 var serverGetOrchInfo = server.GetOrchestratorInfo
 


### PR DESCRIPTION
Follows conventions used elsewhere in the codebase, in addition to
being more idiomatic golang.

See here for a similar pattern:

https://github.com/livepeer/go-livepeer/blob/56a54051e13889fdd8bfb73011598f631fa4c9f1/discovery/db_discovery.go#L174-L207

**What does this pull request do? Explain your changes. (required)**
 Refactors how we collect responses from the GetOrchestratorInfo query to avoid shared state. Use channels instead.

Aside from logging tweaks, no functional changes.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit testing, manual testing


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
