### PR TITLE
eth: fix reward call failures

### DIFF
--- a/eth/eventservices/rewardservice.go
+++ b/eth/eventservices/rewardservice.go
@@ -122,20 +122,17 @@ func (s *RewardService) tryReward() error {
 			}
 		}
 
+		s.pendingTx = tx
+
 		err = s.client.CheckTx(tx)
 		if err != nil {
 			if err == context.DeadlineExceeded {
 				glog.Infof("Reward tx did not confirm within defined time window - will try to replace pending tx next time")
-
-				// Tx did not confirm within defined time window
-				// Store pending tx
-				s.pendingTx = tx
 			}
 
 			return err
 		}
 
-		// Transaction confirmed so there is no pending call for reward()
 		s.pendingTx = nil
 
 		tp, err := s.client.GetTranscoderEarningsPoolForRound(s.client.Account().Address, currentRound)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Alleviate some issues users have been experiencing with reward calls 


**Specific updates (required)**
- Avoid nonce gap issues 
- Avoid multiple tx in flight 
- 

**How did you test each of these updates (required)**
Added a unit tests that confirms nonce gaps are not possible

**Does this pull request close any open issues?**
Fixes #1568 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
