### PR TITLE
core,server: fix price info data race

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -224,17 +224,12 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 	return nil
 }
 
-func (orch *orchestrator) TicketParams(sender ethcommon.Address) (*net.TicketParams, error) {
+func (orch *orchestrator) TicketParams(sender ethcommon.Address, priceInfo *net.PriceInfo) (*net.TicketParams, error) {
 	if orch.node == nil || orch.node.Recipient == nil {
 		return nil, nil
 	}
 
-	price, err := orch.priceInfo(sender)
-	if err != nil {
-		return nil, err
-	}
-
-	params, err := orch.node.Recipient.TicketParams(sender, price)
+	params, err := orch.node.Recipient.TicketParams(sender, big.NewRat(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit))
 	if err != nil {
 		return nil, err
 	}

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -42,7 +42,7 @@ type Orchestrator interface {
 	ServeTranscoder(stream net.Transcoder_RegisterTranscoderServer, capacity int)
 	TranscoderResults(job int64, res *core.RemoteTranscoderResult)
 	ProcessPayment(payment net.Payment, manifestID core.ManifestID) error
-	TicketParams(sender ethcommon.Address) (*net.TicketParams, error)
+	TicketParams(sender ethcommon.Address, priceInfo *net.PriceInfo) (*net.TicketParams, error)
 	PriceInfo(sender ethcommon.Address) (*net.PriceInfo, error)
 	SufficientBalance(addr ethcommon.Address, manifestID core.ManifestID) bool
 	DebitFees(addr ethcommon.Address, manifestID core.ManifestID, price *net.PriceInfo, pixels int64)
@@ -253,12 +253,12 @@ func getOrchestrator(orch Orchestrator, req *net.OrchestratorRequest) (*net.Orch
 }
 
 func orchestratorInfo(orch Orchestrator, addr ethcommon.Address, serviceURI string) (*net.OrchestratorInfo, error) {
-	params, err := orch.TicketParams(addr)
+	priceInfo, err := orch.PriceInfo(addr)
 	if err != nil {
 		return nil, err
 	}
 
-	priceInfo, err := orch.PriceInfo(addr)
+	params, err := orch.TicketParams(addr, priceInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -128,7 +128,7 @@ func (r *stubOrchestrator) ProcessPayment(payment net.Payment, manifestID core.M
 	return nil
 }
 
-func (r *stubOrchestrator) TicketParams(sender ethcommon.Address) (*net.TicketParams, error) {
+func (r *stubOrchestrator) TicketParams(sender ethcommon.Address, priceInfo *net.PriceInfo) (*net.TicketParams, error) {
 	return r.ticketParams, nil
 }
 
@@ -706,7 +706,7 @@ func TestGetOrchestrator_GivenValidSig_ReturnsTranscoderURI(t *testing.T) {
 	uri := "http://someuri.com"
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 	orch.On("ServiceURI").Return(url.Parse(uri))
-	orch.On("TicketParams", mock.Anything).Return(nil, nil)
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(nil, nil)
 	orch.On("PriceInfo", mock.Anything).Return(nil, nil)
 	oInfo, err := getOrchestrator(orch, &net.OrchestratorRequest{})
 
@@ -734,8 +734,8 @@ func TestGetOrchestrator_GivenValidSig_ReturnsOrchTicketParams(t *testing.T) {
 	expectedParams := defaultTicketParams()
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 	orch.On("ServiceURI").Return(url.Parse(uri))
-	orch.On("TicketParams", mock.Anything).Return(expectedParams, nil)
-	orch.On("PriceInfo", mock.Anything).Return(nil, nil)
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(expectedParams, nil)
+	orch.On("PriceInfo", mock.Anything, mock.Anything).Return(nil, nil)
 	oInfo, err := getOrchestrator(orch, &net.OrchestratorRequest{})
 
 	assert := assert.New(t)
@@ -750,7 +750,8 @@ func TestGetOrchestrator_TicketParamsError(t *testing.T) {
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 	orch.On("ServiceURI").Return(url.Parse(uri))
 	expErr := errors.New("TicketParams error")
-	orch.On("TicketParams", mock.Anything).Return(nil, expErr)
+	orch.On("PriceInfo", mock.Anything).Return(nil, nil)
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(nil, expErr)
 
 	_, err := getOrchestrator(orch, &net.OrchestratorRequest{})
 
@@ -768,7 +769,7 @@ func TestGetOrchestrator_GivenValidSig_ReturnsOrchPriceInfo(t *testing.T) {
 	}
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 	orch.On("ServiceURI").Return(url.Parse(uri))
-	orch.On("TicketParams", mock.Anything).Return(nil, nil)
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(nil, nil)
 	orch.On("PriceInfo", mock.Anything).Return(expectedPrice, nil)
 	oInfo, err := getOrchestrator(orch, &net.OrchestratorRequest{})
 
@@ -785,7 +786,6 @@ func TestGetOrchestrator_PriceInfoError(t *testing.T) {
 
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 	orch.On("ServiceURI").Return(url.Parse(uri))
-	orch.On("TicketParams", mock.Anything).Return(&net.TicketParams{}, nil)
 	orch.On("PriceInfo", mock.Anything).Return(nil, expErr)
 
 	_, err := getOrchestrator(orch, &net.OrchestratorRequest{})
@@ -871,8 +871,8 @@ func (o *mockOrchestrator) ProcessPayment(payment net.Payment, manifestID core.M
 	return args.Error(0)
 }
 
-func (o *mockOrchestrator) TicketParams(sender ethcommon.Address) (*net.TicketParams, error) {
-	args := o.Called(sender)
+func (o *mockOrchestrator) TicketParams(sender ethcommon.Address, priceInfo *net.PriceInfo) (*net.TicketParams, error) {
+	args := o.Called(sender, priceInfo)
 	if args.Get(0) != nil {
 		return args.Get(0).(*net.TicketParams), args.Error(1)
 	}

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -677,7 +677,7 @@ func TestServeSegment_ReturnMultipleTranscodedSegmentData(t *testing.T) {
 	url, _ := url.Parse("foo")
 	orch.On("ServiceURI").Return(url)
 	orch.On("PriceInfo", mock.Anything).Return(&net.PriceInfo{}, nil)
-	orch.On("TicketParams", mock.Anything).Return(&net.TicketParams{}, nil)
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(&net.TicketParams{}, nil)
 	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
 	orch.On("SufficientBalance", mock.Anything, s.ManifestID).Return(true)
 
@@ -803,7 +803,7 @@ func TestServeSegment_UpdateOrchestratorInfo(t *testing.T) {
 	uri, err := url.Parse("http://google.com")
 	require.Nil(err)
 	orch.On("ServiceURI").Return(uri)
-	orch.On("TicketParams", mock.Anything).Return(params, nil).Once()
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(params, nil).Once()
 	orch.On("PriceInfo", mock.Anything).Return(price, nil)
 	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil).Once()
 	orch.On("SufficientBalance", mock.Anything, s.ManifestID).Return(true)
@@ -845,7 +845,7 @@ func TestServeSegment_UpdateOrchestratorInfo(t *testing.T) {
 
 	// Test orchestratorInfo error
 	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil).Once()
-	orch.On("TicketParams", mock.Anything).Return(nil, errors.New("TicketParams error")).Once()
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(nil, errors.New("TicketParams error")).Once()
 
 	resp = httpPostResp(handler, bytes.NewReader(seg.Data), headers)
 	defer resp.Body.Close()
@@ -920,7 +920,7 @@ func TestServeSegment_DebitFees_SingleRendition(t *testing.T) {
 	url, _ := url.Parse("foo")
 	orch.On("ServiceURI").Return(url)
 	orch.On("PriceInfo", mock.Anything).Return(&net.PriceInfo{}, nil)
-	orch.On("TicketParams", mock.Anything).Return(&net.TicketParams{}, nil)
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(&net.TicketParams{}, nil)
 	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
 	orch.On("SufficientBalance", mock.Anything, s.ManifestID).Return(true)
 
@@ -984,7 +984,7 @@ func TestServeSegment_DebitFees_MultipleRenditions(t *testing.T) {
 	url, _ := url.Parse("foo")
 	orch.On("ServiceURI").Return(url)
 	orch.On("PriceInfo", mock.Anything).Return(&net.PriceInfo{}, nil)
-	orch.On("TicketParams", mock.Anything).Return(&net.TicketParams{}, nil)
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(&net.TicketParams{}, nil)
 	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
 	orch.On("SufficientBalance", mock.Anything, s.ManifestID).Return(true)
 
@@ -1058,7 +1058,7 @@ func TestServeSegment_DebitFees_OSSaveDataError_BreakLoop(t *testing.T) {
 	url, _ := url.Parse("foo")
 	orch.On("ServiceURI").Return(url)
 	orch.On("PriceInfo", mock.Anything).Return(&net.PriceInfo{}, nil)
-	orch.On("TicketParams", mock.Anything).Return(&net.TicketParams{}, nil)
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(&net.TicketParams{}, nil)
 	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
 	orch.On("SufficientBalance", mock.Anything, s.ManifestID).Return(true)
 
@@ -1134,7 +1134,7 @@ func TestServeSegment_DebitFees_TranscodeSegError_ZeroPixelsBilled(t *testing.T)
 	url, _ := url.Parse("foo")
 	orch.On("ServiceURI").Return(url)
 	orch.On("PriceInfo", mock.Anything).Return(&net.PriceInfo{}, nil)
-	orch.On("TicketParams", mock.Anything).Return(&net.TicketParams{}, nil)
+	orch.On("TicketParams", mock.Anything, mock.Anything).Return(&net.TicketParams{}, nil)
 	orch.On("ProcessPayment", net.Payment{}, s.ManifestID).Return(nil)
 	orch.On("SufficientBalance", mock.Anything, s.ManifestID).Return(true)
 	orch.On("TranscodeSeg", md, seg).Return(nil, errors.New("TranscodeSeg error"))


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fix a data race in `server.orchestratorInfo()` where we have two resources requesting `priceInfo`. Remove multiple calls in favor of a single call and pass through the returned value.

**Specific updates (required)**
- Changed `Orchestrator.TicketParams(sender)` to `Orchestrator.TicketParams(sender, priceInfo)`
- Removed call to `orchestrator.priceInfo()` in `orchestrator.TicketParams()`
- Adjust stubs & mocks to accomodate the tests

**Does this pull request close any open issues?**
Fixes #1452

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
