### PR TITLE
Use JSON config file to specify renditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ where the "movie" stream name is taken from the path in the RTMP URL.
 
 See the documentation on [RTMP ingest](doc/ingest.md) or [HTTP ingest](doc/ingest.md#http-push) for more details.
 
+For information on configuring the [transcoding options](doc/transcodingoptions.md), see the documentation.
+
 #### Authentication of incoming streams
 
 Incoming streams can be authenticated using a webhook. More details in the [webhook docs](doc/rtmpwebhookauth.md).

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -97,7 +97,7 @@ func main() {
 	transcoder := flag.Bool("transcoder", false, "Set to true to be a transcoder")
 	broadcaster := flag.Bool("broadcaster", false, "Set to true to be a broadcaster")
 	orchSecret := flag.String("orchSecret", "", "Shared secret with the orchestrator as a standalone transcoder")
-	transcodingOptions := flag.String("transcodingOptions", "P240p30fps16x9,P360p30fps16x9", "Transcoding options for broadcast job")
+	transcodingOptions := flag.String("transcodingOptions", "P240p30fps16x9,P360p30fps16x9", "Transcoding options for broadcast job, or path to json config")
 	maxAttempts := flag.Int("maxAttempts", 3, "Maximum transcode attempts")
 	maxSessions := flag.Int("maxSessions", 10, "Maximum number of concurrent transcoding sessions for Orchestrator, maximum number or RTMP streams for Broadcaster, or maximum capacity for transcoder")
 	currentManifest := flag.Bool("currentManifest", false, "Expose the currently active ManifestID as \"/stream/current.m3u8\"")
@@ -819,7 +819,11 @@ func main() {
 	//Create Livepeer Node
 
 	//Set up the media server
-	s := server.NewLivepeerServer(*rtmpAddr, n, *httpIngest)
+	s, err := server.NewLivepeerServer(*rtmpAddr, n, *httpIngest, *transcodingOptions)
+	if err != nil {
+		glog.Fatal("Error creating Livepeer server err=", err)
+	}
+
 	ec := make(chan error)
 	tc := make(chan struct{})
 	wc := make(chan struct{})
@@ -837,7 +841,7 @@ func main() {
 	}()
 	if n.NodeType != core.RedeemerNode {
 		go func() {
-			ec <- s.StartMediaServer(msCtx, *transcodingOptions, *httpAddr)
+			ec <- s.StartMediaServer(msCtx, *httpAddr)
 		}()
 	}
 

--- a/common/util.go
+++ b/common/util.go
@@ -40,6 +40,7 @@ var (
 	ErrFormatMime  = fmt.Errorf("unknown VideoProfile format for mime type")
 	ErrFormatExt   = fmt.Errorf("unknown VideoProfile format for extension")
 	ErrProfProto   = fmt.Errorf("unknown VideoProfile profile for protobufs")
+	ErrProfName    = fmt.Errorf("unknown VideoProfile profile name")
 
 	ext2mime = map[string]string{
 		".ts":  "video/mp2t",
@@ -235,7 +236,7 @@ func ProfilesNames(profiles []ffmpeg.VideoProfile) string {
 	return strings.Join(names, ",")
 }
 
-func EncoderProfileNameToValue(profile string) ffmpeg.Profile {
+func EncoderProfileNameToValue(profile string) (ffmpeg.Profile, error) {
 	var EncoderProfileLookup = map[string]ffmpeg.Profile{
 		"":                    ffmpeg.ProfileNone,
 		"none":                ffmpeg.ProfileNone,
@@ -246,9 +247,9 @@ func EncoderProfileNameToValue(profile string) ffmpeg.Profile {
 	}
 	p, ok := EncoderProfileLookup[strings.ToLower(profile)]
 	if !ok {
-		return ffmpeg.ProfileNone
+		return -1, ErrProfName
 	}
-	return p
+	return p, nil
 }
 
 func ProfileExtensionFormat(ext string) ffmpeg.Format {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -201,6 +201,24 @@ func TestVideoProfile_FormatExtension(t *testing.T) {
 		t.Error("Did not get expected error")
 	}
 }
+
+func TestVideoProfile_ProfileNameToValue(t *testing.T) {
+	assert := assert.New(t)
+	inp := []string{"", "h264baseline", "h264main", "h264high", "h264constrainedhigh"}
+	assert.Len(inp, len(ffmpeg.ProfileParameters), "Missing a new profile?")
+	outp := []ffmpeg.Profile{ffmpeg.ProfileNone, ffmpeg.ProfileH264Baseline, ffmpeg.ProfileH264Main, ffmpeg.ProfileH264High, ffmpeg.ProfileH264ConstrainedHigh}
+	assert.Len(inp, len(outp))
+	for i, profile := range inp {
+		p, err := EncoderProfileNameToValue(profile)
+		assert.Nil(err)
+		assert.Equal(outp[i], p)
+	}
+	p, _ := EncoderProfileNameToValue("none")
+	assert.Equal(ffmpeg.ProfileNone, p)
+	_, err := EncoderProfileNameToValue("invalid")
+	assert.Equal(ErrProfName, err, "Could not get profile value")
+}
+
 func TestPriceToFixed(t *testing.T) {
 	assert := assert.New(t)
 

--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -1,6 +1,8 @@
-# RTMP Webhook Authentication
+# Webhook Authentication
 
-Incoming RTMP streams can be authenticated using Webhooks. To use these webhooks, node operators must implement their own web service / endpoint to be accessed only by the Livepeer node. As new RTMP streams appear, the Livepeer node will call this endpoint to determine whether the given stream is allowed.
+Incoming streams can be authenticated using webhooks. To use these webhooks, node operators must implement their own web service / endpoint to be accessed only by the Livepeer node. As new streams appear, the Livepeer node will call this endpoint to determine whether the given stream is allowed.
+
+Webhooks can authenticate streams supported by the RTMP and HTTP push ingest protocols. See the [ingest documentation](ingest.md) for details on how to use these protocols.
 
 To enable webhook authentication functionality, the Livepeer node should be started with the `-authWebhookUrl` flag, along with the webhook endpoint URL.
 
@@ -10,9 +12,9 @@ For example:
 livepeer -authWebhookUrl http://ownserver/auth
 ```
 
-For each incoming RTMP stream, the Livepeer node will make a `POST` request to the `http://ownserver/auth` endpoint, passing the URL of the RTMP request as JSON object.
+For each incoming stream, the Livepeer node will make a `POST` request to the `http://ownserver/auth` endpoint, passing the URL of the request as JSON object.
 
-For example, if the incoming RTMP request was made to `rtmp://livepeer.node/manifest`, the Liverpeer node will provide the following object as a request to the webhook endpoint:
+For example, if the incoming request was made to `rtmp://livepeer.node/manifest`, the Liverpeer node will provide the following object as a request to the webhook endpoint:
 
 ```json
 {
@@ -20,9 +22,9 @@ For example, if the incoming RTMP request was made to `rtmp://livepeer.node/mani
 }
 ```
 
-The webhook server should respond with HTTP status code `200` in order to authenticate / authorize the RTMP stream. A response with a HTTP status code other than `200` will cause the Livepeer node to disconnect the RTMP stream.
+The webhook server should respond with HTTP status code `200` in order to authenticate / authorize the stream. A response with a HTTP status code other than `200` will cause the Livepeer node to disconnect the stream.
 
-The webhook may respond with an empty body.  In this case, the `manifestID` property of the stream will be taken from the RTMP URL.  If the RTMP URL does not specify a manifest id, then it will be generated at random.  Otherwise, the webhook endpoint should respond with a JSON object in the following format:
+The webhook may respond with an empty body.  In this case, the `manifestID` property of the stream will be taken from the URL.  If the URL does not specify a manifest id, then it will be generated at random.  Otherwise, the webhook endpoint should respond with a JSON object in the following format:
 
 ```json
 {

--- a/doc/transcodingoptions.md
+++ b/doc/transcodingoptions.md
@@ -1,0 +1,155 @@
+# Configuring Transcoding Options
+
+The Livepeer node offers several methods to configure the transcoding output.
+
+* Webhook authentication.
+
+* `-transcodingOptions` CLI flag with a list of presets
+
+* `-transcodingOptions` CLI flag with a JSON configuration file
+
+* `/setBroadcastConfig` endpoint for the CLI API
+
+* `livepeer_cli` tool
+
+### Codecs
+
+Transcoding to and from H.264 is supported.
+
+### Aspect Ratio
+
+The Livepeer transcoder maintains the aspect ratio of the source video in order to maintain output video quality. This may sometimes result in the transcoded resolution being somewhat different from the original specification.
+
+ If the aspect ratio of the source video does not match the target aspect ratio, the output is fit to the larger dimension, and the smaller dimension is rescaled proportionately to maintain the source aspect ratio.
+
+If a different behavior is needed, please [let us know](https://github.com/livepeer/go-livepeer/issues/new?template=feature_request.md) by filing a feature request.
+
+### Webhook Authentication
+
+See the [webhook documentation](rtmpwebhookauth.md) for full details. To configure the transcoding output, either the `profiles` or `presets` fields in the webhook response can be set, or both.
+
+The `profiles` field in the webhook follows the JSON options that are described in this document. The valid names for the `preset` field are described in the following section.
+
+### `-transcodingOptions` CLI flag with a list of presets
+
+The Livepeer node comes with a set of pre-defined transcoding presets. At start-up, the node can be configured with a comma-separated list of presets. The available presets are defined within the [LPMS video profiles](https://github.com/livepeer/lpms/blob/master/ffmpeg/videoprofile.go#L60-L92).
+
+
+For example, to run the Livepeer node with the 720P 25fps and 240p 30fps 4x3 presets:
+
+```
+livepeer -transcodingOptions P720p25fps16x9,P240p30fps4x3
+```
+
+### `-transcodingOptions` CLI flag with a JSON configuration file
+
+The Livepeer node can receive transcoding configuration via JSON config file. Run the node with the `-transcodingOptions` flag and a path to the JSON file.
+
+```
+livepeer -transcodingOptions /path/to/config.json
+```
+
+The JSON configuration takes a list of renditions,
+```
+[
+    { rendition },
+    { rendition },
+
+]
+```
+
+Each rendition object takes the following fields:
+
+* `name`  : String identifier by which the rendition can be referred to. If
+  a name is omitted, the default naming scheme follows `webhook_<width>x<height>_<bitrate>`
+* `width` : Integer width
+* `height` : Integer height
+* `bitrate` : Integer bitrate, in bits per second
+* `fps` : Integer framerate, in frames per second. If zero or omitted, no FPS
+  adjustment is done and the output will have the same number of frames spaced
+at similar timing intervals as the source.
+* `fpsDen` : Integer framerate denominator. Useful for interoperability with
+  certain applications, eg NTSC's 29.97 fps (30000/1001). This value defaults to 1 if zero or omitted.
+* `profile` : String codec encoding profile to use. Supported values are
+  "H264Baseline", "H264Main", "H264High", "H264ConstrainedHigh". The field can
+be omitted or set to "None" to use the encoder default.
+* `gop` : String [GOP](https://en.wikipedia.org/wiki/Group_of_pictures) length,
+  in seconds. This may help in post-transcoding segmentation to smooth out
+playback if the original segments are long or irregularly-sized. Omitting this
+field will use the encoder default. To force all intra frames, use "intra".
+
+An example of a full JSON configuration:
+
+```
+[
+    {
+        "name": "ntsc-1080p",
+        "width": 1920,
+        "height": 1080,
+        "bitrate": 5000000,
+        "fps": 30000,
+        "fpsDen": 1001,
+        "profile": H264High,
+        "gop": "2",
+    },{
+        "name": "webrtc-720p",
+        "width": 1280,
+        "height": 720,
+        "bitrate": 1500000,
+        "profile": H264ConstrainedHigh,
+    },{
+        "name":"highlight-reel",
+        "width":160,
+        "height":120,
+        "bitrate":100000,
+        "fps": "0.1",
+        "gop":"intra",
+    }
+]
+```
+
+
+### `/setBroadcastConfig` endpoint for the CLI API
+
+The CLI port has a `/setBroadcastConfig` API . This may be useful if the transcoding options set via CLI flags need to be adjusted at runtime. Note that pricing needs to be set; for offchain transcoding, a placehodler value will suffice.
+
+```
+curl 'http://localhost:7935/setBroadcastConfig?transcodingOptions=P720p25fps16x9,P240p30fps4x3&maxPricePerUnit=1&pixelsPerUnit=1'
+```
+
+### `livepeer_cli` tool
+
+For a wizard-based interface to the CLI API, the `livepeer_cli` tool may be used. Look for the 'Set broadcast config' option and follow the prompts.
+
+```
+livepeer_cli
+# ... status information about the node
+What would you like to do? (default = stats)
+# various options
+16. Set broadcast config
+
+> 16
+Enter a maximum transcoding price per pixel, in wei per pixels (pricePerUnit / pixelsPerUnit).
+eg. 1 wei / 10 pixels = 0,1 wei per pixel
+
+Enter amount of pixels that make up a single unit (default: 1 pixel) - >
+
+Enter the maximum price to pay for 1 pixels in Wei (required) - > 1
+Identifier	Transcoding Options
+0		P144p30fps16x9
+1		P240p25fps16x9
+2		P240p30fps16x9
+3		P240p30fps4x3
+4		P360p25fps16x9
+5		P360p30fps16x9
+6		P360p30fps4x3
+7		P576p25fps16x9
+8		P576p30fps16x9
+9		P720p25fps16x9
+10		P720p30fps16x9
+11		P720p30fps4x3
+12		P720p60fps16x9
+Enter the identifiers of the video profiles you would like to use (use a comma as the delimiter in a list of identifiers) - > 10,3
+
+```
+

--- a/server/cliserver_test.go
+++ b/server/cliserver_test.go
@@ -29,7 +29,7 @@ func newMockServer() *httptest.Server {
 	go func() { n.TranscoderManager.Manage(strm, 5) }()
 	time.Sleep(1 * time.Millisecond)
 	n.Transcoder = n.TranscoderManager
-	s := NewLivepeerServer("127.0.0.1:1938", n, true)
+	s, _ := NewLivepeerServer("127.0.0.1:1938", n, true, "")
 	mux := s.cliWebServerHandlers("addr")
 	srv := httptest.NewServer(mux)
 	return srv
@@ -74,7 +74,7 @@ func TestGetEthChainID(t *testing.T) {
 	err = dbh.SetChainID(big.NewInt(1))
 	require.Nil(err)
 	n, _ := core.NewLivepeerNode(&eth.StubClient{}, "./tmp", dbh)
-	s := NewLivepeerServer("127.0.0.1:1938", n, true)
+	s, _ := NewLivepeerServer("127.0.0.1:1938", n, true, "")
 	mux := s.cliWebServerHandlers("addr")
 	srv = httptest.NewServer(mux)
 	defer srv.Close()
@@ -162,7 +162,7 @@ func TestRegisteredOrchestrators(t *testing.T) {
 
 	n, _ := core.NewLivepeerNode(eth, "./tmp", dbh)
 
-	s := NewLivepeerServer("127.0.0.1:1938", n, true)
+	s, _ := NewLivepeerServer("127.0.0.1:1938", n, true, "")
 	mux := s.cliWebServerHandlers("addr")
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -329,14 +329,17 @@ func jsonProfileToVideoProfile(resp *authWebhookResponse) ([]ffmpeg.VideoProfile
 				gop = time.Duration(gopFloat * float64(time.Second))
 			}
 		}
-
+		encodingProfile, err := common.EncoderProfileNameToValue(profile.Profile)
+		if err != nil {
+			return nil, err
+		}
 		prof := ffmpeg.VideoProfile{
 			Name:         name,
 			Bitrate:      fmt.Sprint(profile.Bitrate),
 			Framerate:    profile.FPS,
 			FramerateDen: profile.FPSDen,
 			Resolution:   fmt.Sprintf("%dx%d", profile.Width, profile.Height),
-			Profile:      common.EncoderProfileNameToValue(profile.Profile),
+			Profile:      encodingProfile,
 			GOP:          gop,
 		}
 		profiles = append(profiles, prof)

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -110,7 +110,7 @@ type authWebhookResponse struct {
 	} `json:"profiles"`
 }
 
-func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bool) *LivepeerServer {
+func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bool, transcodingOptions string) (*LivepeerServer, error) {
 	opts := lpmscore.LPMSOpts{
 		RtmpAddr:     rtmpAddr,
 		RtmpDisabled: true,
@@ -120,6 +120,29 @@ func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bo
 	switch lpNode.NodeType {
 	case core.BroadcasterNode:
 		opts.RtmpDisabled = false
+
+		if transcodingOptions != "" {
+			profiles := BroadcastJobVideoProfiles
+			content, err := ioutil.ReadFile(transcodingOptions)
+			if err == nil && len(content) > 0 {
+				stubResp := &authWebhookResponse{}
+				err = json.Unmarshal(content, &stubResp.Profiles)
+				if err != nil {
+					return nil, err
+				}
+				profiles, err = jsonProfileToVideoProfile(stubResp)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// check the built-in profiles
+				profiles = parsePresets(strings.Split(transcodingOptions, ","))
+			}
+			if len(profiles) <= 0 {
+				return nil, fmt.Errorf("No transcoding profiles found")
+			}
+			BroadcastJobVideoProfiles = profiles
+		}
 	}
 	server := lpmscore.New(&opts)
 	ls := &LivepeerServer{RTMPSegmenter: server, LPMS: server, LivepeerNode: lpNode, HTTPMux: opts.HttpMux, connectionLock: &sync.RWMutex{},
@@ -128,15 +151,11 @@ func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bo
 	if lpNode.NodeType == core.BroadcasterNode && httpIngest {
 		opts.HttpMux.HandleFunc("/live/", ls.HandlePush)
 	}
-	return ls
+	return ls, nil
 }
 
 //StartMediaServer starts the LPMS server
-func (s *LivepeerServer) StartMediaServer(ctx context.Context, transcodingOptions string, httpAddr string) error {
-	if transcodingOptions != "" { // mostly to mitigate race conditions in tests
-		BroadcastJobVideoProfiles = parsePresets(strings.Split(transcodingOptions, ","))
-	}
-
+func (s *LivepeerServer) StartMediaServer(ctx context.Context, httpAddr string) error {
 	glog.V(common.SHORT).Infof("Transcode Job Type: %v", BroadcastJobVideoProfiles)
 
 	//LPMS handlers for handling RTMP video
@@ -199,38 +218,11 @@ func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID str
 				profiles = parsePresets(resp.Presets)
 			}
 
-			for _, profile := range resp.Profiles {
-				name := profile.Name
-				if name == "" {
-					name = "webhook_" + common.DefaultProfileName(
-						profile.Width,
-						profile.Height,
-						profile.Bitrate)
-				}
-				var gop time.Duration
-				if profile.GOP != "" {
-					if profile.GOP == "intra" {
-						gop = ffmpeg.GOPIntraOnly
-					} else {
-						gopFloat, err := strconv.ParseFloat(profile.GOP, 64)
-						if err != nil || gopFloat <= 0.0 {
-							glog.Error("Invalid GOP from webhook err=", err)
-							return nil
-						}
-						gop = time.Duration(gopFloat * float64(time.Second))
-					}
-				}
-				prof := ffmpeg.VideoProfile{
-					Name:         name,
-					Bitrate:      fmt.Sprint(profile.Bitrate),
-					Framerate:    profile.FPS,
-					FramerateDen: profile.FPSDen,
-					Resolution:   fmt.Sprintf("%dx%d", profile.Width, profile.Height),
-					Profile:      common.EncoderProfileNameToValue(profile.Profile),
-					GOP:          gop,
-				}
-				profiles = append(profiles, prof)
+			parsedProfiles, err := jsonProfileToVideoProfile(resp)
+			if err != nil {
+				return nil
 			}
+			profiles = append(profiles, parsedProfiles...)
 
 			// Only set defaults if user did not specify a preset/profile
 			if len(resp.Profiles) <= 0 && len(resp.Presets) <= 0 {
@@ -310,6 +302,46 @@ func authenticateStream(url string) (*authWebhookResponse, error) {
 		monitor.AuthWebhookFinished(took)
 	}
 	return &authResp, nil
+}
+
+func jsonProfileToVideoProfile(resp *authWebhookResponse) ([]ffmpeg.VideoProfile, error) {
+	profiles := []ffmpeg.VideoProfile{}
+	for _, profile := range resp.Profiles {
+		name := profile.Name
+		if name == "" {
+			name = "webhook_" + common.DefaultProfileName(
+				profile.Width,
+				profile.Height,
+				profile.Bitrate)
+		}
+		var gop time.Duration
+		if profile.GOP != "" {
+			if profile.GOP == "intra" {
+				gop = ffmpeg.GOPIntraOnly
+			} else {
+				gopFloat, err := strconv.ParseFloat(profile.GOP, 64)
+				if err != nil {
+					return nil, err
+				}
+				if gopFloat <= 0.0 {
+					return nil, errors.New("invalid gop value")
+				}
+				gop = time.Duration(gopFloat * float64(time.Second))
+			}
+		}
+
+		prof := ffmpeg.VideoProfile{
+			Name:         name,
+			Bitrate:      fmt.Sprint(profile.Bitrate),
+			Framerate:    profile.FPS,
+			FramerateDen: profile.FPSDen,
+			Resolution:   fmt.Sprintf("%dx%d", profile.Width, profile.Height),
+			Profile:      common.EncoderProfileNameToValue(profile.Profile),
+			GOP:          gop,
+		}
+		profiles = append(profiles, prof)
+	}
+	return profiles, nil
 }
 
 func streamParams(rtmpStrm stream.RTMPVideoStream) *core.StreamParameters {

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -1051,5 +1051,22 @@ func TestJsonProfileToVideoProfiles(t *testing.T) {
 	assert.Nil(p)
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "strconv.ParseFloat: parsing")
+	resp.Profiles[0].GOP = ""
 
+	// test default encoding profile
+	p, err = jsonProfileToVideoProfile(resp)
+	assert.Nil(err)
+	assert.Equal(ffmpeg.ProfileNone, p[0].Profile)
+
+	// test encoding profile
+	resp.Profiles[0].Profile = "h264baseline"
+	p, err = jsonProfileToVideoProfile(resp)
+	assert.Nil(err)
+	assert.Equal(ffmpeg.ProfileH264Baseline, p[0].Profile)
+
+	// test invalid encoding profile
+	resp.Profiles[0].Profile = "invalid"
+	p, err = jsonProfileToVideoProfile(resp)
+	assert.Nil(p)
+	assert.Equal(common.ErrProfName, err)
 }

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -265,7 +265,7 @@ func TestPush_HTTPIngest(t *testing.T) {
 	req := httptest.NewRequest("POST", "/live/name/1.mp4", reader)
 
 	// HTTP ingest disabled
-	s := NewLivepeerServer("127.0.0.1:1938", n, false)
+	s, _ := NewLivepeerServer("127.0.0.1:1938", n, false, "")
 	h, pattern := s.HTTPMux.Handler(req)
 	assert.Equal("", pattern)
 
@@ -276,7 +276,7 @@ func TestPush_HTTPIngest(t *testing.T) {
 	assert.Equal(404, resp.StatusCode)
 
 	// HTTP ingest enabled
-	s = NewLivepeerServer("127.0.0.1:1938", n, true)
+	s, _ = NewLivepeerServer("127.0.0.1:1938", n, true, "")
 	h, pattern = s.HTTPMux.Handler(req)
 	assert.Equal("/live/", pattern)
 


### PR DESCRIPTION
**TODO**

- [x] Documentation updates.
- [x] Manual testing with existing workflows - have only tested with the pull prototype
- [x] Limited set of integration tests [here](https://gist.github.com/j0sh/9d884a19bb92e504092e71fd19d812e5#file-run-sh)

**What does this pull request do? Explain your changes. (required)**

Currently, only pre-defined presets can be selected via CLI flags. These presets expose a limited subset of the configuration available to the user. In order to to access all the configuration options, the user needs to run a separate webhook service. While webhooks are extremely useful in a distributed, scaled environment, they are unwieldy for local  use of the node.

This PR enables the ability to configure the output presets via JSON file. The existing `-transcodingOptions` flag is overloaded as follows:

* If the `-transcodingOptions` flag is not set, nothing happens (default presets are used). Matches current behavior. 
* Attempts to read a file based on the value of `-transcodingOptions`.
* If reading the file succeeds, parses and processes the JSON.
* If there is an error reading the file, attempts to parse the preset string. Matches current behavior.
* If no profile is successfully read, fails. This is new behavior.

The existing JSON definition from the webhook is reused. This was the fastest way to get things working. The only thing worse than JSON for configuration is YAML. 🙈  We can always add better format support later.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Moves transcodingOptions processing to `NewLivepeerServer` from `StartMediaServer`. This is a bit neater and makes later work easier ([pull mode](https://github.com/livepeer/go-livepeer/compare/ja/pull) does not start the media server but still needs to initialize a livepeer server)
- Moves JSON-to-VideoProfile parsing into its own helper function.
- Invokes the helper function within `NewLivepeerServer`, in addition to the webhook handler.
- Tightens up error handling around invalid encoding profiles
- Adds test coverage
- Updates documentation, including the addition of a page on transcoding configuration

**How did you test each of these updates (required)**

Tons of unit tests. Most of the changes here are unit tests.

Manually tested as part of the pull mode work.

Regression tests. This also goes through earlier tests which exercises webhook components, which ensures the existing functionality remains unchanged. https://gist.github.com/j0sh/9d884a19bb92e504092e71fd19d812e5/revisions#diff-1b0c2b516b83393edb7200ad5ff12181

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes https://github.com/livepeer/go-livepeer/issues/1271

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
