### PR TITLE
eth: remove polling from round initialiser

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -36,7 +36,6 @@ import (
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
-	"github.com/livepeer/go-livepeer/eth/eventservices"
 	"github.com/livepeer/go-livepeer/eth/watchers"
 	"github.com/livepeer/go-livepeer/verification"
 
@@ -668,7 +667,7 @@ func main() {
 		if *reward {
 			// Start reward service
 			// The node will only call reward if it is active in the current round
-			rs := eventservices.NewRewardService(n.Eth, timeWatcher)
+			rs := eth.NewRewardService(n.Eth, timeWatcher)
 			go func() {
 				if err := rs.Start(ctx); err != nil {
 					serviceErr <- err

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -672,8 +672,8 @@ func main() {
 			go func() {
 				if err := rs.Start(ctx); err != nil {
 					serviceErr <- err
-					return
 				}
+				return
 			}()
 			defer rs.Stop()
 		}
@@ -681,8 +681,13 @@ func main() {
 		if *initializeRound {
 			// Start round initializer
 			// The node will only initialize rounds if it in the upcoming active set for the round
-			initializer := eth.NewRoundInitializer(n.Eth, n.Database, timeWatcher, blockPollingTime)
-			go initializer.Start()
+			initializer := eth.NewRoundInitializer(n.Eth, timeWatcher)
+			go func() {
+				if err := initializer.Start(); err != nil {
+					serviceErr <- err
+				}
+				return
+			}()
 			defer initializer.Stop()
 		}
 

--- a/eth/eventservices/rewardservice.go
+++ b/eth/eventservices/rewardservice.go
@@ -57,7 +57,7 @@ func (s *RewardService) Start(ctx context.Context) error {
 		select {
 		case err := <-sub.Err():
 			if err != nil {
-				glog.Errorf("Block subscription error err=%v", err)
+				glog.Errorf("Round subscription error err=%v", err)
 			}
 		case <-rounds:
 			err := s.tryReward()

--- a/eth/rewardservice.go
+++ b/eth/rewardservice.go
@@ -1,15 +1,11 @@
-package eventservices
+package eth
 
 import (
 	"context"
 	"fmt"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/event"
 	"github.com/golang/glog"
-	"github.com/livepeer/go-livepeer/eth"
-	"github.com/livepeer/go-livepeer/eth/watchers"
 )
 
 var (
@@ -18,18 +14,13 @@ var (
 )
 
 type RewardService struct {
-	client       eth.LivepeerEthClient
+	client       LivepeerEthClient
 	working      bool
 	cancelWorker context.CancelFunc
-	tw           roundsWatcher
+	tw           timeWatcher
 }
 
-type roundsWatcher interface {
-	SubscribeRounds(sink chan<- types.Log) event.Subscription
-	LastInitializedRound() *big.Int
-}
-
-func NewRewardService(client eth.LivepeerEthClient, tw *watchers.TimeWatcher) *RewardService {
+func NewRewardService(client LivepeerEthClient, tw timeWatcher) *RewardService {
 	return &RewardService{
 		client: client,
 		tw:     tw,
@@ -123,7 +114,7 @@ func (s *RewardService) tryReward() error {
 			return err
 		}
 
-		glog.Infof("Called reward for round %v - %v rewards minted", currentRound, eth.FormatUnits(tp.RewardPool, "LPTU"))
+		glog.Infof("Called reward for round %v - %v rewards minted", currentRound, FormatUnits(tp.RewardPool, "LPTU"))
 
 		return nil
 	}

--- a/eth/rewardservice_test.go
+++ b/eth/rewardservice_test.go
@@ -1,4 +1,4 @@
-package eventservices
+package eth
 
 import (
 	"context"
@@ -8,15 +8,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/event"
 	"github.com/golang/glog"
-	"github.com/livepeer/go-livepeer/eth"
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestStart(t *testing.T) {
+func TestRewardService_Start(t *testing.T) {
 	assert := assert.New(t)
 	rs := RewardService{
 		working: true,
@@ -37,7 +35,7 @@ func TestStart(t *testing.T) {
 	assert.Nil(err)
 }
 
-func TestStop(t *testing.T) {
+func TestRewardService_Stop(t *testing.T) {
 	assert := assert.New(t)
 	rs := RewardService{
 		working: false,
@@ -56,7 +54,7 @@ func TestStop(t *testing.T) {
 	assert.False(rs.working)
 }
 
-func TestIsWorking(t *testing.T) {
+func TestRewardService_IsWorking(t *testing.T) {
 	assert := assert.New(t)
 	rs := RewardService{
 		working: false,
@@ -66,10 +64,10 @@ func TestIsWorking(t *testing.T) {
 	assert.True(rs.IsWorking())
 }
 
-func TestReceiveRoundEvent_TryReward(t *testing.T) {
+func TestRewardService_ReceiveRoundEvent_TryReward(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	eth := &eth.MockClient{}
+	eth := &MockClient{}
 	tw := &stubTimeWatcher{
 		lastInitializedRound: big.NewInt(100),
 	}
@@ -151,33 +149,4 @@ func TestReceiveRoundEvent_TryReward(t *testing.T) {
 	infoLogsAfter = glog.Stats.Info.Lines()
 	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
 	assert.Equal(int64(1), infoLogsAfter-infoLogsBefore)
-}
-
-type stubTimeWatcher struct {
-	lastInitializedRound *big.Int
-	roundSink            chan<- types.Log
-	roundSub             event.Subscription
-}
-
-func (m *stubTimeWatcher) SubscribeRounds(sink chan<- types.Log) event.Subscription {
-	m.roundSink = sink
-	m.roundSub = &stubSubscription{errCh: make(<-chan error)}
-	return m.roundSub
-}
-
-func (m *stubTimeWatcher) LastInitializedRound() *big.Int {
-	return m.lastInitializedRound
-}
-
-type stubSubscription struct {
-	errCh        <-chan error
-	unsubscribed bool
-}
-
-func (s *stubSubscription) Unsubscribe() {
-	s.unsubscribed = true
-}
-
-func (s *stubSubscription) Err() <-chan error {
-	return s.errCh
 }

--- a/eth/roundinitializer_test.go
+++ b/eth/roundinitializer_test.go
@@ -9,80 +9,44 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/golang/glog"
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-type stubBlockNumReader struct {
-	blkNum *big.Int
-	err    error
-}
-
-func (rdr *stubBlockNumReader) LastSeenBlock() (*big.Int, error) {
-	if rdr.err != nil {
-		return nil, rdr.err
-	}
-
-	return rdr.blkNum, nil
-}
-
-type stubBlockHashReader struct {
-	blkHash [32]byte
-}
-
-func (rdr *stubBlockHashReader) LastInitializedBlockHash() [32]byte {
-	return rdr.blkHash
-}
-
 func TestRoundInitializer_CurrentEpochSeed(t *testing.T) {
-	client := &MockClient{}
-	blkNumRdr := &stubBlockNumReader{}
-	blkHashRdr := &stubBlockHashReader{}
-	initializer := NewRoundInitializer(client, blkNumRdr, blkHashRdr, 1*time.Second)
+	initializer := NewRoundInitializer(nil, nil)
 
 	assert := assert.New(t)
 
-	// Test error getting block num
-	blkNumRdr.err = errors.New("LastSeenBlock error")
-
-	_, err := initializer.currentEpochSeed(nil, [32]byte{})
-	assert.EqualError(err, blkNumRdr.err.Error())
-
 	// Test epochNum = 0
-	blkNumRdr.err = nil
-	blkNumRdr.blkNum = big.NewInt(5)
 	blkHash := [32]byte{123}
 
-	epochSeed, err := initializer.currentEpochSeed(blkNumRdr.blkNum, blkHash)
-	assert.Nil(err)
+	epochSeed := initializer.currentEpochSeed(big.NewInt(5), big.NewInt(5), blkHash)
 	// epochNum = (5 - 5) / 5 = 0
 	// epochSeed = keccak256(blkHash | 0) = 53205358842179480591542570540016728811976439286094436690881169143335261643310
 	expEpochSeed, _ := new(big.Int).SetString("53205358842179480591542570540016728811976439286094436690881169143335261643310", 10)
 	assert.Equal(expEpochSeed, epochSeed)
 
 	// Test epochNum > 0
-	blkNumRdr.blkNum = big.NewInt(20)
-
-	epochSeed, err = initializer.currentEpochSeed(big.NewInt(5), blkHash)
-	assert.Nil(err)
+	epochSeed = initializer.currentEpochSeed(big.NewInt(20), big.NewInt(5), blkHash)
 	// epochNum = (20 - 5) / 5 = 3
 	// epochSeed = keccak256(blkHash | 3) = 42541119854153860846042329644941941146216657514071318786342840580076059276721
 	expEpochSeed.SetString("42541119854153860846042329644941941146216657514071318786342840580076059276721", 10)
 	assert.Equal(expEpochSeed, epochSeed)
 
 	// Test epochNum > 0 with some # of blocks into the epoch
-	epochSeed, err = initializer.currentEpochSeed(big.NewInt(4), blkHash)
-	assert.Nil(err)
+	epochSeed = initializer.currentEpochSeed(big.NewInt(20), big.NewInt(4), blkHash)
 	// epochNum = (20 - 4) / 5 = 3.2 -> 3
 	assert.Equal(expEpochSeed, epochSeed)
 }
 
 func TestRoundInitializer_ShouldInitialize(t *testing.T) {
 	client := &MockClient{}
-	blkNumRdr := &stubBlockNumReader{}
-	blkHashRdr := &stubBlockHashReader{}
-	initializer := NewRoundInitializer(client, blkNumRdr, blkHashRdr, 1*time.Second)
+	tw := &stubTimeWatcher{}
+	initializer := NewRoundInitializer(client, tw)
 
 	assert := assert.New(t)
 
@@ -94,30 +58,8 @@ func TestRoundInitializer_ShouldInitialize(t *testing.T) {
 	assert.EqualError(err, expErr.Error())
 	assert.False(ok)
 
-	// Test error getting max active set size
-	expErr = errors.New("GetTranscoderPoolMaxSize error")
-	client.On("TranscoderPool").Return(nil, nil).Once()
-	client.On("GetTranscoderPoolMaxSize").Return(nil, expErr).Once()
-
-	ok, err = initializer.shouldInitialize(nil)
-	assert.EqualError(err, expErr.Error())
-	assert.False(ok)
-
 	// Test active set is empty because no registered transcoders
 	client.On("TranscoderPool").Return([]*lpTypes.Transcoder{}, nil).Once()
-	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(2), nil).Once()
-
-	ok, err = initializer.shouldInitialize(nil)
-	assert.Nil(err)
-	assert.False(ok)
-
-	// Test active set is empty because max active set size is 0
-	registered := []*lpTypes.Transcoder{
-		&lpTypes.Transcoder{},
-	}
-	client.On("TranscoderPool").Return(registered, nil).Once()
-	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(0), nil).Once()
-
 	ok, err = initializer.shouldInitialize(nil)
 	assert.Nil(err)
 	assert.False(ok)
@@ -126,28 +68,19 @@ func TestRoundInitializer_ShouldInitialize(t *testing.T) {
 	caller := ethcommon.BytesToAddress([]byte("foo"))
 	client.On("Account").Return(accounts.Account{Address: caller})
 
-	registered = []*lpTypes.Transcoder{
-		&lpTypes.Transcoder{Address: ethcommon.BytesToAddress([]byte("jar"))},
-		&lpTypes.Transcoder{Address: ethcommon.BytesToAddress([]byte("bar"))},
+	registered := []*lpTypes.Transcoder{
+		{Address: ethcommon.BytesToAddress([]byte("jar"))},
+		{Address: ethcommon.BytesToAddress([]byte("bar"))},
 	}
 	client.On("TranscoderPool").Return(registered, nil).Once()
-	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(2), nil).Once()
 
 	ok, err = initializer.shouldInitialize(nil)
 	assert.Nil(err)
 	assert.False(ok)
 
-	// Test that caller is not in active set but it is registered
+	// Test not selected
 	registered = append(registered, &lpTypes.Transcoder{Address: caller})
 	client.On("TranscoderPool").Return(registered, nil)
-	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(2), nil).Once()
-
-	ok, err = initializer.shouldInitialize(nil)
-	assert.Nil(err)
-	assert.False(ok)
-
-	// Test caller not selected
-	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(3), nil)
 
 	seed := big.NewInt(3)
 	ok, err = initializer.shouldInitialize(seed)
@@ -163,49 +96,20 @@ func TestRoundInitializer_ShouldInitialize(t *testing.T) {
 
 func TestRoundInitializer_TryInitialize(t *testing.T) {
 	client := &MockClient{}
-	blkNumRdr := &stubBlockNumReader{}
-	blkHashRdr := &stubBlockHashReader{}
-	initializer := NewRoundInitializer(client, blkNumRdr, blkHashRdr, 1*time.Second)
-
+	tw := &stubTimeWatcher{
+		lastBlock:                big.NewInt(5),
+		lastInitializedRound:     big.NewInt(100),
+		lastInitializedBlockHash: [32]byte{123},
+	}
+	initializer := NewRoundInitializer(client, tw)
+	initializer.nextRoundStartBlock = big.NewInt(5)
 	assert := assert.New(t)
 
-	// Test error checking round initialized
-	expErr := errors.New("CurrentRoundInitialized error")
-	client.On("CurrentRoundInitialized").Return(false, expErr).Once()
+	// Test error checking should initialize
+	expErr := errors.New("shouldInitialize error")
+	client.On("TranscoderPool").Return(nil, expErr).Once()
 
 	err := initializer.tryInitialize()
-	assert.EqualError(err, expErr.Error())
-
-	// Test current round is initialized
-	client.On("CurrentRoundInitialized").Return(true, nil).Once()
-
-	err = initializer.tryInitialize()
-	assert.Nil(err)
-
-	// Test error getting current round start block
-	expErr = errors.New("CurrentRoundStartBlock error")
-	client.On("CurrentRoundStartBlock").Return(nil, expErr).Once()
-	client.On("CurrentRoundInitialized").Return(false, nil)
-
-	err = initializer.tryInitialize()
-	assert.EqualError(err, expErr.Error())
-
-	// Test error getting epoch seed
-	expErr = errors.New("currentEpochSeed error")
-	blkNumRdr.err = expErr
-	startBlkNum := big.NewInt(5)
-	client.On("CurrentRoundStartBlock").Return(startBlkNum, nil)
-
-	err = initializer.tryInitialize()
-	assert.EqualError(err, expErr.Error())
-
-	// Test error checking should initialize
-	expErr = errors.New("shouldInitialize error")
-	client.On("TranscoderPool").Return(nil, expErr).Once()
-	blkNumRdr.err = nil
-	blkNumRdr.blkNum = big.NewInt(5)
-
-	err = initializer.tryInitialize()
 	assert.EqualError(err, expErr.Error())
 
 	// Test should not initialize
@@ -213,27 +117,16 @@ func TestRoundInitializer_TryInitialize(t *testing.T) {
 	client.On("Account").Return(accounts.Account{Address: caller})
 
 	registered := []*lpTypes.Transcoder{
-		&lpTypes.Transcoder{Address: ethcommon.BytesToAddress([]byte("jar"))},
+		{Address: ethcommon.BytesToAddress([]byte("jar"))},
 	}
 	client.On("TranscoderPool").Return(registered, nil).Once()
-	client.On("GetTranscoderPoolMaxSize").Return(big.NewInt(2), nil)
 
 	err = initializer.tryInitialize()
 	assert.Nil(err)
 
-	blkHashRdr.blkHash = [32]byte{123}
-
-	// Test error getting current round
-	expErr = errors.New("CurrentRound error")
-	client.On("CurrentRound").Return(nil, expErr).Once()
-	registered = append([]*lpTypes.Transcoder{&lpTypes.Transcoder{Address: caller}}, registered...)
-	client.On("TranscoderPool").Return(registered, nil)
-
-	err = initializer.tryInitialize()
-	assert.EqualError(err, expErr.Error())
-
 	// Test error when submitting initialization tx
-	client.On("CurrentRound").Return(big.NewInt(5), nil)
+	registered = []*lpTypes.Transcoder{{Address: caller}}
+	client.On("TranscoderPool").Return(registered, nil)
 	expErr = errors.New("InitializeRound error")
 	client.On("InitializeRound").Return(nil, expErr).Once()
 
@@ -254,4 +147,202 @@ func TestRoundInitializer_TryInitialize(t *testing.T) {
 
 	err = initializer.tryInitialize()
 	assert.Nil(err)
+}
+
+func TestRoundInitializer_Start_Stop(t *testing.T) {
+	assert := assert.New(t)
+	tw := &stubTimeWatcher{}
+	client := &MockClient{}
+	quit := make(chan struct{})
+
+	initializer := &RoundInitializer{
+		client: client,
+		tw:     tw,
+		quit:   quit,
+	}
+
+	// RoundLength error
+	expErr := errors.New("RoundLength error")
+	client.On("RoundLength").Return(nil, expErr).Once()
+	err := initializer.Start()
+	assert.EqualError(err, expErr.Error())
+
+	// CurrentRoundStartBlock error
+	expErr = errors.New("CurrentRoundStartBlock error")
+	client.On("RoundLength").Return(big.NewInt(100), nil)
+	client.On("CurrentRoundStartBlock").Return(nil, expErr).Once()
+	err = initializer.Start()
+	assert.EqualError(err, expErr.Error())
+
+	client.On("CurrentRoundStartBlock").Return(big.NewInt(5), nil)
+	// test start and stop loop
+	errC := make(chan error)
+	go func() {
+		errC <- initializer.Start()
+	}()
+
+	time.Sleep(1 * time.Second)
+	initializer.Stop()
+	err = <-errC
+	assert.Nil(err)
+	// should have set next round start block
+	assert.Equal(initializer.nextRoundStartBlock, big.NewInt(105)) // 100 + 5
+}
+
+func TestRoundInitializer_RoundSubscription(t *testing.T) {
+	assert := assert.New(t)
+	tw := &stubTimeWatcher{}
+	client := &MockClient{}
+	quit := make(chan struct{})
+
+	initializer := &RoundInitializer{
+		client: client,
+		tw:     tw,
+		quit:   quit,
+	}
+
+	roundLength := big.NewInt(5)
+
+	client.On("RoundLength").Return(roundLength, nil)
+	client.On("CurrentRoundStartBlock").Return(big.NewInt(5), nil)
+
+	// test start and stop loop
+	errC := make(chan error)
+	go func() {
+		errC <- initializer.Start()
+	}()
+
+	// Test set next round start block on initializer
+	time.Sleep(1 * time.Second)
+	assert.Equal(initializer.nextRoundStartBlock, big.NewInt(10)) // 5 +5
+	tw.currentRoundStartBlock = big.NewInt(100)
+	tw.roundSink <- types.Log{}
+	time.Sleep(1 * time.Second)
+
+	initializer.Stop()
+	err := <-errC
+	assert.Nil(err)
+	assert.Equal(initializer.nextRoundStartBlock, new(big.Int).Add(roundLength, tw.currentRoundStartBlock))
+}
+
+func TestRoundInitializer_BlockSubscription(t *testing.T) {
+	assert := assert.New(t)
+	tw := &stubTimeWatcher{
+		lastBlock:                big.NewInt(5),
+		lastInitializedRound:     big.NewInt(100),
+		lastInitializedBlockHash: [32]byte{123},
+	}
+	client := &MockClient{}
+	quit := make(chan struct{})
+
+	initializer := &RoundInitializer{
+		client: client,
+		tw:     tw,
+		quit:   quit,
+	}
+
+	roundLength := big.NewInt(5)
+
+	client.On("RoundLength").Return(roundLength, nil)
+	client.On("CurrentRoundStartBlock").Return(big.NewInt(5), nil)
+
+	// test start and stop loop
+	errC := make(chan error)
+	go func() {
+		errC <- initializer.Start()
+	}()
+	time.Sleep(1 * time.Second)
+	// block < next round start block do nothing
+	tw.blockSink <- big.NewInt(5)
+	time.Sleep(1 * time.Second)
+	assert.Equal(initializer.nextRoundStartBlock, big.NewInt(10))
+
+	// block >= next round start block , try initialize
+	caller := ethcommon.HexToAddress("foo")
+	registered := []*lpTypes.Transcoder{{Address: caller}}
+	client.On("Account").Return(accounts.Account{Address: caller})
+	client.On("TranscoderPool").Return(registered, nil)
+	client.On("InitializeRound").Return(nil, errors.New("some error")).Once()
+	errLinesBefore := glog.Stats.Error.Lines()
+	// tryInitialize error
+	tw.lastBlock = big.NewInt(100)
+	tw.blockSink <- tw.lastBlock
+	time.Sleep(1 * time.Second)
+	errLinesAfter := glog.Stats.Error.Lines()
+	assert.Equal(int64(1), errLinesAfter-errLinesBefore)
+
+	// try initialize success
+	client.On("InitializeRound").Return(&types.Transaction{}, nil).Once()
+	client.On("CheckTx").Return(nil)
+	errLinesBefore = glog.Stats.Error.Lines()
+	// tryInitialize error
+	tw.blockSink <- big.NewInt(100)
+	time.Sleep(1 * time.Second)
+	errLinesAfter = glog.Stats.Error.Lines()
+	assert.Equal(int64(0), errLinesAfter-errLinesBefore)
+	client.AssertCalled(t, "InitializeRound")
+	client.AssertCalled(t, "CheckTx")
+
+	initializer.Stop()
+	err := <-errC
+	assert.Nil(err)
+}
+
+type stubTimeWatcher struct {
+	lastBlock                *big.Int
+	currentRoundStartBlock   *big.Int
+	poolSize                 *big.Int
+	lastInitializedBlockHash [32]byte
+	lastInitializedRound     *big.Int
+
+	roundSink chan<- types.Log
+	roundSub  event.Subscription
+
+	blockSink chan<- *big.Int
+	blockSub  event.Subscription
+}
+
+func (m *stubTimeWatcher) LastSeenBlock() *big.Int {
+	return m.lastBlock
+}
+
+func (m *stubTimeWatcher) LastInitializedRound() *big.Int {
+	return m.lastInitializedRound
+}
+
+func (m *stubTimeWatcher) LastInitializedBlockHash() [32]byte {
+	return m.lastInitializedBlockHash
+}
+
+func (m *stubTimeWatcher) GetTranscoderPoolSize() *big.Int {
+	return nil
+}
+
+func (m *stubTimeWatcher) CurrentRoundStartBlock() *big.Int {
+	return m.currentRoundStartBlock
+}
+
+func (m *stubTimeWatcher) SubscribeRounds(sink chan<- types.Log) event.Subscription {
+	m.roundSink = sink
+	m.roundSub = &stubSubscription{errCh: make(<-chan error)}
+	return m.roundSub
+}
+
+func (m *stubTimeWatcher) SubscribeBlocks(sink chan<- *big.Int) event.Subscription {
+	m.blockSink = sink
+	m.blockSub = &stubSubscription{errCh: make(<-chan error)}
+	return m.blockSub
+}
+
+type stubSubscription struct {
+	errCh        <-chan error
+	unsubscribed bool
+}
+
+func (s *stubSubscription) Unsubscribe() {
+	s.unsubscribed = true
+}
+
+func (s *stubSubscription) Err() <-chan error {
+	return s.errCh
 }

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -106,6 +106,11 @@ func (m *MockClient) CurrentRoundStartBlock() (*big.Int, error) {
 	return mockBigInt(args, 0), args.Error(1)
 }
 
+func (m *MockClient) RoundLength() (*big.Int, error) {
+	args := m.Called()
+	return mockBigInt(args, 0), args.Error(1)
+}
+
 // TicketBroker
 
 func (m *MockClient) FundDepositAndReserve(depositAmount, reserveAmount *big.Int) (*types.Transaction, error) {

--- a/eth/watchers/timewatcher_test.go
+++ b/eth/watchers/timewatcher_test.go
@@ -21,7 +21,8 @@ func TestSetAndGet_LastInitializedRound_LastInitializedBlockHash(t *testing.T) {
 	round := big.NewInt(5)
 	var hash [32]byte
 	copy(hash[:], "hello world")
-	tw.setLastInitializedRound(round, hash)
+	num := big.NewInt(10)
+	tw.setLastInitializedRound(round, hash, num)
 	assert.Equal(tw.lastInitializedRound, round)
 	assert.Equal(tw.lastInitializedBlockHash, hash)
 
@@ -29,6 +30,7 @@ func TestSetAndGet_LastInitializedRound_LastInitializedBlockHash(t *testing.T) {
 	assert.Equal(r, round)
 	h := tw.LastInitializedBlockHash()
 	assert.Equal(h, hash)
+	assert.Equal(tw.CurrentRoundStartBlock(), num)
 }
 
 func TestSetAndGet_TranscoderPoolSize(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Remove polling from the round initialiser as well as reduce RPC requests by utilising the `TimeWatcher`. 

The only remaining RPC calls in the `RoundInitializer` are `TranscoderPool`, `InitializeRound` and `CheckTx`. 
The RPC calls to get the transcoder pool can be avoided through #1695 

**Specific updates (required)**
- Move RoundInitializer to `eventservices` package, allows them to share stubs 
- Add `TimeWatcher.CurrentRoundStartBlock()` 
- `RoundInitializer` keeps track of a `nextRoundStartBlock *big.int`
- `Roundinitializer` uses `TimeWatcher.SubscribeBlocks()` instead of polling 
- Try Initialize if last seen block > `nextRoundStartBlock` 
- Update unit tests

**How did you test each of these updates (required)**
Unit tests

**Does this pull request close any open issues?**
Fixes #1585 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
