### PR TITLE
Pull mode

### DIFF
--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -115,9 +115,10 @@ if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
     --disable-encoders --disable-decoders --disable-filters --disable-bsfs \
     --disable-postproc --disable-lzma \
     --enable-gnutls --enable-libx264 --enable-gpl \
-    --enable-protocol=https,rtmp,file \
-    --enable-muxer=mpegts,hls,segment,mp4 --enable-demuxer=flv,mpegts,mp4,mov \
-    --enable-bsf=h264_mp4toannexb,aac_adtstoasc,h264_metadata,h264_redundant_pps \
+    --enable-protocol=https,rtmp,file,pipe \
+    --enable-muxer=mpegts,hls,segment,stream_segment,mp4 \
+    --enable-demuxer=flv,mpegts,mp4,mov,concat \
+    --enable-bsf=h264_mp4toannexb,aac_adtstoasc,h264_metadata,h264_redundant_pps,extract_extradata \
     --enable-parser=aac,aac_latm,h264 \
     --enable-filter=abuffer,buffer,abuffersink,buffersink,afifo,fifo,aformat \
     --enable-filter=aresample,asetnsamples,fps,scale \

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -750,6 +750,7 @@ func TestTranscodeSegment_CompleteSession(t *testing.T) {
 }
 
 func TestProcessSegment_MaxAttempts(t *testing.T) {
+	// TODO This fails sometimes. Making this function -race safe might help.
 	assert := assert.New(t)
 
 	// Preliminaries and test setup

--- a/server/pull.go
+++ b/server/pull.go
@@ -1,0 +1,255 @@
+package server
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/golang/glog"
+
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/core"
+
+	"github.com/livepeer/lpms/ffmpeg"
+	"github.com/livepeer/lpms/stream"
+)
+
+type segs struct {
+	val  string
+	next *segs
+}
+
+var invalidSegInfo = errors.New("invalid segment info")
+
+var processSegmentFunc = processSegment
+
+// Control how many segments to transcode in parallel for a given pull.
+// Set to 1 until we have a better way of modulating the concurrency factor
+// eg, by looking at the number of segments allowed inflight
+// Roughly ~4 for a full lineup of 8 orchestrators but this could well vary
+// Note that unit tests set this to a higher number to ensure things work
+var nbWorkers = 1
+
+func (s *LivepeerServer) Pull(fname string, streamName core.ManifestID) error {
+	glog.V(common.VERBOSE).Info(fmt.Sprintf("Pulling fname=%s workers=%d profiles=%v", fname, nbWorkers, BroadcastJobVideoProfiles))
+
+	// TODO this isn't rtmp anymore
+	strm := stream.NewBasicRTMPVideoStream(&core.StreamParameters{ManifestID: streamName, Profiles: BroadcastJobVideoProfiles})
+
+	cxn, err := s.registerConnection(strm)
+	if err != nil {
+		return err
+	}
+	if err := runSegmenter(s.LivepeerNode, cxn, fname); err != nil {
+		return err
+	}
+	removeRTMPStream(s, cxn.mid)
+	// TODO remove based on prefix?
+	return nil
+}
+
+// segInfo is a csv style string containing:
+// <path-to-segment>,<start-time>,<end-time>
+func process(cxn *rtmpConnection, segInfo string) error {
+	// TODO is it possible that we have commas as part of file path?
+	// csv should quote the string. TODO use a proper csv parser.
+	parts := strings.Split(strings.TrimSpace(segInfo), ",")
+	glog.V(common.VERBOSE).Info(parts)
+	if len(parts) != 3 {
+		return invalidSegInfo
+	}
+	segPath := parts[0]
+	fname := filepath.Base(segPath)
+	seq, err := strconv.Atoi(strings.TrimSuffix(fname, filepath.Ext(fname)))
+	if err != nil {
+		return fmt.Errorf("invalid segment seq: %w", err)
+	}
+	segBegin, err := strconv.ParseFloat(parts[1], 64)
+	if err != nil {
+		return fmt.Errorf("invalid segment begin time: %w", err)
+	}
+	segEnd, err := strconv.ParseFloat(parts[2], 64)
+	if err != nil {
+		return fmt.Errorf("invalid segment end time: %w", err)
+	}
+	segData, err := ioutil.ReadFile(segPath)
+	if err != nil {
+		return fmt.Errorf("could not read file: %w", err)
+	}
+	seg := &stream.HLSSegment{
+		Data:     segData,
+		SeqNo:    uint64(seq),
+		Duration: segEnd - segBegin,
+	}
+	_, err = processSegmentFunc(cxn, seg)
+	return err
+}
+
+func runSegmenter(node *core.LivepeerNode, cxn *rtmpConnection, fname string) error {
+
+	rd, wr, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("create pipe err=%w", err)
+	}
+	closeFds := func() {
+		wr.Close()
+		rd.Close()
+	}
+	wg := sync.WaitGroup{}
+	segList := MakeSegList()
+	defer func() {
+		closeFds()
+		wg.Wait()
+	}()
+
+	// TODO Catch interrupt to gracefully terminate the pull (helpful for live)
+	// Close pipes, drain transcoding queue, produce any outputs
+
+	// ffmpeg io queue
+	wg.Add(1)
+	go func(reader io.Reader) {
+		var str string
+		var err error
+		defer wg.Done()
+		buf := bufio.NewReader(reader)
+		segCount := 0
+		for str, err = buf.ReadString('\n'); err == nil; str, err = buf.ReadString('\n') {
+			segCount++
+			segList.Insert(str)
+		}
+		glog.V(common.DEBUG).Info("io queue exit segs=", segCount)
+		segList.MarkComplete()
+	}(rd)
+
+	// worker queue.
+	for i := 0; i < nbWorkers; i++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for {
+				seg, err := segList.Remove()
+				if err == errSegListComplete {
+					return
+				}
+				if err := process(cxn, seg); err != nil {
+					glog.Error("pull error err=", err)
+					// TODO Re-insert into list for special cases, eg
+					// no sessions available (sleep for refresh then retry)
+					// There is no reason for VOD to have missing segs
+					// unless the segments themselves are un-processable
+					// TODO distinguish "non-retryable" error types
+				}
+			}
+		}(i)
+	}
+
+	base := []string{node.WorkDir, "media", string(cxn.params.ManifestID)}
+	baseDir := filepath.Join(base...)
+	err = os.MkdirAll(baseDir, 0744)
+	if err != nil {
+		return fmt.Errorf("creating pull directory err=%w", err)
+	}
+	defer os.RemoveAll(baseDir) // TODO integrate with proper filesystem OS
+
+	oname := filepath.Join(append(base, "%d.ts")...)
+	err = ffmpeg.Transcode2(&ffmpeg.TranscodeOptionsIn{Fname: fname},
+		[]ffmpeg.TranscodeOptions{{
+			Oname:        oname,
+			VideoEncoder: ffmpeg.ComponentOptions{Name: "copy"},
+			AudioEncoder: ffmpeg.ComponentOptions{Name: "copy"},
+			Muxer: ffmpeg.ComponentOptions{
+				Name: "stream_segment",
+				Opts: map[string]string{
+					"segment_list":      fmt.Sprintf("pipe:%d", wr.Fd()),
+					"segment_list_type": "csv",
+					"segment_time":      "2",
+					// TODO OS-agnostic fix for trailing slash
+					"segment_list_entry_prefix": filepath.Join(base...) + "/",
+				}}}})
+	if err != nil {
+		return fmt.Errorf("pull segmenter err=%w", err)
+	}
+
+	wr.Close() // needed to cleanly terminate the read end of the pipe
+	wg.Wait()  // wait for all threads to terminate before closing read fd
+	rd.Close() // now clean up the read fd
+
+	return nil
+}
+
+type concurrentSegList struct {
+	mu *sync.Mutex
+	cv *sync.Cond
+	sl *segList
+
+	complete bool
+}
+
+type segList struct {
+	head *segs
+	tail *segs
+}
+
+var errSegListComplete = errors.New("segments complete")
+var errSegListEmpty = errors.New("empty segment list")
+
+func MakeSegList() *concurrentSegList {
+	mu := &sync.Mutex{}
+	return &concurrentSegList{mu: mu, cv: sync.NewCond(mu), sl: &segList{}}
+}
+
+func (sl *segList) Empty() bool {
+	return sl.head == nil
+}
+func (sl *segList) Insert(seg string) {
+	if sl.head == nil {
+		sl.tail = &segs{val: seg}
+		sl.head = sl.tail
+	} else {
+		sl.tail.next = &segs{val: seg}
+		sl.tail = sl.tail.next
+	}
+}
+func (sl *segList) Remove() (string, error) {
+	if sl == nil || sl.head == nil {
+		return "", errSegListEmpty
+	}
+	v := sl.head.val
+	sl.head = sl.head.next
+	return v, nil
+}
+
+func (csl *concurrentSegList) MarkComplete() {
+	csl.mu.Lock()
+	defer csl.mu.Unlock()
+	csl.complete = true
+	csl.cv.Broadcast()
+}
+func (csl *concurrentSegList) Insert(seg string) {
+	csl.mu.Lock()
+	defer csl.mu.Unlock()
+	if csl.complete {
+		// TODO log??
+		return
+	}
+	csl.sl.Insert(seg)
+	csl.cv.Signal()
+}
+func (csl *concurrentSegList) Remove() (string, error) {
+	csl.mu.Lock()
+	defer csl.mu.Unlock()
+	for !csl.complete && csl.sl.Empty() {
+		csl.cv.Wait()
+	}
+	if csl.complete && csl.sl.Empty() {
+		return "", errSegListComplete
+	}
+	return csl.sl.Remove()
+}

