### PR TITLE
server: discovery auth webhook response

### DIFF
--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -54,11 +54,24 @@ There is simple webhook authentication server [example](https://github.com/livep
 
 ## Orchestrators
 
-Webhooks can be used to authenticate discovery requests. When a webhook URL is provided on node startup using the `-authWebhookUrl` flag the Livepeer node will make a `POST` request to the specified URL on each `GetOrchestratorInfo` call. 
+Webhooks can be used to authenticate discovery requests. When a webhook URL is provided on node startup using the `-authWebhookUrl` flag the Livepeer node will make a `POST` request to the specified URL on each `GetOrchestratorInfo` call.
+
+If a valid `priceInfo` object is provided in the response the orchestrator will use it instead of its default price. A valid price requires `pricePerUnit >= 0` and `pixelsPerUnit > 0`.
 
 #### Request Object
 ```json
 {
-    "id": ""
+    "id": string
+}
+```
+
+#### Response Object
+
+```json
+{
+    "priceInfo": {
+        "pricePerUnit": number,
+        "pixelsPerUnit": number
+    }
 }
 ```

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -889,7 +890,13 @@ func TestGetOrchestrator_WebhookAuth_ReturnsNotOK(t *testing.T) {
 func TestGetOrchestratorWebhookAuth_ReturnsOK(t *testing.T) {
 	orch := &mockOrchestrator{}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		in, err := json.Marshal(&authBroadcasterResponse{})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
+		w.Write(in)
 	})
 	ts := httptest.NewServer(handler)
 	defer ts.Close()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds a response object to the webhook handler during discovery authentication. This object can contain additional settings during discovery such as pricing. 

This PR lays the foundation for tackling #1723 

**Specific updates (required)**
- Add `handleWebhookResponse()` function that returns (a modified) `net.OrchestratorInfo` message
- Add a response object as return value  to `authenticateBroadcasterWebhook()`
- modifiy unit tests

**How did you test each of these updates (required)**
Added and ran unit tests 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
