### PR TITLE
Add non-integer framerate support

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -183,6 +183,7 @@ func FFmpegProfiletoNetProfile(ffmpegProfiles []ffmpeg.VideoProfile) ([]*net.Vid
 			Height:  int32(height),
 			Bitrate: int32(bitrate),
 			Fps:     uint32(profile.Framerate),
+			FpsDen:  uint32(profile.FramerateDen),
 			Format:  format,
 		}
 		profiles = append(profiles, &fullProfile)

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -64,10 +64,11 @@ func TestFFmpegProfiletoNetProfile(t *testing.T) {
 			Resolution: "123x456",
 		},
 		ffmpeg.VideoProfile{
-			Name:       "prof2",
-			Bitrate:    "765k",
-			Framerate:  uint(876),
-			Resolution: "456x987",
+			Name:         "prof2",
+			Bitrate:      "765k",
+			Framerate:    uint(876),
+			FramerateDen: uint(12),
+			Resolution:   "456x987",
 		},
 	}
 
@@ -114,11 +115,16 @@ func TestFFmpegProfiletoNetProfile(t *testing.T) {
 	assert.Equal(fullProfiles[0].Format, net.VideoProfile_MP4)
 	assert.Equal(fullProfiles[1].Format, net.VideoProfile_MPEGTS)
 
+	// Verify FPS denominator behaviour
+	assert.Equal(fullProfiles[0].FpsDen, uint32(0))
+	assert.Equal(fullProfiles[1].FpsDen, uint32(profiles[1].FramerateDen))
+
 	// Invalid format should return error
 	profiles[1].Format = -1
 	fullProfiles, err = FFmpegProfiletoNetProfile(profiles)
 	assert.Equal(ErrFormatProto, err)
 	assert.Nil(fullProfiles)
+
 }
 
 func TestProfilesToHex(t *testing.T) {

--- a/core/lb.go
+++ b/core/lb.go
@@ -219,7 +219,12 @@ func calculateCost(profiles []ffmpeg.VideoProfile) int {
 			// passthrough; estimate 30fps for load balancing purposes
 			framerate = 30
 		}
-		cost += w * h * framerate // TODO incorporate duration
+		framerateDen := int(v.FramerateDen)
+		if 0 == framerateDen {
+			// denominator unset; treat as 1
+			framerateDen = 1
+		}
+		cost += w * h * (framerate / framerateDen) // TODO incorporate duration
 	}
 	return cost
 }

--- a/core/lb_test.go
+++ b/core/lb_test.go
@@ -16,11 +16,14 @@ import (
 
 func TestLB_CalculateCost(t *testing.T) {
 	assert := assert.New(t)
-	profiles := []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9, ffmpeg.P144p30fps16x9}
+	profiles := []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9, ffmpeg.P144p30fps16x9, ffmpeg.P144p30fps16x9}
 	profiles[0].Framerate = 1
 	profiles[1].Framerate = 0 // passthru; estimated to be 30fps for load
-	// 256 * 144 * 1 + 256 * 144 * 30
-	assert.Equal(1142784, calculateCost(profiles))
+	// rational FPS 29.97
+	profiles[2].Framerate = 30000
+	profiles[2].FramerateDen = 1001
+	// (256 * 144 * 1) + (256 * 144 * 30) + (256 * 144 * 29)
+	assert.Equal(2211840, calculateCost(profiles))
 }
 
 func TestLB_LeastLoaded(t *testing.T) {

--- a/core/streamdata.go
+++ b/core/streamdata.go
@@ -61,7 +61,7 @@ func NetSegData(md *SegTranscodingMetadata) (*net.SegData, error) {
 		Hash:       md.Hash.Bytes(),
 		Storage:    storage,
 		Duration:   int32(md.Duration / time.Millisecond),
-		// Triggers failure on Os that don't know how to use FullProfiles/2
+		// Triggers failure on Os that don't know how to use FullProfiles/2/3
 		Profiles: []byte("invalid"),
 	}
 
@@ -76,10 +76,20 @@ func NetSegData(md *SegTranscodingMetadata) (*net.SegData, error) {
 			allTS = false
 		}
 	}
