### PR TITLE
common, discovery, server: exclude orchestrators that return transcode errors or timeout

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -17,6 +17,7 @@ type OrchestratorPool interface {
 	GetURLs() []*url.URL
 	GetOrchestrators(int) ([]*net.OrchestratorInfo, error)
 	Size() int
+	SuspendOrchestrator(orch string)
 }
 
 type OrchestratorStore interface {

--- a/discovery/suspensions.go
+++ b/discovery/suspensions.go
@@ -1,0 +1,84 @@
+package discovery
+
+import (
+	"container/heap"
+	"sync"
+	"time"
+
+	"github.com/livepeer/go-livepeer/net"
+)
+
+type suspensionList struct {
+	mu   sync.Mutex
+	list map[string]time.Time
+}
+
+func newSuspensionList() *suspensionList {
+	return &suspensionList{
+		list: make(map[string]time.Time),
+	}
+}
+
+func (l *suspensionList) suspend(orch string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.list[orch] = time.Now()
+}
+
+func (l *suspensionList) remove(orch string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.list, orch)
+}
+
+func (l *suspensionList) suspendedAt(orch string) time.Time {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.list[orch]
+}
+
+func (l *suspensionList) isSuspended(orch string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_, ok := l.list[orch]
+	return ok
+}
+
+// An Item is something we manage in a priority queue.
+type suspension struct {
+	orch *net.OrchestratorInfo
+	time time.Time
+}
+
+// A PriorityQueue implements heap.Interface and holds Items.
+type priorityQueue []*suspension
+
+func (pq priorityQueue) Len() int { return len(pq) }
+
+func (pq priorityQueue) Less(i, j int) bool {
+	return pq[i].time.After(pq[j].time)
+}
+
+func (pq priorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+}
+
+func (pq *priorityQueue) Push(x interface{}) {
+	item := x.(*suspension)
+	*pq = append(*pq, item)
+}
+
+func (pq *priorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	*pq = old[0 : n-1]
+	return item
+}
+
+func newPriorityQueue() *priorityQueue {
+	pq := &priorityQueue{}
+	heap.Init(pq)
+	return pq
+}

--- a/discovery/suspensions_test.go
+++ b/discovery/suspensions_test.go
@@ -1,0 +1,62 @@
+package discovery
+
+import (
+	"container/heap"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuspensionList(t *testing.T) {
+	assert := assert.New(t)
+	sl := newSuspensionList()
+
+	sl.suspend("foo")
+	assert.True(sl.isSuspended("foo"))
+	sl.remove("foo")
+	assert.False(sl.isSuspended("foo"))
+
+	now := time.Now()
+	sl.list["foo"] = now
+	at := sl.suspendedAt("foo")
+	assert.Equal(now, at)
+
+	now = time.Now().Add(1 * time.Hour)
+	sl.list["foo"] = now
+	assert.True(sl.isSuspended("foo"))
+}
+
+func TestPriorityQueue(t *testing.T) {
+	assert := assert.New(t)
+	pq := newPriorityQueue()
+	susp0 := &suspension{time: time.Now()}
+	heap.Push(pq, susp0)
+	assert.Equal(pq.Len(), 1)
+	assert.Equal(pq.Pop().(*suspension), susp0)
+	assert.Equal(pq.Len(), 0)
+
+	susp1 := &suspension{time: time.Now().Add(1 * time.Hour)}
+	heap.Push(pq, susp0)
+	assert.Equal(pq.Len(), 1)
+	heap.Push(pq, susp1)
+	assert.Equal(pq.Len(), 2)
+	assert.Equal(pq.Pop().(*suspension), susp0)
+	assert.Equal(pq.Len(), 1)
+	assert.Equal(pq.Pop().(*suspension), susp1)
+	assert.Equal(pq.Len(), 0)
+
+	susp2 := &suspension{time: time.Now().Add(-1 * time.Hour)}
+	heap.Push(pq, susp0)
+	assert.Equal(pq.Len(), 1)
+	heap.Push(pq, susp1)
+	assert.Equal(pq.Len(), 2)
+	heap.Push(pq, susp2)
+	assert.Equal(pq.Len(), 3)
+	assert.Equal(pq.Pop().(*suspension), susp2)
+	assert.Equal(pq.Len(), 2)
+	assert.Equal(pq.Pop().(*suspension), susp0)
+	assert.Equal(pq.Len(), 1)
+	assert.Equal(pq.Pop().(*suspension), susp1)
+	assert.Equal(pq.Len(), 0)
+}

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -91,6 +91,19 @@ func (d *stubDiscovery) GetOrchestrators(num int) ([]*net.OrchestratorInfo, erro
 	return d.infos, err
 }
 
+func (d *stubDiscovery) SuspendOrchestrator(orch string) {
+	for i, info := range d.infos {
+		if info.GetTranscoder() != orch {
+			continue
+		}
+		old := d.infos
+		d.infos = old[:i]
+		if i < len(old)-1 {
+			d.infos = append(d.infos[i+1:])
+		}
+	}
+}
+
 func (d *stubDiscovery) Size() int {
 	return len(d.infos)
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This PR implements an orchestrator suspension list which temporarily suspends orchestrators from being included in a session refresh by _any_ active or newly started broadcast session if they timeout, are not reachable or return a transcode error (`OrchestratorBusy` or  `OrchestratorCapped`). 

**Specific updates (required)**
- Created new `suspensionList` and `priorityQueue` types
- Expanded `OrchestratorPool` API with a `SuspendOrchestrator(orch string)` method 
- Make use of `shouldStopSession(error)` to determine if we should suspend an orchestrator and add it to `suspensionList`
- When calling `OrchestratorPool.GetOrchestrators()` withhold responses from suspended orchestrators and add them to `priorityQueue` if we don't get sufficient responses from non-suspended orchestrators fill up the list with responses from suspended orchestrators until the list is full or we ran out of responses. The priority is decided by the time the orchestrator was suspended at, earlier is higher priority. 

**How did you test each of these updates (required)**
Added / adjusted unit tests

**Does this pull request close any open issues?**
Fixes #1375 

**Checklist:**
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
