### PR TITLE
server: make broadcaster and orchestrator config endpoint form values optional

### DIFF
--- a/server/webserver.go
+++ b/server/webserver.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"encoding/json"
-	"errors"
+
 	"flag"
 	"fmt"
 	"math/big"
@@ -25,6 +25,7 @@ import (
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/livepeer/go-livepeer/monitor"
 	ffmpeg "github.com/livepeer/lpms/ffmpeg"
+	"github.com/pkg/errors"
 )
 
 var vFlag *glog.Level = flag.Lookup("v").Value.(*glog.Level)
@@ -85,58 +86,66 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 	//Set the broadcast config for creating onchain jobs.
 	mux.HandleFunc("/setBroadcastConfig", func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
-			glog.Errorf("Parse Form Error: %v", err)
+			err = errors.Wrapf(err, "Parse form error")
+			glog.Error(err)
+			respondWith400(w, err.Error())
 			return
 		}
 
 		pricePerUnit := r.FormValue("maxPricePerUnit")
-		pr, err := strconv.ParseInt(pricePerUnit, 10, 64)
-		if err != nil {
-			glog.Errorf("Error converting string to int64: %v\n", err)
-			return
-		}
-
 		pixelsPerUnit := r.FormValue("pixelsPerUnit")
-		px, err := strconv.ParseInt(pixelsPerUnit, 10, 64)
-		if err != nil {
-			glog.Errorf("Error converting string to int64: %v\n", err)
-			return
-		}
-		if px <= 0 {
-			glog.Errorf("pixels per unit must be greater than 0, provided %d\n", px)
-			return
-		}
 