-	if allTS {
-		segData.FullProfiles = fullProfiles
+	allIntFPS := true
+	for i := 0; i < len(md.Profiles) && allIntFPS; i++ {
+		if md.Profiles[i].FramerateDen != 0 {
+			allIntFPS = false
+		}
+	}
+	if allIntFPS {
+		if allTS {
+			segData.FullProfiles = fullProfiles
+		} else {
+			segData.FullProfiles2 = fullProfiles
+		}
 	} else {
-		segData.FullProfiles2 = fullProfiles
+		segData.FullProfiles3 = fullProfiles
 	}
 
 	return segData, nil

--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -29,7 +29,7 @@ The webhook may respond with an empty body.  In this case, the `manifestID` prop
     "manifestID": "ManifestID",
     "streamKey":  "SecretKey",
     "presets":    ["Preset", "Names"],
-    "profiles":   [{"name":"ProfileName", "width":320, "height":240, "bitrate":1000000, "fps":30}]
+    "profiles":   [{"name":"ProfileName", "width":320, "height":240, "bitrate":1000000, "fps":30, "fps_den":1}]
 }
 ```
 The Livepeer node will use the returned `manifestID` for the given stream.
@@ -40,6 +40,6 @@ An optional streamKey may be provided in order to protect the RTMP stream from p
 
 Presets can be specified to override the default transcoding options. The available presets are listed [here](https://github.com/livepeer/go-livepeer/blob/master/common/videoprofile_ids.go).
 
-Custom transcoding profiles can be provided if the presets are not sufficient. Given a stream name (manifest ID) of "ManifestID" and a profile name of "ProfileName", the specific profile will be available for playback at `/stream/ManifestID/ProfileName.m3u8`. However, to take advantage of ABR features in HLS players, the top-level stream name should usually be supplied instead, eg `/stream/ManifestID.m3u8` The `bitrate` field is in bits per second. The `fps` field can be omitted to preserve the source frame rate. Both presets and profiles can be used together to specify the desired transcodes.
+Custom transcoding profiles can be provided if the presets are not sufficient. Given a stream name (manifest ID) of "ManifestID" and a profile name of "ProfileName", the specific profile will be available for playback at `/stream/ManifestID/ProfileName.m3u8`. However, to take advantage of ABR features in HLS players, the top-level stream name should usually be supplied instead, eg `/stream/ManifestID.m3u8` The `bitrate` field is in bits per second. The `fps` field can be omitted to preserve the source frame rate. The `fps_den` (denominator) field can also be omitted for a default of `1`. Both presets and profiles can be used together to specify the desired transcodes.
 
 There is simple webhook authentication server [example](https://github.com/livepeer/go-livepeer/blob/master/cmd/simple_auth_server/simple_auth_server.go).

--- a/net/lp_rpc.pb.go
+++ b/net/lp_rpc.pb.go
@@ -562,6 +562,7 @@ type VideoProfile struct {
 	// FPS of VideoProfile
 	Fps                  uint32              `protobuf:"varint,20,opt,name=fps,proto3" json:"fps,omitempty"`
 	Format               VideoProfile_Format `protobuf:"varint,21,opt,name=format,proto3,enum=net.VideoProfile_Format" json:"format,omitempty"`
+	FpsDen               uint32              `protobuf:"varint,22,opt,name=fpsDen,proto3 json:"fpsDen,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
 	XXX_unrecognized     []byte              `json:"-"`
 	XXX_sizecache        int32               `json:"-"`

