### PR TITLE
monitor, eth: log deposit and reserve for the broadcaster only when monitor is enabled

### DIFF
--- a/eth/watchers/senderwatcher.go
+++ b/eth/watchers/senderwatcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
 	"github.com/livepeer/go-livepeer/eth/contracts"
+	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/pm"
 )
 
@@ -259,6 +260,11 @@ func (sw *SenderWatcher) handleLog(log types.Log) error {
 		if eventName == "ReserveFunded" {
 			sw.reserveChangeFeed.Send(sender)
 		}
+	}
+
+	if sender == sw.lpEth.Account().Address && monitor.Enabled {
+		monitor.Deposit(sender.Hex(), sw.senders[sender].Deposit)
+		monitor.Reserve(sender.Hex(), sw.senders[sender].Reserve.FundsRemaining)
 	}
 
 	return nil


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Add statements for the monitoring package that log the reserve and deposit for a broadcaster when monitoring is enabled upon the senderWatcher receiving an event.

To make sure only events pertaining to the broadcaster are logged (and events are only logged when in broadcaster mode) we check whether the address for which the event was emitted is the current ETH client address.

**Specific updates (required)**
- Add necessary logic to `monitor` package 
- Adds calls to `monitor.Deposit()` and `monitor.Reserve()` in the `senderWatcher` 


**Does this pull request close any open issues?**
Fixes #1540 


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
