### PR TITLE
pm: fix expected ticket expiration params backwards compatability

### DIFF
--- a/pm/sender.go
+++ b/pm/sender.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 )
 
@@ -113,7 +114,7 @@ func (s *sender) CreateTicketBatch(sessionID string, size int) (*TicketBatch, er
 	// Ensure backwards compatbility
 	// If no expirationParams are included by O
 	// B sets the values based upon its last seen round
-	if expirationParams == nil {
+	if expirationParams == nil || expirationParams.CreationRound == 0 || expirationParams.CreationRoundBlockHash == (ethcommon.Hash{}) {
 		expirationParams = s.expirationParams()
 	}
 

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -286,9 +286,8 @@ func TestCreateTicketBatch_UsesSessionParamsInBatch(t *testing.T) {
 	assert.Equal(ticketParams.ExpirationBlock, batch.ExpirationBlock)
 	assert.Equal(ticketParams.PricePerPixel, batch.PricePerPixel)
 	assert.Equal(expectedExpParams, batch.ExpirationParams)
-	// No ExpirationParams, get data from TimeManager
 
-	// ExpirationParams sent by orchestrator
+	// No ExpirationParams, get data from TimeManager
 	ticketParams = TicketParams{
 		Recipient:         recipient,
 		FaceValue:         big.NewInt(1111),
@@ -297,6 +296,28 @@ func TestCreateTicketBatch_UsesSessionParamsInBatch(t *testing.T) {
 		RecipientRandHash: recipientRandHash,
 		ExpirationBlock:   big.NewInt(1),
 		PricePerPixel:     big.NewRat(1, 1),
+		ExpirationParams:  &TicketExpirationParams{},
+	}
+	sessionID = sender.StartSession(ticketParams)
+
+	batch, err = sender.CreateTicketBatch(sessionID, 1)
+	require.Nil(t, err)
+	assert.Equal(creationRound, batch.CreationRound)
+	assert.Equal(creationRoundBlkHash[:], batch.CreationRoundBlockHash.Bytes())
+	assert.Equal(&TicketExpirationParams{
+		CreationRound:          creationRound,
+		CreationRoundBlockHash: creationRoundBlkHash,
+	}, batch.TicketExpirationParams)
+
+	ticketParams = TicketParams{
+		Recipient:         recipient,
+		FaceValue:         big.NewInt(1111),
+		WinProb:           big.NewInt(2222),
+		Seed:              big.NewInt(3333),
+		RecipientRandHash: recipientRandHash,
+		ExpirationBlock:   big.NewInt(1),
+		PricePerPixel:     big.NewRat(1, 1),
+		ExpirationParams:  nil,
 	}
 	sessionID = sender.StartSession(ticketParams)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes the backwards compatibility requirement for #1428. 

Originally there is a check that retrieves the necessary `ExpirationParams` from the `Timewatcher` if the Orchestrator does not provide these in `TicketParams`
```
	expirationParams := ticketParams.ExpirationParams
	// Ensure backwards compatbility
	// If no expirationParams are included by O
	// B sets the values based upon its last seen round
	if expirationParams == nil {
		expirationParams = s.expirationParams()
	}
```

We however us a helper `pmTicketParams` on the broadcaster to convert the received `net.TicketParams` to `pm.TicketParams`

This helper initialises `ticketParams.ExpirationParams` 

```		
ExpirationParams: &pm.TicketExpirationParams{
			CreationRound:          params.ExpirationParams.GetCreationRound(),
			CreationRoundBlockHash: ethcommon.BytesToHash(params.ExpirationParams.GetCreationRoundBlockHash()),
		},
```

So we actually have to check for zero values on `expirationParams` fields and not the encapsulating struct itself 



**How did you test each of these updates (required)**
Adjusted & ran unit tests
Ran Labrador on rinkeby

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
