### PR TITLE
server: Set request timeouts based on segment duration.

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -24,7 +24,7 @@ import (
 )
 
 // HTTPTimeout timeout used in HTTP connections between nodes
-const HTTPTimeout = 8 * time.Second
+var HTTPTimeout = 8 * time.Second
 
 const maxInt64 = int64(math.MaxInt64)
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -25,6 +25,8 @@ import (
 )
 
 var refreshTimeout = 2500 * time.Millisecond
+var maxDuration = (5 * time.Minute)
+var maxDurationSec = maxDuration.Seconds()
 
 var Policy *verification.Policy
 var BroadcastCfg = &BroadcastConfig{}
@@ -278,6 +280,11 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, erro
 	cpl := cxn.pl
 	mid := cxn.mid
 	vProfile := cxn.profile
+
+	if seg.Duration > maxDurationSec || seg.Duration < 0 {
+		glog.Errorf("Invalid duration nonce=%d manifestID=%s seqNo=%d dur=%v", nonce, mid, seg.SeqNo, seg.Duration)
+		return nil, fmt.Errorf("Invalid duration %v", seg.Duration)
+	}
 
 	glog.V(common.DEBUG).Infof("Processing segment nonce=%d manifestID=%s seqNo=%d dur=%v", nonce, mid, seg.SeqNo, seg.Duration)
 	if monitor.Enabled {

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -1462,6 +1462,21 @@ func TestProcessSegment_VideoFormat(t *testing.T) {
 	assert.Equal("saved_P240p30fps16x9/0.ts", seg.Name)
 }
 
+func TestProcessSegment_CheckDuration(t *testing.T) {
+	assert := assert.New(t)
+	seg := &stream.HLSSegment{Duration: -1.0}
+	cxn := &rtmpConnection{}
+
+	// Check less-than-zero
+	_, err := processSegment(cxn, seg)
+	assert.Equal("Invalid duration -1", err.Error())
+
+	// CHeck greater than max duration
+	seg.Duration = maxDurationSec + 0.01
+	_, err = processSegment(cxn, seg)
+	assert.Equal("Invalid duration 300.01", err.Error())
+}
+
 func genBcastSess(t *testing.T, url string, os drivers.OSSession, mid core.ManifestID) *BroadcastSession {
 	segData := []*net.TranscodedSegmentData{
 		{Url: url, Pixels: 100},

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -137,7 +137,9 @@ func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bo
 
 //StartMediaServer starts the LPMS server
 func (s *LivepeerServer) StartMediaServer(ctx context.Context, transcodingOptions string, httpAddr string) error {
-	BroadcastJobVideoProfiles = parsePresets(strings.Split(transcodingOptions, ","))
+	if transcodingOptions != "" { // mostly to mitigate race conditions in tests
+		BroadcastJobVideoProfiles = parsePresets(strings.Split(transcodingOptions, ","))
+	}
 
 	glog.V(common.SHORT).Infof("Transcode Job Type: %v", BroadcastJobVideoProfiles)
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -680,6 +680,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	// Do the transcoding!
 	urls, err := processSegment(cxn, seg)
 	if err != nil {
+		// TODO distinguish between user errors (400) and server errors (500)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -546,8 +546,9 @@ func ignoreRoutines() []goleak.Option {
 func TestPush_ShouldRemoveSessionAfterTimeout(t *testing.T) {
 	defer goleak.VerifyNone(t, ignoreRoutines()...)
 
-	oldRI := refreshIntervalHttpPush
-	refreshIntervalHttpPush = 2 * time.Millisecond
+	oldRI := httpPushTimeout
+	httpPushTimeout = 2 * time.Millisecond
+	defer func() { httpPushTimeout = oldRI }()
 	assert := assert.New(t)
 	s, cancel := setupServerWithCancel()
 	w := httptest.NewRecorder()
@@ -565,12 +566,12 @@ func TestPush_ShouldRemoveSessionAfterTimeout(t *testing.T) {
 	s.connectionLock.Unlock()
 	cancel()
 	assert.False(exists)
-	refreshIntervalHttpPush = oldRI
 }
 
 func TestPush_ShouldNotPanicIfSessionAlreadyRemoved(t *testing.T) {
-	oldRI := refreshIntervalHttpPush
-	refreshIntervalHttpPush = 5 * time.Millisecond
+	oldRI := httpPushTimeout
+	httpPushTimeout = 5 * time.Millisecond
+	defer func() { httpPushTimeout = oldRI }()
 	assert := assert.New(t)
 	s := setupServer()
 	defer serverCleanup(s)
@@ -591,7 +592,6 @@ func TestPush_ShouldNotPanicIfSessionAlreadyRemoved(t *testing.T) {
 	_, exists = s.rtmpConnections["mani2"]
 	s.connectionLock.Unlock()
 	assert.False(exists)
-	refreshIntervalHttpPush = oldRI
 }
 
 func TestPush_ResetWatchdog(t *testing.T) {

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -36,7 +36,7 @@ func requestSetup(s *LivepeerServer) (http.Handler, *strings.Reader, *httptest.R
 	return handler, reader, writer
 }
 
-func TestMultipartReturn(t *testing.T) {
+func TestPush_MultipartReturn(t *testing.T) {
 	assert := assert.New(t)
 	s := setupServer()
 	defer serverCleanup(s)
@@ -199,7 +199,7 @@ func TestMultipartReturn(t *testing.T) {
 	assert.Equal(503, resp.StatusCode)
 }
 
-func TestMemoryRequestError(t *testing.T) {
+func TestPush_MemoryRequestError(t *testing.T) {
 	// assert http request body error returned
 	assert := assert.New(t)
 	s := setupServer()
@@ -218,7 +218,7 @@ func TestMemoryRequestError(t *testing.T) {
 	assert.Contains(strings.TrimSpace(string(body)), "Error reading http request body")
 }
 
-func TestEmptyURLError(t *testing.T) {
+func TestPush_EmptyURLError(t *testing.T) {
 	// assert http request body error returned
 	assert := assert.New(t)
 	s := setupServer()
@@ -235,7 +235,7 @@ func TestEmptyURLError(t *testing.T) {
 	assert.Equal("Bad URL\n", string(body))
 }
 
-func TestShouldUpdateLastUsed(t *testing.T) {
+func TestPush_ShouldUpdateLastUsed(t *testing.T) {
 	assert := assert.New(t)
 	s := setupServer()
 	defer serverCleanup(s)
@@ -541,7 +541,7 @@ func ignoreRoutines() []goleak.Option {
 	return res
 }
 
-func TestShouldRemoveSessionAfterTimeout(t *testing.T) {
+func TestPush_ShouldRemoveSessionAfterTimeout(t *testing.T) {
 	defer goleak.VerifyNone(t, ignoreRoutines()...)
 
 	oldRI := refreshIntervalHttpPush
@@ -566,7 +566,7 @@ func TestShouldRemoveSessionAfterTimeout(t *testing.T) {
 	refreshIntervalHttpPush = oldRI
 }
 
-func TestShouldNotPanicIfSessionAlreadyRemoved(t *testing.T) {
+func TestPush_ShouldNotPanicIfSessionAlreadyRemoved(t *testing.T) {
 	oldRI := refreshIntervalHttpPush
 	refreshIntervalHttpPush = 5 * time.Millisecond
 	assert := assert.New(t)
@@ -592,7 +592,7 @@ func TestShouldNotPanicIfSessionAlreadyRemoved(t *testing.T) {
 	refreshIntervalHttpPush = oldRI
 }
 
-func TestFileExtensionError(t *testing.T) {
+func TestPush_FileExtensionError(t *testing.T) {
 	// assert file extension error returned
 	assert := assert.New(t)
 	s := setupServer()
@@ -610,7 +610,7 @@ func TestFileExtensionError(t *testing.T) {
 	assert.Contains(strings.TrimSpace(string(body)), "ignoring file extension")
 }
 
-func TestStorageError(t *testing.T) {
+func TestPush_StorageError(t *testing.T) {
 	// assert storage error
 	assert := assert.New(t)
 	s := setupServer()
@@ -636,7 +636,7 @@ func TestStorageError(t *testing.T) {
 	drivers.NodeStorage = tempStorage
 }
 
-func TestForAuthWebhookFailure(t *testing.T) {
+func TestPush_ForAuthWebhookFailure(t *testing.T) {
 	// assert app data error
 	assert := assert.New(t)
 	s := setupServer()
@@ -659,7 +659,7 @@ func TestForAuthWebhookFailure(t *testing.T) {
 	AuthWebhookURL = ""
 }
 
-func TestResolutionWithoutContentResolutionHeader(t *testing.T) {
+func TestPush_ResolutionWithoutContentResolutionHeader(t *testing.T) {
 	assert := assert.New(t)
 	server := setupServer()
 	defer serverCleanup(server)
@@ -680,7 +680,7 @@ func TestResolutionWithoutContentResolutionHeader(t *testing.T) {
 	server.rtmpConnections = map[core.ManifestID]*rtmpConnection{}
 }
 
-func TestResolutionWithContentResolutionHeader(t *testing.T) {
+func TestPush_ResolutionWithContentResolutionHeader(t *testing.T) {
 	assert := assert.New(t)
 	server := setupServer()
 	defer serverCleanup(server)
@@ -702,7 +702,7 @@ func TestResolutionWithContentResolutionHeader(t *testing.T) {
 	server.rtmpConnections = map[core.ManifestID]*rtmpConnection{}
 }
 
-func TestWebhookRequestURL(t *testing.T) {
+func TestPush_WebhookRequestURL(t *testing.T) {
 	assert := assert.New(t)
 	s := setupServer()
 	defer serverCleanup(s)

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
@@ -42,7 +43,7 @@ var errFormat = errors.New("unrecognized profile output format")
 var tlsConfig = &tls.Config{InsecureSkipVerify: true}
 var httpClient = &http.Client{
 	Transport: &http2.Transport{TLSClientConfig: tlsConfig},
-	Timeout:   common.HTTPTimeout,
+	// Don't set a timeout here; pass a context to the request
 }
 
 func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
@@ -340,8 +341,17 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 		return nil, err
 	}
 
+	// set a minimum timeout to accommodate transport / processing overhead
+	dur := common.HTTPTimeout
+	paddedDur := 4.0 * seg.Duration // use a multiplier of 4 for now
+	if paddedDur > dur.Seconds() {
+		dur = time.Duration(paddedDur * float64(time.Second))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), dur)
+	defer cancel()
+
 	ti := sess.OrchestratorInfo
-	req, err := http.NewRequest("POST", ti.Transcoder+"/segment", bytes.NewBuffer(data))
+	req, err := http.NewRequestWithContext(ctx, "POST", ti.Transcoder+"/segment", bytes.NewBuffer(data))
 	if err != nil {
 		glog.Errorf("Could not generate transcode request to orch=%s", ti.Transcoder)
 		if monitor.Enabled {
@@ -369,7 +379,7 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 		if monitor.Enabled {
 			monitor.SegmentUploadFailed(nonce, seg.SeqNo, monitor.SegmentUploadErrorUnknown, err.Error(), false)
 		}
-		return nil, err
+		return nil, fmt.Errorf("header timeout: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -407,7 +417,7 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 		if monitor.Enabled {
 			monitor.SegmentTranscodeFailed(monitor.SegmentTranscodeErrorReadBody, nonce, seg.SeqNo, err, false)
 		}
-		return nil, err
+		return nil, fmt.Errorf("body timeout: %w", err)
 	}
 	transcodeDur := tookAllDur - uploadDur
 

--- a/test.sh
+++ b/test.sh
@@ -18,11 +18,16 @@ cd discovery
 go test -logtostderr=true -race
 t_discovery=$?
 cd ..
+# Be more strict with HTTP push tests: run with race detector enabled
+cd server
+go test -logtostderr=true -run Push_ -race
+t_push=$?
+cd ..
 
 ./test_args.sh
 t_args=$?
 
-if (($t1!=0||$t2_lb!=0||$t2_nv!=0||$t_args!=0||$t_discovery!=0))
+if (($t1!=0||$t2_lb!=0||$t2_nv!=0||$t_args!=0||$t_discovery!=0||$t_push!=0))
 then
     printf "\n\nSome Tests Failed\n\n"
     exit -1


### PR DESCRIPTION
### TODO
- [x] Some sort of hard cap on durations. 5 minutes? ~~10? 15?~~
- [x] Watchdog to defer session teardown. Maybe not absolutely necessary, since multipart results are still returned even if the session is cleaned out from underneath it, but it could cause problems in the future. For example, the HLS playlist is not populated due to a `SessionEnded` error.
- [ ] ~~Split T support (requires changes to the wire protocol and probably payment processing). Issue writeup forthcoming~~ Split T was more work than expected, so will leave it out of this PR. Payment processing changes here: https://github.com/livepeer/go-livepeer/pull/1491


### What does this pull request do? Explain your changes. (required)

Sets broadcaster request timeouts based on segment duration, and the associated support for that.

### Specific updates (required)
<!--- List out all significant updates your code introduces -->
- Set request timeout using a cancellable context. The timeout is padded to 4 times the segment duration.
- Remove default `common.HTTPTimeout` from `http.Client`  which would have triggered if `request timeout > common.HTTPTimeout`
- Uses `common.HTTPTimeout` as a minimum if the (padded) segment duration is shorter. This is so we don't time out on very short segments - there are typically overheads with transport, processing, etc.
- Kicks the session timeout watchdog if the segment is still being transcoded and we're within 90% of session expiration.
- Add unit tests. All HTTP push tests are now run under the race detector.

### Commits

#### server: Set request timeouts based on segment duration. … 349e2c5
Better accommodates segments that may be longer than 2 seconds.

Uses a duration multiplier of 4, which should roughly line up with
the default timeout of 8 seconds (4 * 2s default segment length).

#### server: Constrain min and max segment durations. … 860dfb8
* Minimizes the risk of a broken connection from long transcodes
* Minimizes value at risk with probabilistic micropayments

#### server: Prefix push tests. … 8579778
Allows running push tests standalone.

#### server: Run HTTP push tests under -race. … 7fc2f08
The change to the BroadcastJobVideoProfiles assignment was the
only thing necessary to make the race detector pass. All other
tests still pass unchanged.

This *may* be a behavioral change if someone was, for some reason,
starting up the node with an empty set of transcoding profiles.

#### server: Kick watchdog periodically. … 9f94d61
Prevents the session from being cleaned up in the middle of a
long-running transcode.

### How did you test each of these updates (required)

- [x] Unit tests
- [x] Manually tested with an entire big buck bunny

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


### Does this pull request close any open issues?**

- Closes https://github.com/livepeer/go-livepeer/issues/1480
- Partial solution for https://github.com/livepeer/go-livepeer/issues/1478


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
