### PR TITLE
>= go1.15.5 Linux & Darwin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
 jobs:
   build-builder:
     docker:
-      - image: circleci/golang:1-stretch
+      - image: circleci/golang:1.15.5
     working_directory: /go/src/github.com/livepeer/go-livepeer
 
     environment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.13.x
+  - 1.15.x
 os: osx
 osx_image: xcode10.2
 env:

--- a/docker/Dockerfile.build-linux
+++ b/docker/Dockerfile.build-linux
@@ -1,19 +1,19 @@
 FROM ubuntu:16.04
 
-ENV PATH "/usr/lib/go-1.13/bin:/go/bin:${PATH}"
+ENV PATH "/usr/local/go/bin:/go/bin:${PATH}"
 ENV PKG_CONFIG_PATH "/root/compiled/lib/pkgconfig"
 ENV CPATH /usr/local/cuda/include
 ENV LIBRARY_PATH /usr/local/cuda/lib64
 
 RUN apt-get update \
   && apt-get install -y software-properties-common curl apt-transport-https \
-  && add-apt-repository ppa:longsleep/golang-backports -y \
+  && curl https://dl.google.com/go/go1.15.5.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
   && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs)  stable" \
   && apt-key adv --keyserver keyserver.ubuntu.com --recv 15CF4D18AF4F7421 \
   && add-apt-repository "deb [arch=amd64] http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" \
   && apt-get update \
-  && apt-get -y install clang-8 clang-tools-8 build-essential pkg-config autoconf gnutls-dev golang-1.13-go sudo git python docker-ce-cli
+  && apt-get -y install clang-8 clang-tools-8 build-essential pkg-config autoconf gnutls-dev sudo git python docker-ce-cli
 
 RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 30 \
   && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 30

--- a/server/cliserver_test.go
+++ b/server/cliserver_test.go
@@ -179,7 +179,7 @@ func TestActivateOrchestrator(t *testing.T) {
 	body, err = ioutil.ReadAll(res.Body)
 	res.Body.Close()
 	require.Nil(err)
-	assert.Equal(strings.TrimSpace(string(body)), "parse hello world: invalid URI for request")
+	assert.Equal(strings.TrimSpace(string(body)), "parse \"hello world\": invalid URI for request")
 	form["serviceURI"] = []string{"http://foo.bar:1337"}
 
 	req = bytes.NewBufferString(form.Encode())


### PR DESCRIPTION
- Use go1.15.5 for Linux. A tar archive is downloaded from dl.google.com instead of installing using apt because the most recent version in the longsleep/golang-backports repo is go1.15.2.
- Use go1.15.x for Darwin. At the moment, the latest version is go1.15.6
- Fix a test that broke after the switch to go1.15.5 for linux

Upgrading to >= go1.15.5 for Windows is a bit trickier so I left that for #1701. 

Not sure if this actually resolves #1700, but at least the tests pass for this PR. Will leave that issue open for a bit and observe if it is still a problem.

Fixes #1668 