### PR TITLE
server: fix TestSubmitSegment_HttpPostError test

### DIFF
--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -1355,7 +1355,7 @@ func TestSubmitSegment_HttpPostError(t *testing.T) {
 		Broadcaster: stubBroadcaster2(),
 		ManifestID:  core.RandomManifestID(),
 		OrchestratorInfo: &net.OrchestratorInfo{
-			Transcoder: "https://foo.com",
+			Transcoder: "https://127.0.0.1",
 			PriceInfo: &net.PriceInfo{
 				PricePerUnit:  1,
 				PixelsPerUnit: 1,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes a failing test that checks for a "connection refused" error on foo.com but the server for that domain doesn't actually have http2 enabled so the test fails. Sets it to post to `https://localhost/segment` instead.