### PR TITLE
server/pushapi: continue with old RTMP connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/jackpal/go-nat-pmp v1.0.1 // indirect
 	github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 // indirect
 	github.com/livepeer/lpms v0.0.0-20201130142735-967c18793f06
-	github.com/livepeer/m3u8 v0.11.0
+	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,9 @@ github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cO
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/lpms v0.0.0-20201130142735-967c18793f06 h1:g8BFFP464d+vlc6hyouO4IaqDy4VAEn/9OZfruBMRwc=
 github.com/livepeer/lpms v0.0.0-20201130142735-967c18793f06/go.mod h1:Vd2O4BVQI/Yj2hzjnNcyTj+qib8zb0hh7GunKP6KJc8=
-github.com/livepeer/m3u8 v0.11.0 h1:aI2hLXV5h5VqxjjmAOs55TpUR35KzNL2XWLkbETql5g=
 github.com/livepeer/m3u8 v0.11.0/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
+github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
+github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
If an old connection is found later due to segments arriving too closely, continue with that connection instead of returning a 500 to the client.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Improve handling for simultaneous segments at the start of a push api stream 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
1. Followed the reproduction steps at #1665
2. Got a 500 before this patch.
3. Apply this patch
4. Get a 503 "Service Unavailable" due to "No sessions available" instead

**Does this pull request close any open issues?**
<!-- Fixes # -->

Partly handles #1665 
For actually handling simultaneous segments instead of throwing the 503, need to implement changes mentioned in #1658 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
