### PR TITLE
db,pm: avoid redeeming expired tickets

### DIFF
--- a/pm/queue_test.go
+++ b/pm/queue_test.go
@@ -67,9 +67,13 @@ func TestTicketQueueLoop(t *testing.T) {
 
 	sender := RandAddress()
 	ts := newStubTicketStore()
-	tm := &stubTimeManager{}
+	tm := &stubTimeManager{round: big.NewInt(100)}
+	sm := &LocalSenderMonitor{
+		ticketStore: ts,
+		tm:          tm,
+	}
 
-	q := newTicketQueue(ts, sender, tm.SubscribeBlocks)
+	q := newTicketQueue(sender, sm)
 	q.Start()
 	defer q.Stop()
 
@@ -105,7 +109,7 @@ func TestTicketQueueLoop(t *testing.T) {
 	qlen, err = q.Length()
 	assert.Nil(err)
 	assert.Equal(1, qlen)
-	earliest, err := q.store.SelectEarliestWinningTicket(sender)
+	earliest, err := q.store.SelectEarliestWinningTicket(sender, nonExpTicket.CreationRound)
 	assert.Nil(err)
 	assert.Equal(earliest, nonExpTicket)
 
@@ -125,9 +129,13 @@ func TestTicketQueueLoopConcurrent(t *testing.T) {
 
 	sender := RandAddress()
 	ts := newStubTicketStore()
-	tm := &stubTimeManager{}
+	tm := &stubTimeManager{round: big.NewInt(100)}
+	sm := &LocalSenderMonitor{
+		ticketStore: ts,
+		tm:          tm,
+	}
 
-	q := newTicketQueue(ts, sender, tm.SubscribeBlocks)
+	q := newTicketQueue(sender, sm)
 	q.Start()
 	defer q.Stop()
 
@@ -188,9 +196,13 @@ func TestTicketQueueConsumeBlockNums(t *testing.T) {
 
 	sender := RandAddress()
 	ts := newStubTicketStore()
-	tm := &stubTimeManager{}
+	tm := &stubTimeManager{round: big.NewInt(100)}
+	sm := &LocalSenderMonitor{
+		ticketStore: ts,
+		tm:          tm,
+	}
 
-	q := newTicketQueue(ts, sender, tm.SubscribeBlocks)
+	q := newTicketQueue(sender, sm)
 	q.Start()
 	defer q.Stop()
 	time.Sleep(20 * time.Millisecond)
@@ -206,9 +218,13 @@ func TestTicketQueue_Add(t *testing.T) {
 
 	sender := RandAddress()
 	ts := newStubTicketStore()
-	tm := &stubTimeManager{}
+	tm := &stubTimeManager{round: big.NewInt(100)}
+	sm := &LocalSenderMonitor{
+		ticketStore: ts,
+		tm:          tm,
+	}
 
-	q := newTicketQueue(ts, sender, tm.SubscribeBlocks)
+	q := newTicketQueue(sender, sm)
 
 	ticket := defaultSignedTicket(sender, 0)
 
@@ -227,9 +243,13 @@ func TestTicketQueue_Length(t *testing.T) {
 
 	sender := RandAddress()
 	ts := newStubTicketStore()
-	tm := &stubTimeManager{}
+	tm := &stubTimeManager{round: big.NewInt(100)}
+	sm := &LocalSenderMonitor{
+		ticketStore: ts,
+		tm:          tm,
+	}
 
-	q := newTicketQueue(ts, sender, tm.SubscribeBlocks)
+	q := newTicketQueue(sender, sm)
 
 	ts.tickets[sender] = []*SignedTicket{defaultSignedTicket(sender, 0), defaultSignedTicket(sender, 1), defaultSignedTicket(sender, 2)}
 

--- a/pm/queue_test.go
+++ b/pm/queue_test.go
@@ -1,6 +1,7 @@
 package pm
 
 import (
+	"fmt"
 	"math/big"
 	"sync"
 	"testing"
@@ -30,8 +31,9 @@ func defaultSignedTicket(sender ethcommon.Address, senderNonce uint32) *SignedTi
 }
 
 type queueConsumer struct {
-	redeemable []*redemption
-	mu         sync.Mutex
+	redeemable    []*redemption
+	mu            sync.Mutex
+	redemptionErr error
 }
 
 // Redeemable returns the consumed redeemable tickets from a ticket queue
@@ -56,7 +58,7 @@ func (qc *queueConsumer) Wait(num int, e RedeemableEmitter, done chan struct{}) 
 			ticket.resCh <- struct {
 				txHash ethcommon.Hash
 				err    error
-			}{RandHash(), nil}
+			}{ticket.SignedTicket.Hash(), qc.redemptionErr}
 		}
 	}
 	done <- struct{}{}
@@ -121,7 +123,42 @@ func TestTicketQueueLoop(t *testing.T) {
 	redeemable := qc.Redeemable()
 	for i := 0; i < numTickets; i++ {
 		assert.Equal(uint32(i), redeemable[i].SignedTicket.SenderNonce)
+		assert.True(ts.submitted[fmt.Sprintf("%x", redeemable[i].SignedTicket.Sig)])
 	}
+}
+
+func TestTicketQueueLoop_IsUsedTicket_MarkAsRedeemed(t *testing.T) {
+	assert := assert.New(t)
+
+	sender := RandAddress()
+	ts := newStubTicketStore()
+	tm := &stubTimeManager{round: big.NewInt(100)}
+	sm := &LocalSenderMonitor{
+		ticketStore: ts,
+		tm:          tm,
+	}
+
+	q := newTicketQueue(sender, sm)
+	q.Start()
+	defer q.Stop()
+
+	ticket := defaultSignedTicket(sender, 0)
+	q.Add(ticket)
+
+	qlen, err := q.Length()
+	assert.Nil(err)
+	assert.Equal(1, qlen)
+
+	qc := &queueConsumer{redemptionErr: errIsUsedTicket}
+	done := make(chan struct{})
+	go qc.Wait(1, q, done)
+	time.Sleep(20 * time.Millisecond)
+
+	tm.blockNumSink <- big.NewInt(1)
+	<-done
+	time.Sleep(20 * time.Millisecond)
+
+	assert.True(ts.submitted[fmt.Sprintf("%x", ticket.Sig)])
 }
 
 func TestTicketQueueLoopConcurrent(t *testing.T) {

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -268,7 +268,7 @@ func (sm *LocalSenderMonitor) ensureCache(addr ethcommon.Address) {
 // Caller should hold the lock for LocalSenderMonitor unless the caller is
 // ensureCache() in which case the caller of ensureCache() should hold the lock
 func (sm *LocalSenderMonitor) cache(addr ethcommon.Address) {
-	queue := newTicketQueue(sm.ticketStore, addr, sm.tm.SubscribeBlocks)
+	queue := newTicketQueue(addr, sm)
 	queue.Start()
 	done := make(chan struct{})
 	go sm.startTicketQueueConsumerLoop(queue, done)

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -354,6 +354,21 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 		return nil, err
 	}
 
+	// Fail early if ticket is used
+	used, err := sm.broker.IsUsedTicket(ticket.Ticket)
+	if err != nil {
+		if monitor.Enabled {
+			monitor.TicketRedemptionError(ticket.Ticket.Sender.String())
+		}
+		return nil, err
+	}
+	if used {
+		if monitor.Enabled {
+			monitor.TicketRedemptionError(ticket.Ticket.Sender.String())
+		}
+		return nil, errIsUsedTicket
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), sm.cfg.RPCTimeout)
 	gasPrice, err := sm.cfg.SuggestGasPrice(ctx)
 	if err != nil {

--- a/pm/sendermonitor_test.go
+++ b/pm/sendermonitor_test.go
@@ -896,6 +896,7 @@ func localSenderMonitorFixture() (*LocalSenderMonitorConfig, *stubBroker, *stubS
 	smgr := newStubSenderManager()
 	tm := &stubTimeManager{
 		transcoderPoolSize: big.NewInt(5),
+		round:              big.NewInt(100),
 	}
 	return cfg, b, smgr, tm
 }

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -54,7 +54,7 @@ func (ts *stubTicketStore) StoreWinningTicket(ticket *SignedTicket) error {
 	return nil
 }
 
-func (ts *stubTicketStore) SelectEarliestWinningTicket(sender ethcommon.Address) (*SignedTicket, error) {
+func (ts *stubTicketStore) SelectEarliestWinningTicket(sender ethcommon.Address, minCreationRound int64) (*SignedTicket, error) {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 	if ts.loadShouldFail {
@@ -95,7 +95,7 @@ func (ts *stubTicketStore) RemoveWinningTicket(ticket *SignedTicket) error {
 	return nil
 }
 
-func (ts *stubTicketStore) WinningTicketCount(sender ethcommon.Address) (int, error) {
+func (ts *stubTicketStore) WinningTicketCount(sender ethcommon.Address, minCreationRound int64) (int, error) {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 	if ts.loadShouldFail {

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -138,6 +138,7 @@ type stubBroker struct {
 	claimableReserveShouldFail bool
 
 	checkTxErr error
+	isUsedErr  error
 }
 
 func newStubBroker() *stubBroker {
@@ -187,6 +188,10 @@ func (b *stubBroker) RedeemWinningTicket(ticket *Ticket, sig []byte, recipientRa
 func (b *stubBroker) IsUsedTicket(ticket *Ticket) (bool, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if b.isUsedErr != nil {
+		return false, b.isUsedErr
+	}
 
 	return b.usedTickets[ticket.Hash()], nil
 }

--- a/pm/ticketstore.go
+++ b/pm/ticketstore.go
@@ -1,13 +1,15 @@
 package pm
 
-import ethcommon "github.com/ethereum/go-ethereum/common"
+import (
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
 
 // TicketStore is an interface which describes an object capable
 // of persisting tickets
 type TicketStore interface {
 	// SelectEarliestWinningTicket selects the earliest stored winning ticket for a 'sender'
 	// which is not yet redeemed
-	SelectEarliestWinningTicket(sender ethcommon.Address) (*SignedTicket, error)
+	SelectEarliestWinningTicket(sender ethcommon.Address, minCreationRound int64) (*SignedTicket, error)
 
 	// RemoveWinningTicket removes a ticket
 	RemoveWinningTicket(ticket *SignedTicket) error
@@ -20,5 +22,5 @@ type TicketStore interface {
 	MarkWinningTicketRedeemed(ticket *SignedTicket, txHash ethcommon.Hash) error
 
 	// WinningTicketCount returns the amount of non-redeemed winning tickets for a sender in the TicketStore
-	WinningTicketCount(sender ethcommon.Address) (int, error)
+	WinningTicketCount(sender ethcommon.Address, minCreationRound int64) (int, error)
 }

--- a/pm/validator.go
+++ b/pm/validator.go
@@ -15,6 +15,7 @@ var (
 	errInvalidTicketSignature        = errors.New("invalid ticket signature")
 	errInvalidCreationRound          = errors.New("invalid ticket creation round")
 	errInvalidCreationRoundBlockHash = errors.New("invalid ticket creation round block hash")
+	errIsUsedTicket                  = errors.New("ticket already used")
 )
 
 // Validator is an interface which describes an object capable


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR avoids the redemption of expired winning tickets.


**Specific updates (required)**
- Change signatures of `SelectEarliestWinningTicket` and `WinningTicketCount` to take in a `minCreationRound` parameter. The `creationRound` for tickets stored would have to be greater or equal to this value to be considered a non-expired ticket (the expiry is two rounds)
- Adjust the respective SQL queries
- Check whether a ticket is already redeemed before trying to redeem a ticket, mark it as redeemed if that's the case 7b3a95c0

**How did you test each of these updates (required)**
Added unit tests , cherry picked this onto the Livepool orchestrator and observe my stale ticket is no longer being retried endlessly.

**Does this pull request close any open issues?**
Fixes #1594 
Fixes #632

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
