### PR TITLE
build: add --disable-nls to gnutls

### DIFF
--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -83,7 +83,7 @@ if [[ $(uname) != *"MSYS"* ]]; then
     curl -LO https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.18.tar.xz
     tar xf gnutls-3.5.18.tar.xz
     cd gnutls-3.5.18
-    LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" LIBS="-lhogweed -lnettle -lgmp" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools
+    LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" LIBS="-lhogweed -lnettle -lgmp" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools --disable-nls
     make
     make install
     # gnutls doesn't properly set up its pkg-config or something? without this line ffmpeg and go


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
I was having trouble building go-livepeer since upgrading to Catalina, and adding `--disable-nls` to the gnutls build fixed it. I'm not really sure what's up with that but I don't think we're using NLS for anything.

A previous version of this PR also moved the ffmpeg build directory from the user's home directory to a `.gitignore`'d subdirectory. Then I realized that `~/compiled` is hardcoded in like 30 places in the code and decided not to do that today.

**How did you test each of these updates (required)**
Ran B/O/T locally and everything seemed to work. I'll run a quick GPU test but gnutls only manages the ffmpeg-layer HTTPS connections so I think we're fine as long as the B<>O connection works at all.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
