### PR TITLE
server: Propagate last error when max transcodes hit.

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -320,7 +320,8 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, erro
 
 	for i := 0; i < MaxAttempts; i++ {
 		// if fails, retry; rudimentary
-		if urls, err := transcodeSegment(cxn, seg, name, sv); err == nil {
+		var urls []string
+		if urls, err = transcodeSegment(cxn, seg, name, sv); err == nil {
 			return urls, nil
 		}
 
@@ -332,7 +333,10 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, erro
 
 		// recoverable error, retry
 	}
-	return nil, errors.New("Hit max transcode attempts")
+	if err != nil {
+		err = fmt.Errorf("Hit max transcode attempts: %w", err)
+	}
+	return nil, err
 }
 
 func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,


### PR DESCRIPTION

Also suppresses a returned error when MaxAttempts == 0.

**Specific updates (required)**
- Propagates last error when max attempts hit
- Suppresses returned error when MaxAttempts == 0
- Adjusts test cases to match

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->

Makes it easier to diagnose errors. If max attempts is consistently being hit, this is usually an indication something is wrong with the segment.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