-		var price *big.Rat
-		if pr > 0 {
-			price = big.NewRat(pr, px)
+		if pricePerUnit != "" && pixelsPerUnit != "" {
+			pr, err := strconv.ParseInt(pricePerUnit, 10, 64)
+			if err != nil {
+				err = errors.Wrapf(err, "Error converting string to int64")
+				glog.Error(err)
+				respondWith400(w, err.Error())
+				return
+			}
+
+			px, err := strconv.ParseInt(pixelsPerUnit, 10, 64)
+			if err != nil {
+				err = errors.Wrapf(err, "Error converting string to int64")
+				glog.Error(err)
+				respondWith400(w, err.Error())
+				return
+			}
+			if px <= 0 {
+				err = errors.Wrapf(err, "pixels per unit must be greater than 0, provided %d\n", px)
+				glog.Error(err)
+				respondWith400(w, err.Error())
+				return
+			}
+
+			var price *big.Rat
+			if pr > 0 {
+				price = big.NewRat(pr, px)
+			}
+
+			BroadcastCfg.SetMaxPrice(price)
+
+			glog.Infof("Maximum transcoding price: %d per %q pixels\n", pr, px)
 		}
 
 		transcodingOptions := r.FormValue("transcodingOptions")
-		if transcodingOptions == "" {
-			glog.Errorf("Need to provide transcoding options")
-			return
-		}
-
-		profiles := []ffmpeg.VideoProfile{}
-		for _, pName := range strings.Split(transcodingOptions, ",") {
-			p, ok := ffmpeg.VideoProfileLookup[pName]
-			if ok {
-				profiles = append(profiles, p)
+		if transcodingOptions != "" {
+			profiles := []ffmpeg.VideoProfile{}
+			for _, pName := range strings.Split(transcodingOptions, ",") {
+				p, ok := ffmpeg.VideoProfileLookup[pName]
+				if ok {
+					profiles = append(profiles, p)
+				}
 			}
+			if len(profiles) == 0 {
+				err := fmt.Errorf("Invalid transcoding options: %v", transcodingOptions)
+				glog.Error(err)
+				respondWith400(w, err.Error())
+				return
+			}
+			BroadcastJobVideoProfiles = profiles
+			glog.Infof("Transcode Job Type: %v", BroadcastJobVideoProfiles)
 		}
-		if len(profiles) == 0 {
-			glog.Errorf("Invalid transcoding options: %v", transcodingOptions)
-			return
-		}
-		BroadcastCfg.SetMaxPrice(price)
-		BroadcastJobVideoProfiles = profiles
-		if price != nil {
-			glog.Infof("Maximum transcoding price: %d per %q pixels\n", pr, px)
-		} else {
-			glog.Info("Maximum transcoding price per pixel not set, broadcaster is currently set to accept ANY price.\n")
-		}
-		glog.Infof("Transcode Job Type: %v", BroadcastJobVideoProfiles)
 	})
 
 	mux.HandleFunc("/getBroadcastConfig", func(w http.ResponseWriter, r *http.Request) {
@@ -338,47 +347,62 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 	//Set transcoder config on-chain.
 	mux.HandleFunc("/setOrchestratorConfig", func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
-			glog.Errorf("Parse Form Error: %v", err)
+			err = errors.Wrapf(err, "Parse form error")
+			glog.Error(err)
+			respondWith400(w, err.Error())
 			return
 		}
 
-		blockRewardCutStr := r.FormValue("blockRewardCut")
-		if blockRewardCutStr == "" {
-			glog.Errorf("Need to provide block reward cut")
-			return
+		pixels := r.FormValue("pixelsPerUnit")
+		price := r.FormValue("pricePerUnit")
+		if pixels != "" && price != "" {
+			if err := s.setOrchestratorPriceInfo(price, pixels); err != nil {
+				glog.Error(err)
+				respondWith400(w, err.Error())
+				return
+			}
 		}
-		blockRewardCut, err := strconv.ParseFloat(blockRewardCutStr, 64)
-		if err != nil {
-			glog.Errorf("Cannot convert block reward cut: %v", err)
-			return
+
+		var (
+			blockRewardCut float64
+			feeShare       float64
+			err            error
+		)
+		blockRewardCutStr := r.FormValue("blockRewardCut")
+
+		if blockRewardCutStr != "" {
+			blockRewardCut, err = strconv.ParseFloat(blockRewardCutStr, 64)
+			if err != nil {
+				err = errors.Wrapf(err, "Cannot convert block reward cut")
+				glog.Error(err)
+				respondWith400(w, err.Error())
+				return
+			}
 		}
 
 		feeShareStr := r.FormValue("feeShare")
-		if feeShareStr == "" {
-			glog.Errorf("Need to provide fee share")
-			return
-		}
-		feeShare, err := strconv.ParseFloat(feeShareStr, 64)
-		if err != nil {
-			glog.Errorf("Cannot convert fee share: %v", err)
-			return
-		}
-
-		if err := s.setOrchestratorPriceInfo(r.FormValue("pricePerUnit"), r.FormValue("pixelsPerUnit")); err != nil {
-			glog.Error(err)
-			return
+		if feeShareStr != "" {
+			feeShare, err = strconv.ParseFloat(feeShareStr, 64)
+			if err != nil {
+				err = errors.Wrapf(err, "Cannot convert fee share")
+				glog.Error(err)
+				respondWith400(w, err.Error())
+				return
+			}
 		}
 
 		t, err := s.LivepeerNode.Eth.GetTranscoder(s.LivepeerNode.Eth.Account().Address)
 		if err != nil {
 			glog.Error(err)
+			respondWith500(w, err.Error())
 			return
 		}
 
-		if t.RewardCut.Cmp(eth.FromPerc(blockRewardCut)) != 0 || t.FeeShare.Cmp(eth.FromPerc(feeShare)) != 0 {
+		if feeShareStr != "" && blockRewardCutStr != "" && (t.RewardCut.Cmp(eth.FromPerc(blockRewardCut)) != 0 || t.FeeShare.Cmp(eth.FromPerc(feeShare)) != 0) {
 			tx, err := s.LivepeerNode.Eth.Transcoder(eth.FromPerc(blockRewardCut), eth.FromPerc(feeShare))
 			if err != nil {
 				glog.Error(err)
+				respondWith500(w, err.Error())
 				return
 			}
 
@@ -387,19 +411,25 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 			err = s.LivepeerNode.Eth.CheckTx(tx)
 			if err != nil {
 				glog.Error(err)
+				respondWith500(w, err.Error())
 				return
 			}
 		}
 
 		serviceURI := r.FormValue("serviceURI")
-		if _, err := url.ParseRequestURI(serviceURI); err != nil {
-			glog.Error(err)
-			return
-		}
-
-		if t.ServiceURI != serviceURI {
-			if err := s.setServiceURI(serviceURI); err != nil {
+		if serviceURI != "" {
+			if _, err := url.ParseRequestURI(serviceURI); err != nil {
+				glog.Error(err)
+				respondWith400(w, err.Error())
 				return
+			}
+
+			if t.ServiceURI != serviceURI {
+				if err := s.setServiceURI(serviceURI); err != nil {
+					glog.Error(err)
+					respondWith500(w, err.Error())
+					return
+				}
 			}
 		}
 	})


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This pull requests allows the form values passed into the `setOrchestratorConfig` and `setBroadcasterConfig` endpoints to be optional. 

if a field is not provided then its related configuration will not be altered on the node. 

This PR is a requirement for https://github.com/Livepool-io/livepeer-usd-pricer

**How did you test each of these updates (required)**
- [x] manual testing 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
