### PR TITLE
Miscellaneous test-related changes.

### DIFF
--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -163,7 +163,7 @@ func TestDBOrchestratorPoolCacheSize(t *testing.T) {
 	require.NotNil(emptyPool)
 	assert.Equal(0, emptyPool.Size())
 
-	addresses := []string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"}
+	addresses := []string{"stub1", "stub2", "stub3"}
 	orchestrators := StubOrchestrators(addresses)
 	for _, o := range orchestrators {
 		dbh.UpdateOrch(ethOrchToDBOrch(o))

--- a/eth/watchers/orchestratorwatcher_test.go
+++ b/eth/watchers/orchestratorwatcher_test.go
@@ -26,11 +26,11 @@ func TestOrchWatcher_WatchAndStop(t *testing.T) {
 	assert.Nil(err)
 
 	go ow.Watch()
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	// Test Stop
 	ow.Stop()
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	assert.True(watcher.sub.unsubscribed)
 }
 
@@ -61,10 +61,10 @@ func TestOrchWatcher_HandleLog_TranscoderActivated(t *testing.T) {
 
 	go ow.Watch()
 	defer ow.Stop()
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	watcher.sink <- []*blockwatch.Event{blockEvent}
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	assert.Equal(stubActivationRound.Int64(), stubStore.activationRound)
 	assert.Equal(stubStore.deactivationRound, maxFutureRound)
 	assert.Equal(stubStore.ethereumAddr, stubTranscoder.String())
@@ -74,7 +74,7 @@ func TestOrchWatcher_HandleLog_TranscoderActivated(t *testing.T) {
 	errorLogsBefore := glog.Stats.Error.Lines()
 	lpEth.Err = errors.New("GetServiceURI error")
 	watcher.sink <- []*blockwatch.Event{blockEvent}
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	errorLogsAfter := glog.Stats.Error.Lines()
 	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
 	lpEth.Err = nil
@@ -82,7 +82,7 @@ func TestOrchWatcher_HandleLog_TranscoderActivated(t *testing.T) {
 	blockEvent.Type = blockwatch.Removed
 	lpEth.Orch.ServiceURI = "http://mytranscoder.lpt:0000"
 	watcher.sink <- []*blockwatch.Event{blockEvent}
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	assert.Equal(stubStore.activationRound, int64(5))
 	assert.Equal(stubStore.deactivationRound, int64(100))
 	assert.Equal(stubStore.ethereumAddr, lpEth.Orch.Address.String())
@@ -92,7 +92,7 @@ func TestOrchWatcher_HandleLog_TranscoderActivated(t *testing.T) {
 	errorLogsBefore = glog.Stats.Error.Lines()
 	lpEth.Err = errors.New("GetTranscoder error")
 	watcher.sink <- []*blockwatch.Event{blockEvent}
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	errorLogsAfter = glog.Stats.Error.Lines()
 	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
 	lpEth.Err = nil
@@ -124,16 +124,16 @@ func TestOrchWatcher_HandleLog_TranscoderDeactivated(t *testing.T) {
 
 	go ow.Watch()
 	defer ow.Stop()
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	watcher.sink <- []*blockwatch.Event{blockEvent}
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	assert.Equal(stubDeactivationRound.Int64(), stubStore.deactivationRound)
 	assert.Equal(stubStore.ethereumAddr, stubTranscoder.String())
 
 	blockEvent.Type = blockwatch.Removed
 	watcher.sink <- []*blockwatch.Event{blockEvent}
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	assert.Equal(stubStore.deactivationRound, int64(10))
 	assert.Equal(stubStore.activationRound, int64(5))
 	assert.Equal(stubStore.ethereumAddr, lpEth.Orch.Address.String())
@@ -163,9 +163,9 @@ func TestOrchWatcher_HandleRoundEvent_CacheOrchestratorStake(t *testing.T) {
 	go ow.Watch()
 	defer ow.Stop()
 
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	tw.sink <- newRoundEvent
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	assert.Equal(stubStore.stake, int64(500000000))
 
@@ -173,7 +173,7 @@ func TestOrchWatcher_HandleRoundEvent_CacheOrchestratorStake(t *testing.T) {
 	lpEth.RoundsErr = errors.New("CurrentRound error")
 	errorLogsBefore := glog.Stats.Error.Lines()
 	tw.sink <- newRoundEvent
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	errorLogsAfter := glog.Stats.Error.Lines()
 	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
 	lpEth.RoundsErr = nil
@@ -182,7 +182,7 @@ func TestOrchWatcher_HandleRoundEvent_CacheOrchestratorStake(t *testing.T) {
 	stubStore.selectErr = errors.New("SelectOrchs error")
 	errorLogsBefore = glog.Stats.Error.Lines()
 	tw.sink <- newRoundEvent
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	errorLogsAfter = glog.Stats.Error.Lines()
 	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
 	stubStore.selectErr = nil
@@ -191,7 +191,7 @@ func TestOrchWatcher_HandleRoundEvent_CacheOrchestratorStake(t *testing.T) {
 	lpEth.TranscoderPoolError = errors.New("TranscoderEarningsPoolForRound error")
 	errorLogsBefore = glog.Stats.Error.Lines()
 	tw.sink <- newRoundEvent
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	errorLogsAfter = glog.Stats.Error.Lines()
 	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
 	lpEth.TranscoderPoolError = nil
@@ -200,7 +200,7 @@ func TestOrchWatcher_HandleRoundEvent_CacheOrchestratorStake(t *testing.T) {
 	stubStore.updateErr = errors.New("UpdateOrch error")
 	errorLogsBefore = glog.Stats.Error.Lines()
 	tw.sink <- newRoundEvent
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	errorLogsAfter = glog.Stats.Error.Lines()
 	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
 	stubStore.updateErr = nil

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -59,9 +59,7 @@ if [[ $(uname) != *"MSYS"* ]]; then
   if [ ! -e "$HOME/gmp-6.1.2" ]; then
     cd "$HOME"
     curl -LO https://github.com/livepeer/livepeer-builddeps/raw/34900f2b1be4e366c5270e3ee5b0d001f12bd8a4/gmp-6.1.2.tar.xz
-    xz -d gmp-6.1.2.tar.xz
-    tar xf gmp-6.1.2.tar
-    rm gmp-6.1.2.tar
+    tar xf gmp-6.1.2.tar.xz
     cd "$HOME/gmp-6.1.2"
     ./configure --prefix="$HOME/compiled" --disable-shared  --with-pic --enable-fat
     make
@@ -73,7 +71,6 @@ if [[ $(uname) != *"MSYS"* ]]; then
     cd $HOME
     curl -LO https://github.com/livepeer/livepeer-builddeps/raw/34900f2b1be4e366c5270e3ee5b0d001f12bd8a4/nettle-3.4.1.tar.gz
     tar xf nettle-3.4.1.tar.gz
-    rm nettle-3.4.1.tar.gz
     cd nettle-3.4.1
     LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --disable-shared --enable-pic
     make
@@ -84,9 +81,7 @@ if [[ $(uname) != *"MSYS"* ]]; then
   if [ ! -e "$HOME/gnutls-3.5.18" ]; then
     cd $HOME
     curl -LO https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.18.tar.xz
-    xz -d gnutls-3.5.18.tar.xz
-    tar xf gnutls-3.5.18.tar
-    rm gnutls-3.5.18.tar
+    tar xf gnutls-3.5.18.tar.xz
     cd gnutls-3.5.18
     LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" LIBS="-lhogweed -lnettle -lgmp" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools
     make

--- a/test.sh
+++ b/test.sh
@@ -1,37 +1,28 @@
 #!/usr/bin/env bash
 
+set -eux
+
 #Test script to run all the tests for continuous integration
 
-go test ./... -v
-t1=$?
+go test ./...
 
 cd core
 # Be more strict with load balancer tests: run with race detector enabled
-go test -logtostderr=true -run LB_ -race
-t2_lb=$?
+go test -run LB_ -race
 # Be more strict with nvidia tests: run with race detector enabled
-go test -logtostderr=true -run Nvidia_ -race
-t2_nv=$?
+go test -run Nvidia_ -race
 cd ..
+
 # Be more strict with discovery tests: run with race detector enabled
 cd discovery
-go test -logtostderr=true -race
-t_discovery=$?
+go test -race
 cd ..
+
 # Be more strict with HTTP push tests: run with race detector enabled
 cd server
-go test -logtostderr=true -run Push_ -race
-t_push=$?
+go test -run Push_ -race
 cd ..
 
 ./test_args.sh
-t_args=$?
 
-if (($t1!=0||$t2_lb!=0||$t2_nv!=0||$t_args!=0||$t_discovery!=0||$t_push!=0))
-then
-    printf "\n\nSome Tests Failed\n\n"
-    exit -1
-else
-    printf "\n\nAll Tests Passed\n\n"
-    exit 0
-fi
+printf "\n\nAll Tests Passed\n\n"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Miscellaneous changes to various aspects of the unit tests.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- e96be1c test: Simplify test script.
There's a couple effects from this change:
  - Reduces the verbosity of the tests, making it easier to spot failing cases
  - Using `set -e` makes the script exit immediately on a nonzero exit code. Mitigates the need to explicitly track and check test results.

- 12cb7eb discovery: Replace actual addresses with stubs. … 
This particular test fails if there happens to be another
process listening at any of the given ports.
For example, an actual Livepeer process.
Using dummy values seems to work and won't collide.

- 3e9d02d watcher: Increase sleep times during tests. … 
Makes tests less flaky on slower CI instances.

- b9cc7ef install_ffmpeg: Decompress and extract in a single step. … 
Not all machines have xd installed.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit tests


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
