### PR TITLE
server, net: Handle back compat for MP4.

### DIFF
--- a/net/lp_rpc.proto
+++ b/net/lp_rpc.proto
@@ -124,8 +124,12 @@ message SegData {
   // XXX should we include this in a sig somewhere until certs are authenticated?
   repeated OSInfo storage = 32;
 
-  // Transcoding profiles to use. Supersedes `profiles` field 
+  // Transcoding profiles to use. Supersedes `profiles` field
+  // Deprecated by `fullProfiles2` but may still be used for mpegts formats
   repeated VideoProfile fullProfiles = 33;
+
+  // Transcoding profiles to use. Supersedes `fullProfiles` field
+  repeated VideoProfile fullProfiles2 = 34;
 }
 
 message VideoProfile {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -215,6 +215,7 @@ func TestRPCSeg(t *testing.T) {
 	s := &BroadcastSession{
 		Broadcaster: b,
 		ManifestID:  mid,
+		Profiles:    []ffmpeg.VideoProfile{ffmpeg.P720p30fps16x9},
 	}
 
 	baddr := ethcrypto.PubkeyToAddress(b.priv.PublicKey)

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -513,6 +513,8 @@ func genSegCreds(sess *BroadcastSession, seg *stream.HLSSegment) (string, error)
 		FullProfiles: fullProfiles,
 		Sig:          sig,
 		Storage:      storage,
+		// Triggers failure on Os that don't know how to use FullProfiles/2
+		Profiles: []byte("invalid"),
 	}
 	data, err := proto.Marshal(segData)
 	if err != nil {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is another approach to compatibility rather than a hard break via versioning as described in https://github.com/livepeer/go-livepeer/pull/1433 .

* Makes MP4 requests fail out on orchestrators that don't support MP4 (or more generally, the `FullProfile` field for non-preset renditions introduced in https://github.com/livepeer/go-livepeer/pull/1242 )

* Maintains compatibility with orchestrators that can only process mpegts

**Specific updates (required)**

- https://github.com/livepeer/go-livepeer/pull/1439/commits/5deedb6ae742af5a939214927ddfa65633550e1f Adds a new `FullProfiles2` field to net.SegData
- https://github.com/livepeer/go-livepeer/pull/1439/commits/103c540ae9761e2f15f998e72e8a656e7e7b5334 Use the old `FullProfiles` field if the output format is only mpegts . This maintains compatibility with older orchestrators that only know mpegts.
- https://github.com/livepeer/go-livepeer/pull/1439/commits/2212e9cd00639d0bdfa93d861993a38de0d20d86 Fails out with orchestrators that do not support the above two fields
- Adds unit tests
- https://github.com/livepeer/go-livepeer/pull/1439/commits/9dfcabfb3cc4676410be52a329fc675e759e8ea6 Update to generated protocol buffers, to be fixed up with https://github.com/livepeer/go-livepeer/pull/1429/commits/bf412084c7d5ec464915ad84bdd2149ea47f7e80

**How did you test each of these updates (required)**

* Added unit tests
* Manual testing with:
  * old B -> new O (mpegts only)
  * new B -> old O (one test for mpegts, another for mp4)
  * new B -> new O (one test for mpegts, another for mp4)

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
