### PR TITLE
server: Use core.StreamParameters in BroadcastSession.

### DIFF
--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -172,7 +172,7 @@ func TestSelectOrchestrator(t *testing.T) {
 	}
 
 	// Sanity check a few easy fields
-	if sess[0].ManifestID != mid {
+	if sess[0].Params.ManifestID != mid {
 		t.Error("Expected manifest id")
 	}
 	if sess[0].BroadcasterOS != storage {
@@ -181,7 +181,7 @@ func TestSelectOrchestrator(t *testing.T) {
 	if sess[0].OrchestratorInfo != sd.infos[0] || sd.infos[0] == sd.infos[1] {
 		t.Error("Unexpected orchestrator info")
 	}
-	if len(sess[0].Profiles) != 1 || sess[0].Profiles[0] != sp.Profiles[0] {
+	if len(sess[0].Params.Profiles) != 1 || sess[0].Params.Profiles[0] != sp.Profiles[0] {
 		t.Error("Unexpected profiles")
 	}
 	if sess[0].Sender != nil {

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -79,8 +79,8 @@ func TestPush_MultipartReturn(t *testing.T) {
 	})
 
 	sess := StubBroadcastSession(ts.URL)
-	sess.Profiles = []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9}
-	sess.ManifestID = "mani"
+	sess.Params.Profiles = []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9}
+	sess.Params.ManifestID = "mani"
 	bsm := bsmWithSessList([]*BroadcastSession{sess})
 
 	url, _ := url.ParseRequestURI("test://some.host")

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -90,8 +90,7 @@ type BalanceUpdate struct {
 // BroadcastSession - session-specific state for broadcasters
 type BroadcastSession struct {
 	Broadcaster      common.Broadcaster
-	ManifestID       core.ManifestID
-	Profiles         []ffmpeg.VideoProfile
+	Params           *core.StreamParameters
 	OrchestratorInfo *net.OrchestratorInfo
 	OrchestratorOS   drivers.OSSession
 	BroadcasterOS    drivers.OSSession

--- a/server/selection_test.go
+++ b/server/selection_test.go
@@ -12,6 +12,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/stretchr/testify/assert"
 )
@@ -483,9 +484,9 @@ func TestMinLSSelector_RemoveUnknownSession(t *testing.T) {
 
 	// Use ManifestID to identify each session
 	sessions := []*BroadcastSession{
-		&BroadcastSession{ManifestID: "foo"},
-		&BroadcastSession{ManifestID: "bar"},
-		&BroadcastSession{ManifestID: "baz"},
+		&BroadcastSession{Params: &core.StreamParameters{ManifestID: "foo"}},
+		&BroadcastSession{Params: &core.StreamParameters{ManifestID: "bar"}},
+		&BroadcastSession{Params: &core.StreamParameters{ManifestID: "baz"}},
 	}
 
 	resetUnknownSessions := func() {
@@ -498,22 +499,22 @@ func TestMinLSSelector_RemoveUnknownSession(t *testing.T) {
 	resetUnknownSessions()
 	sel.removeUnknownSession(0)
 	assert.Len(sel.unknownSessions, 2)
-	assert.Equal("baz", string(sel.unknownSessions[0].ManifestID))
-	assert.Equal("bar", string(sel.unknownSessions[1].ManifestID))
+	assert.Equal("baz", string(sel.unknownSessions[0].Params.ManifestID))
+	assert.Equal("bar", string(sel.unknownSessions[1].Params.ManifestID))
 
 	// Test remove from middle of list
 	resetUnknownSessions()
 	sel.removeUnknownSession(1)
 	assert.Len(sel.unknownSessions, 2)
-	assert.Equal("foo", string(sel.unknownSessions[0].ManifestID))
-	assert.Equal("baz", string(sel.unknownSessions[1].ManifestID))
+	assert.Equal("foo", string(sel.unknownSessions[0].Params.ManifestID))
+	assert.Equal("baz", string(sel.unknownSessions[1].Params.ManifestID))
 
 	// Test remove from back of list
 	resetUnknownSessions()
 	sel.removeUnknownSession(2)
 	assert.Len(sel.unknownSessions, 2)
-	assert.Equal("foo", string(sel.unknownSessions[0].ManifestID))
-	assert.Equal("bar", string(sel.unknownSessions[1].ManifestID))
+	assert.Equal("foo", string(sel.unknownSessions[0].Params.ManifestID))
+	assert.Equal("bar", string(sel.unknownSessions[1].Params.ManifestID))
 
 	// Test remove when list length = 1
 	sel.unknownSessions = []*BroadcastSession{&BroadcastSession{}}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
server: Use core.StreamParameters in BroadcastSession.

Makes further extensions a bit easier, cf. capability discovery.
Required for https://github.com/livepeer/go-livepeer/pull/1539

The ManifestID and Profiles parameters already exist within the
params, so also remove those from the broadcast session.

<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds `Params` field to `rpc.BroadcastSession`
- Removes `BroadcastSession.ManifestID` and `BroadcastSession.Profiles` in favor of `BroadacstSession.Params` in order to reduce duplication
- Fix up all usages of the manifest ID / profiles, including tests

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit tests pass

**Does this pull request close any open issues?**
<!-- Fixes # -->

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
