### PR TITLE
User session

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -963,12 +963,12 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// getPlalistsFromStore finds all the json playlist files belonging to the provided manifests
+// getPlaylistsFromStore finds all the json playlist files belonging to the provided manifests
 // returns:
 // - a map of manifestID -> a list of indices pointing to JSON files in the returned list of JSON files
 // - a list of JSON files for all manifestIDs provided
 // - the latest playlist time
-func getPlalistsFromStore(ctx context.Context, sess drivers.OSSession, manifests []string) (map[string][]int, []string, time.Time, error) {
+func getPlaylistsFromStore(ctx context.Context, sess drivers.OSSession, manifests []string) (map[string][]int, []string, time.Time, error) {
 	var latestPlaylistTime time.Time
 	var jsonFiles []string
 	filesMap := make(map[string][]int)
@@ -1118,7 +1118,7 @@ func (s *LivepeerServer) HandleRecordings(w http.ResponseWriter, r *http.Request
 	} else {
 		manifests = []string{manifestID}
 	}
-	jsonFilesMap, jsonFiles, latestPlaylistTime, err := getPlalistsFromStore(ctx, sess, manifests)
+	jsonFilesMap, jsonFiles, latestPlaylistTime, err := getPlaylistsFromStore(ctx, sess, manifests)
 	if err != nil {
 		glog.Error(err)
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Join couple of transcoding sessions to
one 'user' session in recordings


**Specific updates (required)**
- add 'previousSessions' field to the AuthWebhook response
- in /recordings handler use 'previousSessions' field's content to find all the transcoding sessions belonging to this one
  'user' session and join them to one manifest

**How did you test each of these updates (required)**
Manually 


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
