### PR TITLE
[READY] DroneCI GPU integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,18 @@ jobs:
           # Our Docker tag name should be our branch name with just alphanums
           BRANCH_TAG=$(echo $CIRCLE_BRANCH | sed 's/\//-/g' | tr -cd '[:alnum:]_-')
           VERSION_TAG=$(./print_version.sh)
+          SHA_TAG=$(git describe --always --long --abbrev=8)
           docker build -t current-build -f docker/Dockerfile.release-linux .
-          for TAG in $BRANCH_TAG $VERSION_TAG; do
+          for TAG in $BRANCH_TAG $VERSION_TAG $SHA_TAG; do
             docker tag current-build livepeer/go-livepeer:${TAG}-linux
             docker push livepeer/go-livepeer:${TAG}-linux
             # Manifest step is optional in case the Windows build hasn't finished yet
             docker manifest create livepeer/go-livepeer:${TAG} livepeer/go-livepeer:${TAG}-linux livepeer/go-livepeer:${TAG}-windows || true
             docker manifest push livepeer/go-livepeer:${TAG} || true
           done
+      - run:
+          name: Notify DroneCI
+          command: curl -X POST https://drone.livepeer-ac.live/hook
 
   build:
     docker:
@@ -99,7 +103,6 @@ jobs:
       - run:
           name: Notify that new build has been uploaded
           command: curl -X POST https://holy-bread-207a.livepeer.workers.dev
-
       - save_cache:
           key: v3-pkg-cache
           paths:

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,22 +6,34 @@ platform:
   arch: amd64
   os: linux
 
-services:
+steps:
+- name: wait-for-images
+  image: ya7ya/wait-for-docker:latest
+  commands:
+  - -h livepeer/go-livepeer -p $DRONE_TARGET_BRANCH -t 5 -r 5
 - name: broadcaster
   group: test
   detach: true
   image: livepeer/go-livepeer:master
+  depends_on:
+  - wait-for-images
   commands:
   - /usr/bin/livepeer -broadcaster -network offchain -maxSessions=200 -rtmpAddr=localhost:1935 -cliAddr=localhost:7935 -httpAddr=localhost:8935 -orchAddr=localhost:8936 -monitor=true -transcodingOptions=P240p30fps16x9,P360p30fps16x9,P576p30fps16x9,P720p30fps16x9 -v=9
 - name: orchestrator
   group: test
   detach: true
   image: livepeer/go-livepeer:master
+  depends_on:
+  - wait-for-images
   environment:
-    nvidia : 0,1,2,3,4,5,6,7
+    NVIDIA_DRIVER_CAPABILITIES: compute,video,utility
+    NVIDIA : 0,1,2,3,4,5,6,7
+    DRONE_RESOURCE_LIMIT_GPU: "8"
   commands: 
-  - /usr/bin/livepeer -v=9 -orchestrator -network offchain -transcoder -monitor=true -cliAddr=localhost:7936 -httpAddr=localhost:8936 -serviceAddr=localhost:8936 -maxSessions=80
-steps:
+  - /usr/bin/livepeer -v=9 -orchestrator -network offchain -transcoder -monitor=true -cliAddr=localhost:7936 -httpAddr=localhost:8936 -serviceAddr=localhost:8936 -maxSessions=80 -nvidia=0,1,2,3,4,5,6
+  resources:
+    limits:
+      nvidia.com/gpu: 8
 - name: build
   image: golang:1.13
   environment:
@@ -36,7 +48,11 @@ steps:
 - name: stream-tester
   group: test
   image: livepeer/streamtester:latest
+  depends_on:
+  - wait-for-images
+  - orchestrator
+  - broadcaster
   environment:
     GODEBUG: http2client=0
   commands:
-    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -profiles '1' -v '15' -file=/drone/src/official_test_source_2s_keys_24pfs_3min.mp4
+    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -profiles '4' -v '15' -file=/drone/src/official_test_source_2s_keys_24pfs_3min.mp4

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,11 +10,17 @@ steps:
 - name: wait-for-images
   image: ya7ya/wait-for-docker:latest
   commands:
