### PR TITLE
Fix recordings

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -380,3 +380,10 @@ func RatPriceInfo(priceInfo *net.PriceInfo) (*big.Rat, error) {
 
 	return big.NewRat(priceInfo.PricePerUnit, pixelsPerUnit), nil
 }
+
+func JoinPaths(path1, path2 string) string {
+	if !strings.HasSuffix(path1, "/") {
+		return path1 + "/" + path2
+	}
+	return path1 + path2
+}

--- a/common/util.go
+++ b/common/util.go
@@ -381,9 +381,9 @@ func RatPriceInfo(priceInfo *net.PriceInfo) (*big.Rat, error) {
 	return big.NewRat(priceInfo.PricePerUnit, pixelsPerUnit), nil
 }
 
-func JoinPaths(path1, path2 string) string {
-	if !strings.HasSuffix(path1, "/") {
-		return path1 + "/" + path2
+func JoinURL(url, path string) string {
+	if !strings.HasSuffix(url, "/") {
+		return url + "/" + path
 	}
-	return path1 + path2
+	return url + path
 }

--- a/core/playlistmanager.go
+++ b/core/playlistmanager.go
@@ -91,11 +91,11 @@ func (jpl *JsonPlaylist) AddMaster(ajpl *JsonPlaylist) {
 }
 
 // AddSegmentsToMPL adds segments to the MediaPlaylist
-func (jpl *JsonPlaylist) AddSegmentsToMPL(manifestID, trackName string, mpl *m3u8.MediaPlaylist, extURL string) {
+func (jpl *JsonPlaylist) AddSegmentsToMPL(manifestIDs []string, trackName string, mpl *m3u8.MediaPlaylist, extURL string) {
 	for _, seg := range jpl.Segments[trackName] {
 		// make relative URL from absolute one
 		uri := seg.URI
-		mindex := strings.Index(uri, manifestID)
+		mindex, manifestIDlen := indexOf(uri, manifestIDs)
 		if mindex != -1 {
 			// If extURL was specified we will put absolute URL to the segment into manifest
 			// extURL points to the root of object store, so we should take part of the 'uri'
@@ -107,7 +107,7 @@ func (jpl *JsonPlaylist) AddSegmentsToMPL(manifestID, trackName string, mpl *m3u
 			if extURL != "" {
 				uri = path.Join(extURL, uri[mindex:])
 			} else {
-				uri = uri[mindex+len(manifestID)+1:]
+				uri = uri[mindex+manifestIDlen+1:]
 			}
 		}
 		mseg := &m3u8.MediaSegment{
@@ -331,4 +331,16 @@ func newMediaSegment(uri string, duration float64) *m3u8.MediaSegment {
 		URI:      uri,
 		Duration: duration,
 	}
+}
+
+// indexOf finds index of one of substrings
+// returns index and length of substring
+func indexOf(str string, substrs []string) (int, int) {
+	for _, sub := range substrs {
+		mindex := strings.Index(str, sub)
+		if mindex != -1 {
+			return mindex, len(sub)
+		}
+	}
+	return -1, 0
 }

--- a/core/playlistmanager.go
+++ b/core/playlistmanager.go
@@ -104,7 +104,7 @@ func (jpl *JsonPlaylist) AddSegmentsToMPL(manifestIDs []string, trackName string
 			// (broadcaster.com/recordings/manifestID/index.m3u8), so we're taking
 			// part of the 'uri' after the manifestID
 			if extURL != "" {
-				uri = common.JoinPaths(extURL, uri[mindex:])
+				uri = common.JoinURL(extURL, uri[mindex:])
 			} else {
 				uri = uri[mindex+manifestIDlen+1:]
 			}

--- a/core/playlistmanager.go
+++ b/core/playlistmanager.go
@@ -3,7 +3,6 @@ package core
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -105,7 +104,7 @@ func (jpl *JsonPlaylist) AddSegmentsToMPL(manifestIDs []string, trackName string
 			// (broadcaster.com/recordings/manifestID/index.m3u8), so we're taking
 			// part of the 'uri' after the manifestID
 			if extURL != "" {
-				uri = path.Join(extURL, uri[mindex:])
+				uri = common.JoinPaths(extURL, uri[mindex:])
 			} else {
 				uri = uri[mindex+manifestIDlen+1:]
 			}

--- a/core/playlistmanager_test.go
+++ b/core/playlistmanager_test.go
@@ -71,7 +71,7 @@ func TestJSONList1(t *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(mpl)
 	mpl.Live = false
-	mjspl.AddSegmentsToMPL("manifestID", "source", mpl, "")
+	mjspl.AddSegmentsToMPL([]string{"manifestID"}, "source", mpl, "")
 	mpls := string(mpl.Encode().Bytes())
 	assert.Equal("#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-TARGETDURATION:3\n#EXTINF:2.100,\ntest_seg/1.ts\n#EXTINF:2.000,\ntest_seg/2.ts\n#EXTINF:2.500,\ntest_seg/3.ts\n#EXTINF:2.500,\ntest_seg/4.ts\n#EXT-X-ENDLIST\n", mpls)
 }

--- a/drivers/local.go
+++ b/drivers/local.go
@@ -95,8 +95,15 @@ func (ostore *MemorySession) ListFiles(ctx context.Context, prefix, delim string
 		cprefix = strings.Join(pp[:len(pp)-1], "/") + "/"
 		pprefix = pp[len(pp)-1]
 	}
+	dCache := ostore.dCache
+	if prefix != "" && Testing {
+		sid := strings.Split(prefix, "/")[0]
+		if osess, has := ostore.os.sessions[sid]; has {
+			dCache = osess.dCache
+		}
+	}
 
-	for cachePath, cache := range ostore.dCache {
+	for cachePath, cache := range dCache {
 		if strings.HasPrefix(cachePath, cprefix) {
 			for _, it := range cache.cache {
 				if it.name != "" {
@@ -162,8 +169,14 @@ func (ostore *MemorySession) GetData(name string) []byte {
 
 	ostore.dLock.RLock()
 	defer ostore.dLock.RUnlock()
-
-	if cache, ok := ostore.dCache[path]; ok {
+	dCache := ostore.dCache
+	if Testing {
+		sid := strings.Split(path, "/")[0]
+		if osess, has := ostore.os.sessions[sid]; has {
+			dCache = osess.dCache
+		}
+	}
+	if cache, ok := dCache[path]; ok {
 		return cache.GetData(file)
 	}
 	return nil

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -1226,7 +1226,7 @@ func (s *LivepeerServer) HandleRecordings(w http.ResponseWriter, r *http.Request
 	if finalize {
 		for trackName := range mainJspl.Segments {
 			mpl := mediaLists[trackName]
-			mainJspl.AddSegmentsToMPL(manifestID, trackName, mpl, resp.RecordObjectStoreURL)
+			mainJspl.AddSegmentsToMPL(manifests, trackName, mpl, resp.RecordObjectStoreURL)
 			fileName := trackName + ".m3u8"
 			nows := time.Now()
 			_, err = sess.SaveData(fileName, mpl.Encode().Bytes(), nil)
@@ -1247,7 +1247,7 @@ func (s *LivepeerServer) HandleRecordings(w http.ResponseWriter, r *http.Request
 		}
 	} else if !returnMasterPlaylist {
 		mpl := mediaLists[track]
-		mainJspl.AddSegmentsToMPL(manifestID, track, mpl, resp.RecordObjectStoreURL)
+		mainJspl.AddSegmentsToMPL(manifests, track, mpl, resp.RecordObjectStoreURL)
 		// check (debug code)
 		startSeq := mpl.Segments[0].SeqId
 		for _, seg := range mpl.Segments[1:] {

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -818,6 +818,8 @@ func TestPush_ForAuthWebhookFailure(t *testing.T) {
 	defer serverCleanup(s)
 	handler, reader, w := requestSetup(s)
 
+	oldURL := AuthWebhookURL
+	defer func() { AuthWebhookURL = oldURL }()
 	AuthWebhookURL = "notaurl"
 	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
 
@@ -829,9 +831,6 @@ func TestPush_ForAuthWebhookFailure(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(http.StatusInternalServerError, resp.StatusCode)
 	assert.Contains(strings.TrimSpace(string(body)), "Could not create stream ID")
-
-	// reset AuthWebhookURL to original value
-	AuthWebhookURL = ""
 }
 
 func TestPush_ResolutionWithoutContentResolutionHeader(t *testing.T) {
@@ -897,6 +896,8 @@ func TestPush_WebhookRequestURL(t *testing.T) {
 
 	defer ts.Close()
 
+	oldURL := AuthWebhookURL
+	defer func() { AuthWebhookURL = oldURL }()
 	AuthWebhookURL = ts.URL
 	handler, reader, w := requestSetup(s)
 	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
@@ -931,6 +932,8 @@ func TestPush_OSPerStream(t *testing.T) {
 	}))
 
 	defer whts.Close()
+	oldURL := AuthWebhookURL
+	defer func() { AuthWebhookURL = oldURL }()
 	AuthWebhookURL = whts.URL
 
 	ts, mux := stubTLSServer()

--- a/server/recordings_test.go
+++ b/server/recordings_test.go
@@ -36,6 +36,8 @@ func TestRecordingHandler(t *testing.T) {
 		"previousSessions":["sess1","sess2"]}`))
 	}))
 	defer whts.Close()
+	oldURL := AuthWebhookURL
+	defer func() { AuthWebhookURL = oldURL }()
 	AuthWebhookURL = whts.URL
 
 	makeReq := func(method, uri string) *http.Response {
@@ -73,13 +75,13 @@ func TestRecordingHandler(t *testing.T) {
 	body, _ := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	assert.Equal(200, resp.StatusCode)
-	assert.Equal("#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-TARGETDURATION:2100\n#EXTINF:2100.000,\nhttps:/pub.test/sess1/testNode/P144p25fps16x9/1.ts\n#EXT-X-DISCONTINUITY\n#EXTINF:2100.000,\nhttps:/pub.test/sess2/testNode/P144p25fps16x9/2.ts\n#EXT-X-DISCONTINUITY\n#EXTINF:2100.000,\nhttps:/pub.test/sess3/testNode/P144p25fps16x9/3.ts\n#EXT-X-ENDLIST\n", string(body))
+	assert.Equal("#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-TARGETDURATION:2100\n#EXTINF:2100.000,\nhttps://pub.test/sess1/testNode/P144p25fps16x9/1.ts\n#EXT-X-DISCONTINUITY\n#EXTINF:2100.000,\nhttps://pub.test/sess2/testNode/P144p25fps16x9/2.ts\n#EXT-X-DISCONTINUITY\n#EXTINF:2100.000,\nhttps://pub.test/sess3/testNode/P144p25fps16x9/3.ts\n#EXT-X-ENDLIST\n", string(body))
 	fir, err := msess3.ReadData(context.Background(), "sess3/P144p25fps16x9.m3u8")
 	assert.Nil(err)
 	assert.NotNil(fir)
 	body, _ = ioutil.ReadAll(fir.Body)
 	fir.Body.Close()
-	assert.Equal("#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-TARGETDURATION:2100\n#EXTINF:2100.000,\nhttps:/pub.test/sess1/testNode/P144p25fps16x9/1.ts\n#EXT-X-DISCONTINUITY\n#EXTINF:2100.000,\nhttps:/pub.test/sess2/testNode/P144p25fps16x9/2.ts\n#EXT-X-DISCONTINUITY\n#EXTINF:2100.000,\nhttps:/pub.test/sess3/testNode/P144p25fps16x9/3.ts\n#EXT-X-ENDLIST\n", string(body))
+	assert.Equal("#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-TARGETDURATION:2100\n#EXTINF:2100.000,\nhttps://pub.test/sess1/testNode/P144p25fps16x9/1.ts\n#EXT-X-DISCONTINUITY\n#EXTINF:2100.000,\nhttps://pub.test/sess2/testNode/P144p25fps16x9/2.ts\n#EXT-X-DISCONTINUITY\n#EXTINF:2100.000,\nhttps://pub.test/sess3/testNode/P144p25fps16x9/3.ts\n#EXT-X-ENDLIST\n", string(body))
 }
 
 func TestRecording(t *testing.T) {
@@ -102,6 +104,8 @@ func TestRecording(t *testing.T) {
 	}))
 
 	defer whts.Close()
+	oldURL := AuthWebhookURL
+	defer func() { AuthWebhookURL = oldURL }()
 	AuthWebhookURL = whts.URL
 	makeReq := func(method, uri string) *http.Response {
 		writer := httptest.NewRecorder()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes absolute urls to the segments in the VOD playlists

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- when `recordObjectStoreUrl` set for object store correctly generate public urls for sessions specified in `previousSessions` field
 

**How did you test each of these updates (required)**
Added unit test


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
