### PR TITLE
cmd: redeemer and redeemerAddr flags

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -41,6 +41,7 @@ const (
 	BroadcasterNode NodeType = iota
 	OrchestratorNode
 	TranscoderNode
+	RedeemerNode
 )
 
 //LivepeerNode handles videos going in and coming out of the Livepeer network.


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Introduces flags to start an orchestrator with a ticket redemption service by providing the `-redeemer=true` flag. Other ochestrators in a multi-O cluster can connect to it using the `-redeemerAddr` flag. 

If either flag is omitted the node will start normally 

I didn't choose to support operating in standalone mode _yet_ . I feel like that can be done once we rework the main.go file a little bit and extract e.g. the blockwatcher as well. 

**How did you test each of these updates (required)**
Ran a local setup using the devtool 

```
I0527 03:11:52.402810   60759 livepeer.go:534] redeemer started
I0527 03:11:52.403949   60759 redeemer.go:164] new MonitorMaxFloat subscriber: 127.0.0.1:50398
```

**Does this pull request close any open issues?**
Fixes #1516 


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
