### PR TITLE
CI: Add livepeer_bench to automated builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       run: ./install_ffmpeg.sh
     - name: Build Livepeer
       shell: msys2 {0}
-      run: ./ci_env.sh make livepeer livepeer_cli
+      run: ./ci_env.sh make livepeer livepeer_cli livepeer_bench
     - name: Upload build
       shell: msys2 {0}
       env: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
   - git fetch --unshallow --tags
   - ./install_ffmpeg.sh
   - go mod download
-  - ./ci_env.sh make livepeer livepeer_cli
+  - ./ci_env.sh make livepeer livepeer_cli livepeer_bench
   - ./upload_build.sh

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -21,6 +21,6 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY . .
-RUN make livepeer livepeer_cli
+RUN make livepeer livepeer_cli livepeer_bench
 
 CMD ./upload_build.sh

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -44,8 +44,6 @@ mkdir $BASE
 cp $NODE $BASE
 cp $CLI $BASE
 
-NODE_MD5=`md5sum ${NODE}`
-CLI_MD5=`md5sum ${CLI}`
 NODE_SHA256=`shasum -a 256 ${NODE}`
 CLI_SHA256=`shasum -a 256 ${CLI}`
 
@@ -94,5 +92,5 @@ curl -X PUT -T "${FILE}" \
   -H "Authorization: AWS ${GCLOUD_KEY}:${signature}" \
   $fullUrl
 
-curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION_AND_NETWORK/${FILE}\nMD5:\n${NODE_MD5}\n${CLI_MD5}\nSHA256:\n${NODE_SHA256}\n${CLI_SHA256}\"}" $DISCORD_URL 2>/dev/null
+curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION_AND_NETWORK/${FILE}\nSHA256:\n${NODE_SHA256}\n${CLI_SHA256}\"}" $DISCORD_URL 2>/dev/null
 echo "done"

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -46,10 +46,6 @@ cp $NODE $BASE
 cp $CLI $BASE
 cp $BENCH $BASE
 
-NODE_SHA256=`shasum -a 256 ${NODE}`
-CLI_SHA256=`shasum -a 256 ${CLI}`
-BENCH_SHA256=`shasum -a 256 ${BENCH}`
-
 # do a basic upload so we know if stuff's working prior to doing everything else
 if [[ $ARCH == "windows" ]]; then
   FILE=$BASE.zip
@@ -64,6 +60,8 @@ else
   FILE=$BASE.tar.gz
   tar -czvf ./$FILE ./$BASE
 fi
+
+FILE_SHA256=`shasum -a 256 ${FILE}`
 
 # Quick self-check to see if the thing can execute at all
 (cd $BASE && $NODE -version)
@@ -95,5 +93,5 @@ curl -X PUT -T "${FILE}" \
   -H "Authorization: AWS ${GCLOUD_KEY}:${signature}" \
   $fullUrl
 
-curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION_AND_NETWORK/${FILE}\nSHA256:\n${NODE_SHA256}\n${CLI_SHA256}\n${BENCH_SHA256}\"}" $DISCORD_URL 2>/dev/null
+curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION_AND_NETWORK/${FILE}\nSHA256:\n${FILE_SHA256}\"}" $DISCORD_URL 2>/dev/null
 echo "done"

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -39,13 +39,16 @@ done
 
 NODE="./livepeer${EXT}"
 CLI="./livepeer_cli${EXT}"
+BENCH="./livepeer_bench${EXT}"
 
 mkdir $BASE
 cp $NODE $BASE
 cp $CLI $BASE
+cp $BENCH $BASE
 
 NODE_SHA256=`shasum -a 256 ${NODE}`
 CLI_SHA256=`shasum -a 256 ${CLI}`
+BENCH_SHA256=`shasum -a 256 ${BENCH}`
 
 # do a basic upload so we know if stuff's working prior to doing everything else
 if [[ $ARCH == "windows" ]]; then
@@ -92,5 +95,5 @@ curl -X PUT -T "${FILE}" \
   -H "Authorization: AWS ${GCLOUD_KEY}:${signature}" \
   $fullUrl
 
-curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION_AND_NETWORK/${FILE}\nSHA256:\n${NODE_SHA256}\n${CLI_SHA256}\"}" $DISCORD_URL 2>/dev/null
+curl --fail -s -H "Content-Type: application/json" -X POST -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $ARCH-amd64\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION_AND_NETWORK/${FILE}\nSHA256:\n${NODE_SHA256}\n${CLI_SHA256}\n${BENCH_SHA256}\"}" $DISCORD_URL 2>/dev/null
 echo "done"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!--- List out all significant updates your code introduces -->
- Don't generate MD5 sums for binaries, instead only generate SHA256
- Add `livepeer_bench` binary to automated build process(es)

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- [ ] Let the CI process run on this PR and verify builds on discord

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1693
Fixes #1697 
