### PR TITLE
Reduce discovery related log output of Bs

### DIFF
--- a/monitor/census.go
+++ b/monitor/census.go
@@ -721,7 +721,6 @@ func InitCensus(nodeType NodeType, version string) {
 
 // LogDiscoveryError records discovery error
 func LogDiscoveryError(code string) {
-	glog.Error("Discovery error=" + code)
 	if strings.Contains(code, "OrchestratorCapped") {
 		code = "OrchestratorCapped"
 	} else if strings.Contains(code, "Canceled") {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -224,7 +224,7 @@ func GetOrchestratorInfo(ctx context.Context, bcast common.Broadcaster, orchestr
 }
 
 func startOrchestratorClient(uri *url.URL) (net.OrchestratorClient, *grpc.ClientConn, error) {
-	glog.Infof("Connecting RPC to %v", uri)
+	glog.V(common.DEBUG).Infof("Connecting RPC to %v", uri)
 	conn, err := grpc.Dial(uri.Host,
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 		grpc.WithBlock(),


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

A few logging related updates to reduce the log output of Bs (in particular when they are running on mainnet where the possibility of offline orchestrators during discovery is higher):

- Remove the discovery error log from `monitor.LogDiscoveryError()` because this function is called in a single [place](https://github.com/livepeer/go-livepeer/blob/5784f8cea0a6033749a1e35af72ed1539e3fef87/discovery/discovery.go#L83) and only after `GetOrchestratorInfo()` is called which already handles error logging
- Set the log level for the "Connecting RPC to...` log in `startOrchestratorClient()` to DEBUG. When using using the default log level a typical B on mainnet would could see bursts of 40-50 of these logs pretty frequently. A typical user doesn't need to see these logs for day to day operations and can always set a higher log level if they do need to see them.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Manual.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
