### PR TITLE
eth: Remove gas price logging

### DIFF
--- a/eth/gaspricemonitor.go
+++ b/eth/gaspricemonitor.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/monitor"
 )
 
@@ -130,8 +129,6 @@ func (gpm *GasPriceMonitor) fetchAndUpdateGasPrice(ctx context.Context) error {
 	if monitor.Enabled {
 		monitor.SuggestedGasPrice(gasPrice)
 	}
-
-	glog.V(common.DEBUG).Infof("Cached gas price: %v", gasPrice)
 
 	return nil
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR removes logging whenever the GasPriceMonitor fetches & caches the gas price returned by a `eth_gasPrice` RPC call.

I don't feel particularly strongly about this change, but it does seem like this log statement provides little to no utility and just results in a sizable (a new log every 5 seconds with the default -blockPollingInterval value) number of logs that need to be sifted through.

An alternative is to increase the verbosity of the log statement from DEBUG to VERBOSE as suggested [here](https://github.com/livepeer/go-livepeer/issues/1483#issuecomment-628173813). Since there isn't really any actionable information in the current gas price log statements, I'm leaning towards just removing it altogether in this PR.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

None.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Closes #1483 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
