### PR TITLE
discovery: fix WHPool test race condition

### DIFF
--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1007,7 +1007,9 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 	//  assert that list is not refreshed if lastRequest is more than 1 min ago and hash is the same
 	wg.Add(whpool.Size())
 	lastReq = time.Now().Add(-2 * time.Minute)
+	whpool.mu.Lock()
 	whpool.lastRequest = lastReq
+	whpool.mu.Unlock()
 	orchInfo, err = whpool.GetOrchestrators(2)
 	require.Nil(err)
 	assert.Len(orchInfo, 2)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes a race condition in TestNewWHOrchestratorPoolCache

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
