### PR TITLE
cmd: Remove default values for -ethUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ everything from scratch.
 ### Quick start
 - Make sure you have successfully gone through the steps in 'Installing Livepeer' and 'Additional Dependencies'.
 
-- Run `./livepeer -broadcaster -network rinkeby`.
+- Run `./livepeer -broadcaster -network rinkeby -ethUrl <ETHEREUM_RPC_URL>`.
+  * `<ETHEREUM_RPC_URL>` is the JSON-RPC URL of an Ethereum node
 
 - Run `./livepeer_cli`.
   * You should see a wizard launch in the command line.
@@ -105,7 +106,7 @@ Livepeer node doesn't do any storage management, it only saves data and never de
 
 We'll walk through the steps of becoming a transcoder on the test network.  To learn more about the transcoder, refer to the [Livepeer whitepaper](https://github.com/livepeer/wiki/blob/master/WHITEPAPER.md) and the [Transcoding guide](http://livepeer.readthedocs.io/en/latest/transcoding.html).
 
-- `livepeer -orchestrator -transcoder -network rinkeby` to start the node as an orchestrator with an attached local transcoder .
+- `livepeer -orchestrator -transcoder -network rinkeby -ethUrl <ETHEREUM_RPC_URL>` to start the node as an orchestrator with an attached local transcoder .
 
 - `livepeer_cli` - make sure you have test ether and test Livepeer token.  Refer to the Quick Start section for getting test ether and test tokens.
 
@@ -121,7 +122,7 @@ We'll walk through the steps of becoming a transcoder on the test network.  To l
 
 Orchestrators can be run in standalone mode without an attached transcoder. Standalone transcoders will need to connect to this orchestrator in order for the orchestrator to process jobs.
 
-- `livepeer -network rinkeby -orchestrator -orchSecret asdf`
+- `livepeer -network rinkeby -ethUrl <ETHEREUM_RPC_URL> -orchestrator -orchSecret asdf`
 
 The orchSecret is a shared secret used to authenticate remote transcoders. It can be any arbitrary string.
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -107,7 +107,7 @@ func main() {
 	ethAcctAddr := flag.String("ethAcctAddr", "", "Existing Eth account address")
 	ethPassword := flag.String("ethPassword", "", "Password for existing Eth account address")
 	ethKeystorePath := flag.String("ethKeystorePath", "", "Path for the Eth Key")
-	ethUrl := flag.String("ethUrl", "", "geth/parity rpc or websocket url")
+	ethUrl := flag.String("ethUrl", "", "Ethereum node JSON-RPC URL")
 	ethController := flag.String("ethController", "", "Protocol smart contract address")
 	gasLimit := flag.Int("gasLimit", 0, "Gas limit for ETH transactions")
 	gasPrice := flag.Int("gasPrice", 0, "Gas price for ETH transactions")
@@ -163,7 +163,6 @@ func main() {
 	}
 
 	type NetworkConfig struct {
-		ethUrl        string
 		ethController string
 	}
 
@@ -171,11 +170,9 @@ func main() {
 
 	configOptions := map[string]*NetworkConfig{
 		"rinkeby": {
-			ethUrl:        "https://rinkeby.infura.io/v3/09642b98164d43eb890939eb9a7ec500",
 			ethController: "0xA268AEa9D048F8d3A592dD7f1821297972D4C8Ea",
 		},
 		"mainnet": {
-			ethUrl:        "wss://mainnet.infura.io/ws/v3/be11162798084102a3519541eded12f6",
 			ethController: "0xf96d54e490317c557a967abfa5d6e33006be69b3",
 		},
 	}
@@ -200,9 +197,6 @@ func main() {
 
 	// Setting config options based on specified network
 	if netw, ok := configOptions[*network]; ok {
-		if *ethUrl == "" {
-			*ethUrl = netw.ethUrl
-		}
 		if *ethController == "" {
 			*ethController = netw.ethController
 		}
@@ -322,8 +316,7 @@ func main() {
 
 		//Get the Eth client connection information
 		if *ethUrl == "" {
-			glog.Error("Need to specify ethUrl")
-			return
+			glog.Fatal("Need to specify an Ethereum node JSON-RPC URL using -ethUrl")
 		}
 
 		//Set up eth client

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,0 +1,14 @@
+# Development
+
+## Testing
+
+Some tests depend on access to the JSON-RPC API of an Ethereum node connected to mainnet or Rinkeby.
+
+- To run mainnet tests, the `MAINNET_ETH_URL` environment variable should be set. If the variable is not set, the mainnet tests will be skipped.
+- To run Rinkeby tests, the `RINKEBY_ETH_URL` environment variable should be set. If the variable is not set, the Rinkeby tests will b eskipped
+
+To run tests:
+
+```
+bash test.sh
+```

--- a/doc/ethereum.md
+++ b/doc/ethereum.md
@@ -1,0 +1,12 @@
+# Ethereum
+
+## Connecting to an Ethereum network
+
+When connecting to an Ethereum network, an Ethereum RPC provider needs to be specified via the `-ethUrl` flag.
+
+- To connect to mainnet, the node should be started with `-network mainnet` and the URL for `-ethUrl` should be for a mainnet Ethereum node.
+- To connect to Rinkeby, the node should be started with `-network rinkeby` and the URL for `-ethUrl` should be for a Rinkeby Ethereum node.
+- To connect to a private network, the node should be started with `-network <NETWORK_NAME>` (`<NETWORK_NAME>` is the name of the private network), the URL for `-ethUrl` should be for a private network Ethereum node and value for `-ethController` should be the address of the Controller contract deployed on the private network.
+- To connect to an off-chain network, the node should be started without the `-network` flag (the default value is `offchain`). The `-ethUrl` and the `-ethController` flags are unnecessary.
+
+See [this guide](https://livepeer.readthedocs.io/en/latest/quickstart.html#connecting-to-an-ethereum-node) for instructions on obtaining a URL that be used with the `-ethUrl` flag.


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR removes the default values for the `-ethUrl` flag. After this PR, whenever the node connects to an on-chain network, an Ethereum node JSON-RPC URL will need to be explicitly provided using the `-ethUrl` flag.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Remove the default values for the `-ethUrl` flag
- Only run mainnet tests in `test_args.sh` if the `MAINNET_ETH_URL` env variable is set
- Only run Rinkeby tests in `test_args.sh` if the `RINKEBY_ETH_URL` env variable is set
- Use `-ethUrl` in README commands

Values for `MAINNET_ETH_URL` and `RINKEBY_ETH_URL` are set via CircleCI.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated tests in `test_args.sh`.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1434 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
