### PR TITLE
ci: Bump libhogweed/libnettle version for Windows

### DIFF
--- a/upload_build.sh
+++ b/upload_build.sh
@@ -51,7 +51,7 @@ if [[ $ARCH == "windows" ]]; then
   FILE=$BASE.zip
   ls /mingw64/bin/
   # This list was produced by `ldd livepeer.exe`
-  LIBS="libffi-7.dll libgcc_s_seh-1.dll libgmp-10.dll libgnutls-30.dll libhogweed-5.dll libiconv-2.dll libidn2-0.dll libintl-8.dll libnettle-7.dll libp11-kit-0.dll libtasn1-6.dll libunistring-2.dll libwinpthread-1.dll zlib1.dll"
+  LIBS="libffi-7.dll libgcc_s_seh-1.dll libgmp-10.dll libgnutls-30.dll libhogweed-6.dll libiconv-2.dll libidn2-0.dll libintl-8.dll libnettle-8.dll libp11-kit-0.dll libtasn1-6.dll libunistring-2.dll libwinpthread-1.dll zlib1.dll"
   for LIB in $LIBS; do
     cp -r /mingw64/bin/$LIB ./$BASE
   done


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes the Windows build failure in CI due to MSYS2 shipping with libhogweed-6 + libnettle-7 when `upload_build.sh` expects libhogweed-5 + libnettle-8. A similar issue occurred with #1462.

See this example [build failure](https://dev.azure.com/ericxtang/Livepeer%20pipeline/_build/results?buildId=1829&view=logs&j=63c6e092-18c2-5f48-2863-30f858b2a93b&t=042fc50d-cea6-5e09-a550-f624443f682c) in Azure pipelines.

The build fails here:

```
cp: cannot stat '/mingw64/bin/libhogweed-5.dll': No such file or directory
Exit code 1
At D:\a\1\s\windows-build.ps1:18 char:5
+     throw "Exit code $LASTEXITCODE"
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (Exit code 1:String) [], RuntimeException
    + FullyQualifiedErrorId : Exit code 1
```

The logs seem to indicate that a new version of libhogweed is included:

```
libgmpxx-4.dll
libgnutls-30.dll
libgnutlsxx-28.dll
libgomp-1.dll
libhogweed-6.dll # <- looks like MSYS2 is shipping with a new version
libiconv-2.dll
libidn2-0.dll

...

libnettle-8.dll # <- looks like MSYS2 is shipping with a new version
libp11-kit-0.dll
libquadmath-0.dll
```

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Update the libhogweed + libnettle version in `upload_build.sh`

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
