### PR TITLE
PushAPI: Handle playbackID clash between different streamIDs

### DIFF
--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -587,8 +587,8 @@ func TestCreateRTMPStreamHandler(t *testing.T) {
 		t.Error("Handler failed ", err)
 	}
 	// Test collisions via stream reuse
-	if sid := createSid(u); sid != nil {
-		t.Error("Expected failure due to naming collision")
+	if sid := createSid(u); sid == nil {
+		t.Error("Did not expect a failure due to naming collision")
 	}
 	// Ensure the stream ID is reusable after the stream ends
 	if err := endHandler(u, st); err != nil {
@@ -670,7 +670,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 	}
 
 	// Check assigned IDs
-	mid := streamParams(strm).ManifestID
+	mid := streamParams(strm.AppData()).ManifestID
 	if s.LatestPlaylist().ManifestID() != mid {
 		t.Error("Unexpected Manifest ID")
 	}
@@ -867,7 +867,7 @@ func TestRegisterConnection(t *testing.T) {
 	strm = stream.NewBasicRTMPVideoStream(&core.StreamParameters{ManifestID: core.RandomManifestID(), Profiles: profiles})
 	cxn, err = s.registerConnection(strm)
 	assert.Nil(err)
-	job, err := core.JobCapabilities(streamParams(strm))
+	job, err := core.JobCapabilities(streamParams(strm.AppData()))
 	assert.Nil(err)
 	assert.Equal(job, cxn.params.Capabilities)
 	// check for capabilities: exit with an invalid cap
@@ -925,7 +925,7 @@ func TestBroadcastSessionManagerWithStreamStartStop(t *testing.T) {
 	u, _ := url.Parse("rtmp://localhost")
 	sid := createSid(u)
 	st := stream.NewBasicRTMPVideoStream(sid)
-	mid := streamParams(st).ManifestID
+	mid := streamParams(st.AppData()).ManifestID
 
 	// assert that ManifestID has not been added to rtmpConnections yet
 	_, exists := s.rtmpConnections[mid]


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Improve handling of new streams that re-use a playbackID for which an old stream session hasn't ended yet.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- [x] Remove HTTP500 error for playbackID clash
- [x] Close the old stream session for same playbackID and open a new one 
- [x] Unit Tests
- ~~[ ] WIP: Re-use HLS playlist via [EXT-X-DISCONTINUITY](https://tools.ietf.org/html/draft-pantos-http-live-streaming-23#section-4.3.2.3) tag~~ *will move it to a separate PR*

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- [x] Manual test via the `curl` reproduction steps
- [x] Unit Test before & after

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #1673 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
