### PR TITLE
Misc on-chain mode updates 

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -52,8 +52,8 @@ var (
 	// The maximum blocks for the block watcher to retain
 	blockWatcherRetentionLimit = 20
 
-	// The gas required to redeem a PM ticket
-	redeemGas = 100000
+	// Estimate of the gas required to redeem a PM ticket
+	redeemGas = 250000
 	// The multiplier on the transaction cost to use for PM ticket faceValue
 	txCostMultiplier = 100
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -586,6 +586,15 @@ func main() {
 				panic(fmt.Errorf("-depositMultiplier must be greater than 0, but %v provided. Restart the node with a valid value for -depositMultiplier", *depositMultiplier))
 			}
 
+			// Fetch and cache broadcaster on-chain info
+			info, err := senderWatcher.GetSenderInfo(n.Eth.Account().Address)
+			if err != nil {
+				glog.Error("Failed to get broadcaster on-chain info: ", err)
+				return
+			}
+			glog.Info("Broadcaster Deposit: ", eth.FormatUnits(info.Deposit, "ETH"))
+			glog.Info("Broadcaster Reserve: ", eth.FormatUnits(info.Reserve.FundsRemaining, "ETH"))
+
 			n.Sender = pm.NewSender(n.Eth, timeWatcher, senderWatcher, ev, *depositMultiplier)
 
 			if *pixelsPerUnit <= 0 {

--- a/eth/watchers/senderwatcher.go
+++ b/eth/watchers/senderwatcher.go
@@ -71,6 +71,11 @@ func (sw *SenderWatcher) setSenderInfo(addr ethcommon.Address, info *pm.SenderIn
 	sw.mu.Lock()
 	defer sw.mu.Unlock()
 	sw.senders[addr] = info
+
+	if addr == sw.lpEth.Account().Address && monitor.Enabled {
+		monitor.Deposit(addr.Hex(), info.Deposit)
+		monitor.Reserve(addr.Hex(), info.Reserve.FundsRemaining)
+	}
 }
 
 // ClaimedReserve returns the amount claimed from a sender's reserve by the node operator

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -35,7 +35,7 @@ fi
 
 if [ ! -e "$HOME/nasm/nasm" ]; then
   # sudo apt-get -y install asciidoc xmlto # this fails :(
-  git clone -b nasm-2.14.02 https://repo.or.cz/nasm.git "$HOME/nasm"
+  git clone -b nasm-2.14.02 https://github.com/livepeer/nasm.git "$HOME/nasm"
   cd "$HOME/nasm"
   ./autogen.sh
   ./configure --prefix="$HOME/compiled"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR includes a few small updates pertaining to on-chain mode. See below.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 83a0730: Add statements for logging a broadcaster's deposit/reserve when caching the broadcaster's on-chain info
- 331c6e2: Cache the broadcaster's on-chain info on startup. This avoids a RPC call when the broadcaster sends its first payment or when it validates the first ticket params received from an orchestrator. This also logs the broadcaster's deposit/reserve on startup so that the information can immediately be exposed by Prometheus (the node is already logging the deposit/reserve whenever an on-chain event is received pertaining to the deposit or reserve). This allows a node operator to immediately start operating the broadcaster's deposit/reserve after startup by querying the Prometheus metrics.
- 73bf6cc: Sets the hardcoded ticket redemption gas estimate to 250k. The actual gas cost of ticket redemption on mainnet has varied from around 190k to around 300k. The gas cost is higher when ticket redemption triggers a claim from the reserve (which requires additional contract storage ops). This 250k value should usually be an overestimate when no reserve claim occurs. The downside is that when the 250k is an overestimate, the minimum ticket face value required by an orchestrator ended up being a little higher than it needs to be *or* the % overhead added to the orchestrator's price ends up being a little higher than it needs to be when the broadcaster's reserve cannot cover the minimum ticket face value. But, this 250k value will be an underestimate when a reserve claim occurs. I decided to set this value for now because it is a straightforward change that at least makes sure that the orchestrator is compensated properly when no reserve claim occurs (the status quo is that the gas estimate for ticket redemption of 100k is *always* an underestimate) and I think a better way to more accurately estimate the ticket redemption gas cost can be left for later.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Manual tests.

Fixes #1554 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
