### PR TITLE
cmd, eth, server: remove claim earnings option

### DIFF
--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -91,7 +91,6 @@ func (w *wizard) initializeOptions() []wizardOpt {
 		{desc: "Invoke \"rebond\"", invoke: w.rebond},
 		{desc: "Invoke \"withdraw stake\" (LPT)", invoke: w.withdrawStake},
 		{desc: "Invoke \"withdraw fees\" (ETH)", invoke: w.withdrawFees},
-		{desc: "Invoke \"claim\" (for rewards and fees)", invoke: w.claimRewardsAndFees},
 		{desc: "Invoke \"transfer\" (LPT)", invoke: w.transferTokens},
 		{desc: "Invoke \"reward\"", invoke: w.callReward, orchestrator: true},
 		{desc: "Invoke multi-step \"become an orchestrator\"", invoke: w.activateOrchestrator, orchestrator: true},

--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -332,29 +332,3 @@ func (w *wizard) withdrawStake() {
 func (w *wizard) withdrawFees() {
 	httpPost(fmt.Sprintf("http://%v:%v/withdrawFees", w.host, w.httpPort))
 }
-
-func (w *wizard) claimRewardsAndFees() {
-	currentRound, err := w.currentRound()
-	if err != nil {
-		glog.Errorf("error getting current round: %v\n", err)
-		return
-	}
-	fmt.Printf("Current round: %v\n", currentRound.Int64())
-
-	d, err := w.getDelegatorInfo()
-	if err != nil {
-		glog.Error(err)
-		return
-	}
-
-	fmt.Printf("Last claim round: %v\n", d.LastClaimRound)
-
-	fmt.Printf("Enter end round - ")
-	endRound := w.readBigInt()
-
-	val := url.Values{
-		"endRound": {fmt.Sprintf("%v", endRound.String())},
-	}
-
-	httpPostWithParams(fmt.Sprintf("http://%v:%v/claimEarnings", w.host, w.httpPort), val)
-}

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -241,8 +241,8 @@ func (e *StubClient) WithdrawStake(*big.Int) (*types.Transaction, error) {
 	return nil, nil
 }
 func (e *StubClient) WithdrawFees() (*types.Transaction, error) { return nil, nil }
-func (e *StubClient) ClaimEarnings(endRound *big.Int) error {
-	return nil
+func (e *StubClient) ClaimEarnings(endRound *big.Int) (*types.Transaction, error) {
+	return nil, nil
 }
 func (e *StubClient) GetTranscoder(addr common.Address) (*lpTypes.Transcoder, error) {
 	if e.Err != nil {

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -717,7 +717,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 				if !init {
 					return errors.New("Round not initialized")
 				}
-				err = s.LivepeerNode.Eth.ClaimEarnings(endRound)
+				_, err = s.LivepeerNode.Eth.ClaimEarnings(endRound)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Removes the option from the CLI to manually claim earnings 

**Specific updates (required)**
- 46e7eee >> Removes the manual claim option from the CLI  
- 105a575 >> Removes autoClaimEarnings function from the ETH client and unwraps most functions that made use of it to now use the `BondingManager` contract bindings directly
- 170f099d65f724fe7b32318150e3bd3bb9b06b67 >> Keep the /claimEarnings endpoint around but no longer require an endRound field , ignore it if it is provided and just claim through currentRound 

**How did you test each of these updates (required)**


**Does this pull request close any open issues?**
Fixes #1635 


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
