### PR TITLE
verification: Update results parsing + remove model from request

### DIFF
--- a/verification/epic.go
+++ b/verification/epic.go
@@ -44,7 +44,6 @@ type epicRequest struct {
 	Source         string          `json:"source"`
 	Renditions     []epicRendition `json:"renditions"`
 	OrchestratorID string          `json:"orchestratorID"`
-	Model          string          `json:"model"`
 }
 
 type epicResultFields struct {
@@ -52,7 +51,11 @@ type epicResultFields struct {
 	AudioAvailable bool    `json:"audio_available"`
 	AudioDistance  float64 `json:"audio_dist"`
 	Pixels         int64   `json:"pixels"`
-	Tamper         float64 `json:"tamper"`
+	// 1 if the model detects a tamper and 0 otherwise
+	Tamper int `json:"tamper"`
+	// This value is used to order multiple results that are all marked as tampered which might indicate a misclassification
+	// In this case, the result with the highest distance is considered the most preferable
+	OCSVMDist float64 `json:"ocsvm_dist"`
 }
 
 type epicResults struct {
@@ -79,13 +82,13 @@ func epicResultsToVerificationResults(er *epicResults) (*Results, error) {
 		if v.AudioAvailable && v.AudioDistance != 0.0 && err == nil {
 			err = ErrAudioMismatch
 		}
-		if v.VideoAvailable && v.Tamper <= 0 && err == nil {
+		if v.VideoAvailable && v.Tamper > 0 && err == nil {
 			err = ErrTampered
 		}
 		if !v.VideoAvailable && err == nil {
 			err = ErrVideoUnavailable
 		}
-		score += v.Tamper / float64(len(er.Results))
+		score += v.OCSVMDist / float64(len(er.Results))
 		pixels = append(pixels, v.Pixels)
 	}
 	return &Results{Score: score, Pixels: pixels}, err
@@ -135,7 +138,6 @@ func (e *EpicClassifier) Verify(params *Params) (*Results, error) {
 		Source:         sourcePath,
 		Renditions:     renditions,
 		OrchestratorID: oid,
-		Model:          "https://storage.googleapis.com/verification-models/verification.tar.xz",
 	}
 	reqData, err := json.Marshal(req)
 	if err != nil {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the `EpicClassifier` type in the `verification` package to be compatible with the latest version of [verification-classifier](https://github.com/livepeer/verification-classifier). The specific changes in verification-classifier that required updates in `EpicClassifier` are:

- The API response returns an integer for the `tamper` field where 1 indicates Tampered and 0 indicates Correct. 1/0 is returned now instead of a continuous value because the verifier uses a meta model (combines the output of the old OCSVM model with another Catboost Classifier model - the former is better at avoiding misclassifying correct videos as tampered and the latter is better at catching tampered videos) that does not output a continuous value
- The API response returns a float for the `ocsvm_dist` field that *is* a continuous value representing the distance from the decision boundary for the OCSVM model. This value was previously returned for the `tamper` field. This value can still be used to order results in cases where all results are marked as tampered which might indicate a misclassification
- The model URL is no longer needed in the API request because the verifier now loads a specific model on startup

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 82c82c0: Update the results parsing code for the API response and remove the model URL from the API request

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests and ran a local broadcaster + orchestrator + verifier.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