-  - /wait-for-it.sh -h livepeer/go-livepeer -p $(DRONE_TARGET_BRANCH) -t 5 -r 5
+  - /wait-for-it.sh -h livepeer/go-livepeer -p ${DRONE_COMMIT_SHA:0:8} -t 60 -r 10
 - name: broadcaster
   group: test
   detach: true
-  image: livepeer/go-livepeer:master
+  image: livepeer/go-livepeer:${DRONE_COMMIT_SHA:0:8}
+  settings:
+    digest: ${DRONE_COMMIT_SHA:0:8}
+  when:
+    branch:
+      exclude:
+      - master
   depends_on:
   - wait-for-images
   commands:
@@ -22,18 +28,53 @@ steps:
 - name: orchestrator
   group: test
   detach: true
-  image: livepeer/go-livepeer:master
+  image: livepeer/go-livepeer:${DRONE_COMMIT_SHA:0:8}
+  settings:
+    digest: ${DRONE_COMMIT_SHA:0:8}
+  when:
+    branch:
+      exclude:
+      - master
   depends_on:
   - wait-for-images
   environment:
     NVIDIA_DRIVER_CAPABILITIES: compute,video,utility
     NVIDIA : 0,1,2,3,4,5,6,7
-    DRONE_RESOURCE_LIMIT_GPU: "8"
+    DRONE_RESOURCE_LIMIT_GPU: "4"
   commands: 
-  - /usr/bin/livepeer -v=9 -orchestrator -network offchain -transcoder -monitor=true -cliAddr=localhost:7936 -httpAddr=localhost:8936 -serviceAddr=localhost:8936 -maxSessions=80 -nvidia=0,1,2,3,4,5,6
+  - /usr/bin/livepeer -v=9 -orchestrator -network offchain -transcoder -monitor=true -cliAddr=localhost:7936 -httpAddr=localhost:8936 -serviceAddr=localhost:8936 -maxSessions=80 -nvidia=0,1,2,3
   resources:
     limits:
-      nvidia.com/gpu: 8
+      nvidia.com/gpu: 4
+- name: broadcaster-master
+  group: test
+  detach: true
+  image: livepeer/go-livepeer:master
+  when:
+    branch:
+      - master
+  depends_on:
+  - wait-for-images
+  commands:
+  - /usr/bin/livepeer -broadcaster -network offchain -maxSessions=200 -rtmpAddr=localhost:1935 -cliAddr=localhost:7935 -httpAddr=localhost:8935 -orchAddr=localhost:8936 -monitor=true -transcodingOptions=P240p30fps16x9,P360p30fps16x9,P576p30fps16x9,P720p30fps16x9 -v=9
+- name: orchestrator-master
+  group: test
+  detach: true
+  image: livepeer/go-livepeer:master
+  when:
+    branch:
+      - master
+  depends_on:
+  - wait-for-images
+  environment:
+    NVIDIA_DRIVER_CAPABILITIES: compute,video,utility
+    NVIDIA : 0,1,2,3,4,5,6,7
+    DRONE_RESOURCE_LIMIT_GPU: "4"
+  commands: 
+  - /usr/bin/livepeer -v=9 -orchestrator -network offchain -transcoder -monitor=true -cliAddr=localhost:7936 -httpAddr=localhost:8936 -serviceAddr=localhost:8936 -maxSessions=80 -nvidia=0,1,2,3
+  resources:
+    limits:
+      nvidia.com/gpu: 4
 - name: build
   image: golang:1.13
   environment:
@@ -41,13 +82,13 @@ steps:
       GOPATH: /go
       DOCKER_CLI_EXPERIMENTAL: enabled
   commands:
-  - echo 'hi'
   - pwd
+  - echo $DRONE_TARGET_BRANCH $DRONE_COMMIT_SHA
   - cd /drone/src
   - wget https://storage.googleapis.com/lp_testharness_assets/official_test_source_2s_keys_24pfs_3min.mp4
 - name: stream-tester
   group: test
-  image: livepeer/streamtester:latest
+  image: ya7ya/stream-tester:latest
   depends_on:
   - wait-for-images
   - orchestrator
@@ -55,4 +96,23 @@ steps:
   environment:
     GODEBUG: http2client=0
   commands:
