### PR TITLE
Record and log additional metrics for O

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -313,16 +313,16 @@ func main() {
 
 	if *monitor {
 		lpmon.Enabled = true
-		nodeType := "dflt"
+		nodeType := lpmon.Default
 		switch n.NodeType {
 		case core.BroadcasterNode:
-			nodeType = "bctr"
+			nodeType = lpmon.Broadcaster
 		case core.OrchestratorNode:
-			nodeType = "orch"
+			nodeType = lpmon.Orchestrator
 		case core.TranscoderNode:
-			nodeType = "trcr"
+			nodeType = lpmon.Transcoder
 		case core.RedeemerNode:
-			nodeType = "rdmr"
+			nodeType = lpmon.Redeemer
 		}
 		lpmon.InitCensus(nodeType, core.LivepeerVersion)
 	}

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -554,7 +554,7 @@ func (n *LivepeerNode) transcodeSeg(config transcodeConfig, seg *stream.HLSSegme
 	took := time.Since(start)
 	glog.V(common.DEBUG).Infof("Transcoding of segment manifestID=%s sessionID=%s seqNo=%d took=%v", string(md.ManifestID), md.AuthToken.SessionId, seg.SeqNo, took)
 	if monitor.Enabled {
-		monitor.SegmentTranscoded(0, seg.SeqNo, took, common.ProfilesNames(md.Profiles))
+		monitor.SegmentTranscoded(0, seg.SeqNo, md.Duration, took, common.ProfilesNames(md.Profiles))
 	}
 
 	// Prepare the result object

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -51,7 +51,7 @@ func (lt *LocalTranscoder) Transcode(md *SegTranscodingMetadata) (*TranscodeData
 		// When orchestrator works as transcoder, `fname` will be relative path to file in local
 		// filesystem and will not contain seqNo in it. For that case `SegmentTranscoded` will
 		// be called in orchestrator.go
-		monitor.SegmentTranscoded(0, seqNo, time.Since(start), common.ProfilesNames(profiles))
+		monitor.SegmentTranscoded(0, seqNo, md.Duration, time.Since(start), common.ProfilesNames(profiles))
 	}
 
 	return resToTranscodeData(res, opts)
@@ -89,7 +89,7 @@ func (nv *NvidiaTranscoder) Transcode(md *SegTranscodingMetadata) (*TranscodeDat
 		// When orchestrator works as transcoder, `fname` will be relative path to file in local
 		// filesystem and will not contain seqNo in it. For that case `SegmentTranscoded` will
 		// be called in orchestrator.go
-		monitor.SegmentTranscoded(0, seqNo, time.Since(start), common.ProfilesNames(profiles))
+		monitor.SegmentTranscoded(0, seqNo, md.Duration, time.Since(start), common.ProfilesNames(profiles))
 	}
 
 	return resToTranscodeData(res, out)

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -479,7 +479,7 @@ func InitCensus(nodeType NodeType, version string) {
 		{
 			Name:        "download_time_seconds",
 			Measure:     census.mDownloadTime,
-			Description: "Download (from orchestrator) time",
+			Description: "Download time",
 			TagKeys:     baseTags,
 			Aggregation: view.Distribution(0, .10, .20, .50, .100, .150, .200, .500, .1000, .5000, 10.000),
 		},

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -891,7 +891,9 @@ func SetTranscodersNumberAndLoad(load, capacity, number int) {
 
 func SegmentEmerged(nonce, seqNo uint64, profilesNum int, dur float64) {
 	glog.V(logLevel).Infof("Logging SegmentEmerged... nonce=%d seqNo=%d duration=%v", nonce, seqNo, dur)
-	census.segmentEmerged(nonce, seqNo, profilesNum)
+	if census.nodeType == Broadcaster {
+		census.segmentEmerged(nonce, seqNo, profilesNum)
+	}
 	stats.Record(census.ctx, census.mSourceSegmentDuration.M(dur))
 }
 

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -50,6 +50,16 @@ const (
 	// importing `common` package here introduces import cycles
 )
 
+type NodeType string
+
+const (
+	Default      NodeType = "dflt"
+	Orchestrator NodeType = "orch"
+	Broadcaster  NodeType = "bctr"
+	Transcoder   NodeType = "trcr"
+	Redeemer     NodeType = "rdmr"
+)
+
 // Enabled true if metrics was enabled in command line
 var Enabled bool
 
@@ -60,7 +70,7 @@ var timeoutWatcherPause = 15 * time.Second
 
 type (
 	censusMetricsCounter struct {
-		nodeType                      string
+		nodeType                      NodeType
 		nodeID                        string
 		ctx                           context.Context
 		kGPU                          tag.Key
@@ -165,7 +175,7 @@ var census censusMetricsCounter
 // used in unit tests
 var unitTestMode bool
 
-func InitCensus(nodeType, version string) {
+func InitCensus(nodeType NodeType, version string) {
 	census = censusMetricsCounter{
 		emergeTimes: make(map[uint64]map[uint64]time.Time),
 		nodeID:      NodeID,
@@ -184,7 +194,7 @@ func InitCensus(nodeType, version string) {
 	census.kSender = tag.MustNewKey("sender")
 	census.kRecipient = tag.MustNewKey("recipient")
 	census.kManifestID = tag.MustNewKey("manifestID")
-	census.ctx, err = tag.New(ctx, tag.Insert(census.kNodeType, nodeType), tag.Insert(census.kNodeID, NodeID))
+	census.ctx, err = tag.New(ctx, tag.Insert(census.kNodeType, string(nodeType)), tag.Insert(census.kNodeID, NodeID))
 	if err != nil {
 		glog.Fatal("Error creating context", err)
 	}
@@ -255,7 +265,7 @@ func InitCensus(nodeType, version string) {
 	goos := tag.MustNewKey("goos")
 	goversion := tag.MustNewKey("goversion")
 	livepeerversion := tag.MustNewKey("livepeerversion")
-	ctx, err = tag.New(ctx, tag.Insert(census.kNodeType, nodeType), tag.Insert(census.kNodeID, NodeID),
+	ctx, err = tag.New(ctx, tag.Insert(census.kNodeType, string(nodeType)), tag.Insert(census.kNodeID, NodeID),
 		tag.Insert(compiler, runtime.Compiler), tag.Insert(goarch, runtime.GOARCH), tag.Insert(goos, runtime.GOOS),
 		tag.Insert(goversion, runtime.Version()), tag.Insert(livepeerversion, version))
 	if err != nil {

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -495,7 +495,7 @@ func InitCensus(nodeType NodeType, version string) {
 			Measure:     census.mSourceSegmentDuration,
 			Description: "Source segment's duration",
 			TagKeys:     baseTags,
-			Aggregation: view.Distribution(0, 100, 250, 500, 750, 1000, 1500, 2000, 2500, 3000, 5000, 10000, 20000, 30000),
+			Aggregation: view.Distribution(0, .5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 10, 15, 20),
 		},
 		{
 			Name:        "max_sessions_total",

--- a/monitor/census_test.go
+++ b/monitor/census_test.go
@@ -49,7 +49,7 @@ func TestLastSegmentTimeout(t *testing.T) {
 	defer func() { unitTestMode = false }()
 	NodeID = "testid"
 
-	InitCensus("tst", "testversion")
+	InitCensus("bctr", "testversion")
 	// defer func() {
 	// 	shutDown <- nil
 	// }()

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -532,7 +532,7 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 
 	// transcode succeeded; continue processing response
 	if monitor.Enabled {
-		monitor.SegmentTranscoded(nonce, seg.SeqNo, transcodeDur, common.ProfilesNames(params.Profiles))
+		monitor.SegmentTranscoded(nonce, seg.SeqNo, time.Duration(seg.Duration*float64(time.Second)), transcodeDur, common.ProfilesNames(params.Profiles))
 	}
 
 	glog.Infof("Successfully transcoded segment nonce=%d manifestID=%s sessionID=%s segName=%s seqNo=%d orch=%s dur=%s", nonce,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Record and log the following metrics on O:
- Source segment duration
- Download time for source segment
- Transcode score for a segment which is defined as source segment duration / transcode time (this is added for standalone T as well)

B downloads the transcoded results from O separately and the associated HTTP handler lives in LPMS so I did not try to add metrics instrumentation there for now. As a result, this PR does not include the ability to measure the ratio between source segment duration and round trip time from O's POV.

A few other minor updates:
- 1702ba5 uses a NodeType type instead of a string in the `monitor` package. I felt that this would be less prone to error when writing conditionals based on the current node type as is done in 7a05697 which skips extra state tracking code in `SegmentEmerged` if the function is used for a node type other than a broadcaster
- 321f5d0 tweaks the view distribution for the source segment duration metric to make the percentile graph of source segment duration easier to understand

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested manually and observed metrics using livepeer/docker-livepeer#44.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1661 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
