### PR TITLE
Fixed a typo, added make to dependencies

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -51,7 +51,7 @@ You can also build your own executables from source code.
 
 &ensp; 2\. Make sure you have the necessary libraries installed:
 
- * Linux (Ubuntu): `apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git`
+ * Linux (Ubuntu): `apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git make`
 
  * OSX: `brew update && brew install pkg-config autoconf gnutls`
 
@@ -65,7 +65,7 @@ cd go-livepeer
 
 &ensp; 4\. Install `FFmpeg` as a dependency.  Run the following command from your `livepeer` folder:
 ```
-.install_ffmpeg.sh 
+./install_ffmpeg.sh 
 ```
 
 ### Make the software

--- a/doc/install.md
+++ b/doc/install.md
@@ -51,7 +51,7 @@ You can also build your own executables from source code.
 
 &ensp; 2\. Make sure you have the necessary libraries installed:
 
- * Linux (Ubuntu): `apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git make`
+ * Linux (Ubuntu): `apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git`
 
  * OSX: `brew update && brew install pkg-config autoconf gnutls`
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Documentation changes only - fixed a typo, added a missing dependency

**Specific updates (required)**

- added `make` to the `apt-get update...` command in "Build from source"
- missing `/` before `install_ffmpeg.sh`

**How did you test each of these updates (required)**

1. Start from clean Ubuntu `18.04.4` hosted server

2. Run the following to install packages, clone `go-livepeer` and install `FFmpeg`:
```
sudo apt-get update
sudo apt-get -y install build-essential pkg-config autoconf gnutls-dev git make
mkdir livepeer && cd livepeer
git clone https://github.com/livepeer/go-livepeer.git
cd go-livepeer
./install_ffmpeg.sh
cd ~
```

3. Run the following to download and install `go`, per [Go's "Getting Started" guide](https://golang.org/doc/install):
```
wget https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz
sudo tar -C /usr/local -xzf go1.14.2.linux-amd64.tar.gz
```

4. Added `export PATH=$PATH:/usr/local/go/bin` to `$HOME/.profile`

5. Ran `source $HOME/.profile` per [Go's "Getting Started" guide]

6. Ran the following to make the software:
```
cd livepeer/go-livepeer
PKG_CONFIG_PATH=~/compiled/lib/pkgconfig make
```

7. Ran `./test.sh` which reported `Some Tests Failed` (unrelated to these changes) - here is a log of 
[test results](https://github.com/livepeer/go-livepeer/files/4563298/test.results.txt)

**Checklist:**
- [x] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass