### PR TITLE
server: fix EthChainID webserver endpoint in offchain mode to return 'offchain' instead of '0'

### DIFF
--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -173,5 +173,5 @@ var DevenvChainID = "54321"
 func (w *wizard) checkNet() {
 	nID := httpGet(fmt.Sprintf("http://%v:%v/EthChainID", w.host, w.httpPort))
 	w.testnet = nID == RinkebyChainID || nID == DevenvChainID
-	w.offchain = nID == "offchain"
+	w.offchain = nID == "0"
 }

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -1077,15 +1077,11 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 			w.Write([]byte("0"))
 			return
 		}
-		be, err := s.LivepeerNode.Eth.Backend()
+		chainID, err := s.LivepeerNode.Database.ChainID()
 		if err != nil {
-			glog.Errorf("Error getting eth backend: %v", err)
+			glog.Errorf("Error getting eth network ID err=%v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
-		}
-		chainID, err := be.ChainID(r.Context())
-		if err != nil {
-			glog.Errorf("Error getting eth network ID: %v", err)
 		}
 		w.Write([]byte(chainID.String()))
 	})


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes a bug whereby the `EthChainID` webserver handler returns "0" when offchain , but the actual check compares against the string literal "offchain" 

https://github.com/livepeer/go-livepeer/blob/c4a3004f8318220b42eacea33d392049cb7fa188/server/webserver.go#L1077

https://github.com/livepeer/go-livepeer/blob/c4a3004f8318220b42eacea33d392049cb7fa188/cmd/livepeer_cli/livepeer_cli.go#L173

**Specific updates (required)**
- write "offchain" to the http response in offchain mode
- add unit test for on-chain mode

**How did you test each of these updates (required)**
adjusted & ran unit tests
ran reproduction steps in CLI (run in offchain mode, then run CLI)

**Does this pull request close any open issues?**
Fixes #1378 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
