### PR TITLE
ci: Allow non-tagged mainnet builds

### DIFF
--- a/ci_env.sh
+++ b/ci_env.sh
@@ -35,15 +35,10 @@ for networkBranch in $NETWORK_BRANCHES; do
   fi
 done
 
-# Disallow non-tagged mainnet releases
+# Allow non-tagged mainnet builds, but tagged releases should be on the mainnet branch
 generatedVersion=$(./print_version.sh)
 definedVersion=$(cat VERSION)
-if [[ $HIGHEST_CHAIN_TAG == "mainnet" ]]; then
-  if [[ $generatedVersion != $definedVersion ]]; then
-    echo "disallowing mainnet release without semver tag; $generatedVersion != $definedVersion"
-    exit 1
-  fi
-else
+if [[ $HIGHEST_CHAIN_TAG != "mainnet" ]]; then
   if [[ $generatedVersion == $definedVersion ]]; then
     echo "disallowing semver tag release $generatedVersion on branch '$branch', should be 'mainnet'"
     exit 1

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -598,11 +598,11 @@ func TestSenderNoncesCleanupLoop(t *testing.T) {
 	}{1, big.NewInt(1)}
 
 	go r.senderNoncesCleanupLoop()
-	time.Sleep(time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	lsb := big.NewInt(1)
 	tm.blockNumSink <- lsb
-	time.Sleep(time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	// rand0 should still be present
 	_, ok := r.senderNonces[rand0]
@@ -616,7 +616,7 @@ func TestSenderNoncesCleanupLoop(t *testing.T) {
 
 	lsb = big.NewInt(2)
 	tm.blockNumSink <- lsb
-	time.Sleep(time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	// rand0 should still be present
 	_, ok = r.senderNonces[rand0]
@@ -628,6 +628,6 @@ func TestSenderNoncesCleanupLoop(t *testing.T) {
 
 	// test quit
 	r.Stop()
-	time.Sleep(time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	assert.True(tm.blockNumSub.(*stubSubscription).unsubscribed)
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Allow non-tagged mainnet builds. Semver tag releases still need to be on the mainnet branch.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- add5d16: Remove the requirement that builds on the mainnet branch need to be tagged
- 20f6266: Fixes a flaky test in the `pm` package that was causing CI to fail

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Test commits to trigger CI builds.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
