### PR TITLE
common: Fix off-by-one DB test failure.

### DIFF
--- a/common/db_test.go
+++ b/common/db_test.go
@@ -1066,7 +1066,7 @@ func TestMarkWinningTicketRedeemed_Update_TxHash_And_SubmittedAt(t *testing.T) {
 	err = row.Scan(&txHashActual, &redeemedAt)
 	require.Nil(err)
 	assert.Equal(txHash.Hex(), txHashActual)
-	assert.Equal(redeemedAt.Day(), time.Now().Day())
+	assert.InDelta(redeemedAt.Day(), time.Now().Day(), 1)
 }
 
 func TestRemoveWinningTicket(t *testing.T) {


### PR DESCRIPTION
Apparently the day inserted in the DB can be different from
the current day by one value...? Accommodate this by allowing
a difference of 1.

**What does this pull request do? Explain your changes. (required)**

Adjusts test for DB submission time to accept a difference of one day.
This was failing on my machine for some reason. Haven't looked at what
may be happening beyond this quick fix.


**How did you test each of these updates (required)**

Unit tests

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
