### PR TITLE
server: transcode auth webhook

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -784,6 +784,15 @@ func main() {
 		lpmon.MaxSessions(core.MaxSessions)
 	}
 
+	if *authWebhookURL != "" {
+		_, err := validateURL(*authWebhookURL)
+		if err != nil {
+			glog.Fatal("Error setting auth webhook URL ", err)
+		}
+		glog.Info("Using auth webhook URL ", *authWebhookURL)
+		server.AuthWebhookURL = *authWebhookURL
+	}
+
 	if n.NodeType == core.BroadcasterNode {
 		// default lpms listener for broadcaster; same as default rpc port
 		// TODO provide an option to disable this?
@@ -821,14 +830,6 @@ func main() {
 		if n.OrchestratorPool == nil {
 			// Not a fatal error; may continue operating in segment-only mode
 			glog.Error("No orchestrator specified; transcoding will not happen")
-		}
-		if *authWebhookURL != "" {
-			_, err := validateURL(*authWebhookURL)
-			if err != nil {
-				glog.Fatal("Error setting auth webhook URL ", err)
-			}
-			glog.Info("Using auth webhook URL ", *authWebhookURL)
-			server.AuthWebhookURL = *authWebhookURL
 		}
 
 		isLocalHTTP, err := isLocalURL("https://" + *httpAddr)

--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -1,6 +1,6 @@
 # Webhook Authentication
 
-Incoming streams can be authenticated using webhooks. To use these webhooks, node operators must implement their own web service / endpoint to be accessed only by the Livepeer node. As new streams appear, the Livepeer node will call this endpoint to determine whether the given stream is allowed.
+Incoming streams can be authenticated using webhooks on both orchestrator and broadcaster nodes. To use these webhooks, node operators must implement their own web service / endpoint to be accessed only by the Livepeer node. As new streams appear, the Livepeer node will call this endpoint to determine whether the given stream is allowed.
 
 Webhooks can authenticate streams supported by the RTMP and HTTP push ingest protocols. See the [ingest documentation](ingest.md) for details on how to use these protocols.
 

--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -54,11 +54,24 @@ There is simple webhook authentication server [example](https://github.com/livep
 
 ## Orchestrators
 
-Webhooks can be used to authenticate discovery requests. When a webhook URL is provided on node startup using the `-authWebhookUrl` flag the Livepeer node will make a `POST` request to the specified URL on each `GetOrchestratorInfo` call. 
+Webhooks can be used to authenticate discovery requests. When a webhook URL is provided on node startup using the `-authWebhookUrl` flag the Livepeer node will make a `POST` request to the specified URL on each `GetOrchestratorInfo` call.
+
+If a valid `priceInfo` object is provided in the response the orchestrator will use it instead of its default price. A valid price requires `pricePerUnit >= 0` and `pixelsPerUnit > 0`.
 
 #### Request Object
 ```json
 {
-    "id": ""
+    "id": string
+}
+```
+
+#### Response Object
+
+```json
+{
+    "priceInfo": {
+        "pricePerUnit": string,
+        "pixelsPerUnit": string
+    }
 }
 ```

--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -2,7 +2,7 @@
 
 Incoming streams can be authenticated using webhooks on both orchestrator and broadcaster nodes. To use these webhooks, node operators must implement their own web service / endpoint to be accessed only by the Livepeer node. As new streams appear, the Livepeer node will call this endpoint to determine whether the given stream is allowed.
 
-Webhooks can authenticate streams supported by the RTMP and HTTP push ingest protocols. See the [ingest documentation](ingest.md) for details on how to use these protocols.
+The webhook server should respond with HTTP status code `200` in order to authenticate / authorize the stream. A response with a HTTP status code other than `200` will cause the Livepeer node to disconnect the stream.
 
 To enable webhook authentication functionality, the Livepeer node should be started with the `-authWebhookUrl` flag, along with the webhook endpoint URL.
 
@@ -11,6 +11,10 @@ For example:
 ```console
 livepeer -authWebhookUrl http://ownserver/auth
 ```
+
+## Broadcasters 
+
+Webhooks can authenticate streams supported by the RTMP and HTTP push ingest protocols. See the [ingest documentation](ingest.md) for details on how to use these protocols.
 
 For each incoming stream, the Livepeer node will make a `POST` request to the `http://ownserver/auth` endpoint, passing the URL of the request as JSON object.
 
@@ -21,8 +25,6 @@ For example, if the incoming request was made to `rtmp://livepeer.node/manifest`
     "url": "rtmp://livepeer.node/manifest"
 }
 ```
-
-The webhook server should respond with HTTP status code `200` in order to authenticate / authorize the stream. A response with a HTTP status code other than `200` will cause the Livepeer node to disconnect the stream.
 
 The webhook may respond with an empty body.  In this case, the `manifestID` property of the stream will be taken from the URL.  If the URL does not specify a manifest id, then it will be generated at random.  Otherwise, the webhook endpoint should respond with a JSON object in the following format:
 
@@ -49,3 +51,14 @@ The `profile` field is used to select the codec (H264) profile. Supported values
 The `gop` field is used to set the [GOP](https://en.wikipedia.org/wiki/Group_of_pictures) length, in seconds. This may help in post-transcoding segmentation to smooth out playback if the original segments are long or irregularly sized. Omitting this field will use the encoder default. To force all intra frames, use "intra".
 
 There is simple webhook authentication server [example](https://github.com/livepeer/go-livepeer/blob/master/cmd/simple_auth_server/simple_auth_server.go).
+
+## Orchestrators
+
+Webhooks can be used to authenticate discovery requests. When a webhook URL is provided on node startup using the `-authWebhookUrl` flag the Livepeer node will make a `POST` request to the specified URL on each `GetOrchestratorInfo` call. 
+
+#### Request Object
+```json
+{
+    "id": ""
+}
+```

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -889,7 +890,13 @@ func TestGetOrchestrator_WebhookAuth_ReturnsNotOK(t *testing.T) {
 func TestGetOrchestratorWebhookAuth_ReturnsOK(t *testing.T) {
 	orch := &mockOrchestrator{}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		in, err := json.Marshal(&authBroadcasterResponse{})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
+		w.Write(in)
 	})
 	ts := httptest.NewServer(handler)
 	defer ts.Close()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Allows Orchestrators to specify an `-authWebhookUrl` to authenticate broadcasters upon discovery (`GetOrchestatorInfo`). 

**Specific updates (required)**
- created an `authenticateBroadcaster()` function in `server/rpc.go` this will no-op if no `-authWebhookUrl` is specified

- Add a call to `authenticateBroadcaster()` when calling `getOrchestrator()` in `server/rpc.go`

- Added unit tests for this new behaviour for `getOrchestrator()` using the `httptest` package which spins up a one-off http server which we specify as  `server.AuthWebhookUrl`

- Updated documentation on auth webhooks in `doc` 

**How did you test each of these updates (required)**
Added unit/integration tests

**Does this pull request close any open issues?**
Fixes #1569 

**Checklist:**
- [x] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
