### PR TITLE
CircleCI fix + Git check for fixup commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,7 @@ jobs:
 
     steps:
       - checkout
-      - setup_remote_docker:
-          # This actually only exists for paid plans. But it's good luck!
-          docker_layer_caching: true
-
+      - setup_remote_docker
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
 
       # First, build the Linux-specific builder container
@@ -70,9 +67,7 @@ jobs:
     steps:
       - checkout
 
-      - setup_remote_docker:
-          # This actually only exists for paid plans. But it's good luck!
-          docker_layer_caching: true
+      - setup_remote_docker
 
       - run: mkdir -p $TEST_RESULTS
 

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,11 @@
+name: Git Checks
+
+on: [push]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v1.1.1


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes a CircleCI failure due to the use of the `docker_layer_caching` key for `remote_docker_setup` (CircleCI used to ignore this key for free plans, but it looks like they now block jobs for free plans that use the key - see [this example](https://app.circleci.com/pipelines/github/livepeer/go-livepeer/1054/workflows/89045eb0-ca38-4ed4-8efd-4db79f29d9dd/jobs/6248/steps)) and also adds a [GH action](https://github.com/13rac1/block-fixup-merge-action) to block PR merges when a branch contains fixup commits.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See the commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I observed CircleCI jobs no longer being blocked after removing the `docker_layer_caching` key and I observed the block fixup merge GH action fail when I pushed a fixup commit to this branch.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1520 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