--- a/server/pull_test.go
+++ b/server/pull_test.go
@@ -1,0 +1,356 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+	"pgregory.net/rapid"
+
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/drivers"
+
+	"github.com/livepeer/lpms/ffmpeg"
+	"github.com/livepeer/lpms/stream"
+)
+
+func TestPull_ProcessLine(t *testing.T) {
+	// test input lines of this expected format:
+	// <path-to-segment>,<start-time>,<end-time>
+
+	// preliminaries
+	assert := assert.New(t)
+	tmpdir, err := ioutil.TempDir("", "")
+	defer os.RemoveAll(tmpdir)
+	assert.Nil(err)
+	fname := filepath.Join(tmpdir, "0.ts")
+	err = ioutil.WriteFile(fname, []byte("hello"), 0644)
+	assert.Nil(err)
+	var expectedDur *float64
+	oldFunc := processSegmentFunc
+	defer func() { processSegmentFunc = oldFunc }()
+	processSegmentFunc = func(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, error) {
+		if expectedDur != nil {
+			if !assert.InDelta(*expectedDur, seg.Duration, 0.0001) {
+				return nil, errors.New("mismatched duration")
+			}
+		}
+		return nil, nil
+	}
+
+	cxn := &rtmpConnection{}
+
+	// test invalid part length : 0, 1, 4
+	err = process(cxn, "one part")
+	assert.Equal(invalidSegInfo, err)
+	err = process(cxn, "two, parts")
+	assert.Equal(invalidSegInfo, err)
+	err = process(cxn, "four, parts, still, invalid")
+	assert.Equal(invalidSegInfo, err)
+
+	// test invalid seq no
+	err = process(cxn, "invalid file,1,2")
+	assert.Contains(err.Error(), "invalid segment seq:")
+
+	// test acceptable seq numbers for filename
+	// verify this by ensuring that it attempts to read the given file
+	err = process(cxn, "0,1,2")
+	assert.Contains(err.Error(), "could not read file:")
+	err = process(cxn, "0.ext,1,2")
+	assert.Contains(err.Error(), "could not read file:")
+	err = process(cxn, "path/0,1,2")
+	assert.Contains(err.Error(), "could not read file:")
+	err = process(cxn, "relative/path/to/0,1,2")
+	assert.Contains(err.Error(), "could not read file:")
+	err = process(cxn, "relative/path/to/0.ext,1,2")
+	assert.Contains(err.Error(), "could not read file:")
+	err = process(cxn, "/absolute/path/0,1,2")
+	assert.Contains(err.Error(), "could not read file:")
+	err = process(cxn, "/absolute/path/to/0,1,2")
+	assert.Contains(err.Error(), "could not read file:")
+	err = process(cxn, "/absolute/path/to/0.ext,1,2")
+	assert.Contains(err.Error(), "could not read file:")
+
+	// test invalid begin time
+	err = process(cxn, "0, 1,2")
+	assert.Contains(err.Error(), "invalid segment begin time:")
+	err = process(cxn, "0,1.a,2")
+	assert.Contains(err.Error(), "invalid segment begin time:")
+
+	// test invalid end time
+	err = process(cxn, fname+",1, 2")
+	assert.Contains(err.Error(), "invalid segment end time:")
+	err = process(cxn, fname+",1,a")
+	assert.Contains(err.Error(), "invalid segment end time:")
+
+	// test valid begin, end times and durations
+	rapid.Check(t, func(t *rapid.T) {
+		begin := rapid.Float64().Draw(t, "begin").(float64)
+		end := rapid.Float64().Draw(t, "end").(float64)
+		dur := end - begin
+		expectedDur = &dur
+		err = process(cxn, fmt.Sprintf("%s,%f,%f", fname, begin, end))
+		assert.Nil(err)
+	})
+}
+
+func TestPull_Registration(t *testing.T) {
+	// preliminaries
+	assert := assert.New(t)
+	ffmpeg.InitFFmpeg()
+	defer goleak.VerifyNone(t, ignoreRoutines()...)
+	tmpdir, err := ioutil.TempDir("", "")
+	defer os.RemoveAll(tmpdir)
+	assert.Nil(err)
+	oldStorage := drivers.NodeStorage
+	defer func() { drivers.NodeStorage = oldStorage }()
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
+	oldWorkers := nbWorkers
+	nbWorkers = 5
+	defer func() { nbWorkers = oldWorkers }()
+	n, err := core.NewLivepeerNode(nil, tmpdir, nil)
+	assert.Nil(err)
+	s, err := NewLivepeerServer("", n, false, "")
+	assert.Nil(err)
+
+	waitMu := &sync.Mutex{}
+	doWait := true
+	wait := &doWait
+	segmentCh := make(chan struct{})
+	oldFunc := processSegmentFunc
+	defer func() { processSegmentFunc = oldFunc }()
+	processSegmentFunc = func(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, error) {
+		waitMu.Lock()
+		w := *wait
+		waitMu.Unlock()
+		if w {
+			<-segmentCh
+		}
+		return nil, nil
+	}
+
+	// ensure mid does not exist
+	mid := core.RandomManifestID()
+	s.connectionLock.Lock()
+	assert.NotContains(mid, s.rtmpConnections)
+	s.connectionLock.Unlock()
+
+	// ensure pull dir does not exist
+	_, err = os.Stat(filepath.Join(tmpdir, "media", string(mid)))
+	assert.IsType(&os.PathError{}, err)
+
+	// begin pull process
+	pullCompleteChan := make(chan struct{})
+	go func() {
+		err := s.Pull("test.flv", mid)
+		assert.Nil(err)
+		pullCompleteChan <- struct{}{}
+	}()
+
+	// ensure mid now exists
+	runLoop := true
+	midChecked := false
+	for runLoop {
+		select {
+		case segmentCh <- struct{}{}:
+			s.connectionLock.Lock()
+			assert.Contains(s.rtmpConnections, mid)
+			// check pull dir now exists
+			stat, err := os.Stat(filepath.Join(tmpdir, "media", string(mid)))
+			assert.Nil(err)
+			assert.True(stat.IsDir(), "pull dir does not exist")
+			s.connectionLock.Unlock()
+			midChecked = true
+			waitMu.Lock()
+			doWait = false
+			waitMu.Unlock()
+			break
+		case <-pullCompleteChan:
+			runLoop = false
+			break
+		default:
+		}
+	}
+
+	// ensure mid is removed
+	s.connectionLock.Lock()
+	assert.NotContains(mid, s.rtmpConnections)
+	// ensure pull dir has been removed
+	_, err = os.Stat(filepath.Join(tmpdir, "media", string(mid)))
+	assert.IsType(&os.PathError{}, err)
+	s.connectionLock.Unlock()
+	assert.True(midChecked, "manifest ID presence was not checked")
+}
+
+func TestPull_RunPull(t *testing.T) {
+	assert := assert.New(t)
+	ffmpeg.InitFFmpeg()
+	defer goleak.VerifyNone(t, ignoreRoutines()...)
+	oldStorage := drivers.NodeStorage
+	defer func() { drivers.NodeStorage = oldStorage }()
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
+	oldWorkers := nbWorkers
+	nbWorkers = 5
+	defer func() { nbWorkers = oldWorkers }()
+	tmpdir, err := ioutil.TempDir("", "")
+	defer os.RemoveAll(tmpdir)
+	assert.Nil(err)
+	oldFunc := processSegmentFunc
+	defer func() { processSegmentFunc = oldFunc }()
+	mu := &sync.Mutex{}
+	segCount := 0
+	processSegmentFunc = func(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, error) {
+		time.Sleep(time.Millisecond) // just enough to make the thread yield
+		mu.Lock()
+		defer mu.Unlock()
+		segCount++
+		return nil, nil
+	}
+
+	n, err := core.NewLivepeerNode(nil, tmpdir, nil)
+	assert.Nil(err)
+	s, err := NewLivepeerServer("", n, false, "")
+	assert.Nil(err)
+
+	// invalid 'video' file
+	err = s.Pull("pull_test.go", core.RandomManifestID())
+	assert.Contains(err.Error(), "pull segmenter err=Invalid data found")
+
+	// nonexistent file
+	err = s.Pull("nonexistent", core.RandomManifestID())
+	assert.Equal("pull segmenter err=No such file or directory", err.Error())
+
+	// invalid work dir
+	n.WorkDir = "pull_test.go"
+	err = s.Pull("test.flv", core.RandomManifestID())
+	assert.Contains(err.Error(), "creating pull directory err=mkdir")
+	n.WorkDir = tmpdir
+
+	// normal cases. run a bunch of concurrents
+	wg := &sync.WaitGroup{}
+	nbConc := 75 // Reduce if hitting "too many open files" frequently
+	for i := 0; i < nbConc; i++ {
+		wg.Add(1)
+		go func() {
+			err := s.Pull("test.flv", core.RandomManifestID())
+			assert.Nil(err)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	assert.Equal(10*nbConc, segCount)
+}
+
+// state machine checks for linked list
+type segMachine struct {
+	segList      *segList
+	segLen       int      // length of the segment list
+	machineState []string // complete history of all inserts
+	machinePos   int      // current head
+}
+
+func (sm *segMachine) Init(t *rapid.T) {
+	sm.segList = &segList{}
+	sm.machineState = []string{}
+}
+func (sm *segMachine) Insert(t *rapid.T) {
+	val := rapid.String().String()
+	sm.segList.Insert(val)
+	sm.segLen++
+	sm.machineState = append(sm.machineState, val)
+}
+
+func (sm *segMachine) Remove(t *rapid.T) {
+	assert := assert.New(t)
+	val, err := sm.segList.Remove()
+	if sm.segLen == 0 {
+		assert.Empty(val)
+		assert.Equal(errSegListEmpty, err)
+		return
+	}
+	assert.Equal(sm.machineState[sm.machinePos], val)
+	sm.segLen--
+	sm.machinePos++
+}
+func (sm *segMachine) Check(t *rapid.T) {
+	assert := assert.New(t)
+	if sm.segLen == 0 {
+		assert.Nil(sm.segList.head)
+		return
+	}
+	// ensure head / tail matches
+	assert.Equal(sm.machineState[sm.machinePos], sm.segList.head.val)
+	assert.Equal(sm.machineState[len(sm.machineState)-1], sm.segList.tail.val)
+
+	// ensure all intermediate elements match
+	cursor := sm.segList.head
+	for i := 1; i < sm.segLen; i++ {
+		cursor = cursor.next
+		assert.NotNil(cursor)
+		assert.Equal(sm.machineState[sm.machinePos+i], cursor.val)
+	}
+	assert.Equal(cursor, sm.segList.tail)
+	assert.Nil(sm.segList.tail.next)
+}
+
+func TestPull_SegmentList(t *testing.T) {
+	rapid.Check(t, rapid.Run(&segMachine{}))
+}
+
+func TestPull_ConcurrentSegmentList(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		assert := assert.New(t)
+		nbWorkers := rapid.IntRange(1, 25).Draw(t, "nbWorkers").(int)
+		nbInserts := rapid.IntRange(0, 1000).Draw(t, "nbInserts").(int)
+		chComplete := make(chan struct{}, nbInserts)
+		segList := MakeSegList()
+		wg := sync.WaitGroup{}
+		for i := 0; i < nbWorkers; i++ {
+			wg.Add(1)
+			go func() {
+				defer func() { wg.Done() }()
+				for {
+					_, err := segList.Remove()
+					if err == errSegListComplete {
+						return
+					} else {
+						assert.Nil(err)
+					}
+					chComplete <- struct{}{}
+				}
+			}()
+		}
+
+		// count removals - do this in a thread to ensure we can time out
+		go func() {
+			wg.Add(1)
+			for i := 0; i < nbInserts; i++ {
+				<-chComplete
+			}
+			wg.Done()
+		}()
+
+		// insert. do each insert in a separate thread to stress concurrency
+		wg.Add(nbInserts)
+		insertWg := sync.WaitGroup{}
+		insertWg.Add(nbInserts)
+		for i := 0; i < nbInserts; i++ {
+			go func() {
+				defer func() { insertWg.Done(); wg.Done() }()
+				segList.Insert(rapid.String().String())
+			}()
+		}
+		assert.True(wgWait(&insertWg), "insert waitgroup timed out")
+		segList.MarkComplete() // completed inserting
+
+		assert.True(wgWait(&wg), "main waitgroup timed out")
+		assert.True(segList.sl.Empty(), "list was not completely drained")
+	})
+}

