### PR TITLE
Enable free transcoding for on-chain mode when price is 0

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -513,11 +513,14 @@ func main() {
 			// Set price per pixel base info
 			if *pixelsPerUnit <= 0 {
 				// Can't divide by 0
-				panic(fmt.Errorf("The amount of pixels per unit must be greater than 0, provided %d instead\n", *pixelsPerUnit))
+				panic(fmt.Errorf("-pixelsPerUnit must be > 0, provided %d", *pixelsPerUnit))
 			}
-			if *pricePerUnit <= 0 {
-				// Prevent orchestrator from unknowingly provide free transcoding
-				panic(fmt.Errorf("Price per unit of pixels must be greater than 0, provided %d instead\n", *pricePerUnit))
+			if !isFlagSet["pricePerUnit"] && *pricePerUnit == 0 {
+				// Prevent orchestrators from unknowingly providing free transcoding
+				panic(fmt.Errorf("-pricePerUnit must be set"))
+			}
+			if *pricePerUnit < 0 {
+				panic(fmt.Errorf("-pricePerUnit must be >= 0, provided %d", *pricePerUnit))
 			}
 			n.SetBasePrice(big.NewRat(int64(*pricePerUnit), int64(*pixelsPerUnit)))
 			glog.Infof("Price: %d wei for %d pixels\n ", *pricePerUnit, *pixelsPerUnit)

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1408,6 +1408,15 @@ func TestPriceInfo(t *testing.T) {
 	assert.Equal(priceInfo.PricePerUnit, expPrice.Num().Int64())
 	assert.Equal(priceInfo.PixelsPerUnit, expPrice.Denom().Int64())
 
+	// basePrice = 0 => expPricePerPixel = 0
+	n.SetBasePrice(big.NewRat(0, 1))
+	orch = NewOrchestrator(n, nil)
+
+	priceInfo, err = orch.PriceInfo(ethcommon.Address{})
+	assert.Nil(err)
+	assert.Zero(priceInfo.PricePerUnit)
+	assert.Equal(int64(1), priceInfo.PixelsPerUnit)
+
 	// test no overflows
 	basePrice = big.NewRat(25000, 1)
 	n.SetBasePrice(basePrice)
@@ -1456,6 +1465,7 @@ func TestPriceInfo_TxMultiplierError_ReturnsError(t *testing.T) {
 	expError := errors.New("TxMultiplier Error")
 
 	n, _ := NewLivepeerNode(nil, "", nil)
+	n.SetBasePrice(big.NewRat(1, 1))
 	recipient := new(pm.MockRecipient)
 	n.Recipient = recipient
 	recipient.On("TxCostMultiplier", mock.Anything).Return(nil, expError)

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -36,7 +36,7 @@ type Recipient interface {
 	// for a provided sender ETH adddress
 	TicketParams(sender ethcommon.Address, price *big.Rat) (*TicketParams, error)
 
-	// TxCostMultiplier returns the multiplier -
+	// TxCostMultiplier returns the tx cost multiplier for an address
 	TxCostMultiplier(sender ethcommon.Address) (*big.Rat, error)
 
 	// EV returns the recipients EV requirement for a ticket as configured on startup
@@ -179,9 +179,14 @@ func (r *recipient) TicketParams(sender ethcommon.Address, price *big.Rat) (*Tic
 
 	seed := new(big.Int).SetBytes(randBytes)
 
-	faceValue, err := r.faceValue(sender)
-	if err != nil {
-		return nil, err
+	faceValue := big.NewInt(0)
+	// If price is 0 face value, win prob and EV are 0 because no payments are required
+	if price.Num().Cmp(big.NewInt(0)) > 0 {
+		var err error
+		faceValue, err = r.faceValue(sender)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	lastBlock := r.tm.LastSeenBlock()

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -392,9 +392,21 @@ func TestTicketParams(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
+	// Test price = 0
+	params, err := r.TicketParams(sender, big.NewRat(0, 1))
+	assert.Nil(err)
+	assert.Equal(big.NewInt(0), params.FaceValue)
+	assert.Equal(big.NewInt(0), params.WinProb)
+
+	// Test price < 0
+	params, err = r.TicketParams(sender, big.NewRat(-1, 1))
+	assert.Nil(err)
+	assert.Equal(big.NewInt(0), params.FaceValue)
+	assert.Equal(big.NewInt(0), params.WinProb)
+
 	// Test SenderMonitor.MaxFloat() error
 	sm.maxFloatErr = errors.New("MaxFloat error")
-	_, err := r.TicketParams(sender, big.NewRat(1, 1))
+	_, err = r.TicketParams(sender, big.NewRat(1, 1))
 	assert.EqualError(err, sm.maxFloatErr.Error())
 
 	// Test correct params returned when default faceValue < maxFloat

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -650,6 +650,8 @@ func TestValidatePrice(t *testing.T) {
 	err := validatePrice(s)
 	assert.Nil(err)
 
+	defer BroadcastCfg.SetMaxPrice(nil)
+
 	// B MaxPrice > O Price
 	BroadcastCfg.SetMaxPrice(big.NewRat(5, 1))
 	err = validatePrice(s)

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -77,7 +77,10 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !orch.SufficientBalance(sender, segData.ManifestID) {
+	// Balance check is only necessary if the price is non-zero
+	// We do not need to worry about differentiating between the case where the price is 0 as the default when no price is attached vs.
+	// the case where the price is actually set to 0 because ProcessPayment() should guarantee a price attached
+	if payment.GetExpectedPrice().GetPricePerUnit() > 0 && !orch.SufficientBalance(sender, segData.ManifestID) {
 		glog.Errorf("Insufficient credit balance for stream - manifestID=%v\n", segData.ManifestID)
 		http.Error(w, "Insufficient balance", http.StatusBadRequest)
 		return

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -1184,13 +1184,12 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 }
 
 func (s *LivepeerServer) setOrchestratorPriceInfo(pricePerUnitStr, pixelsPerUnitStr string) error {
-
 	pricePerUnit, err := strconv.ParseInt(pricePerUnitStr, 10, 64)
 	if err != nil {
 		return fmt.Errorf("Error converting pricePerUnit string to int64: %v\n", err)
 	}
-	if pricePerUnit <= 0 {
-		return fmt.Errorf("price unit must be greater than 0, provided %d\n", pricePerUnit)
+	if pricePerUnit < 0 {
+		return fmt.Errorf("price unit must be greater than or equal to 0, provided %d\n", pricePerUnit)
 	}
 
 	pixelsPerUnit, err := strconv.ParseInt(pixelsPerUnitStr, 10, 64)

--- a/server/webserver_test.go
+++ b/server/webserver_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"strings"
 	"testing"
+
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,11 +29,8 @@ func TestSetOrchestratorPriceInfo(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Zero(t, s.LivepeerNode.GetBasePrice().Cmp(big.NewRat(1, 1)))
 
-	//Price per unit <= 0
-	err = s.setOrchestratorPriceInfo("0", "1")
-	assert.EqualErrorf(t, err, err.Error(), "price unit must be greater than 0, provided %d\n", 0)
 	err = s.setOrchestratorPriceInfo("-5", "1")
-	assert.EqualErrorf(t, err, err.Error(), "price unit must be greater than 0, provided %d\n", -5)
+	assert.EqualErrorf(t, err, err.Error(), "price unit must be greater than or equal to 0, provided %d\n", -5)
 
 	// pixels per unit <= 0
 	err = s.setOrchestratorPriceInfo("1", "0")

--- a/test_args.sh
+++ b/test_args.sh
@@ -128,24 +128,15 @@ else
     [ ! -d  "$CUSTOM_DATADIR"/rinkeby ] # sanity check that network isn't included
     kill $pid
 
-    # Orchestrator needs to explicitly set PricePerUnit otherwise it will default to 0 resulting in a fatal error
-    res=0
-    $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -network rinkeby $ETH_ARGS || res=$?
-    [ $res -ne 0 ]
+    # Check that price can be set to 0 with -pricePerUnit 0
+    $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -s3bucket abc -pricePerUnit 0 -network rinkeby $ETH_ARGS 2>&1 | grep "Should specify both s3bucket and s3creds" 
+    # Check that -pricePerUnit needs to be set
+    $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -s3bucket abc -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pricePerUnit must be set"
     # Orchestrator needs PricePerUnit > 0 
-    res=0
-    $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pricePerUnit 0 -network rinkeby $ETH_ARGS || res=$?
-    [ $res -ne 0 ]
-    res=0
-    $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pricePerUnit -5 -network rinkeby $ETH_ARGS || res=$?
-    [ $res -ne 0 ]
+    $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -s3bucket abc -pricePerUnit -5 -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pricePerUnit must be >= 0, provided -5"
     # Orchestrator needs PixelsPerUnit > 0
-    res=0
-    $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pixelsPerUnit 0 -pricePerUnit 5 -network rinkeby $ETH_ARGS || res=$?
-    [ $res -ne 0 ]
-    res=0
-    $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pixelsPerUnit -5 -pricePerUnit 5 -network rinkeby $ETH_ARGS || res=$?
-    [ $res -ne 0 ]
+    $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -s3bucket abc -pixelsPerUnit 0 -pricePerUnit 5 -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pixelsPerUnit must be > 0, provided 0"
+    $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -s3bucket abc -pixelsPerUnit -5 -pricePerUnit 5 -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pixelsPerUnit must be > 0, provided -5"
 
     # Broadcaster needs a valid rational number for -maxTicketEV
     res=0


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR enables on-chain Os to transcode for free when their price is set to 0. See #1615 for a few reasons why this can be useful.

Additional implications of this PR include:

- The transcoding workflow in on-chain mode when price = 0 is pretty much equivalent to the transcoding workflow in off-chain mode
- Since an O's price can be updated via the webserver endpoint, it's possible to toggle payments on/off not only while the node is running, but during a stream as well. So, if there is a problem with the payment workflow for whatever reason O's price can be set to 0 to disable payments.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests.

I've done some manual testing using the devtool scripts + a private on-chain network that has consisted of:

- B with deposit & reserve > 0 streaming into O with price = 0
- B with deposit & reserve = 0 streaming into O with price = 0
- B with deposit & reserve = 0 streaming into O with price = 0 and then O sets price > 0 causing transcoding to stop
- B with deposit & reserve = 0 failing to stream into O with price > 0 and then O sets price = 0 causing transcoding to start

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1615 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
