### PR TITLE
please oh please, do not merge: CPU retry hack

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -249,6 +249,7 @@ func main() {
 				}
 			}
 			n.Transcoder = core.NewLoadBalancingTranscoder(*nvidia, core.NewNvidiaTranscoder)
+			n.BackupTranscoder = core.NewLocalTranscoder(*datadir)
 		} else {
 			n.Transcoder = core.NewLocalTranscoder(*datadir)
 		}

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -249,7 +249,8 @@ func main() {
 				}
 			}
 			n.Transcoder = core.NewLoadBalancingTranscoder(*nvidia, core.NewNvidiaTranscoder)
-			n.BackupTranscoder = core.NewLocalTranscoder(*datadir)
+			n.TranscoderManager = core.NewRemoteTranscoderManager()
+			n.BackupTranscoder = n.TranscoderManager
 		} else {
 			n.Transcoder = core.NewLocalTranscoder(*datadir)
 		}

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -253,6 +253,8 @@ func main() {
 			n.BackupTranscoder = n.TranscoderManager
 		} else {
 			n.Transcoder = core.NewLocalTranscoder(*datadir)
+			n.TranscoderManager = core.NewRemoteTranscoderManager()
+			n.BackupTranscoder = n.TranscoderManager
 		}
 	}
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -58,6 +58,7 @@ type LivepeerNode struct {
 	OrchestratorPool  common.OrchestratorPool
 	OrchSecret        string
 	Transcoder        Transcoder
+	BackupTranscoder  Transcoder
 	TranscoderManager *RemoteTranscoderManager
 	Balances          *AddressBalances
 

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -487,7 +487,9 @@ func (n *LivepeerNode) transcodeSeg(config transcodeConfig, seg *stream.HLSSegme
 	transcoder := n.Transcoder
 
 	var url string
-	_, isLocal := transcoder.(*LocalTranscoder)
+	// _, isLocalCPU := transcoder.(*LocalTranscoder)
+	// _, isNvidia := transcoder.(*NvidiaTranscoder)
+	isLocal := true
 	// Small optimization: serve from disk for local transcoding
 	if isLocal {
 		url = fname

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -535,8 +535,7 @@ func (n *LivepeerNode) transcodeSeg(config transcodeConfig, seg *stream.HLSSegme
 
 	tData, err := runTranscode(transcoder)
 	if err != nil {
-		// if err.Error() == "ZeroSegments" && n.BackupTranscoder != nil {
-		if true {
+		if err.Error() == "ZeroSegments" && n.BackupTranscoder != nil {
 			glog.Errorf("Attempting backup CPU transcode for manifestID=%s seqNo=%d",
 				string(md.ManifestID), seg.SeqNo)
 			tData, err = runTranscode(n.BackupTranscoder)


### PR DESCRIPTION
This is a rather inelegant workaround for https://github.com/livepeer/lpms/issues/168.

CPU transcoding of single-frame segments appears to work in versions of go-livepeer prior to https://github.com/livepeer/go-livepeer/commit/ed8e8c4e1c2984221c1ba9711771940d1f27b53e. So, this change enables the transcoder server as `node.BackupTranscoder` in `-orchestrator -transcoder` mode. In production, an [old, slightly tweaked version of go-livepeer](https://github.com/livepeer/go-livepeer/tree/eli/working-1frame) attaches to that transcode server. When a segment is ingested, transcoding is first attempted using the local Nvidia transcoder. If that results in a `ZeroSegments` error, it falls back to the remote transcoder.

Let's do something better than this real soon 😃 On the other hand...

![image](https://user-images.githubusercontent.com/257909/76593046-59b1c400-64b2-11ea-88d8-425c81225342.png)

Nice.