### PR TITLE
server+verification: Fix tests for Go 1.14

### DIFF
--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -1125,7 +1125,7 @@ func TestRefreshSession(t *testing.T) {
 	newSess, err := refreshSession(sess)
 	assert.Nil(newSess)
 	assert.Error(err)
-	assert.EqualError(err, "parse \u007f: net/url: invalid control character in URL")
+	assert.EqualError(err, `parse "\u007f": net/url: invalid control character in URL`)
 
 	// trigger getOrchestratorInfo error
 	getOrchestratorInfoRPC = func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL) (*net.OrchestratorInfo, error) {

--- a/verification/epic_test.go
+++ b/verification/epic_test.go
@@ -189,7 +189,7 @@ func TestEpic_Verify(t *testing.T) {
 	ec.Addr = ""
 	_, err = ec.Verify(params)
 	assert.NotNil(err)
-	assert.Equal(`Post : unsupported protocol scheme ""`, err.Error())
+	assert.Equal(`Post "": unsupported protocol scheme ""`, err.Error())
 
 	ec.Addr = ts.URL + "/nonexistent" // 404s
 	_, err = ec.Verify(params)


### PR DESCRIPTION
The format of errors from the net/url and http packages changed in Go
1.14.
