### PR TITLE
server: Estimate input framerate in fee estimation for fps passthrough.

### DIFF
--- a/core/lb.go
+++ b/core/lb.go
@@ -215,7 +215,12 @@ func calculateCost(profiles []ffmpeg.VideoProfile) int {
 		if err != nil {
 			continue
 		}
-		cost += w * h * int(v.Framerate) // TODO incorporate duration
+		framerate := int(v.Framerate)
+		if 0 == framerate {
+			// passthrough; estimate 30fps for load balancing purposes
+			framerate = 30
+		}
+		cost += w * h * framerate // TODO incorporate duration
 	}
 	return cost
 }

--- a/core/lb_test.go
+++ b/core/lb_test.go
@@ -14,6 +14,15 @@ import (
 	"github.com/livepeer/lpms/ffmpeg"
 )
 
+func TestLB_CalculateCost(t *testing.T) {
+	assert := assert.New(t)
+	profiles := []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9, ffmpeg.P144p30fps16x9}
+	profiles[0].Framerate = 1
+	profiles[1].Framerate = 0 // passthru; estimated to be 30fps for load
+	// 256 * 144 * 1 + 256 * 144 * 30
+	assert.Equal(1142784, calculateCost(profiles))
+}
+
 func TestLB_LeastLoaded(t *testing.T) {
 	assert := assert.New(t)
 	lb := NewLoadBalancingTranscoder("0,1,2,3,4", newStubTranscoder).(*LoadBalancingTranscoder)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -433,10 +433,11 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	// set profiles with valid values, presets empty
 	ts7 := makeServer(`{"manifestID":"a", "profiles": [
 		{"name": "prof1", "bitrate": 432, "fps": 560, "width": 123, "height": 456},
-		{"name": "prof2", "bitrate": 765, "fps": 876, "width": 456, "height": 987}]}`)
+		{"name": "prof2", "bitrate": 765, "fps": 876, "width": 456, "height": 987},
+		{"name": "passthru_fps", "bitrate": 890, "width": 789, "height": 654}]}`)
 	defer ts7.Close()
 	params = createSid(u).(*streamParameters)
-	assert.Len(params.profiles, 2)
+	assert.Len(params.profiles, 3)
 
 	expectedProfiles := []ffmpeg.VideoProfile{
 		ffmpeg.VideoProfile{
@@ -451,9 +452,15 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 			Framerate:  uint(876),
 			Resolution: "456x987",
 		},
+		ffmpeg.VideoProfile{
+			Name:       "passthru_fps",
+			Bitrate:    "890",
+			Resolution: "789x654",
+			Framerate:  0,
+		},
 	}
 
-	assert.Len(params.profiles, 2)
+	assert.Len(params.profiles, 3)
 	assert.Equal(expectedProfiles, params.profiles, "Did not have matching profiles")
 
 	// set profiles with invalid values, presets empty
@@ -468,13 +475,14 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	// set profiles and presets
 	ts9 := makeServer(`{"manifestID":"a", "presets":["P240p30fps16x9", "P720p30fps16x9"], "profiles": [
 		{"name": "prof1", "bitrate": 432, "fps": 560, "width": 123, "height": 456},
-		{"name": "prof2", "bitrate": 765, "fps": 876, "width": 456, "height": 987}]}`)
+		{"name": "prof2", "bitrate": 765, "fps": 876, "width": 456, "height": 987},
+		{"name": "passthru_fps", "bitrate": 890, "width": 789, "height": 654}]}`)
 
 	defer ts9.Close()
 	params = createSid(u).(*streamParameters)
 	jointProfiles := append([]ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P720p30fps16x9}, expectedProfiles...)
 
-	assert.Len(params.profiles, 4)
+	assert.Len(params.profiles, 5)
 	assert.Equal(jointProfiles, params.profiles, "Did not have matching profiles")
 
 	// all invalid presets in webhook should lead to empty set

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -336,7 +336,7 @@ func TestEstimateFee(t *testing.T) {
 	assert.Zero(fee.Cmp(expFee))
 
 	// Test estimation with non-integer duration
-	// pixels = (256 * 144 * 30 * 3) * (426 * 240 * 30 * 3)
+	// pixels = (256 * 144 * 30 * 3) + (426 * 240 * 30 * 3)
 	expFee = new(big.Rat).SetInt64(12519360)
 	expFee.Mul(expFee, new(big.Rat).SetFloat64(pixelEstimateMultiplier))
 	expFee.Mul(expFee, priceInfo)
@@ -344,6 +344,17 @@ func TestEstimateFee(t *testing.T) {
 	fee, err = estimateFee(&stream.HLSSegment{Duration: 2.2}, profiles, priceInfo)
 	assert.Nil(err)
 	assert.Zero(fee.Cmp(expFee))
+
+	// Test estimation with fps pass-through
+	// pixels = (256 * 144 * 120 * 3) + (426 * 240 * 30 * 3)
+	profiles[0].Framerate = 0
+	expFee = new(big.Rat).SetInt64(22472640)
+	expFee.Mul(expFee, new(big.Rat).SetFloat64(pixelEstimateMultiplier))
+	expFee.Mul(expFee, priceInfo)
+	fee, err = estimateFee(&stream.HLSSegment{Duration: 3.0}, profiles, priceInfo)
+	assert.Nil(err)
+	assert.Zero(fee.Cmp(expFee))
+	assert.Equal(uint(0), profiles[0].Framerate, "Profile framerate was reset")
 }
 
 func TestNewBalanceUpdate(t *testing.T) {

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -565,9 +565,15 @@ func estimateFee(seg *stream.HLSSegment, profiles []ffmpeg.VideoProfile, priceIn
 		if err != nil {
 			return nil, err
 		}
+		framerate := p.Framerate
+		if framerate == 0 {
+			// FPS is being passed through (no fps adjustment)
+			// TODO incorporate the actual number of frames from the input
+			framerate = 120 // conservative estimate of input fps
+		}
 
 		// Take the ceiling of the duration to always overestimate
-		outPixels += int64(w*h) * int64(p.Framerate) * int64(math.Ceil(seg.Duration))
+		outPixels += int64(w*h) * int64(framerate) * int64(math.Ceil(seg.Duration))
 	}
 
 	// feeEstimate = pixels * pixelEstimateMultiplier * priceInfo


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

There is oversight with fee estimation when doing FPS pass-through. FPS pass-through is signaled via a `Framerate` value of 0, which would result in an estimated fee of zero.

Since we don't yet have the exact source frame rate (or the number of source frames), we just make a conservative guess of 120fps. This should ensure the estimated fee is sufficient in most normal scenarios.

Also added webhook tests because I needed to double check that it actually worked, and didn't see any corresponding unit tests.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- server: Estimate input framerate in fee estimation for fps passthrough. cc390ee
- server: Add webhook tests for fps passthrough. e6d65ce


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Unit tests

**Does this pull request close any open issues?**
<!-- Fixes # -->

Addresses some issues mentioned in https://github.com/livepeer/go-livepeer/issues/1478 around fee estimation.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
