### PR TITLE
./install_ffmpeg.sh needs curl

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -51,7 +51,7 @@ You can also build your own executables from source code.
 
 &ensp; 2\. Make sure you have the necessary libraries installed:
 
- * Linux (Ubuntu): `apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git`
+ * Linux (Ubuntu): `apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git curl`
 
  * OSX: `brew update && brew install pkg-config autoconf gnutls`
 


### PR DESCRIPTION
`curl` is required as part of `./install_ffmpeg.sh` script and the process fails without it.

It is not included in other packages, so must be explicitly installed for the process to work.

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
