### PR TITLE
Build from source requires Ubuntu 18.04

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -51,7 +51,7 @@ You can also build your own executables from source code.
 
 &ensp; 2\. Make sure you have the necessary libraries installed:
 
- * Linux (Ubuntu 18.04): `apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git curl`
+ * Linux (Ubuntu: 16.04 or 18.04): `apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git curl`
 
  * OSX: `brew update && brew install pkg-config autoconf gnutls`
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -51,7 +51,7 @@ You can also build your own executables from source code.
 
 &ensp; 2\. Make sure you have the necessary libraries installed:
 
- * Linux (Ubuntu): `apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git curl`
+ * Linux (Ubuntu 18.04): `apt-get update && apt-get -y install build-essential pkg-config autoconf gnutls-dev git curl`
 
  * OSX: `brew update && brew install pkg-config autoconf gnutls`
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This change clarifies that the `install_ffmpeg.sh` step of the `install.md` document requires `Ubuntu 18.04` to complete successfully.

Previous testing was done on `Ubuntu 20.04 LTS`, on which `install_ffmpeg.sh` was shown to consistently fail, as documented in https://github.com/livepeer/go-livepeer/issues/1500

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Added that `18.04` version of Ubuntu is required

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested running the commands as shown below in the following environments, with these results:

|                       	| Ubuntu 18.04 LTS 	| Ubuntu 20.04 LTS 	|
|-----------------------	|:----------------:	|:----------------:	|
| Amazon AWS     	|      success     	|      not tested      	|
| Digital Ocean VPS     	|      success     	|      failed      	|
| Exoscale VPS          	|      success     	|      failed      	|
| Lenovo Thinkpad T490s 	|    not tested    	|      failed      	|

Commands run as `ubuntu` from clean install:
```
sudo apt-get update
sudo apt-get -y install build-essential pkg-config autoconf gnutls-dev git curl
mkdir livepeer && cd livepeer
git clone https://github.com/livepeer/go-livepeer.git
cd go-livepeer
./install_ffmpeg.sh
wget https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz
sudo tar -C /usr/local -xzf go1.14.4.linux-amd64.tar.gz
export PATH=$PATH:/usr/local/go/bin
PKG_CONFIG_PATH=~/compiled/lib/pkgconfig make
```

**Does this pull request close any open issues?**
<!-- Fixes # -->

None.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass