### PR TITLE
discovery: fix all WH Pool test race conditions that sometimes causes CI to fail

### DIFF
--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -990,7 +990,9 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 
 	// assert that list is not refreshed if lastRequest is less than 1 min ago and hash is the same
 	wg.Add(whpool.Size())
+	whpool.mu.Lock()
 	lastReq := whpool.lastRequest
+	whpool.mu.Unlock()
 	orchInfo, err := whpool.GetOrchestrators(2)
 	require.Nil(err)
 	assert.Len(orchInfo, 2)
@@ -1030,14 +1032,16 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 	//  assert that list is not refreshed if lastRequest is less than 1 min ago and hash is not the same
 	wg.Add(whpool.Size())
 	lastReq = time.Now()
+	whpool.mu.Lock()
 	whpool.lastRequest = lastReq
+	whpool.mu.Unlock()
 	orchInfo, err = whpool.GetOrchestrators(2)
 	require.Nil(err)
 	assert.Len(orchInfo, 2)
 	assert.Equal(3, whpool.Size())
 	assert.Equal(lastReq, whpool.lastRequest)
 
-	urls = whpool.pool.GetURLs()
+	urls = whpool.GetURLs()
 	assert.Len(urls, 3)
 
 	for _, addr := range addresses {
@@ -1048,7 +1052,9 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 	//  assert that list is refreshed if lastRequest is longer than 1 min ago and hash is not the same
 	wg.Add(whpool.Size())
 	lastReq = time.Now().Add(-2 * time.Minute)
+	whpool.mu.Lock()
 	whpool.lastRequest = lastReq
+	whpool.mu.Unlock()
 	orchInfo, err = whpool.GetOrchestrators(2)
 	require.Nil(err)
 	assert.Len(orchInfo, 2)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes all race conditions in the Webhool Orchestrator pool tests that sometimes cause CI to fail

similar to #1438 

**How did you test each of these updates (required)**
` go test ./discovery -race -count 20 -run TestNewWHOrchestratorPoolCache`

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
