### PR TITLE
pm: Fix busy ticket queue loop

### DIFF
--- a/pm/queue.go
+++ b/pm/queue.go
@@ -145,7 +145,6 @@ ticketLoop:
 			}
 		case <-q.quit:
 			return
-		default:
 		}
 	}
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes a busy ticket queue loop that was causing CPU usage on any node that creates a ticket queue loop (either an O that is redeeming tickets on its own or a transactor that is running a ticket redeemer service) to spike to 100% as soon as the ticket queue loop is created (i.e. if `SenderMonitor.MaxFloat()` is called). The CPU spike would last until the SenderMonitor stops the ticket queue loop when it [stops monitoring an address due to inactivity](https://github.com/livepeer/go-livepeer/blob/master/pm/sendermonitor.go#L343) for a certain period of time.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested manually. Without this change, as soon as you connect an O to a transactor running a redeemer service (i.e. using the `-redeemer` flag), you can observe the CPU usage of the transactor spike to 100%. With this change, the CPU usage of the transactor in this setup does not spike. The same is true if you start an O that does standalone redemption.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1618 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
