### PR TITLE
ci: Use msys2/setup-msys2 for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,21 +7,26 @@ jobs:
       run: git config --global core.autocrlf false
     - uses: actions/checkout@v1
     - name: Setup Msys2 environment
-      uses: numworks/setup-msys2@v1
+      uses: msys2/setup-msys2@v2
       with:
         msystem: MSYS
     - name: Install prerequisites
-      run: msys2do pacman -S --noconfirm --noprogressbar --ask=20 perl binutils git make autoconf zip mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-pkg-config mingw-w64-x86_64-clang
+      shell: msys2 {0}
+      run: pacman -S --noconfirm --noprogressbar --ask=20 perl binutils git make autoconf zip mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-pkg-config mingw-w64-x86_64-clang
     - name: Install Go 1.13
-      run: msys2do pacman -U --noconfirm --noprogressbar --ask=20 http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-go-1.13.8-1-any.pkg.tar.xz
+      shell: msys2 {0}
+      run: pacman -U --noconfirm --noprogressbar --ask=20 http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-go-1.13.8-1-any.pkg.tar.xz
     - name: Build ffmpeg
-      run: msys2do ./install_ffmpeg.sh
+      shell: msys2 {0}
+      run: ./install_ffmpeg.sh
     - name: Build Livepeer
-      run: msys2do ./ci_env.sh make livepeer livepeer_cli
+      shell: msys2 {0}
+      run: ./ci_env.sh make livepeer livepeer_cli
     - name: Upload build
+      shell: msys2 {0}
       env: 
         CIRCLE_BRANCH: ${{ github.head_ref }}
         GCLOUD_KEY: ${{ secrets.GCLOUD_KEY }}
         GCLOUD_SECRET: ${{ secrets.GCLOUD_SECRET }}
         DISCORD_URL: ${{ secrets.DISCORD_URL }}
-      run: msys2do ./upload_build.sh
+      run: ./upload_build.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       run: pacman -S --noconfirm --noprogressbar --ask=20 perl binutils git make autoconf zip mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-pkg-config mingw-w64-x86_64-clang
     - name: Install Go 1.13
       shell: msys2 {0}
-      run: pacman -U --noconfirm --noprogressbar --ask=20 http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-go-1.13.8-1-any.pkg.tar.xz
+      run: pacman -U --noconfirm --noprogressbar --ask=20 https://sourceforge.net/projects/msys2/files/REPOS/MINGW/x86_64/mingw-w64-x86_64-go-1.13.8-1-any.pkg.tar.xz
     - name: Build ffmpeg
       shell: msys2 {0}
       run: ./install_ffmpeg.sh

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -54,7 +54,7 @@ if [[ $ARCH == "windows" ]]; then
   FILE=$BASE.zip
   ls /mingw64/bin/
   # This list was produced by `ldd livepeer.exe`
-  LIBS="libffi-6.dll libgcc_s_seh-1.dll libgmp-10.dll libgnutls-30.dll libhogweed-4.dll libiconv-2.dll libidn2-0.dll libintl-8.dll libnettle-6.dll libp11-kit-0.dll libtasn1-6.dll libunistring-2.dll libwinpthread-1.dll zlib1.dll"
+  LIBS="libffi-7.dll libgcc_s_seh-1.dll libgmp-10.dll libgnutls-30.dll libhogweed-6.dll libiconv-2.dll libidn2-0.dll libintl-8.dll libnettle-8.dll libp11-kit-0.dll libtasn1-6.dll libunistring-2.dll libwinpthread-1.dll zlib1.dll"
   for LIB in $LIBS; do
     cp -r /mingw64/bin/$LIB ./$BASE
   done


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes the Windows GH action workflow which is currently broken.

- Switched from `numworks/setup-msys2` action to the `msys2/setup-msys2` GH action since the latter looks like latter has [replaced the former](https://github.com/numworks/setup-msys2/issues/37)
- Switch to a Sourceforge mirror for installing go1.13 using pacman. At the time of writing this GH issue, `repo.msys2.org` is down (and I believe has been down for a few days...). pacman fails over to other mirrors when installing packages, but since we're installing go1.13 via a remote URL I think we need to specify a different URL
- Update the Windows dependencies referenced in `upload_build.sh`. Looks like they've changed with the version of msys2 setup with the new GH action

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