--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,7 @@ cd ..
 # Be more strict with HTTP push tests: run with race detector enabled
 cd server
 go test -run Push_ -race
+go test -run Pull_ -race
 go test -run RegisterConnection -race
 cd ..
 

--- a/test_args.sh
+++ b/test_args.sh
@@ -287,5 +287,18 @@ $TMPDIR/livepeer -broadcaster -transcodingOptions $TMPDIR/invalid.json 2>&1 |   
 echo '[{"width":"1","height":"2"}]' > $TMPDIR/schema.json
 $TMPDIR/livepeer -broadcaster -transcodingOptions $TMPDIR/schema.json 2>&1 | grep "cannot unmarshal string into Go struct field .width of type int"
 
+# Check pull
+# TODO verify results once they are persistent
+$TMPDIR/livepeer -pull server/test.flv
+
+# Check pull with streamname
+# TODO verify results once they are persistent
+$TMPDIR/livepeer -pull server/test.flv -streamName foo
+
+# Check pull of invalid file
+$TMPDIR/livepeer -pull go.mod 2>&1 | grep "pull segmenter err=Invalid data found when processing input"
+
+# Check pull of nonexistent file
+$TMPDIR/livepeer -pull nonexistent 2>&1 | grep "pull segmenter err=No such file or directory"
 
 rm -rf $TMPDIR


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Adds a single-shot pull mode. With `livepeer -pull <input>` , it'll load a video, segment and transcode. After transcoding completes, the node exits. The input has been tested with local VOD files, HTTP [1] and RTMP.

