### PR TITLE
Toggle local verification with -localVerify

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -822,6 +822,7 @@ func main() {
 			}
 			verification.VerifierPath = *verifierPath
 		} else if *localVerify {
+			glog.Info("Local verification enabled")
 			server.Policy = &verification.Policy{Retries: 2}
 		}
 

--- a/doc/verification.md
+++ b/doc/verification.md
@@ -1,0 +1,14 @@
+# Verification
+
+The Livepeer node supports two types of verification when running with the `-broadcaster` flag:
+
+- Local verification
+    - This currently involves pixel count and signature verification.
+    - Pixel count verification ensures that the number of pixels that the orchestrator uses to charge the broadcaster for payments matches the number of pixels actually encoded by the orchestrator. The orchestrator reports the number of pixels encoded with each result returned to the broadcaster and the broadcaster compares this value with the actual number of pixels in the results.
+    - Signature verification ensures that the results received are cryptographically signed using a known Ethereum account associated with an orchestrator. The Ethereum account used to sign the results may be an on-chain registered address or it may be an account specified in the address field of the `OrchestratorInfo` message sent to the broadcaster during discovery.
+- Tamper verification
+    - This currently uses an external verifier that checks if a video has been tampered.
+
+Local verification is enabled by default when the node is connected to Rinkeby and mainnet and disabled by default when the node is running in off-chain mode. Local verification can be explicitly enabled by starting the node with `-localVerify` and can be explicitly disabled with `-localVerify=false`.
+
+Tamper verification is disabled by default and can be enabled by specifying `-verifierURL`. See this [guide](https://livepeer.readthedocs.io/en/latest/broadcasting.html#transcoding-verification-experimental) for instructions on connecting the node to an external verifier that runs tamper verification. Note that when tamper verification is enabled, local verification is also enabled.

--- a/test_args.sh
+++ b/test_args.sh
@@ -160,6 +160,12 @@ else
     $TMPDIR/livepeer -broadcaster -depositMultiplier 0 -network rinkeby $ETH_ARGS || res=$?
     [ $res -ne 0 ]
 
+    # Check that local verification is enabled by default in on-chain mode
+    $TMPDIR/livepeer -broadcaster -transcodingOptions invalid -network rinkeby $ETH_ARGS 2>&1 | grep "Local verification enabled"
+    
+    # Check that local verification is disabled via -localVerify in on-chain mode
+    $TMPDIR/livepeer -broadcaster -transcodingOptions invalid -localVerify=false -network rinkeby $ETH_ARGS 2>&1 | grep -v "Local verification enabled"
+
     ETH_ARGS=$OLD_ETH_ARGS
 fi
 
@@ -287,5 +293,10 @@ $TMPDIR/livepeer -broadcaster -transcodingOptions $TMPDIR/invalid.json 2>&1 |   
 echo '[{"width":"1","height":"2"}]' > $TMPDIR/schema.json
 $TMPDIR/livepeer -broadcaster -transcodingOptions $TMPDIR/schema.json 2>&1 | grep "cannot unmarshal string into Go struct field .width of type int"
 
+# Check that local verification is disabled by default in off-chain mode
+$TMPDIR/livepeer -broadcaster -transcodingOptions invalid 2>&1 | grep -v "Local verification enabled"
+
+# Check that local verification is enabled via -localVerify in off-chain mode
+$TMPDIR/livepeer -broadcaster -transcodingOptions invalid -localVerify=true 2>&1 | grep "Local verification enabled"
 
 rm -rf $TMPDIR


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds a `-localVerify` flag with the following behavior:

- If the node is in on-chain mode, the default is `localVerify = true`
- If the node is in off-chain mode, the default is `localVerify = false`
- A user can also explicitly set `-localVerify=true|false`
- When `localVerify = true`, the node will enable pixel count and signature verification
- When `-verifierURL != ""`, the node will also enable pixel count and signature verification
- When `localVerify = false`, the node will disable pixel count and signature verification

This flag should be useful when the node is running in on-chain mode, but working with trusted orchestrators. In this case, the node does not need to incur additional overhead for local verification.

This PR also adds docs on verification that provides a high level overview on how to enable/disable local + tamper verification.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated `test_args.sh` and manually tested.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
