### PR TITLE
Move StreamParameters into core

### DIFF
--- a/core/stream_test.go
+++ b/core/stream_test.go
@@ -10,7 +10,29 @@ import (
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/lpms/ffmpeg"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestStreamParameters(t *testing.T) {
+	assert := assert.New(t)
+
+	// empty params
+	s := StreamParameters{}
+	assert.Equal("/", s.StreamID())
+
+	// key only
+	s = StreamParameters{RtmpKey: "source"}
+	assert.Equal("/source", s.StreamID())
+
+	// mid only
+	mid := ManifestID("abc")
+	s = StreamParameters{ManifestID: mid}
+	assert.Equal("abc/", s.StreamID())
+
+	// both mid + key
+	s = StreamParameters{ManifestID: mid, RtmpKey: "source"}
+	assert.Equal("abc/source", s.StreamID())
+}
 
 func TestSegmentFlatten(t *testing.T) {
 	md := SegTranscodingMetadata{

--- a/core/streamdata.go
+++ b/core/streamdata.go
@@ -10,6 +10,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/net"
 
 	"github.com/livepeer/lpms/ffmpeg"
@@ -20,6 +21,19 @@ var ErrManifestID = errors.New("ErrManifestID")
 const (
 	DefaultManifestIDLength = 4
 )
+
+type StreamParameters struct {
+	ManifestID ManifestID
+	RtmpKey    string
+	Profiles   []ffmpeg.VideoProfile
+	Resolution string
+	Format     ffmpeg.Format
+	OS         drivers.OSSession
+}
+
+func (s *StreamParameters) StreamID() string {
+	return string(s.ManifestID) + "/" + s.RtmpKey
+}
 
 type SegTranscodingMetadata struct {
 	ManifestID ManifestID

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -187,7 +187,7 @@ func (bsm *BroadcastSessionsManager) suspendOrch(sess *BroadcastSession) {
 	bsm.sus.suspend(sess.OrchestratorInfo.GetTranscoder(), bsm.poolSize/bsm.numOrchs)
 }
 
-func NewSessionManager(node *core.LivepeerNode, params *streamParameters, sel BroadcastSessionsSelector) *BroadcastSessionsManager {
+func NewSessionManager(node *core.LivepeerNode, params *core.StreamParameters, sel BroadcastSessionsSelector) *BroadcastSessionsManager {
 	var poolSize float64
 	if node.OrchestratorPool != nil {
 		poolSize = float64(node.OrchestratorPool.Size())
@@ -211,7 +211,7 @@ func NewSessionManager(node *core.LivepeerNode, params *streamParameters, sel Br
 	return bsm
 }
 
-func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, count int, sus *suspender) ([]*BroadcastSession, error) {
+func selectOrchestrator(n *core.LivepeerNode, params *core.StreamParameters, count int, sus *suspender) ([]*BroadcastSession, error) {
 	if n.OrchestratorPool == nil {
 		glog.Info("No orchestrators specified; not transcoding")
 		return nil, errDiscovery

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -196,7 +196,7 @@ func NewSessionManager(node *core.LivepeerNode, params *streamParameters, pl cor
 	numOrchs := int(math.Min(poolSize, maxInflight*2))
 	sus := newSuspender()
 	bsm := &BroadcastSessionsManager{
-		mid:     params.mid,
+		mid:     params.ManifestID,
 		sel:     sel,
 		sessMap: make(map[string]*BroadcastSession),
 		createSessions: func() ([]*BroadcastSession, error) {
@@ -241,7 +241,7 @@ func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core
 		}
 
 		if n.Balances != nil {
-			balance = core.NewBalance(ticketParams.Recipient, params.mid, n.Balances)
+			balance = core.NewBalance(ticketParams.Recipient, params.ManifestID, n.Balances)
 		}
 
 		var orchOS drivers.OSSession
@@ -258,8 +258,8 @@ func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core
 
 		session := &BroadcastSession{
 			Broadcaster:      core.NewBroadcaster(n),
-			ManifestID:       params.mid,
-			Profiles:         params.profiles,
+			ManifestID:       params.ManifestID,
+			Profiles:         params.Profiles,
 			OrchestratorInfo: tinfo,
 			OrchestratorOS:   orchOS,
 			BroadcasterOS:    bcastOS,

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -187,7 +187,7 @@ func (bsm *BroadcastSessionsManager) suspendOrch(sess *BroadcastSession) {
 	bsm.sus.suspend(sess.OrchestratorInfo.GetTranscoder(), bsm.poolSize/bsm.numOrchs)
 }
 
-func NewSessionManager(node *core.LivepeerNode, params *streamParameters, pl core.PlaylistManager, sel BroadcastSessionsSelector) *BroadcastSessionsManager {
+func NewSessionManager(node *core.LivepeerNode, params *streamParameters, sel BroadcastSessionsSelector) *BroadcastSessionsManager {
 	var poolSize float64
 	if node.OrchestratorPool != nil {
 		poolSize = float64(node.OrchestratorPool.Size())
@@ -200,7 +200,7 @@ func NewSessionManager(node *core.LivepeerNode, params *streamParameters, pl cor
 		sel:     sel,
 		sessMap: make(map[string]*BroadcastSession),
 		createSessions: func() ([]*BroadcastSession, error) {
-			return selectOrchestrator(node, params, pl, numOrchs, sus)
+			return selectOrchestrator(node, params, numOrchs, sus)
 		},
 		sessLock: &sync.Mutex{},
 		numOrchs: numOrchs,
@@ -211,7 +211,7 @@ func NewSessionManager(node *core.LivepeerNode, params *streamParameters, pl cor
 	return bsm
 }
 
-func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core.PlaylistManager, count int, sus *suspender) ([]*BroadcastSession, error) {
+func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, count int, sus *suspender) ([]*BroadcastSession, error) {
 	if n.OrchestratorPool == nil {
 		glog.Info("No orchestrators specified; not transcoding")
 		return nil, errDiscovery
@@ -249,10 +249,10 @@ func selectOrchestrator(n *core.LivepeerNode, params *streamParameters, cpl core
 			orchOS = drivers.NewSession(tinfo.Storage[0])
 		}
 
-		bcastOS := cpl.GetOSSession()
+		bcastOS := params.OS
 		if bcastOS.IsExternal() {
 			// Give each O its own OS session to prevent front running uploads
-			pfx := fmt.Sprintf("%v/%v", cpl.ManifestID(), core.RandomManifestID())
+			pfx := fmt.Sprintf("%v/%v", params.ManifestID, core.RandomManifestID())
 			bcastOS = drivers.NodeStorage.NewSession(pfx)
 		}
 

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -206,12 +206,11 @@ func TestNewSessionManager(t *testing.T) {
 	assert := assert.New(t)
 
 	mid := core.RandomManifestID()
-	params := &streamParameters{}
 	storage := drivers.NewMemoryDriver(nil).NewSession(string(mid))
-	pl := core.NewBasicPlaylistManager(mid, storage)
+	params := &streamParameters{OS: storage}
 
 	// Check empty pool produces expected numOrchs
-	sess := NewSessionManager(n, params, pl, &LIFOSelector{})
+	sess := NewSessionManager(n, params, &LIFOSelector{})
 	assert.Equal(0, sess.numOrchs)
 
 	// Check numOrchs up to maximum and a bit beyond
@@ -219,7 +218,7 @@ func TestNewSessionManager(t *testing.T) {
 	n.OrchestratorPool = sd
 	max := int(common.HTTPTimeout.Seconds()/SegLen.Seconds()) * 2
 	for i := 0; i < 10; i++ {
-		sess = NewSessionManager(n, params, pl, &LIFOSelector{})
+		sess = NewSessionManager(n, params, &LIFOSelector{})
 		if i < max {
 			assert.Equal(i, sess.numOrchs)
 		} else {

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -207,7 +207,7 @@ func TestNewSessionManager(t *testing.T) {
 
 	mid := core.RandomManifestID()
 	storage := drivers.NewMemoryDriver(nil).NewSession(string(mid))
-	params := &streamParameters{OS: storage}
+	params := &core.StreamParameters{OS: storage}
 
 	// Check empty pool produces expected numOrchs
 	sess := NewSessionManager(n, params, &LIFOSelector{})

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -68,26 +68,13 @@ var httpPushResetTimer = func() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), sleepDur)
 }
 
-type streamParameters struct {
-	ManifestID core.ManifestID
-	RtmpKey    string
-	Profiles   []ffmpeg.VideoProfile
-	Resolution string
-	Format     ffmpeg.Format
-	OS         drivers.OSSession
-}
-
-func (s *streamParameters) StreamID() string {
-	return string(s.ManifestID) + "/" + s.RtmpKey
-}
-
 type rtmpConnection struct {
 	mid         core.ManifestID
 	nonce       uint64
 	stream      stream.RTMPVideoStream
 	pl          core.PlaylistManager
 	profile     *ffmpeg.VideoProfile
-	params      *streamParameters
+	params      *core.StreamParameters
 	sessManager *BroadcastSessionsManager
 	lastUsed    time.Time
 }
@@ -260,7 +247,7 @@ func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID str
 		if key == "" {
 			key = common.RandomIDGenerator(StreamKeyBytes)
 		}
-		return &streamParameters{
+		return &core.StreamParameters{
 			ManifestID: mid,
 			RtmpKey:    key,
 			// HTTP push mutates `profiles` so make a copy of it
@@ -308,9 +295,9 @@ func authenticateStream(url string) (*authWebhookResponse, error) {
 	return &authResp, nil
 }
 
-func streamParams(rtmpStrm stream.RTMPVideoStream) *streamParameters {
+func streamParams(rtmpStrm stream.RTMPVideoStream) *core.StreamParameters {
 	d := rtmpStrm.AppData()
-	p, ok := d.(*streamParameters)
+	p, ok := d.(*core.StreamParameters)
 	if !ok {
 		glog.Error("Mismatched type for RTMP app data")
 		return nil

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -69,15 +69,15 @@ var httpPushResetTimer = func() (context.Context, context.CancelFunc) {
 }
 
 type streamParameters struct {
-	mid        core.ManifestID
-	rtmpKey    string
-	profiles   []ffmpeg.VideoProfile
-	resolution string
-	format     ffmpeg.Format
+	ManifestID core.ManifestID
+	RtmpKey    string
+	Profiles   []ffmpeg.VideoProfile
+	Resolution string
+	Format     ffmpeg.Format
 }
 
 func (s *streamParameters) StreamID() string {
-	return string(s.mid) + "/" + s.rtmpKey
+	return string(s.ManifestID) + "/" + s.RtmpKey
 }
 
 type rtmpConnection struct {
@@ -260,10 +260,10 @@ func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID str
 			key = common.RandomIDGenerator(StreamKeyBytes)
 		}
 		return &streamParameters{
-			mid:     mid,
-			rtmpKey: key,
+			ManifestID: mid,
+			RtmpKey:    key,
 			// HTTP push mutates `profiles` so make a copy of it
-			profiles: append([]ffmpeg.VideoProfile(nil), profiles...),
+			Profiles: append([]ffmpeg.VideoProfile(nil), profiles...),
 		}
 	}
 }
@@ -379,7 +379,7 @@ func endRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 		}
 
 		//Remove RTMP stream
-		err := removeRTMPStream(s, params.mid)
+		err := removeRTMPStream(s, params.ManifestID)
 		if err != nil {
 			return err
 		}
@@ -395,21 +395,21 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 	if params == nil {
 		return nil, errMismatchedParams
 	}
-	mid := params.mid
+	mid := params.ManifestID
 	if drivers.NodeStorage == nil {
 		glog.Error("Missing node storage")
 		return nil, errStorage
 	}
 	storage := drivers.NodeStorage.NewSession(string(mid))
 	// Build the source video profile from the RTMP stream.
-	if params.resolution == "" {
-		params.resolution = fmt.Sprintf("%vx%v", rtmpStrm.Width(), rtmpStrm.Height())
+	if params.Resolution == "" {
+		params.Resolution = fmt.Sprintf("%vx%v", rtmpStrm.Width(), rtmpStrm.Height())
 	}
 	vProfile := ffmpeg.VideoProfile{
 		Name:       "source",
-		Resolution: params.resolution,
+		Resolution: params.Resolution,
 		Bitrate:    "4000k", // Fix this
-		Format:     params.format,
+		Format:     params.Format,
 	}
 	hlsStrmID := core.MakeStreamID(mid, &vProfile)
 	s.connectionLock.RLock()
@@ -633,12 +633,12 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 		}
 		st := stream.NewBasicRTMPVideoStream(appData)
 		params := streamParams(st)
-		params.resolution = r.Header.Get("Content-Resolution")
-		params.format = format
+		params.Resolution = r.Header.Get("Content-Resolution")
+		params.Format = format
 		// Set output formats if not explicitly specified
-		for i, v := range params.profiles {
+		for i, v := range params.Profiles {
 			if ffmpeg.FormatNone == v.Format {
-				params.profiles[i].Format = format
+				params.Profiles[i].Format = format
 			}
 		}
 
@@ -749,7 +749,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 		if length == 0 {
 			typ, ext, length = "application/vnd+livepeer.uri", ".txt", len(url)
 		} else {
-			format := cxn.params.profiles[i].Format
+			format := cxn.params.Profiles[i].Format
 			ext, err = common.ProfileFormatExtension(format)
 			if err != nil {
 				glog.Error("Unknown extension for format: ", err)
@@ -760,7 +760,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 				glog.Error("Unknown mime type for format: ", err)
 			}
 		}
-		profile := cxn.params.profiles[i].Name
+		profile := cxn.params.Profiles[i].Name
 		fname := fmt.Sprintf(`"%s_%d%s"`, profile, seq, ext)
 		hdrs := textproto.MIMEHeader{
 			"Content-Type":        {typ + "; name=" + fname},

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -95,7 +95,7 @@ func TestPush_MultipartReturn(t *testing.T) {
 		pl:          pl,
 		profile:     &ffmpeg.P144p30fps16x9,
 		sessManager: bsm,
-		params:      &streamParameters{profiles: []ffmpeg.VideoProfile{ffmpeg.P144p25fps16x9}},
+		params:      &streamParameters{Profiles: []ffmpeg.VideoProfile{ffmpeg.P144p25fps16x9}},
 	}
 
 	s.rtmpConnections["mani"] = cxn
@@ -416,7 +416,7 @@ func TestPush_MP4(t *testing.T) {
 	// Check formats
 	for _, cxn := range s.rtmpConnections {
 		assert.Equal(ffmpeg.FormatMP4, cxn.profile.Format)
-		for _, p := range cxn.params.profiles {
+		for _, p := range cxn.params.Profiles {
 			assert.Equal(ffmpeg.FormatMP4, p.Format)
 		}
 	}
@@ -446,9 +446,9 @@ func TestPush_SetVideoProfileFormats(t *testing.T) {
 	assert.Len(s.rtmpConnections, 1)
 	for _, cxn := range s.rtmpConnections {
 		assert.Equal(ffmpeg.FormatMPEGTS, cxn.profile.Format)
-		assert.Len(cxn.params.profiles, 2)
+		assert.Len(cxn.params.Profiles, 2)
 		assert.Len(BroadcastJobVideoProfiles, 2)
-		for i, p := range cxn.params.profiles {
+		for i, p := range cxn.params.Profiles {
 			assert.Equal(ffmpeg.FormatMPEGTS, p.Format)
 			// HTTP push mutates the profiles, causing undesirable changes to
 			// the default set of broadcast profiles that persist to subsequent
@@ -467,9 +467,9 @@ func TestPush_SetVideoProfileFormats(t *testing.T) {
 	assert.Len(s.rtmpConnections, 1)
 	for _, cxn := range s.rtmpConnections {
 		assert.Equal(ffmpeg.FormatMPEGTS, cxn.profile.Format)
-		assert.Len(cxn.params.profiles, 2)
+		assert.Len(cxn.params.Profiles, 2)
 		assert.Len(BroadcastJobVideoProfiles, 2)
-		for i, p := range cxn.params.profiles {
+		for i, p := range cxn.params.Profiles {
 			assert.Equal(ffmpeg.FormatMPEGTS, p.Format)
 			assert.Equal(ffmpeg.FormatNone, BroadcastJobVideoProfiles[i].Format)
 		}
@@ -486,9 +486,9 @@ func TestPush_SetVideoProfileFormats(t *testing.T) {
 	cxn, ok := s.rtmpConnections["new"]
 	assert.True(ok, "stream did not exist")
 	assert.Equal(ffmpeg.FormatMP4, cxn.profile.Format)
-	assert.Len(cxn.params.profiles, 2)
+	assert.Len(cxn.params.Profiles, 2)
 	assert.Len(BroadcastJobVideoProfiles, 2)
-	for i, p := range cxn.params.profiles {
+	for i, p := range cxn.params.Profiles {
 		assert.Equal(ffmpeg.FormatMP4, p.Format)
 		assert.Equal(ffmpeg.FormatNone, BroadcastJobVideoProfiles[i].Format)
 	}
@@ -517,9 +517,9 @@ func TestPush_SetVideoProfileFormats(t *testing.T) {
 	cxn, ok = s.rtmpConnections["web"]
 	assert.True(ok, "stream did not exist")
 	assert.Equal(ffmpeg.FormatMP4, cxn.profile.Format)
-	assert.Len(cxn.params.profiles, 2)
+	assert.Len(cxn.params.Profiles, 2)
 	assert.Len(BroadcastJobVideoProfiles, 2)
-	for i, p := range cxn.params.profiles {
+	for i, p := range cxn.params.Profiles {
 		assert.Equal(ffmpeg.FormatMP4, p.Format)
 		assert.Equal(ffmpeg.FormatNone, BroadcastJobVideoProfiles[i].Format)
 	}

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -95,7 +95,7 @@ func TestPush_MultipartReturn(t *testing.T) {
 		pl:          pl,
 		profile:     &ffmpeg.P144p30fps16x9,
 		sessManager: bsm,
-		params:      &streamParameters{Profiles: []ffmpeg.VideoProfile{ffmpeg.P144p25fps16x9}},
+		params:      &core.StreamParameters{Profiles: []ffmpeg.VideoProfile{ffmpeg.P144p25fps16x9}},
 	}
 
 	s.rtmpConnections["mani"] = cxn

--- a/test.sh
+++ b/test.sh
@@ -21,6 +21,7 @@ cd ..
 # Be more strict with HTTP push tests: run with race detector enabled
 cd server
 go test -run Push_ -race
+go test -run RegisterConnection -race
 cd ..
 
 ./test_args.sh


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

The upcoming support for capability discovery (https://github.com/livepeer/go-livepeer/issues/1519) means we need a way to:

* Determine the capabilities a job requires
* Use these capabilities to filter out eligible orchestrators during discovery

The most suitable, pre-existing structure for this seems to be `streamParameters`. Currently, `streamParameters` is used to propagate job-specific data between LPMS handlers, and is the primary configuration structure used by the webhook. It is also used during orchestrator selection. Hence, adding capabilities to `streamParameters` seems suitable, since most of the ... stream parameters .... required to generate the capabilities are already present within the structure. However, the current form of `streamParameters` poses a few issues for capability discovery:

* We probably don't want capability discovery to be located within `server` as that is large enough. `core` seems to be a better fit. (Happy to discuss this point further if anyone feels otherwise.)

* Fields within `streamParameters` need to be public to facilitate its use from `server` and `core`.

* `streamParameters` doesn't yet capture all the information that might be needed for capability discovery. One example: indicating which storage system the broadcaster is using. This would be useful as we expand driver support (eg: Azure, IPFS, Sia, etc) and need to select for orchestrators that support these drivers.

**Specific updates (required)**

* Moves `server.streamParameters` into `core.StreamParameters` 3ccf893
* Makes fields public for use within other modules 9e4998c
* Adds an "OS" field to the stream parameters. Not strictly necessary, but done mostly as an example. One nice side effect is this is we can remove the `PlaylistManager` from the orchestrator selection. f0d9fe1


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit testing. This is mostly a refactoring; no functional changes.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
