### PR TITLE
Start Redeemer with TLS creds

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -523,7 +523,7 @@ func main() {
 				*redeemerAddr = defaultAddr(*redeemerAddr, "127.0.0.1", RpcPort)
 				rc, err := server.NewRedeemerClient(*redeemerAddr, senderWatcher, timeWatcher)
 				if err != nil {
-					glog.Error("Unable to start redeemer client:", err)
+					glog.Error("Unable to start redeemer client: ", err)
 					return
 				}
 				sm = rc
@@ -612,8 +612,14 @@ func main() {
 			}
 
 			*httpAddr = defaultAddr(*httpAddr, "127.0.0.1", RpcPort)
+			url, err := url.ParseRequestURI("https://" + *httpAddr)
+			if err != nil {
+				glog.Error("Could not parse redeemer URI: ", err)
+				return
+			}
+
 			go func() {
-				if err := r.Start(*httpAddr); err != nil {
+				if err := r.Start(url, n.WorkDir); err != nil {
 					redeemerErr <- err
 					return
 				}

--- a/server/redeemer_test.go
+++ b/server/redeemer_test.go
@@ -652,7 +652,7 @@ func TestRedeemerClient_CleanupLoop(t *testing.T) {
 	}
 
 	oldCleanupTime := cleanupLoopTime
-	cleanupLoopTime = 3 * time.Millisecond
+	cleanupLoopTime = 20 * time.Millisecond
 	defer func() {
 		cleanupLoopTime = oldCleanupTime
 	}()
@@ -669,13 +669,13 @@ func TestRedeemerClient_CleanupLoop(t *testing.T) {
 	// sender1 will be cleared
 	go r.startCleanupLoop()
 	time.Sleep(cleanupLoopTime)
-	close(r.quit)
-	time.Sleep(time.Millisecond)
-	r.quit = make(chan struct{})
+	time.Sleep(10 * time.Millisecond)
 	_, ok := r.senders[sender0]
 	assert.True(ok)
 	_, ok = r.senders[sender1]
 	assert.False(ok)
+
+	close(r.quit)
 }
 
 // Stubs

--- a/server/redeemer_test.go
+++ b/server/redeemer_test.go
@@ -5,7 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/big"
+	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -46,6 +49,35 @@ func TestRedeemerServer_NewRedeemer(t *testing.T) {
 	r, err = NewRedeemer(recipient, &eth.StubClient{}, &pm.LocalSenderMonitor{})
 	assert.Nil(err)
 	assert.Equal(r.recipient, recipient)
+}
+
+func TestRedeemerServer_Start(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	r, err := NewRedeemer(ethcommon.BytesToAddress([]byte("foo")), &eth.StubClient{}, &pm.LocalSenderMonitor{})
+	require.Nil(err)
+
+	url, err := url.ParseRequestURI("https://127.0.0.1:8935")
+	require.Nil(err)
+
+	tmpdir, err := ioutil.TempDir("", "")
+	require.Nil(err)
+	defer os.Remove(tmpdir)
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- r.Start(url, tmpdir)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+
+	// Check that client can connect to server
+	_, err = NewRedeemerClient(url.Host, newStubSenderManager(), &stubTimeManager{})
+	assert.Nil(err)
+
+	r.Stop()
+	assert.Nil(<-errCh)
 }
 
 func TestRedeemerServer_QueueTicket(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes a bug where the RedeemerClient is unable to connect to the Redeemer server because the RedeemerClient expects a TLS connection (it sets [grpc.TransportCredentials(credentials.NewTLS(...))](https://github.com/livepeer/go-livepeer/blob/c251e355e24675b1d37a430d45d4e4d834342d46/server/redeemer.go#L164) when dialing the Redeemer server), but the Redeemer server is not started with TLS creds. Now, the `getCert()` function to either load a local certificate or generate a self-signed certificate if a local certificate does not exist which is used to configure the Redeemer server.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- b0fe71f: server: Fix flaky TestRedeemerClient_CleanupLoop
- 7bfa6b6: cmd+server: Start RedeemerServer with TLS creds

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit tests and manually tested connecting an orchestrator running a RedeemerClient with a Redeemer server.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
