### PR TITLE
Enable/disable HTTP ingest

### DIFF
--- a/cmd/livepeer/livepeer_test.go
+++ b/cmd/livepeer/livepeer_test.go
@@ -56,3 +56,32 @@ func TestSetupOrchestrator(t *testing.T) {
 	err = setupOrchestrator(context.Background(), n, false)
 	assert.EqualError(err, "GetTranscoder error")
 }
+
+func TestIsLocalURL(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test url.ParseRequestURI error
+	_, err := isLocalURL("127.0.0.1:8935")
+	assert.NotNil(err)
+
+	// Test loopback URLs
+	isLocal, err := isLocalURL("https://127.0.0.1:8935")
+	assert.Nil(err)
+	assert.True(isLocal)
+	isLocal, err = isLocalURL("https://127.0.0.2:8935")
+	assert.Nil(err)
+	assert.True(isLocal)
+
+	// Test localhost URL
+	isLocal, err = isLocalURL("https://localhost:8935")
+	assert.Nil(err)
+	assert.True(isLocal)
+
+	// Test non-local URL
+	isLocal, err = isLocalURL("https://0.0.0.0:8935")
+	assert.Nil(err)
+	assert.False(isLocal)
+	isLocal, err = isLocalURL("https://7.7.7.7:8935")
+	assert.Nil(err)
+	assert.False(isLocal)
+}

--- a/doc/ingest.md
+++ b/doc/ingest.md
@@ -92,6 +92,8 @@ into the Livepeer network. Upon ingest, HTTP stream is pushed to the segmenter
 prior to transcoding. The stream can be pushed via a PUT or POST HTTP request to the
 `/live/` endpoint. HTTP request timeout is 8 seconds.
 
+HTTP ingest is enabled by default. However, if the HTTP server is publicly accessible (i.e. listening on a non-local host) and an authentication webhook URL is not specified then HTTP ingest will be disabled. In this case, to enable HTTP ingest, set an authentication webhook URL using `-authWebhookUrl` and/or use the `-httpIngest` flag when starting the node. To always disable HTTP ingest start the node with `-httpIngest=false`.
+
 The body of the request should be the binary data of the video segment.
 
 Two HTTP headers should be provided:

--- a/server/cliserver_test.go
+++ b/server/cliserver_test.go
@@ -29,7 +29,7 @@ func newMockServer() *httptest.Server {
 	go func() { n.TranscoderManager.Manage(strm, 5) }()
 	time.Sleep(1 * time.Millisecond)
 	n.Transcoder = n.TranscoderManager
-	s := NewLivepeerServer("127.0.0.1:1938", n)
+	s := NewLivepeerServer("127.0.0.1:1938", n, true)
 	mux := s.cliWebServerHandlers("addr")
 	srv := httptest.NewServer(mux)
 	return srv
@@ -140,7 +140,7 @@ func TestRegisteredOrchestrators(t *testing.T) {
 
 	n, _ := core.NewLivepeerNode(eth, "./tmp", dbh)
 
-	s := NewLivepeerServer("127.0.0.1:1938", n)
+	s := NewLivepeerServer("127.0.0.1:1938", n, true)
 	mux := s.cliWebServerHandlers("addr")
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -114,7 +114,7 @@ type authWebhookResponse struct {
 	} `json:"profiles"`
 }
 
-func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode) *LivepeerServer {
+func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bool) *LivepeerServer {
 	opts := lpmscore.LPMSOpts{
 		RtmpAddr:     rtmpAddr,
 		RtmpDisabled: true,
@@ -129,7 +129,7 @@ func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode) *LivepeerServ
 	ls := &LivepeerServer{RTMPSegmenter: server, LPMS: server, LivepeerNode: lpNode, HTTPMux: opts.HttpMux, connectionLock: &sync.RWMutex{},
 		rtmpConnections: make(map[core.ManifestID]*rtmpConnection),
 	}
-	if lpNode.NodeType == core.BroadcasterNode {
+	if lpNode.NodeType == core.BroadcasterNode && httpIngest {
 		opts.HttpMux.HandleFunc("/live/", ls.HandlePush)
 	}
 	return ls

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -42,7 +42,7 @@ func setupServerWithCancel() (*LivepeerServer, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 	if S == nil {
 		n, _ := core.NewLivepeerNode(nil, "./tmp", nil)
-		S = NewLivepeerServer("127.0.0.1:1938", n)
+		S = NewLivepeerServer("127.0.0.1:1938", n, true)
 		go S.StartMediaServer(ctx, "", "127.0.0.1:8080")
 		go S.StartCliWebserver("127.0.0.1:8938")
 	}

--- a/test_args.sh
+++ b/test_args.sh
@@ -192,4 +192,39 @@ kill $pid
 run_lp -broadcaster -verifierUrl http://host -s3bucket foo/bar -s3creds baz/bat
 kill $pid
 
+# Check that HTTP ingest is disabled when -httpAddr is publicly accessible and there is no auth webhook URL and -httpIngest defaults to false
+run_lp -broadcaster -httpAddr 0.0.0.0
+curl -X PUT http://localhost:8935/live/movie/0.ts | grep "404 page not found"
+kill $pid
+
+# Check that HTTP ingest is disabled when -httpAddr is not publicly accessible and -httpIngest is set to false
+run_lp -broadcaster -httpIngest=false
+curl -X PUT http://localhost:8935/live/movie/0.ts | grep "404 page not found"
+kill $pid
+
+# Check that HTTP ingest is disabled when -httpAddr is publicly accessible and there is a auth webhook URL and -httpIngest is set to false
+run_lp -broadcaster -httpAddr 0.0.0.0 -authWebhookUrl http://foo.com -httpIngest=false
+curl -X PUT http://localhost:8935/live/movie/0.ts | grep "404 page not found"
+kill $pid
+
+# Check that HTTP ingest is enabled when -httpIngest is true
+run_lp -broadcaster -httpAddr 0.0.0.0 -httpIngest
+curl -X PUT http://localhost:8935/live/movie/0.ts | grep -v "404 page not found"
+kill $pid
+
+# Check that HTTP ingest is enabled when -httpAddr sets the hostname to 127.0.0.1
+run_lp -broadcaster -httpAddr 127.0.0.1
+curl -X PUT http://localhost:8935/live/movie/0.ts | grep -v "404 page not found"
+kill $pid
+
+# Check that HTTP ingest is enabled when -httpAddr sets the hostname to localhost
+run_lp -broadcaster -httpAddr localhost 
+curl -X PUT http://localhost:8935/live/movie/0.ts | grep -v "404 page not found"
+kill $pid
+
+# Check that HTTP ingest is enabled when there is an auth webhook URL
+run_lp -broadcaster -httpAddr 0.0.0.0 -authWebhookUrl http://foo.com
+curl -X PUT http://localhost:8935/live/movie/0.ts | grep -v "404 page not found"
+kill $pid
+
 rm -rf $TMPDIR


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR enables/disables HTTP ingest according to the following rules:

- HTTP ingest is enabled by default
- If the HTTP server is publicly accessible (i.e. `-httpAddr` uses a non-local host) and there is no authentication webhook URL specified then HTTP ingest is disabled
    - In this case, HTTP ingest can be enabled with any of the following:
        - Configure `-authWebhookUrl`
        - Set `-httpIngest`

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history for a description of each update.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests and tested manually.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1441

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
