### PR TITLE
docs: use git clone instead of go get

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -14,7 +14,7 @@ You can also build the executables from scratch.
 
 &ensp; 1\. If you have never set up your Go programming environment, do so according to Go's [Getting Started Guide](https://golang.org/doc/install).
 
-&ensp; 2\. You can fetch the code running `go get github.com/livepeer/go-livepeer/cmd/livepeer` in terminal.
+&ensp; 2\. You can fetch the code running `git clone https://github.com/livepeer/go-livepeer.git` in terminal.
 
 &ensp; 3\. Make sure you have the necessary libraries installed:
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Update installation from source instructions to use `git clone` instead of `go get`

**Checklist:**
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
