### PR TITLE
Nv/roundtrip latencyscore

### DIFF
--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -464,7 +464,7 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 	return &ReceivedTranscodeResult{
 		TranscodeData: tdata,
 		Info:          tr.Info,
-		LatencyScore:  transcodeDur.Seconds() / seg.Duration,
+		LatencyScore:  tookAllDur.Seconds() / seg.Duration,
 	}, nil
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
- Use round trip latency to calculate latency score
- Fix flaky `SubmitSegment` test where latency score tests sometimes failed

**Specific updates (required)**
- use `tookAllDur` to calculate latency score
- add a small sleep to the stub `/segment` request to simulate network latency, increase the segment


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
Fixes #1376 
Fixes #1353 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
