### PR TITLE
cmd: remove unused error check for price per segment

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -759,11 +759,6 @@ func main() {
 	msCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	if err != nil {
-		glog.Errorf("Error setting max price per segment: %v", err)
-		return
-	}
-
 	if *currentManifest {
 		glog.Info("Current ManifestID will be available over ", *httpAddr)
 		s.ExposeCurrentManifest = *currentManifest


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
removes some unused code related to price per segment pre-streamflow