### PR TITLE
bump Linux build to go 1.14

### DIFF
--- a/docker/Dockerfile.build-linux
+++ b/docker/Dockerfile.build-linux
@@ -1,19 +1,25 @@
 FROM ubuntu:16.04
 
-ENV PATH "/usr/lib/go-1.13/bin:/go/bin:${PATH}"
+ENV PATH "/usr/local/go/bin:/go/bin:${PATH}"
 ENV PKG_CONFIG_PATH "/root/compiled/lib/pkgconfig"
 ENV CPATH /usr/local/cuda/include
 ENV LIBRARY_PATH /usr/local/cuda/lib64
 
 RUN apt-get update \
   && apt-get install -y software-properties-common curl apt-transport-https \
-  && add-apt-repository ppa:longsleep/golang-backports -y \
   && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
   && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs)  stable" \
   && apt-key adv --keyserver keyserver.ubuntu.com --recv 15CF4D18AF4F7421 \
   && add-apt-repository "deb [arch=amd64] http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" \
   && apt-get update \
-  && apt-get -y install clang-8 clang-tools-8 build-essential pkg-config autoconf gnutls-dev golang-1.13-go sudo git python docker-ce-cli
+  && apt-get -y install clang-8 clang-tools-8 build-essential pkg-config autoconf gnutls-dev sudo git python docker-ce-cli
+
+ENV GOROOT /usr/local/go
+ENV GOPATH /go
+
+RUN curl -o go.tar.gz https://dl.google.com/go/go1.14.linux-amd64.tar.gz \
+  && tar -xzf go.tar.gz \
+  && mv go /usr/local/go
 
 RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 30 \
   && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 30

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -1125,7 +1125,7 @@ func TestRefreshSession(t *testing.T) {
 	newSess, err := refreshSession(sess)
 	assert.Nil(newSess)
 	assert.Error(err)
-	assert.EqualError(err, "parse \u007f: net/url: invalid control character in URL")
+	assert.EqualError(err, `parse "\u007f": net/url: invalid control character in URL`)
 
 	// trigger getOrchestratorInfo error
 	getOrchestratorInfoRPC = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {

--- a/verification/epic_test.go
+++ b/verification/epic_test.go
@@ -189,7 +189,7 @@ func TestEpic_Verify(t *testing.T) {
 	ec.Addr = ""
 	_, err = ec.Verify(params)
 	assert.NotNil(err)
-	assert.Equal(`Post : unsupported protocol scheme ""`, err.Error())
+	assert.Equal(`Post "": unsupported protocol scheme ""`, err.Error())
 
 	ec.Addr = ts.URL + "/nonexistent" // 404s
 	_, err = ec.Verify(params)


### PR DESCRIPTION
It wasn't in the Ubuntu golang backports PPA we were using for some reason. So I downloaded it manually from Google.

Our Darwin and Windows versions are dependent on whatever homebrew and MSYS2 install, so it turns out they were already on Go 1.14. Sweet! That's a pretty good indication that it works okay.