### PR TITLE
eth: prefill last seen block state in timewatcher

### DIFF
--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -165,6 +165,7 @@ type StubClient struct {
 	BlockHashToReturn            common.Hash
 	ProcessHistoricalUnbondError error
 	Orchestrators                []*lpTypes.Transcoder
+	Round                        *big.Int
 	RoundsErr                    error
 	SenderInfo                   *pm.SenderInfo
 	PoolSize                     *big.Int
@@ -182,18 +183,20 @@ type stubTranscoder struct {
 
 func (e *StubClient) Setup(password string, gasLimit uint64, gasPrice *big.Int) error { return nil }
 func (e *StubClient) Account() accounts.Account                                       { return accounts.Account{Address: e.TranscoderAddress} }
-func (e *StubClient) Backend() (Backend, error)                                       { return nil, ErrMissingBackend }
+func (e *StubClient) Backend() (Backend, error)                                       { return nil, nil }
 
 // Rounds
 
-func (e *StubClient) InitializeRound() (*types.Transaction, error)       { return nil, nil }
-func (e *StubClient) CurrentRound() (*big.Int, error)                    { return big.NewInt(0), e.RoundsErr }
-func (e *StubClient) LastInitializedRound() (*big.Int, error)            { return big.NewInt(0), e.RoundsErr }
-func (e *StubClient) BlockHashForRound(round *big.Int) ([32]byte, error) { return [32]byte{}, nil }
-func (e *StubClient) CurrentRoundInitialized() (bool, error)             { return false, nil }
-func (e *StubClient) CurrentRoundLocked() (bool, error)                  { return false, nil }
-func (e *StubClient) CurrentRoundStartBlock() (*big.Int, error)          { return nil, nil }
-func (e *StubClient) Paused() (bool, error)                              { return false, nil }
+func (e *StubClient) InitializeRound() (*types.Transaction, error) { return nil, nil }
+func (e *StubClient) CurrentRound() (*big.Int, error)              { return big.NewInt(0), e.RoundsErr }
+func (e *StubClient) LastInitializedRound() (*big.Int, error)      { return e.Round, e.RoundsErr }
+func (e *StubClient) BlockHashForRound(round *big.Int) ([32]byte, error) {
+	return e.BlockHashToReturn, nil
+}
+func (e *StubClient) CurrentRoundInitialized() (bool, error)    { return false, nil }
+func (e *StubClient) CurrentRoundLocked() (bool, error)         { return false, nil }
+func (e *StubClient) CurrentRoundStartBlock() (*big.Int, error) { return nil, nil }
+func (e *StubClient) Paused() (bool, error)                     { return false, nil }
 
 // Token
 

--- a/eth/watchers/stub.go
+++ b/eth/watchers/stub.go
@@ -266,14 +266,20 @@ func (s *stubSubscription) Err() <-chan error {
 }
 
 type stubBlockWatcher struct {
-	sink chan<- []*blockwatch.Event
-	sub  *stubSubscription
+	sink         chan<- []*blockwatch.Event
+	sub          *stubSubscription
+	latestHeader *blockwatch.MiniHeader
+	err          error
 }
 
 func (bw *stubBlockWatcher) Subscribe(sink chan<- []*blockwatch.Event) event.Subscription {
 	bw.sink = sink
 	bw.sub = &stubSubscription{errCh: make(<-chan error)}
 	return bw.sub
+}
+
+func (bw *stubBlockWatcher) GetLatestBlock() (*blockwatch.MiniHeader, error) {
+	return bw.latestHeader, bw.err
 }
 
 type stubUnbondingLock struct {

--- a/eth/watchers/timewatcher.go
+++ b/eth/watchers/timewatcher.go
@@ -122,6 +122,16 @@ func (tw *TimeWatcher) Watch() error {
 		return fmt.Errorf("error fetching initial transcoderPoolSize err=%v", err)
 	}
 
+	lastSeenBlock, err := tw.watcher.GetLatestBlock()
+	if err != nil {
+		return fmt.Errorf("error fetching last seen block err=%v", err)
+	}
+	blockNum := big.NewInt(0)
+	if lastSeenBlock != nil {
+		blockNum = lastSeenBlock.Number
+	}
+	tw.setLastSeenBlock(blockNum)
+
 	events := make(chan []*blockwatch.Event, 10)
 	sub := tw.watcher.Subscribe(events)
 	defer sub.Unsubscribe()

--- a/eth/watchers/types.go
+++ b/eth/watchers/types.go
@@ -8,6 +8,7 @@ import (
 
 type BlockWatcher interface {
 	Subscribe(sink chan<- []*blockwatch.Event) event.Subscription
+	GetLatestBlock() (*blockwatch.MiniHeader, error)
 }
 
 type timeWatcher interface {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Prefetch the state for `lastSeenBlock` in the timewatcher to prevent nil pointer errors when no blocks have elapsed and thus the state isn't populated through backfilling

**Specific updates (required)**
- Added a StubBackend for testing
- Added fetching last seen block number when calling `timeWatcher.Watch()`

**How did you test each of these updates (required)**
Added unit tests

**Does this pull request close any open issues?**
Fixes #1420 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
