### PR TITLE
common,core,cmd,pm: DB Backed ticket retry queue 

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -511,7 +511,7 @@ func main() {
 			}
 			defer gpm.Stop()
 
-			sm := pm.NewSenderMonitor(n.Eth.Account().Address, n.Eth, senderWatcher, timeWatcher, cleanupInterval, smTTL)
+			sm := pm.NewSenderMonitor(n.Eth.Account().Address, n.Eth, senderWatcher, timeWatcher, n.Database, cleanupInterval, smTTL)
 			// Start sender monitor
 			sm.Start()
 			defer sm.Stop()
@@ -525,7 +525,6 @@ func main() {
 				recipientAddr,
 				n.Eth,
 				validator,
-				n.Database,
 				gpm,
 				sm,
 				timeWatcher,

--- a/common/db.go
+++ b/common/db.go
@@ -672,6 +672,7 @@ func (db *DB) UnbondingLocks(currentRound *big.Int) ([]*DBUnbondingLock, error) 
 	return unbondingLocks, nil
 }
 
+// StoreWinningTicket stores a signed ticket
 func (db *DB) StoreWinningTicket(ticket *pm.SignedTicket) error {
 	if ticket == nil || ticket.Ticket == nil {
 		return errors.New("cannot store nil ticket")
@@ -703,6 +704,8 @@ func (db *DB) StoreWinningTicket(ticket *pm.SignedTicket) error {
 	return nil
 }
 
+// MarkWinningTicketRedeemed stores the on-chain transaction hash and timestamp of redemption
+// This marks the ticket as being 'redeemed'
 func (db *DB) MarkWinningTicketRedeemed(ticket *pm.SignedTicket, txHash ethcommon.Hash) error {
 	if ticket == nil || ticket.Ticket == nil {
 		return errors.New("cannot update nil ticket")
@@ -725,6 +728,7 @@ func (db *DB) MarkWinningTicketRedeemed(ticket *pm.SignedTicket, txHash ethcommo
 	return nil
 }
 
+// RemoveWinningTicket removes a ticket
 func (db *DB) RemoveWinningTicket(ticket *pm.SignedTicket) error {
 	if ticket == nil || ticket.Ticket == nil {
 		return errors.New("cannot delete nil ticket")
@@ -742,6 +746,8 @@ func (db *DB) RemoveWinningTicket(ticket *pm.SignedTicket) error {
 	return nil
 }
 
+// SelectEarliestWinningTicket selects the earliest stored winning ticket for a 'sender'
+// which is not yet redeemed
 func (db *DB) SelectEarliestWinningTicket(sender ethcommon.Address) (*pm.SignedTicket, error) {
 	row := db.selectEarliestWinningTicket.QueryRow(sender.Hex())
 	var (
@@ -782,6 +788,7 @@ func (db *DB) SelectEarliestWinningTicket(sender ethcommon.Address) (*pm.SignedT
 	}, nil
 }
 
+// WinningTicketCount returns the amount of non-redeemed winning tickets for a 'sender'
 func (db *DB) WinningTicketCount(sender ethcommon.Address) (int, error) {
 	row := db.winningTicketCount.QueryRow(sender.Hex())
 	var count64 int64

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -201,7 +201,7 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 
 			go func(ticket *pm.Ticket, sig []byte, seed *big.Int) {
 				if err := orch.node.Recipient.RedeemWinningTicket(ticket, sig, seed); err != nil {
-					glog.Errorf("error redeeming ticket manifestID=%v recipientRandHash=%x senderNonce=%v: %v", manifestID, ticket.RecipientRandHash, ticket.SenderNonce, err)
+					glog.Errorf("error redeeming ticket manifestID=%v recipientRandHash=%x senderNonce=%v err=%v", manifestID, ticket.RecipientRandHash, ticket.SenderNonce, err)
 				}
 			}(ticket, tsp.Sig, seed)
 		}

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -421,9 +421,9 @@ func (r *recipient) redeemManager() {
 	// Listen for redeemable tickets that should be retried
 	for {
 		select {
-		case ticket := <-r.sm.Redeemable():
-			if err := r.redeemWinningTicket(ticket.Ticket, ticket.Sig, ticket.RecipientRand); err != nil {
-				glog.Errorf("error redeeming ticket - sender=%x recipientRandHash=%x senderNonce=%v err=%v", ticket.Sender, ticket.RecipientRandHash, ticket.SenderNonce, err)
+		case red := <-r.sm.Redeemable():
+			if err := r.redeemWinningTicket(red.SignedTicket.Ticket, red.SignedTicket.Sig, red.SignedTicket.RecipientRand); err != nil {
+				glog.Errorf("error redeeming ticket - sender=%x recipientRandHash=%x senderNonce=%v err=%v", red.SignedTicket.Sender, red.SignedTicket.RecipientRandHash, red.SignedTicket.SenderNonce, err)
 			}
 		case <-r.quit:
 			return

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -289,10 +289,12 @@ func TestReceiveTicket_InvalidRecipientRand_AlreadyRevealed(t *testing.T) {
 	r.RedeemWinningTicket(ticket, sig, params.Seed)
 	recipientRand := genRecipientRand(sender, secret, params)
 	// Redeem ticket to invalidate recipientRand
-	sm.Redeemable() <- &SignedTicket{
-		Ticket:        ticket,
-		Sig:           sig,
-		RecipientRand: recipientRand,
+	sm.Redeemable() <- &redemption{
+		SignedTicket: &SignedTicket{
+			Ticket:        ticket,
+			Sig:           sig,
+			RecipientRand: recipientRand,
+		},
 	}
 	time.Sleep(20 * time.Millisecond)
 
@@ -814,7 +816,9 @@ func TestRedeemManager_Error(t *testing.T) {
 	errorLogsBefore := glog.Stats.Error.Lines()
 
 	sm.maxFloatErr = errors.New("MaxFloat error")
-	sm.redeemable <- &SignedTicket{ticket, sig, recipientRand}
+	sm.redeemable <- &redemption{
+		SignedTicket: &SignedTicket{ticket, sig, recipientRand},
+	}
 
 	time.Sleep(time.Millisecond * 20)
 	errorLogsAfter := glog.Stats.Error.Lines()
@@ -852,7 +856,9 @@ func TestRedeemManager(t *testing.T) {
 
 	errorLogsBefore := glog.Stats.Error.Lines()
 
-	sm.redeemable <- &SignedTicket{ticket, sig, recipientRand}
+	sm.redeemable <- &redemption{
+		SignedTicket: &SignedTicket{ticket, sig, recipientRand},
+	}
 
 	time.Sleep(time.Millisecond * 20)
 	errorLogsAfter := glog.Stats.Error.Lines()

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -29,7 +28,7 @@ type SenderMonitor interface {
 	Stop()
 
 	// QueueTicket adds a ticket to the queue for a remote sender
-	QueueTicket(addr ethcommon.Address, ticket *SignedTicket)
+	QueueTicket(addr ethcommon.Address, ticket *SignedTicket) error
 
 	// AddFloat adds to a remote sender's max float
 	AddFloat(addr ethcommon.Address, amount *big.Int) error
@@ -147,15 +146,13 @@ func (sm *senderMonitor) MaxFloat(addr ethcommon.Address) (*big.Int, error) {
 }
 
 // QueueTicket adds a ticket to the queue for a remote sender
-func (sm *senderMonitor) QueueTicket(addr ethcommon.Address, ticket *SignedTicket) {
+func (sm *senderMonitor) QueueTicket(addr ethcommon.Address, ticket *SignedTicket) error {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
 	sm.ensureCache(addr)
 
-	sm.senders[addr].queue.Add(ticket)
-	glog.Infof("Queued ticket sender=%v recipientRandHash=%v senderNonce=%v", ticket.Sender.Hex(), ticket.RecipientRandHash.Hex(), ticket.SenderNonce)
-
+	return sm.senders[addr].queue.Add(ticket)
 }
 
 // ValidateSender checks whether a sender's unlock period ends the round after the next round

--- a/pm/ticketstore.go
+++ b/pm/ticketstore.go
@@ -13,5 +13,8 @@ type TicketStore interface {
 	// Store persists a signed winning ticket
 	StoreWinningTicket(ticket *SignedTicket) error
 
+	// MarkWinningTicketRedeemed stores the submission time and transaction hash
+	MarkWinningTicketRedeemed(ticket *SignedTicket, txHash ethcommon.Hash) error
+
 	WinningTicketCount(sender ethcommon.Address) (int, error)
 }

--- a/pm/ticketstore.go
+++ b/pm/ticketstore.go
@@ -1,17 +1,17 @@
 package pm
 
-import (
-	"math/big"
-)
+import ethcommon "github.com/ethereum/go-ethereum/common"
 
 // TicketStore is an interface which describes an object capable
 // of persisting tickets
 type TicketStore interface {
-	// Store persists a ticket with its signature and recipientRand
-	// for a session ID
-	StoreWinningTicket(sessionID string, ticket *Ticket, sig []byte, recipientRand *big.Int) error
+	SelectEarliestWinningTicket(sender ethcommon.Address) (*SignedTicket, error)
 
-	// Load fetches all persisted tickets in the store with their signatures and recipientRands
-	// for a session ID
-	LoadWinningTickets(sessionIDs []string) (tickets []*Ticket, sigs [][]byte, recipientRands []*big.Int, err error)
+	// RemoveWinningTicket removes a ticket from the TicketStore
+	RemoveWinningTicket(ticket *SignedTicket) error
+
+	// Store persists a signed winning ticket
+	StoreWinningTicket(ticket *SignedTicket) error
+
+	WinningTicketCount(sender ethcommon.Address) (int, error)
 }

--- a/pm/ticketstore.go
+++ b/pm/ticketstore.go
@@ -5,16 +5,20 @@ import ethcommon "github.com/ethereum/go-ethereum/common"
 // TicketStore is an interface which describes an object capable
 // of persisting tickets
 type TicketStore interface {
+	// SelectEarliestWinningTicket selects the earliest stored winning ticket for a 'sender'
+	// which is not yet redeemed
 	SelectEarliestWinningTicket(sender ethcommon.Address) (*SignedTicket, error)
 
-	// RemoveWinningTicket removes a ticket from the TicketStore
+	// RemoveWinningTicket removes a ticket
 	RemoveWinningTicket(ticket *SignedTicket) error
 
-	// Store persists a signed winning ticket
+	// StoreWinningTicket stores a signed ticket
 	StoreWinningTicket(ticket *SignedTicket) error
 
-	// MarkWinningTicketRedeemed stores the submission time and transaction hash
+	// MarkWinningTicketRedeemed stores the on-chain transaction hash and timestamp of redemption
+	// This marks the ticket as being 'redeemed'
 	MarkWinningTicketRedeemed(ticket *SignedTicket, txHash ethcommon.Hash) error
 
+	// WinningTicketCount returns the amount of non-redeemed winning tickets for a sender in the TicketStore
 	WinningTicketCount(sender ethcommon.Address) (int, error)
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR introduces a DB backed `ticketqueue` and removes the need for the `recipient` to store or redeem winning tickets. Instead the sendermonitor will now consume winning tickets and the queue has permanent storage. 

**Specific updates (required)**
- bfcae67: Reworks the DB table and methods for `winningTickets` 
   - The method signature for `StoreWinningTicket` now uses `pm.SignedTicket` to reduce arguments 
  - Added `LoadLatestTicket(sender)` , `RemoveWinningTicket(signedTicket)` and `WinningTicketCount(sender)`  

- d7c0f76: Reworks the `TicketStore` interface to accomodate to the database API changes, fb6cc80 reworks the stub used for testing. 

- Removes `TicketStore` and ticket redemption logic from the `recipient` , instead move that over to the `SenderMonitor` 

- 69ef438  reworks the ticketqueue to use `TicketStore`: 
  - Remove the conditional variable with lock from the queue, implementations of the `TicketStore` have to make sure they are thread safe. 
  - Updated Add() and Length() and added pop() 
  - Accept sender address and ticketstore in the constructor

**How did you test each of these updates (required)**
Added , adjusted & ran unit tests

**Does this pull request close any open issues?**
Fixes #942 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
