### PR TITLE
cmd: intialise broadcaster senderinfo on node startup

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -598,6 +598,18 @@ func main() {
 				glog.Infof("Maximum transcoding price per pixel is not greater than 0: %v, broadcaster is currently set to accept ANY price.\n", *maxPricePerUnit)
 				glog.Infoln("To update the broadcaster's maximum acceptable transcoding price per pixel, use the CLI or restart the broadcaster with the appropriate 'maxPricePerUnit' and 'pixelsPerUnit' values")
 			}
+
+			// set broadcaster sender info cache
+			info, err := senderWatcher.GetSenderInfo(n.Eth.Account().Address)
+			if err != nil {
+				glog.Error(err)
+				return
+			}
+			if *monitor {
+				lpmon.Deposit(n.Eth.Account().Address.Hex(), info.Deposit)
+				lpmon.Reserve(n.Eth.Account().Address.Hex(), info.Reserve.FundsRemaining)
+			}
+
 		}
 
 		if *redeemer {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Initialises B's senderinfo on the `senderWatcher` on node startup to avoid nil pointer errors on `Reserve.FundsRemaining` 


**Does this pull request close any open issues?**
Fixes #1554 


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
