### PR TITLE
db: prevent nil pointer error if no rows in sql query result

### DIFF
--- a/common/db.go
+++ b/common/db.go
@@ -521,11 +521,11 @@ func (db *DB) SelectOrchs(filter *DBOrchFilter) ([]*DBOrch, error) {
 	}
 
 	rows, err := db.dbh.Query(buildSelectOrchsQuery(filter))
-	defer rows.Close()
 	if err != nil {
 		glog.Error("db: Unable to get orchestrators updated in the last 24 hours: ", err)
 		return nil, err
 	}
+	defer rows.Close()
 	orchs := []*DBOrch{}
 	for rows.Next() {
 		var (
@@ -881,10 +881,10 @@ func (db *DB) FindLatestMiniHeader() (*blockwatch.MiniHeader, error) {
 func (db *DB) FindAllMiniHeadersSortedByNumber() ([]*blockwatch.MiniHeader, error) {
 	var headers []*blockwatch.MiniHeader
 	rows, err := db.findAllMiniHeadersSortedByNumber.Query()
-	defer rows.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var (
 			number  int64


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
If there are no rows in the SQL result set then `rows` will/could be `nil` and calling `rows.Close()` before handling the error could result in a nil pointer error. 

SQLite seems to handle this well but I ran into it using postgres, might be good riddance regardless. 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
