### PR TITLE
server: All stake wt. to fastest session of an address

### DIFF
--- a/server/selection.go
+++ b/server/selection.go
@@ -189,8 +189,6 @@ func (s *MinLSSelector) selectUnknownSession() *BroadcastSession {
 		r = 1 + rand.Int63n(totalStake)
 	}
 
-	// Generate a random integer used to determine how to divide stake between sessions for the same address
-	stakeDivRand := rand.Int()
 	// Run a weighted random selection on unknownSessions
 	// We iterate through each session and subtract the stake weight for the session's orchestrator from r (initialized to a random stake weight)
 	// If subtracting the stake weight for the current session from r results in a value <= 0, we select the current session
@@ -198,20 +196,11 @@ func (s *MinLSSelector) selectUnknownSession() *BroadcastSession {
 	// will result in a value <= 0
 	for i, sess := range s.unknownSessions {
 		addr := ethcommon.BytesToAddress(sess.OrchestratorInfo.TicketParams.Recipient)
-		// If we could not fetch the stake weight for addrs[i] then its stake weight defaults to 0
-		// The stake weight for a session is the stake weight of the address divided by the # of sessions the
-		// address is associated with
-		stake := stakes[addr] / int64(addrCount[addr])
-		// If stakeDivRand % addrCount[addr] == 0 then the session is assigned any "leftover" stake that cannot be evenly divided
-		// between all sessions for addr
-		if stakeDivRand%addrCount[addr] == 0 {
-			stake += stakes[addr] % int64(addrCount[addr])
-		}
-		r -= stake
-		// Decrement stake weight available for the address' remaining sessions so the last session
-		// uses the remaining stake weight available for the address
-		stakes[addr] -= stake
-		addrCount[addr]--
+		// If we could not fetch the stake weight for addr then its stake weight defaults to 0
+		r -= stakes[addr]
+		// The first session in the list of a particular address gets *all* the stake
+		// so set the remaining stake for that address's session to zero
+		stakes[addr] = 0
 
 		if r <= 0 {
 			s.removeUnknownSession(i)


### PR DESCRIPTION

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

While selecting an Orchestrator during on-chain mode, give all stake weight to the *fastest* O session if multiple sessions belong to the same ETH address. (See #1614 for details)

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
Look at the commits

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Updated the unit test for Stake weight division amongst sessions of the same address

**Does this pull request close any open issues?**
<!-- Fixes # -->
Resolves #1614 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs on ArchLinux ~~OSX and devenv~~
- [x] All tests in `./test.sh` pass
