### PR TITLE
misc fixes: ticket queue error logging and formatting hex values

### DIFF
--- a/pm/queue.go
+++ b/pm/queue.go
@@ -113,7 +113,9 @@ func (q *ticketQueue) startQueueLoop() {
 	for {
 		select {
 		case err := <-sub.Err():
-			glog.Error(err)
+			if err != nil {
+				glog.Errorf("Block subscription error err=%v", err)
+			}
 		case latestBlock := <-blockNums:
 			numTickets := q.Length()
 			for i := 0; i < int(numTickets); i++ {

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -160,7 +160,7 @@ func (sm *senderMonitor) QueueTicket(addr ethcommon.Address, ticket *SignedTicke
 	sm.ensureCache(addr)
 
 	sm.senders[addr].queue.Add(ticket)
-	glog.Infof("Queued ticket sender=%x recipientRandHash=%x senderNonce=%v", ticket.Sender.Hex(), ticket.RecipientRandHash.Hex(), ticket.SenderNonce)
+	glog.Infof("Queued ticket sender=%v recipientRandHash=%v senderNonce=%v", ticket.Sender.Hex(), ticket.RecipientRandHash.Hex(), ticket.SenderNonce)
 
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR includes two fixes:

- Only log non-nil block subscription errors in `pm/queue.go`
- Format hex values properly in log statements in `SenderMonitor.QueueTicket()`.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- d9fb95f: Adds a nil-check for block subscription errors in `pm/queue.go` and also updates the error message to indicate that it is a block subscription error
- 07886b9: Updates the log message in `SenderMonitor.QueueTicket()` to use `%v` instead of `%x` for already encoded hex values

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Ran a local on-chain setup using the devtool.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