--- a/net/lp_rpc.pb.go
+++ b/net/lp_rpc.pb.go
@@ -456,7 +456,10 @@ type SegData struct {
 	// Deprecated by `fullProfiles2` but may still be used for mpegts formats
 	FullProfiles []*VideoProfile `protobuf:"bytes,33,rep,name=fullProfiles,proto3" json:"fullProfiles,omitempty"`
 	// Transcoding profiles to use. Supersedes `fullProfiles` field
-	FullProfiles2        []*VideoProfile `protobuf:"bytes,34,rep,name=fullProfiles2,proto3" json:"fullProfiles2,omitempty"`
+	// Deprecated by `fullProfiles3` but may still be used for integer FPS
+	FullProfiles2 []*VideoProfile `protobuf:"bytes,34,rep,name=fullProfiles2,proto3" json:"fullProfiles2,omitempty"`
+	// Transcoding profiles to use. Supersedes `fullProfiles2` field
+	FullProfiles3        []*VideoProfile `protobuf:"bytes,35,rep,name=fullProfiles3,proto3" json:"fullProfiles3,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
 	XXX_unrecognized     []byte          `json:"-"`
 	XXX_sizecache        int32           `json:"-"`
@@ -546,6 +549,13 @@ func (m *SegData) GetFullProfiles() []*VideoProfile {
 func (m *SegData) GetFullProfiles2() []*VideoProfile {
 	if m != nil {
 		return m.FullProfiles2
+	}
+	return nil
+}
+
+func (m *SegData) GetFullProfiles3() []*VideoProfile {
+	if m != nil {
+		return m.FullProfiles3
 	}
 	return nil
 }

--- a/net/lp_rpc.proto
+++ b/net/lp_rpc.proto
@@ -160,6 +160,9 @@ message VideoProfile {
     MP4        = 1;
   }
   Format format = 21;
+
+  // FPS Denominator of VideoProfile
+  uint32 fpsDen = 22;
 }
 
 // Individual transcoded segment data.

--- a/net/lp_rpc.proto
+++ b/net/lp_rpc.proto
@@ -135,7 +135,11 @@ message SegData {
   repeated VideoProfile fullProfiles = 33;
 
   // Transcoding profiles to use. Supersedes `fullProfiles` field
+  // Deprecated by `fullProfiles3` but may still be used for integer FPS
   repeated VideoProfile fullProfiles2 = 34;
+
+  // Transcoding profiles to use. Supersedes `fullProfiles2` field
+  repeated VideoProfile fullProfiles3 = 35;
 }
 
 message VideoProfile {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -116,6 +116,7 @@ type authWebhookResponse struct {
 		Height  int    `json:"height"`
 		Bitrate int    `json:"bitrate"`
 		FPS     uint   `json:"fps"`
+		FPSDen  uint   `json:"fpsDen"`
 	} `json:"profiles"`
 }
 
@@ -217,10 +218,11 @@ func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID str
 						profile.Bitrate)
 				}
 				prof := ffmpeg.VideoProfile{
-					Name:       name,
-					Bitrate:    fmt.Sprint(profile.Bitrate),
-					Framerate:  profile.FPS,
-					Resolution: fmt.Sprintf("%dx%d", profile.Width, profile.Height),
+					Name:         name,
+					Bitrate:      fmt.Sprint(profile.Bitrate),
+					Framerate:    profile.FPS,
+					FramerateDen: profile.FPSDen,
+					Resolution:   fmt.Sprintf("%dx%d", profile.Width, profile.Height),
 				}
 				profiles = append(profiles, prof)
 			}

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -433,7 +433,7 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	// set profiles with valid values, presets empty
 	ts7 := makeServer(`{"manifestID":"a", "profiles": [
 		{"name": "prof1", "bitrate": 432, "fps": 560, "width": 123, "height": 456},
-		{"name": "prof2", "bitrate": 765, "fps": 876, "width": 456, "height": 987},
+		{"name": "prof2", "bitrate": 765, "fps": 876, "fpsDen": 12, "width": 456, "height": 987},
 		{"name": "passthru_fps", "bitrate": 890, "width": 789, "height": 654}]}`)
 	defer ts7.Close()
 	params = createSid(u).(*streamParameters)
@@ -441,22 +441,25 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 
 	expectedProfiles := []ffmpeg.VideoProfile{
 		ffmpeg.VideoProfile{
-			Name:       "prof1",
-			Bitrate:    "432",
-			Framerate:  uint(560),
-			Resolution: "123x456",
+			Name:         "prof1",
+			Bitrate:      "432",
+			Framerate:    uint(560),
+			FramerateDen: 0,
+			Resolution:   "123x456",
 		},
 		ffmpeg.VideoProfile{
-			Name:       "prof2",
-			Bitrate:    "765",
-			Framerate:  uint(876),
-			Resolution: "456x987",
+			Name:         "prof2",
+			Bitrate:      "765",
+			Framerate:    uint(876),
+			FramerateDen: uint(12),
+			Resolution:   "456x987",
 		},
 		ffmpeg.VideoProfile{
-			Name:       "passthru_fps",
-			Bitrate:    "890",
-			Resolution: "789x654",
-			Framerate:  0,
+			Name:         "passthru_fps",
+			Bitrate:      "890",
+			Resolution:   "789x654",
+			Framerate:    0,
+			FramerateDen: 0,
 		},
 	}
 
@@ -475,7 +478,7 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	// set profiles and presets
 	ts9 := makeServer(`{"manifestID":"a", "presets":["P240p30fps16x9", "P720p30fps16x9"], "profiles": [
 		{"name": "prof1", "bitrate": 432, "fps": 560, "width": 123, "height": 456},
-		{"name": "prof2", "bitrate": 765, "fps": 876, "width": 456, "height": 987},
+		{"name": "prof2", "bitrate": 765, "fps": 876, "fpsDen": 12, "width": 456, "height": 987},
 		{"name": "passthru_fps", "bitrate": 890, "width": 789, "height": 654}]}`)
 
 	defer ts9.Close()

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -313,7 +313,9 @@ func coreSegMetadata(segData *net.SegData) (*core.SegTranscodingMetadata, error)
 	}
 	var err error
 	profiles := []ffmpeg.VideoProfile{}
-	if len(segData.FullProfiles2) > 0 {
+	if len(segData.FullProfiles3) > 0 {
+		profiles, err = makeFfmpegVideoProfiles(segData.FullProfiles3)
+	} else if len(segData.FullProfiles2) > 0 {
 		profiles, err = makeFfmpegVideoProfiles(segData.FullProfiles2)
 	} else if len(segData.FullProfiles) > 0 {
 		profiles, err = makeFfmpegVideoProfiles(segData.FullProfiles)

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -374,6 +374,18 @@ func TestEstimateFee(t *testing.T) {
 	assert.Nil(err)
 	assert.Zero(fee.Cmp(expFee))
 	assert.Equal(uint(0), profiles[0].Framerate, "Profile framerate was reset")
+
+	// Test estimation with non-integer fps
+	// pixels = (256 * 144 * ceil(30000/1001) * 3) + (426 * 240 * 30 * 3)
+	// Calculations should take ceiling of fps i.e. 29.97 -> 30
+	profiles[0].Framerate = 30000
+	profiles[0].FramerateDen = 1001
+	expFee = new(big.Rat).SetInt64(12519360)
+	expFee.Mul(expFee, new(big.Rat).SetFloat64(pixelEstimateMultiplier))
+	expFee.Mul(expFee, priceInfo)
+	fee, err = estimateFee(&stream.HLSSegment{Duration: 3.0}, profiles, priceInfo)
+	assert.Nil(err)
+	assert.Zero(fee.Cmp(expFee))
 }
 
 func TestNewBalanceUpdate(t *testing.T) {

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -386,6 +386,7 @@ func TestMakeFfmpegVideoProfiles(t *testing.T) {
 			Height:  int32(456),
 			Bitrate: int32(789),
 			Fps:     uint32(912),
+			FpsDen:  uint32(15),
 		},
 		{
 			Name:    "prof2",
@@ -393,24 +394,27 @@ func TestMakeFfmpegVideoProfiles(t *testing.T) {
 			Height:  int32(654),
 			Bitrate: int32(321),
 			Fps:     uint32(198),
+			//FpsDen:  0,
 		},
 	}
 
 	// testing happy case scenario
 	expectedProfiles := []ffmpeg.VideoProfile{
 		{
-			Name:       videoProfiles[0].Name,
-			Bitrate:    fmt.Sprint(videoProfiles[0].Bitrate),
-			Framerate:  uint(videoProfiles[0].Fps),
-			Resolution: fmt.Sprintf("%dx%d", videoProfiles[0].Width, videoProfiles[0].Height),
-			Format:     ffmpeg.FormatMPEGTS,
+			Name:         videoProfiles[0].Name,
+			Bitrate:      fmt.Sprint(videoProfiles[0].Bitrate),
+			Framerate:    uint(videoProfiles[0].Fps),
+			FramerateDen: uint(videoProfiles[0].FpsDen),
+			Resolution:   fmt.Sprintf("%dx%d", videoProfiles[0].Width, videoProfiles[0].Height),
+			Format:       ffmpeg.FormatMPEGTS,
 		},
 		{
-			Name:       videoProfiles[1].Name,
-			Bitrate:    fmt.Sprint(videoProfiles[1].Bitrate),
-			Framerate:  uint(videoProfiles[1].Fps),
-			Resolution: fmt.Sprintf("%dx%d", videoProfiles[1].Width, videoProfiles[1].Height),
-			Format:     ffmpeg.FormatMPEGTS,
+			Name:         videoProfiles[1].Name,
+			Bitrate:      fmt.Sprint(videoProfiles[1].Bitrate),
+			Framerate:    uint(videoProfiles[1].Fps),
+			FramerateDen: uint(0),
+			Resolution:   fmt.Sprintf("%dx%d", videoProfiles[1].Width, videoProfiles[1].Height),
+			Format:       ffmpeg.FormatMPEGTS,
 		},
 	}
 

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -303,6 +303,7 @@ func TestGenSegCreds_FullProfiles(t *testing.T) {
 	err = proto.Unmarshal(buf, &segData)
 	assert.Nil(err)
 	expectedProfiles, err = common.FFmpegProfiletoNetProfile(profiles)
+	assert.Equal(expectedProfiles[1].FpsDen, uint32(s.Profiles[1].FramerateDen))
 	assert.Equal([]byte("invalid"), segData.Profiles)
 	assert.Equal(expectedProfiles, segData.FullProfiles3)
 	assert.Empty(segData.FullProfiles)
@@ -352,11 +353,12 @@ func TestCoreSegMetadata_FullProfiles(t *testing.T) {
 			Resolution: "123x456",
 		},
 		ffmpeg.VideoProfile{
-			Name:       "prof2",
-			Bitrate:    "765k",
-			Framerate:  uint(876),
-			Resolution: "456x987",
-			Format:     ffmpeg.FormatMP4,
+			Name:         "prof2",
+			Bitrate:      "765k",
+			Framerate:    uint(876),
+			FramerateDen: uint(12),
+			Resolution:   "456x987",
+			Format:       ffmpeg.FormatMP4,
 		},
 	}
 
@@ -419,7 +421,6 @@ func TestMakeFfmpegVideoProfiles(t *testing.T) {
 			Height:  int32(654),
 			Bitrate: int32(321),
 			Fps:     uint32(198),
-			//FpsDen:  0,
 		},
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This PR adds support for non-integer framerates (#1474) by passing an optional FPS denominator field everywhere (like protobufs, webhooks etc.).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- bce44ea817ec6df1049f30da6e8ccc3517174c07
  - Add FPS Denominator field in VideoProfile protobuf struct
  - Verify correct conversion of VideoProfile structs between LPMS <-> Protobuf
  - Ensure all uses of FPS like pixel calc & cost calc use denominator as well
- b669b5549ff367d01a4211df0bdc6de1652a6fcb Add ability to set fps denominator through the AuthWebhook's JSON response
- 0ef95a5621a41a99d3dad72925c59a19cfbf75ef Add `FullProfiles3` field to maintain back compat with late upgraders who wouldn't support the new Denominator field
- 2958518ecda29f7a138431d7309a1f6e93e4cf26 Serialize `ffmpeg.VideoProfile` to `net.VideoProfile`, also update webhook docs.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Unit Tests for every change
- Manual Testing
  - [x] Non-int FPS with new B -> new OT Works
  - [x] Non-int FPS with new B -> old OT Fails
  - [x] Int FPS with old B -> new OT Works

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1474 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