Also adds a `-streamName` parameter to set the output stream name (manifest ID). If omitted, the stream name is randomly generated.

As segments come in, they are added to a queue. Workers pull from the queue until completion. Multiple segments can be processed in parallel,  but the concurrency factor is hard-coded to 1 until there's a better way of modulating the concurrency (more info within code comments).

The internal node type is set to a broadcaster, but listeners for RTMP/HTTP/CLI are not enabled. This should allow for most broadcaster-specific features to be enabled.

The source segments are placed into `<datadir/media/streamName/>` . The `streamName/` directory is removed after transcoding completes.

In all, this is somewhat useless until the node receives a proper filesystem OS and recording support. See the [earlier pull branch](https://github.com/livepeer/go-livepeer/compare/ja/pull) and the [accompanying documentation](https://gist.github.com/j0sh/5d1112843e620530e759d09ca275cfed) for how the pull feature has worked in the past.

Should in theory also work with mainnet orchestrators, but only tested offchain. (DB writes might become an issue under heavy concurrency, so maybe use separate datadirs if doing multiple single-shot pulls while onchain.)

Some form of this should make it into LPMS eventually to replace the RTMP listener; it would resolve issues around segment polling and faster-than-realtime video ingest (eg, ffmpeg without `-re`).

[1] Normal HTTP videos please. Tested with live HTTP MP4s generated by Mist and those don't play well with the ffmpeg segmenter at the moment; not only are proper segments not produced (seems to be missing sps/pps extradata),  the transcoder *does not exit*. Big problem.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Pull mode via `-pull`
- Stream name via `-streamName`
- Unit tests

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit testing, manual testing.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
