### PR TITLE
server: fix current round locked check in activateOrchestrator

### DIFF
--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -181,6 +181,8 @@ type StubClient struct {
 	CheckTxErr                   error
 	TotalStake                   *big.Int
 	TranscoderPoolError          error
+	RoundLocked                  bool
+	RoundLockedErr               error
 }
 
 type stubTranscoder struct {
@@ -200,7 +202,7 @@ func (e *StubClient) BlockHashForRound(round *big.Int) ([32]byte, error) {
 	return e.BlockHashToReturn, nil
 }
 func (e *StubClient) CurrentRoundInitialized() (bool, error)    { return false, nil }
-func (e *StubClient) CurrentRoundLocked() (bool, error)         { return false, nil }
+func (e *StubClient) CurrentRoundLocked() (bool, error)         { return e.RoundLocked, e.RoundLockedErr }
 func (e *StubClient) CurrentRoundStartBlock() (*big.Int, error) { return nil, nil }
 func (e *StubClient) Paused() (bool, error)                     { return false, nil }
 

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -231,12 +231,12 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 			return
 		}
 
-		ok, err := s.LivepeerNode.Eth.CurrentRoundLocked()
+		isLocked, err := s.LivepeerNode.Eth.CurrentRoundLocked()
 		if err != nil {
 			respondWith500(w, err.Error())
 			return
 		}
-		if !ok {
+		if isLocked {
 			respondWith500(w, "current round is locked")
 			return
 		}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fix current round locked check in `/activateOrchestrator` endpoint for the CLI server which will always respond that the current round is locked 

**Does this pull request close any open issues?**
Fixes #1648 


**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
