### PR TITLE
Add some transcoding metrics for O + T split

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -704,6 +704,7 @@ func (rt *RemoteTranscoder) Transcode(md *SegTranscodingMetadata) (*TranscodeDat
 		return nil, err
 	}
 
+	start := time.Now()
 	msg := &net.NotifySegment{
 		Url:     fname,
 		TaskId:  taskID,
@@ -730,8 +731,8 @@ func (rt *RemoteTranscoder) Transcode(md *SegTranscodingMetadata) (*TranscodeDat
 	case <-ctx.Done():
 		return signalEOF(ErrRemoteTranscoderTimeout)
 	case chanData := <-taskChan:
-		glog.Infof("Successfully received results from remote transcoder=%s segments=%d taskId=%d fname=%s err=%v",
-			rt.addr, len(chanData.TranscodeData.Segments), taskID, fname, chanData.Err)
+		glog.Infof("Successfully received results from remote transcoder=%s segments=%d taskId=%d fname=%s dur=%v err=%v",
+			rt.addr, len(chanData.TranscodeData.Segments), taskID, fname, time.Since(start), chanData.Err)
 		return chanData.TranscodeData, chanData.Err
 	}
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Add a few transcoding metrics for a O + T split:

- Log the round trip between O & T from O's POV
- Log and record the download duration from T on O (use taskID for seqNo)
- Log and record the upload duration to O on a standalone T (use taskID for seqNo)
- Log and record the transcode duration for a standalone Nvidia T

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested manually.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