-    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -profiles '4' -v '15' -file=/drone/src/official_test_source_2s_keys_24pfs_3min.mp4
+    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -profiles '4' -v '1' -file=/drone/src/official_test_source_2s_keys_24pfs_3min.mp4 -stats-file /drone/src/stream_tester_result.json
+- name: result
+  image: golang:1.13
+  depends_on:
+  - stream-tester
+  commands:
+  - cat /drone/src/stream_tester_result.json
+- name: discord-notification
+  image: appleboy/drone-discord
+  settings:
+    webhook_id:
+      from_secret: discord_webhook_id
+    webhook_token:
+      from_secret: discord_webhook_token
+    message: >
+      {{#success build.status}}
+        build {{build.number}} : ${DRONE_COMMIT_SHA:0:8} succeeded. {{build.link}}
+      {{else}}
+        build {{build.number}} failed. {{build.link}}
+      {{/success}}

--- a/.drone.yml
+++ b/.drone.yml
@@ -108,5 +108,5 @@ steps:
   depends_on:
   - stream-tester
   commands:
-  - cat /drone/src/stream_tester_result.json | jq .success_rate2
+  - cat /drone/src/stream_tester_result.json
   

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
 - name: wait-for-images
   image: ya7ya/wait-for-docker:latest
   commands:
-  - -h livepeer/go-livepeer -p $DRONE_TARGET_BRANCH -t 5 -r 5
+  - /wait-for-it.sh -h livepeer/go-livepeer -p $(DRONE_TARGET_BRANCH) -t 5 -r 5
 - name: broadcaster
   group: test
   detach: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -95,24 +95,18 @@ steps:
   - broadcaster
   environment:
     GODEBUG: http2client=0
+    DISCORD_WEBHOOK_URL:
+      from_secret: discord_webhook_url
+    DISCORD_WEBHOOK_USER:
+      from_secret: discord_webhook_user
   commands:
-    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -profiles '4' -v '1' -file=/drone/src/official_test_source_2s_keys_24pfs_3min.mp4 -stats-file /drone/src/stream_tester_result.json
+    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -profiles '4' -v '1' -file=/drone/src/official_test_source_2s_keys_24pfs_3min.mp4 -stats-file /drone/src/stream_tester_result.json -discord-url $DISCORD_WEBHOOK_URL -discord-user-name $DISCORD_WEBHOOK_USER
 - name: result
-  image: golang:1.13
+  image: stedolan/jq
+  entrypoint:
+    - null
   depends_on:
   - stream-tester
   commands:
-  - cat /drone/src/stream_tester_result.json
-- name: discord-notification
-  image: appleboy/drone-discord
-  settings:
-    webhook_id:
-      from_secret: discord_webhook_id
-    webhook_token:
-      from_secret: discord_webhook_token
-    message: >
-      {{#success build.status}}
-        build {{build.number}} : ${DRONE_COMMIT_SHA:0:8} succeeded. {{build.link}}
-      {{else}}
-        build {{build.number}} failed. {{build.link}}
-      {{/success}}
+  - cat /drone/src/stream_tester_result.json | jq .success_rate2
+  

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,10 +31,12 @@ steps:
   commands:
   - echo 'hi'
   - pwd
+  - cd /drone/src
+  - wget https://storage.googleapis.com/lp_testharness_assets/bbb_sunflower_1080p_30fps_normal_t02.mp4
 - name: stream-tester
   group: test
   image: livepeer/streamtester:latest
   environment:
     GODEBUG: http2client=0
   commands:
-    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -picarto -profiles '1' -gaming -picarto-streams '10' -v '15'
+    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -profiles '1' -gaming -v '15' -file=/drone/src/bbb_sunflower_1080p_30fps_normal_t02.mp4

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,11 +32,11 @@ steps:
   - echo 'hi'
   - pwd
   - cd /drone/src
-  - wget https://storage.googleapis.com/lp_testharness_assets/bbb_sunflower_1080p_30fps_normal_t02.mp4
+  - wget https://storage.googleapis.com/lp_testharness_assets/official_test_source_2s_keys_24pfs_3min.mp4
 - name: stream-tester
   group: test
   image: livepeer/streamtester:latest
   environment:
     GODEBUG: http2client=0
   commands:
-    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -profiles '1' -gaming -v '15' -file=/drone/src/bbb_sunflower_1080p_30fps_normal_t02.mp4
+    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -profiles '1' -v '15' -file=/drone/src/official_test_source_2s_keys_24pfs_3min.mp4

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,40 @@
+kind: pipeline
+type: kubernetes
+name: linux
+
+platform:
+  arch: amd64
+  os: linux
+
+services:
+- name: broadcaster
+  group: test
+  detach: true
+  image: livepeer/go-livepeer:master
+  commands:
+  - /usr/bin/livepeer -broadcaster -network offchain -maxSessions=200 -rtmpAddr=localhost:1935 -cliAddr=localhost:7935 -httpAddr=localhost:8935 -orchAddr=localhost:8936 -monitor=true -transcodingOptions=P240p30fps16x9,P360p30fps16x9,P576p30fps16x9,P720p30fps16x9 -v=9
+- name: orchestrator
+  group: test
+  detach: true
+  image: livepeer/go-livepeer:master
+  environment:
+    nvidia : 0,1,2,3,4,5,6,7
+  commands: 
+  - /usr/bin/livepeer -v=9 -orchestrator -network offchain -transcoder -monitor=true -cliAddr=localhost:7936 -httpAddr=localhost:8936 -serviceAddr=localhost:8936 -maxSessions=80
+steps:
+- name: build
+  image: golang:1.13
+  environment:
+      PKG_CONFIG_PATH: /root/compiled/lib/pkgconfig
+      GOPATH: /go
+      DOCKER_CLI_EXPERIMENTAL: enabled
+  commands:
+  - echo 'hi'
+  - pwd
+- name: stream-tester
+  group: test
+  image: livepeer/streamtester:latest
+  environment:
+    GODEBUG: http2client=0
+  commands:
+    - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -picarto -profiles '1' -gaming -picarto-streams '10' -v '15'

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
 - name: wait-for-images
   image: ya7ya/wait-for-docker:latest
   commands:
-  - /wait-for-it.sh -h livepeer/go-livepeer -p ${DRONE_COMMIT_SHA:0:8} -t 60 -r 10
+  - /wait-for-it.sh -h livepeer/go-livepeer -p ${DRONE_COMMIT_SHA:0:8} -t 60 -r 30
 - name: broadcaster
   group: test
   detach: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -102,9 +102,7 @@ steps:
   commands:
     - /root/streamtester -no-bar -latency  -host 'localhost' -rtmp 1935 -media 8935 -profiles '4' -v '1' -file=/drone/src/official_test_source_2s_keys_24pfs_3min.mp4 -stats-file /drone/src/stream_tester_result.json -discord-url $DISCORD_WEBHOOK_URL -discord-user-name $DISCORD_WEBHOOK_USER
 - name: result
-  image: stedolan/jq
-  entrypoint:
-    - null
+  image: golang:1.13
   depends_on:
   - stream-tester
   commands:


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This adds DroneCI configuration to `go-livepeer`, which is like circleCI but self hosted and we have a modified version that allows us to run the tests on GPU enabled pods.

**How does it work?**
Once a PR is opened or new commits are pushed, DroneCI will run 2 `go-livepeer` deployments, one running the PR build , and one running Master build. Then using `stream-tester` it'll stream a sample file to each deployment and get back the results.

The results can then be compared to check whether the new PR build has a better success rate than the current `master` build. The goal is to always make sure we're improving the success rate and not adding new issues.

**improvements**

It'd be cool to compile a sample file that contains all the edge case segments that we come across to make sure the transcoder can still handle them with the new PR modifications.

**Current issues with this PR**

- The tests will fail only if one of the processes returns an error code, this isn't triggered when the transcoder gets a bad segment and keeps on going. but it'll be reflected in the success rate 

- the current test deployment uses 1 broadcaster 1 orchestrator configuration. but this can be changed to a 3 orchestrator setup if needed.

Let me know what you think, Feedback is welcome :wave: 