### PR TITLE
multi: per-stream O suspension list with refresh prioritisation mechanism

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -19,6 +19,10 @@ type OrchestratorPool interface {
 	Size() int
 }
 
+type Suspender interface {
+	Suspended(orch string) int64
+}
+
 type OrchestratorStore interface {
 	OrchCount(filter *DBOrchFilter) (int, error)
 	SelectOrchs(filter *DBOrchFilter) ([]*DBOrch, error)

--- a/common/types.go
+++ b/common/types.go
@@ -15,12 +15,12 @@ type Broadcaster interface {
 
 type OrchestratorPool interface {
 	GetURLs() []*url.URL
-	GetOrchestrators(int) ([]*net.OrchestratorInfo, error)
+	GetOrchestrators(int, Suspender) ([]*net.OrchestratorInfo, error)
 	Size() int
 }
 
 type Suspender interface {
-	Suspended(orch string) int64
+	Suspended(orch string) int
 }
 
 type OrchestratorStore interface {

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -90,7 +90,7 @@ func (dbo *DBOrchestratorPoolCache) GetURLs() []*url.URL {
 	return uris
 }
 
-func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int) ([]*net.OrchestratorInfo, error) {
+func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int, suspender common.Suspender) ([]*net.OrchestratorInfo, error) {
 	uris, err := dbo.getURLs()
 	if err != nil || len(uris) <= 0 {
 		return nil, err
@@ -121,8 +121,7 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int) ([]*n
 	}
 
 	orchPool := NewOrchestratorPoolWithPred(dbo.bcast, uris, pred)
-
-	orchInfos, err := orchPool.GetOrchestrators(numOrchestrators)
+	orchInfos, err := orchPool.GetOrchestrators(numOrchestrators, suspender)
 	if err != nil || len(orchInfos) <= 0 {
 		return nil, err
 	}

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -72,7 +72,7 @@ func TestDeadLock(t *testing.T) {
 	assert := assert.New(t)
 	wg.Add(len(uris))
 	pool := NewOrchestratorPool(nil, uris)
-	infos, err := pool.GetOrchestrators(1)
+	infos, err := pool.GetOrchestrators(1, newStubSuspender())
 	assert.Nil(err, "Should not be error")
 	assert.Len(infos, 1, "Should return one orchestrator")
 	assert.Equal("transcoderfromtestserver", infos[0].Transcoder)
@@ -119,7 +119,7 @@ func TestDeadLock_NewOrchestratorPoolWithPred(t *testing.T) {
 
 	wg.Add(len(uris))
 	pool := NewOrchestratorPoolWithPred(nil, uris, pred)
-	infos, err := pool.GetOrchestrators(1)
+	infos, err := pool.GetOrchestrators(1, newStubSuspender())
 
 	assert.Nil(err, "Should not be error")
 	assert.Len(infos, 1, "Should return one orchestrator")
@@ -235,7 +235,7 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
 	require.NoError(err)
 	assert.Equal(pool.Size(), 3)
-	orchs, err := pool.GetOrchestrators(pool.Size())
+	orchs, err := pool.GetOrchestrators(pool.Size(), newStubSuspender())
 	for _, o := range orchs {
 		assert.Equal(o.PriceInfo, expPriceInfo)
 		assert.Equal(o.Transcoder, expTranscoder)
@@ -579,7 +579,7 @@ func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) 
 
 	urls := pool.GetURLs()
 	assert.Len(urls, 0)
-	infos, err := pool.GetOrchestrators(len(addresses))
+	infos, err := pool.GetOrchestrators(len(addresses), newStubSuspender())
 
 	assert.Nil(err, "Should not be error")
 	assert.Len(infos, 0)
@@ -670,7 +670,7 @@ func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
 	for _, url := range urls {
 		assert.Contains(addresses, url.String())
 	}
-	infos, err := pool.GetOrchestrators(50)
+	infos, err := pool.GetOrchestrators(50, newStubSuspender())
 	for _, info := range infos {
 		assert.Equal(info.PriceInfo, expPriceInfo)
 		assert.Equal(info.Transcoder, expTranscoder)
@@ -782,7 +782,7 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 		assert.Contains(addresses[25:], url.String())
 	}
 
-	infos, err := pool.GetOrchestrators(len(orchestrators))
+	infos, err := pool.GetOrchestrators(len(orchestrators), newStubSuspender())
 
 	assert.Nil(err, "Should not be error")
 	assert.Len(infos, 25)
@@ -844,7 +844,7 @@ func TestCachedPool_GetOrchestrators_TicketParamsValidation(t *testing.T) {
 	sender.On("ValidateTicketParams", mock.Anything).Return(errors.New("ValidateTicketParams error")).Times(25)
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil).Times(25)
 
-	infos, err := pool.GetOrchestrators(len(addresses))
+	infos, err := pool.GetOrchestrators(len(addresses), newStubSuspender())
 	assert.Nil(err)
 	assert.Len(infos, 25)
 	sender.AssertNumberOfCalls(t, "ValidateTicketParams", 50)
@@ -852,7 +852,7 @@ func TestCachedPool_GetOrchestrators_TicketParamsValidation(t *testing.T) {
 	// Test 0 out of 50 orchs pass ticket params validation
 	sender.On("ValidateTicketParams", mock.Anything).Return(errors.New("ValidateTicketParams error")).Times(50)
 
-	infos, err = pool.GetOrchestrators(len(addresses))
+	infos, err = pool.GetOrchestrators(len(addresses), newStubSuspender())
 	assert.Nil(err)
 	assert.Len(infos, 0)
 	sender.AssertNumberOfCalls(t, "ValidateTicketParams", 100)
@@ -950,7 +950,7 @@ func TestCachedPool_GetOrchestrators_OnlyActiveOrchestrators(t *testing.T) {
 	for _, url := range urls {
 		assert.Contains(addresses[:25], url.String())
 	}
-	infos, err := pool.GetOrchestrators(50)
+	infos, err := pool.GetOrchestrators(50, newStubSuspender())
 	for _, info := range infos {
 		assert.Equal(info.PriceInfo, expPriceInfo)
 		assert.Equal(info.Transcoder, expTranscoder)
@@ -993,7 +993,7 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 	whpool.mu.Lock()
 	lastReq := whpool.lastRequest
 	whpool.mu.Unlock()
-	orchInfo, err := whpool.GetOrchestrators(2)
+	orchInfo, err := whpool.GetOrchestrators(2, newStubSuspender())
 	require.Nil(err)
 	assert.Len(orchInfo, 2)
 	assert.Equal(3, whpool.Size())
@@ -1012,7 +1012,7 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 	whpool.mu.Lock()
 	whpool.lastRequest = lastReq
 	whpool.mu.Unlock()
-	orchInfo, err = whpool.GetOrchestrators(2)
+	orchInfo, err = whpool.GetOrchestrators(2, newStubSuspender())
 	require.Nil(err)
 	assert.Len(orchInfo, 2)
 	assert.Equal(3, whpool.Size())
@@ -1035,7 +1035,7 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 	whpool.mu.Lock()
 	whpool.lastRequest = lastReq
 	whpool.mu.Unlock()
-	orchInfo, err = whpool.GetOrchestrators(2)
+	orchInfo, err = whpool.GetOrchestrators(2, newStubSuspender())
 	require.Nil(err)
 	assert.Len(orchInfo, 2)
 	assert.Equal(3, whpool.Size())
@@ -1055,7 +1055,7 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 	whpool.mu.Lock()
 	whpool.lastRequest = lastReq
 	whpool.mu.Unlock()
-	orchInfo, err = whpool.GetOrchestrators(2)
+	orchInfo, err = whpool.GetOrchestrators(2, newStubSuspender())
 	require.Nil(err)
 	assert.Len(orchInfo, 2)
 	assert.Equal(3, whpool.Size())
@@ -1143,21 +1143,23 @@ func TestOrchestratorPool_GetOrchestrators(t *testing.T) {
 	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, server *url.URL) (*net.OrchestratorInfo, error) {
 		defer wg.Done()
 		err := orchCb()
-		return &net.OrchestratorInfo{}, err
+		return &net.OrchestratorInfo{
+			Transcoder: server.String(),
+		}, err
 	}
 
 	pool := NewOrchestratorPool(nil, addresses)
 
 	// Check that we receive everything
 	wg.Add(len(addresses))
-	res, err := pool.GetOrchestrators(len(addresses))
+	res, err := pool.GetOrchestrators(len(addresses), newStubSuspender())
 	assert.Nil(err)
 	assert.Len(res, len(addresses))
 
 	// Check that partial results are received if requested
 	wg.Add(len(addresses))
 	assert.Greater(len(addresses), 1) // sanity
-	res, err = pool.GetOrchestrators(1)
+	res, err = pool.GetOrchestrators(1, newStubSuspender())
 	assert.Nil(err)
 	assert.Len(res, 1)
 	wg.Wait() // prevents races on remaining responses
@@ -1165,7 +1167,7 @@ func TestOrchestratorPool_GetOrchestrators(t *testing.T) {
 	// Check error handling: all errors
 	wg.Add(len(addresses))
 	orchCb = func() error { return errors.New("Error") }
-	res, err = pool.GetOrchestrators(len(addresses))
+	res, err = pool.GetOrchestrators(len(addresses), newStubSuspender())
 	assert.Nil(err)
 	assert.Len(res, 0)
 
@@ -1183,7 +1185,7 @@ func TestOrchestratorPool_GetOrchestrators(t *testing.T) {
 	}
 	wg.Add(len(addresses))
 	start := time.Now()
-	res, err = pool.GetOrchestrators(len(addresses))
+	res, err = pool.GetOrchestrators(len(addresses), newStubSuspender())
 	end := time.Now()
 	assert.Nil(err)
 	assert.Len(res, len(addresses)-1)
@@ -1193,18 +1195,89 @@ func TestOrchestratorPool_GetOrchestrators(t *testing.T) {
 
 }
 
+func TestOrchestratorPool_GetOrchestrators_SuspendedOrchs(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	addresses := stringsToURIs([]string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"})
+
+	wg := sync.WaitGroup{}
+
+	orchCb := func() error { return nil }
+	oldOrchInfo := serverGetOrchInfo
+	defer func() { wg.Wait(); serverGetOrchInfo = oldOrchInfo }()
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, server *url.URL) (*net.OrchestratorInfo, error) {
+		defer wg.Done()
+		err := orchCb()
+		return &net.OrchestratorInfo{
+			Transcoder: server.String(),
+		}, err
+	}
+
+	pool := NewOrchestratorPool(nil, addresses)
+
+	// suspend https://127.0.0.1:8938
+	sus := newStubSuspender()
+	sus.list["https://127.0.0.1:8938"] = 5
+	require.Greater(sus.Suspended("https://127.0.0.1:8938"), 0)
+
+	// don't include suspended orchestrators if enough orchestrators are available
+	wg.Add(len(addresses))
+	res, err := pool.GetOrchestrators(2, sus)
+	assert.Nil(err)
+	assert.Len(res, 2)
+	assert.NotEqual(res[0].GetTranscoder(), "https://127.0.0.1:8938")
+	assert.NotEqual(res[1].GetTranscoder(), "https://127.0.0.1:8938")
+
+	// include suspended O's if not enough non-suspended O's available
+	wg.Add(len(addresses))
+	require.Greater(sus.Suspended("https://127.0.0.1:8938"), 0)
+	res, err = pool.GetOrchestrators(3, sus)
+	assert.Nil(err)
+	assert.Len(res, 3)
+	// suspended Os are added last
+	assert.Equal(res[2].Transcoder, "https://127.0.0.1:8938")
+
+	// no suspended O's, insufficient non-suspended O's
+	sus = newStubSuspender()
+	wg.Add(len(addresses))
+	res, err = pool.GetOrchestrators(4, sus)
+	assert.Nil(err)
+	assert.Len(res, 3)
+
+	// insufficient non-suspended O's, insufficient suspended O's
+	wg.Add(len(addresses))
+	sus.list["https://127.0.0.1:8938"] = 5
+	require.Greater(sus.Suspended("https://127.0.0.1:8938"), 0)
+	res, err = pool.GetOrchestrators(4, sus)
+	assert.Nil(err)
+	assert.Len(res, 3)
+	// suspended Os are added last
+	assert.Equal(res[2].Transcoder, "https://127.0.0.1:8938")
+
+	// lower penalty is included before a higher penalty
+	wg.Add(len(addresses))
+	sus.list["https://127.0.0.1:8937"] = 2
+	require.Greater(sus.Suspended("https://127.0.0.1:8937"), 0)
+	// https://127.0.0.1:8937 should be a lower index than https://127.0.0.1:8938
+	res, err = pool.GetOrchestrators(4, sus)
+	assert.Nil(err)
+	assert.Len(res, 3)
+	assert.Equal(res[1].Transcoder, "https://127.0.0.1:8937")
+	assert.Equal(res[2].Transcoder, "https://127.0.0.1:8938")
+}
+
 func TestOrchestratorPool_ShuffleGetOrchestrators(t *testing.T) {
 	assert := assert.New(t)
 
 	addresses := stringsToURIs([]string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"})
 
-	ch := make(chan *url.URL)
+	ch := make(chan *url.URL, len(addresses))
 
 	oldOrchInfo := serverGetOrchInfo
 	defer func() { serverGetOrchInfo = oldOrchInfo }()
 	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, server *url.URL) (*net.OrchestratorInfo, error) {
 		ch <- server
-		return nil, nil
+		return &net.OrchestratorInfo{Transcoder: server.String()}, nil
 	}
 
 	pool := NewOrchestratorPool(nil, addresses)
@@ -1215,7 +1288,7 @@ func TestOrchestratorPool_ShuffleGetOrchestrators(t *testing.T) {
 	iters := 0
 	for j := 0; j < 10; j++ {
 		iters++
-		_, err := pool.GetOrchestrators(len(addresses))
+		_, err := pool.GetOrchestrators(len(addresses), newStubSuspender())
 		responses := []*url.URL{}
 		for i := 0; i < len(addresses); i++ {
 			select {
@@ -1284,7 +1357,7 @@ func TestOrchestratorPool_GetOrchestratorTimeout(t *testing.T) {
 	getOrchestrators := func(nb int) ([]*net.OrchestratorInfo, error) {
 		// requests go out to all Os in the pool, regardless of number requested
 		wg.Add(pool.Size())
-		return pool.GetOrchestrators(nb)
+		return pool.GetOrchestrators(nb, newStubSuspender())
 	}
 	drainOrchResponses := func(nb int) {
 		for i := 0; i < nb; i++ {

--- a/discovery/stub.go
+++ b/discovery/stub.go
@@ -74,3 +74,15 @@ type orchTest struct {
 func toOrchTest(addr, serviceURI string, pricePerPixel int64) orchTest {
 	return orchTest{EthereumAddr: addr, ServiceURI: serviceURI, PricePerPixel: pricePerPixel}
 }
+
+type stubSuspender struct {
+	list map[string]int
+}
+
+func newStubSuspender() *stubSuspender {
+	return &stubSuspender{make(map[string]int)}
+}
+
+func (s *stubSuspender) Suspended(orch string) int {
+	return s.list[orch]
+}

--- a/discovery/suspensionqueue.go
+++ b/discovery/suspensionqueue.go
@@ -1,0 +1,46 @@
+package discovery
+
+import (
+	"container/heap"
+
+	"github.com/livepeer/go-livepeer/net"
+)
+
+// A suspensionQueue implements heap.Interface and holds suspensions.
+type suspensionQueue []*suspension
+
+// A suspension is the item we manage in the priority queue.
+type suspension struct {
+	orch    *net.OrchestratorInfo
+	penalty int
+}
+
+func (sq suspensionQueue) Len() int { return len(sq) }
+
+func (sq suspensionQueue) Less(i, j int) bool {
+	return sq[i].penalty < sq[j].penalty
+}
+
+func (sq suspensionQueue) Swap(i, j int) {
+	sq[i], sq[j] = sq[j], sq[i]
+}
+
+func (sq *suspensionQueue) Push(x interface{}) {
+	item := x.(*suspension)
+	*sq = append(*sq, item)
+}
+
+func (sq *suspensionQueue) Pop() interface{} {
+	old := *sq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	*sq = old[0 : n-1]
+	return item
+}
+
+func newSuspensionQueue() *suspensionQueue {
+	sq := &suspensionQueue{}
+	heap.Init(sq)
+	return sq
+}

--- a/discovery/suspensionqueue_test.go
+++ b/discovery/suspensionqueue_test.go
@@ -1,0 +1,43 @@
+package discovery
+
+import (
+	"container/heap"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuspensionQueue(t *testing.T) {
+	assert := assert.New(t)
+	sq := newSuspensionQueue()
+	susp0 := &suspension{penalty: 4}
+	heap.Push(sq, susp0)
+	assert.Equal(sq.Len(), 1)
+	assert.Equal(heap.Pop(sq).(*suspension), susp0)
+	assert.Equal(sq.Len(), 0)
+
+	susp1 := &suspension{penalty: 6}
+	heap.Push(sq, susp0)
+	assert.Equal(sq.Len(), 1)
+	heap.Push(sq, susp1)
+	assert.Equal(sq.Len(), 2)
+	assert.True(sq.Less(0, 1))
+	assert.Equal(heap.Pop(sq).(*suspension), susp0)
+	assert.Equal(sq.Len(), 1)
+	assert.Equal(heap.Pop(sq).(*suspension), susp1)
+	assert.Equal(sq.Len(), 0)
+
+	susp2 := &suspension{penalty: 2}
+	heap.Push(sq, susp0)
+	assert.Equal(sq.Len(), 1)
+	heap.Push(sq, susp1)
+	assert.Equal(sq.Len(), 2)
+	heap.Push(sq, susp2)
+	assert.Equal(sq.Len(), 3)
+	assert.Equal(heap.Pop(sq).(*suspension), susp2)
+	assert.Equal(sq.Len(), 2)
+	assert.Equal(heap.Pop(sq).(*suspension), susp0)
+	assert.Equal(sq.Len(), 1)
+	assert.Equal(heap.Pop(sq).(*suspension), susp1)
+	assert.Equal(sq.Len(), 0)
+}

--- a/discovery/wh_discovery.go
+++ b/discovery/wh_discovery.go
@@ -92,7 +92,7 @@ func (w *webhookPool) Size() int {
 	return len(w.GetURLs())
 }
 
-func (w *webhookPool) GetOrchestrators(numOrchestrators int) ([]*net.OrchestratorInfo, error) {
+func (w *webhookPool) GetOrchestrators(numOrchestrators int, suspender common.Suspender) ([]*net.OrchestratorInfo, error) {
 	_, err := w.getURLs()
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func (w *webhookPool) GetOrchestrators(numOrchestrators int) ([]*net.Orchestrato
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
-	return w.pool.GetOrchestrators(numOrchestrators)
+	return w.pool.GetOrchestrators(numOrchestrators, suspender)
 }
 
 var getURLsfromWebhook = func(cbUrl *url.URL) ([]byte, error) {

--- a/server/suspensions.go
+++ b/server/suspensions.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"sync"
+)
+
+// suspender is a list that keep track of suspender orchestrators
+// and the count until which they are suspended
+type suspender struct {
+	mu    sync.Mutex
+	list  map[string]int64 // list of orchestrator => refresh count at which the orchestrator is no longer suspended
+	count int64
+}
+
+// newSuspender returns the pointer to a new Suspender instance
+func newSuspender() *suspender {
+	return &suspender{
+		list: make(map[string]int64),
+	}
+}
+
+// suspend an orchestrator for 'penalty' refreshes
+func (s *suspender) suspend(orch string, penalty int64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.list[orch] += penalty
+}
+
+// Suspended returns a non-zero value if the orchestrator is suspended
+// 'orch' is the service URI of the orchestrator
+// The value returned is the suspension penalty associated with the orchestrator whereby lower is better
+func (s *suspender) Suspended(orch string) int64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.list[orch] < s.count {
+		delete(s.list, orch)
+	}
+	return s.list[orch]
+}
+
+// signalRefresh increases Suspender.count
+func (s *suspender) signalRefresh() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.count++
+}

--- a/server/suspensions.go
+++ b/server/suspensions.go
@@ -8,19 +8,19 @@ import (
 // and the count until which they are suspended
 type suspender struct {
 	mu    sync.Mutex
-	list  map[string]int64 // list of orchestrator => refresh count at which the orchestrator is no longer suspended
-	count int64
+	list  map[string]int // list of orchestrator => refresh count at which the orchestrator is no longer suspended
+	count int
 }
 
 // newSuspender returns the pointer to a new Suspender instance
 func newSuspender() *suspender {
 	return &suspender{
-		list: make(map[string]int64),
+		list: make(map[string]int),
 	}
 }
 
 // suspend an orchestrator for 'penalty' refreshes
-func (s *suspender) suspend(orch string, penalty int64) {
+func (s *suspender) suspend(orch string, penalty int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.list[orch] += penalty
@@ -29,7 +29,7 @@ func (s *suspender) suspend(orch string, penalty int64) {
 // Suspended returns a non-zero value if the orchestrator is suspended
 // 'orch' is the service URI of the orchestrator
 // The value returned is the suspension penalty associated with the orchestrator whereby lower is better
-func (s *suspender) Suspended(orch string) int64 {
+func (s *suspender) Suspended(orch string) int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.list[orch] < s.count {

--- a/server/suspensions_test.go
+++ b/server/suspensions_test.go
@@ -11,14 +11,14 @@ func TestSuspender(t *testing.T) {
 	s := newSuspender()
 
 	s.suspend("foo", 5)
-	assert.Equal(s.Suspended("foo"), int64(5))
+	assert.Equal(s.Suspended("foo"), 5)
 	s.suspend("foo", 5)
-	assert.Equal(s.Suspended("foo"), int64(10))
+	assert.Equal(s.Suspended("foo"), 10)
 	s.count = 11
-	assert.Equal(s.Suspended("foo"), int64(0))
+	assert.Equal(s.Suspended("foo"), 0)
 	_, ok := s.list["foo"]
 	assert.False(ok)
 
 	s.signalRefresh()
-	assert.Equal(s.count, int64(12))
+	assert.Equal(s.count, 12)
 }

--- a/server/suspensions_test.go
+++ b/server/suspensions_test.go
@@ -1,0 +1,24 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuspender(t *testing.T) {
+	assert := assert.New(t)
+	s := newSuspender()
+
+	s.suspend("foo", 5)
+	assert.Equal(s.Suspended("foo"), int64(5))
+	s.suspend("foo", 5)
+	assert.Equal(s.Suspended("foo"), int64(10))
+	s.count = 11
+	assert.Equal(s.Suspended("foo"), int64(0))
+	_, ok := s.list["foo"]
+	assert.False(ok)
+
+	s.signalRefresh()
+	assert.Equal(s.count, int64(12))
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This PR adds a per -stream orchestrator suspension list. Orchestrators will be suspended for Transcoding related errors and timeouts and no longer be included in a session refresh unless there aren't enough orchestrators available otherwise. 

The suspension time is dynamic based on the `OrchestratorPool` size : `OrchestratorPool.Size() / numOrchs`

Suspended orchestrators can still get selected upon a refresh though in case there are not enough non-suspended orchestrators available to fill the working set up to the required size. This happens based on a priority queue implemented as a min-heap, where the value to sort on is the suspension penalty associated with the orchestrator.

The penalty is the refresh count at which the orchestrator is no longer suspended (zero for non-suspended orchestrators). 

* the suspension list is for all streams and is stored in memory 

**Specific updates (required)**

- Introduced a `suspender` type in `server`
- Introduced `priorityQueue` in `discovery`
- Introduced a `Suspender`  interface in `common`

- Changed the `OrchestratorPool.GetOrchestrators(numOrchs int)` API signature to also take a  type implementing the`Suspender` interface as a second argument 
- Added a `Suspender.Suspended() == 0` check in the `GetOrchestratorInfo` loop to determine if an orchestrator is suspended, suspended orchestrators get added to the `priorityQueue`
- If the length of retrieved O's is smaller than `numOrchs` requested, Pop from the `priorityQueue` until full

- Call `newSuspender` in `NewSessionManager()` constructor to initialise each new `BroadcastSessionsManager`  with a `suspender`
- Added a `BroadcastSessionsManager.suspendOrchestator()` method, this will call `suspender.Suspend()` if `shouldStopSession()` evaluates to true
- Removed the `selectOrchestrators` method and the `BroadcastSessionsManager.createSessions` struct field. Instead turned this into a `BroadcastSessionsManager.createSessions()` method
- Stored the values we pass into `selectOrchestrators` as state on the `BroadcastSessionsManager` instead, this should not change much as the memory reserved for the arguments also exists until BroadcastSessionsManager is GC'd (when the stream ends). 


**How did you test each of these updates (required)**
Added & ran unit tests

**Does this pull request close any open issues?**
Fixes #1375

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
