### PR TITLE
monitor: Update transcode score hist dist

### DIFF
--- a/monitor/census.go
+++ b/monitor/census.go
@@ -476,7 +476,7 @@ func InitCensus(nodeType NodeType, version string) {
 			Measure:     census.mTranscodeScore,
 			Description: "Ratio of source segment duration vs. transcode time",
 			TagKeys:     append([]tag.Key{census.kProfiles}, baseTags...),
-			Aggregation: view.Distribution(0, .25, .5, .75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 2.75, 3, 3.25, 3.5, 3.75, 4),
+			Aggregation: view.Distribution(0, .5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 10, 15, 20, 40),
 		},
 		{
 			Name:        "upload_time_seconds",


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Updates the histogram distribution for the `transcode_score` metric to include buckets for scores higher than 4.0 (which are quite common).

Before this PR, the transcode score percentile graph in Grafana looked like this when the transcode score was consistently above 4.0:

![Screen Shot 2020-12-07 at 9 34 33 AM](https://user-images.githubusercontent.com/5933273/101363466-6f042500-386f-11eb-84ac-f3c39233f8da.png)

After this PR, the transcode score percentile graph in Grafana looks like this:

![Screen Shot 2020-12-07 at 9 33 03 AM](https://user-images.githubusercontent.com/5933273/101363294-3a906900-386f-11eb-94d6-3cc4ef9d1fd5.png)

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested manually. See included screenshot.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1675 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
