### PR TITLE
fix missing DLL in Windows build; add self-checks

### DIFF
--- a/upload_build.sh
+++ b/upload_build.sh
@@ -51,9 +51,9 @@ if [[ $ARCH == "windows" ]]; then
   FILE=$BASE.zip
   ls /mingw64/bin/
   # This list was produced by `ldd livepeer.exe`
-  LIBS="libffi-6.dll libgcc_s_seh-1.dll libgmp-10.dll libgnutls-30.dll libhogweed-5.dll libiconv-2.dll libidn2-0.dll libintl-8.dll libnettle-7.dll libp11-kit-0.dll libtasn1-6.dll libunistring-2.dll libwinpthread-1.dll zlib1.dll"
+  LIBS="libffi-7.dll libgcc_s_seh-1.dll libgmp-10.dll libgnutls-30.dll libhogweed-5.dll libiconv-2.dll libidn2-0.dll libintl-8.dll libnettle-7.dll libp11-kit-0.dll libtasn1-6.dll libunistring-2.dll libwinpthread-1.dll zlib1.dll"
   for LIB in $LIBS; do
-    cp -r /mingw64/bin/$LIB ./$BASE || echo "$LIB not found"
+    cp -r /mingw64/bin/$LIB ./$BASE
   done
   zip -r ./$FILE ./$BASE
 else

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -61,6 +61,9 @@ else
   tar -czvf ./$FILE ./$BASE
 fi
 
+# Quick self-check to see if the thing can execute at all
+(cd $BASE && $NODE -version)
+
 if [[ "${GCLOUD_KEY:-}" == "" ]]; then
   echo "GCLOUD_KEY not found, not uploading to Google Cloud."
   exit 0

--- a/windows-build.ps1
+++ b/windows-build.ps1
@@ -49,3 +49,7 @@ Run-Bash '
   source ./ci_env.sh && make livepeer livepeer_cli
   ./upload_build.sh 
 '
+
+Write-Output "Performing self-check; if we fail after this line there are missing DLLs"
+cd livepeer-windows-amd64
+.\livepeer.exe -version


### PR DESCRIPTION
v0.5.6 is broken on Windows. This PR tweaks a library path to fix it. It also adds two checks to ensure the Azure Pipelines build doesn't pass unless the desired libraries are all present and `liveeer.exe -version` runs successfully outside of the MSYS2 environment.

This happened because MSYS2 upgraded some libraries and we're kinda at their mercy right now, packaging whatever libraries that MSYS2 happens to ship with its latest build. https://github.com/livepeer/go-livepeer/issues/1416 would help a little; we could perhaps follow a similar procedure to lock the versions of all the dependencies we use... sounds kinda hard. I kind of think instead we should just get a Windows build environment set up in an archive somewhere so we can just deterministically download something every time.