### PR TITLE
Add reward flag and fail fast if no services are enabled

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -130,6 +130,8 @@ func main() {
 	// Redemption service
 	redeemer := flag.Bool("redeemer", false, "Set to true to run a ticket redemption service")
 	redeemerAddr := flag.String("redeemerAddr", "", "URL of the ticket redemption service to use")
+	// Reward service
+	reward := flag.Bool("reward", false, "Set to true to run a reward service")
 	// Metrics & logging:
 	monitor := flag.Bool("monitor", false, "Set to true to send performance metrics")
 	version := flag.Bool("version", false, "Print out the version")
@@ -622,13 +624,19 @@ func main() {
 			glog.Infof("Redeemer started on %v", *httpAddr)
 		}
 
-		// If the node address is an on-chain registered address, start the reward service
-		t, err := n.Eth.GetTranscoder(n.Eth.Account().Address)
-		if err != nil {
-			glog.Error(err)
-			return
+		if !isFlagSet["reward"] {
+			// If the node address is an on-chain registered address, start the reward service
+			t, err := n.Eth.GetTranscoder(n.Eth.Account().Address)
+			if err != nil {
+				glog.Error(err)
+				return
+			}
+			if t.Status == "Registered" {
+				*reward = true
+			}
 		}
-		if t.Status == "Registered" {
+
+		if *reward {
 			// Start reward service
 			// The node will only call reward if it is active in the current round
 			rs := eventservices.NewRewardService(n.Eth, blockPollingTime)

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -272,8 +272,8 @@ func main() {
 		n.NodeType = core.TranscoderNode
 	} else if *broadcaster {
 		n.NodeType = core.BroadcasterNode
-	} else {
-		glog.Info("Node type not set with -broadcaster, -transcoder, -orchestrator or -redeemer")
+	} else if !*reward && !*initializeRound {
+		glog.Fatalf("No services enabled; must be at least one of -broadcaster, -transcoder, -orchestrator, -redeemer, -reward or -initializeRound")
 	}
 
 	if *monitor {

--- a/doc/ethereum.md
+++ b/doc/ethereum.md
@@ -10,3 +10,15 @@ When connecting to an Ethereum network, an Ethereum RPC provider needs to be spe
 - To connect to an off-chain network, the node should be started without the `-network` flag (the default value is `offchain`). The `-ethUrl` and the `-ethController` flags are unnecessary.
 
 See [this guide](https://livepeer.readthedocs.io/en/latest/quickstart.html#connecting-to-an-ethereum-node) for instructions on obtaining a URL that be used with the `-ethUrl` flag.
+
+## Reward
+
+The node can run a reward service that will automatically call a smart contract function to mint LPT rewards each round that the node's on-chain registered address is in the active set. Note that at the moment, only the on-chain registered address can call the smart contract function to mint LPT rewards.
+
+If the node detects that its address is registered on-chain, it will automatically start the reward service. The reward service can also be explicitly disabled by starting the node with `-reward=false` and explicitly enabled by starting the node with `-reward`.
+
+## Round Initialization
+
+The node can run a round initialization service that will automatically call a smart contract function to initialize the current round.
+
+The round initialization service is disabled by default and can be enabled by starting the node with `-initializeRound`.

--- a/pm/queue_test.go
+++ b/pm/queue_test.go
@@ -193,10 +193,10 @@ func TestTicketQueueConsumeBlockNums(t *testing.T) {
 	q := newTicketQueue(ts, sender, tm.SubscribeBlocks)
 	q.Start()
 	defer q.Stop()
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 
 	tm.blockNumSink <- big.NewInt(10)
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	// Check that the value is consumed
 	assert.Len(tm.blockNumSink, 0)
 }

--- a/test_args.sh
+++ b/test_args.sh
@@ -32,6 +32,11 @@ run_lp () {
 # sanity check that default datadir does not exist
 [ ! -d "$DEFAULT_DATADIR" ]
 
+# check that we exit early if no services are enabled
+res=0
+$TMPDIR/livepeer || res=$?
+[ $res -ne 0 ]
+
 run_lp -broadcaster
 [ -d "$DEFAULT_DATADIR"/offchain ]
 kill $pid


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds a `-reward` flag that can be used to explicitly enable/disable the reward service and also updates the node to fail fast if no services are enabled.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- a8d9d4b: Add the `-reward` flag. By default, the flag value is false. If the node detects that its address is registered on-chain *and* the flag is not set, the flag value is set to true.
- e919460: Update the node to fail fast if no services are enabled. A recent PR updated the node not to fail fast if a node type is not set because we want users to be able to run the node with standalone services such as the reward service or round initializer service. Now, the node considers node types services as well and will fail fast if there are no services enabled.
- 25cf7fd: Add docs for the flags to enable/disable the reward service and round initializer service
- feaa81b: Increase sleep in a flaky test

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Manual testing and added a test for fail fast behavior when no services are enabled in `test_args.sh`.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
