### PR TITLE
eth: rewardservice to use round subscription

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -668,7 +668,7 @@ func main() {
 		if *reward {
 			// Start reward service
 			// The node will only call reward if it is active in the current round
-			rs := eventservices.NewRewardService(n.Eth, blockPollingTime)
+			rs := eventservices.NewRewardService(n.Eth, timeWatcher)
 			rs.Start(ctx)
 			defer rs.Stop()
 		}

--- a/eth/eventservices/rewardservice_test.go
+++ b/eth/eventservices/rewardservice_test.go
@@ -1,0 +1,183 @@
+package eventservices
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/eth"
+	lpTypes "github.com/livepeer/go-livepeer/eth/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStart(t *testing.T) {
+	assert := assert.New(t)
+	rs := RewardService{
+		working: true,
+	}
+	assert.EqualError(rs.Start(context.Background()), ErrRewardServiceStarted.Error())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rs = RewardService{
+		tw:           &stubTimeWatcher{},
+		cancelWorker: cancel,
+	}
+	errC := make(chan error)
+	go func() { errC <- rs.Start(ctx) }()
+	time.Sleep(1 * time.Second)
+	assert.True(rs.working)
+	cancel()
+	err := <-errC
+	assert.Nil(err)
+}
+
+func TestStop(t *testing.T) {
+	assert := assert.New(t)
+	rs := RewardService{
+		working: false,
+	}
+	assert.EqualError(rs.Stop(), ErrRewardServiceStopped.Error())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rs = RewardService{
+		tw:           &stubTimeWatcher{},
+		cancelWorker: cancel,
+	}
+	go rs.Start(ctx)
+	time.Sleep(1 * time.Second)
+	require.True(t, rs.working)
+	rs.Stop()
+	assert.False(rs.working)
+}
+
+func TestIsWorking(t *testing.T) {
+	assert := assert.New(t)
+	rs := RewardService{
+		working: false,
+	}
+	assert.False(rs.IsWorking())
+	rs.working = true
+	assert.True(rs.IsWorking())
+}
+
+func TestReceiveRoundEvent_TryReward(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	eth := &eth.MockClient{}
+	tw := &stubTimeWatcher{
+		lastInitializedRound: big.NewInt(100),
+	}
+	ctx := context.Background()
+	rs := RewardService{
+		client: eth,
+		tw:     tw,
+	}
+
+	go rs.Start(ctx)
+	defer rs.Stop()
+	time.Sleep(1 * time.Second)
+	require.True(rs.IsWorking())
+
+	// Happy case , check that reward was called
+	// Assert that no error was logged
+	eth.On("Account").Return(accounts.Account{})
+	eth.On("GetTranscoder").Return(&lpTypes.Transcoder{
+		LastRewardRound: big.NewInt(1),
+		Active:          true,
+	}, nil)
+	eth.On("Reward").Return(&types.Transaction{}, nil).Times(1)
+	eth.On("CheckTx").Return(nil).Times(1)
+	eth.On("GetTranscoderEarningsPoolForRound").Return(&lpTypes.TokenPools{}, nil)
+
+	errorLogsBefore := glog.Stats.Error.Lines()
+	infoLogsBefore := glog.Stats.Info.Lines()
+
+	tw.roundSink <- types.Log{}
+	time.Sleep(1 * time.Second)
+
+	eth.AssertNumberOfCalls(t, "Reward", 1)
+	eth.AssertNumberOfCalls(t, "CheckTx", 1)
+	eth.AssertNotCalled(t, "ReplaceTransaction")
+
+	errorLogsAfter := glog.Stats.Error.Lines()
+	infoLogsAfter := glog.Stats.Info.Lines()
+	assert.Equal(int64(0), errorLogsAfter-errorLogsBefore)
+	assert.Equal(int64(1), infoLogsAfter-infoLogsBefore)
+
+	// Test for transaction time out error
+	// Call replace transaction
+	eth.On("Reward").Return(&types.Transaction{}, nil).Once()
+	eth.On("CheckTx").Return(context.DeadlineExceeded).Once()
+	eth.On("ReplaceTransaction").Return(&types.Transaction{}, nil)
+	eth.On("CheckTx").Return(nil).Once()
+
+	errorLogsBefore = glog.Stats.Error.Lines()
+	infoLogsBefore = glog.Stats.Info.Lines()
+
+	tw.roundSink <- types.Log{}
+	time.Sleep(1 * time.Second)
+
+	eth.AssertNumberOfCalls(t, "Reward", 2)
+	eth.AssertNumberOfCalls(t, "CheckTx", 3)
+	eth.AssertNumberOfCalls(t, "ReplaceTransaction", 1)
+
+	errorLogsAfter = glog.Stats.Error.Lines()
+	infoLogsAfter = glog.Stats.Info.Lines()
+	assert.Equal(int64(0), errorLogsAfter-errorLogsBefore)
+	assert.Equal(int64(2), infoLogsAfter-infoLogsBefore)
+
+	// Test replacement timeout error
+	eth.On("Reward").Return(&types.Transaction{}, nil).Once()
+	eth.On("CheckTx").Return(context.DeadlineExceeded)
+	eth.On("ReplaceTransaction").Return(&types.Transaction{}, nil)
+
+	errorLogsBefore = glog.Stats.Error.Lines()
+	infoLogsBefore = glog.Stats.Info.Lines()
+
+	tw.roundSink <- types.Log{}
+	time.Sleep(1 * time.Second)
+
+	eth.AssertNumberOfCalls(t, "Reward", 3)
+	eth.AssertNumberOfCalls(t, "CheckTx", 5)
+	eth.AssertNumberOfCalls(t, "ReplaceTransaction", 2)
+
+	errorLogsAfter = glog.Stats.Error.Lines()
+	infoLogsAfter = glog.Stats.Info.Lines()
+	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
+	assert.Equal(int64(1), infoLogsAfter-infoLogsBefore)
+}
+
+type stubTimeWatcher struct {
+	lastInitializedRound *big.Int
+	roundSink            chan<- types.Log
+	roundSub             event.Subscription
+}
+
+func (m *stubTimeWatcher) SubscribeRounds(sink chan<- types.Log) event.Subscription {
+	m.roundSink = sink
+	m.roundSub = &stubSubscription{errCh: make(<-chan error)}
+	return m.roundSub
+}
+
+func (m *stubTimeWatcher) LastInitializedRound() *big.Int {
+	return m.lastInitializedRound
+}
+
+type stubSubscription struct {
+	errCh        <-chan error
+	unsubscribed bool
+}
+
+func (s *stubSubscription) Unsubscribe() {
+	s.unsubscribed = true
+}
+
+func (s *stubSubscription) Err() <-chan error {
+	return s.errCh
+}

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -60,6 +60,26 @@ func (m *MockClient) GetTranscoderPoolMaxSize() (*big.Int, error) {
 	return mockBigInt(args, 0), args.Error(1)
 }
 
