### PR TITLE
docker: Turn on Go mod when installing golangci-lint

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -11,7 +11,8 @@ ENV HIGHEST_CHAIN_TAG ${HIGHEST_CHAIN_TAG}
 COPY ./install_ffmpeg.sh ./install_ffmpeg.sh
 RUN ./install_ffmpeg.sh
 
-RUN go get -v github.com/golangci/golangci-lint/cmd/golangci-lint github.com/jstemmer/go-junit-report
+RUN GO111MODULE=on go get -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.25.0
+RUN go get -v github.com/jstemmer/go-junit-report
 
 ENV GOFLAGS "-mod=readonly"
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Fixes a [CI failure](https://circleci.com/gh/livepeer/go-livepeer/5468?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) caused by:

```
/go/src/github.com/golangci/golangci-lint/pkg/golinters/golint.go:21:14: l.LintPkg undefined (type *"github.com/golangci/lint-1".Linter has no field or method LintPkg)
/go/src/github.com/golangci/golangci-lint/pkg/golinters/gomnd.go:13:6: cannot use magic_numbers.Analyzer (type *"github.com/tommy-muehle/go-mnd/vendor/golang.org/x/tools/go/analysis".Analyzer) as type *"golang.org/x/tools/go/analysis".Analyzer in array or slice literal
The command '/bin/sh -c go get -v github.com/golangci/golangci-lint/cmd/golangci-lint github.com/jstemmer/go-junit-report' returned a non-zero code: 2
```

As mentioned in golangci/golangci-lint#1037 the `golangci-lint` package needs to be installed using Go modules now.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
