### PR TITLE
monitor,server: add segment download time metric

### DIFF
--- a/monitor/census.go
+++ b/monitor/census.go
@@ -467,6 +467,7 @@ func InitCensus(nodeType, nodeID, version string) {
 		{
 			Name:        "download_time_seconds",
 			Measure:     census.mDownloadTime,
+			Description: "Download (from orchestrator) time",
 			TagKeys:     baseTags,
 			Aggregation: view.Distribution(0, .10, .20, .50, .100, .150, .200, .500, .1000, .5000, 10.000),
 		},

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -504,6 +504,7 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 		}
 	}
 
+	dlStart := time.Now()
 	for i, v := range res.Segments {
 		go dlFunc(v.Url, v.Pixels, i)
 	}
@@ -515,6 +516,11 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 	cond.L.Unlock()
 	if dlErr != nil {
 		return nil, dlErr
+	}
+
+	downloadDur := time.Since(dlStart)
+	if monitor.Enabled {
+		monitor.SegmentDownloaded(nonce, seg.SeqNo, downloadDur)
 	}
 
 	if verifier != nil {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds download time and segments downloaded as a metric 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