+func (m *MockClient) GetTranscoder(address common.Address) (*lpTypes.Transcoder, error) {
+	args := m.Called()
+	return args.Get(0).(*lpTypes.Transcoder), args.Error(1)
+}
+
+func (m *MockClient) IsActiveTranscoder() (bool, error) {
+	args := m.Called()
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *MockClient) Reward() (*types.Transaction, error) {
+	args := m.Called()
+	return mockTransaction(args, 0), args.Error(1)
+}
+
+func (m *MockClient) GetTranscoderEarningsPoolForRound(address common.Address, round *big.Int) (*lpTypes.TokenPools, error) {
+	args := m.Called()
+	return args.Get(0).(*lpTypes.TokenPools), args.Error(1)
+}
+
 // RoundsManager
 
 // InitializeRound submits a round initialization transaction
@@ -156,6 +176,11 @@ func (m *MockClient) Account() accounts.Account {
 func (m *MockClient) CheckTx(tx *types.Transaction) error {
 	args := m.Called()
 	return args.Error(0)
+}
+
+func (m *MockClient) ReplaceTransaction(tx *types.Transaction, method string, gasPrice *big.Int) (*types.Transaction, error) {
+	args := m.Called()
+	return mockTransaction(args, 0), args.Error(1)
 }
 
 func (m *MockClient) Vote(pollAddr ethcommon.Address, choiceID *big.Int) (*types.Transaction, error) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Remove polling on a set interval (which executes a ton of RPC requests) to only trying reward when a new round event is received from the `TimeWatcher`. 

**Specific updates (required)**
- Start reward service with time watcher
- use a go routine to start reward service, remove the go-routine inside of `rewardService.Start` and block instead. This follows the convention of most of our other services
- use an interface for the `TimeWatcher` so that we can unit test this service
- Add basic reward service unit tests
- Add some methods to the `eth.MockClient` to facilitate unit tests
- Use a single channel `serviceErr` to catch errors from startup goroutines for several services (currently rewardService and redeemer)

**How did you test each of these updates (required)**
Manually tested using the devtool and added log events 
Unit tests 

**Does this pull request close any open issues?**
Fixes #1584 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
