### PR TITLE
Support multiple segments in-flight between B & O

### DIFF
--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -536,6 +536,10 @@ func TestGetSegmentChan(t *testing.T) {
 		t.Error("SegmentChans mapping did not include channel")
 	}
 
+	if cap(sc) != maxSegmentChannels {
+		t.Error("returned segment channel is not the correct capacity")
+	}
+
 	// Test max sessions
 	oldTranscodeSessions := MaxSessions
 	MaxSessions = 0

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -31,6 +31,8 @@ import (
 	"github.com/livepeer/lpms/stream"
 )
 
+const maxSegmentChannels = 4
+
 var transcodeLoopTimeout = 1 * time.Minute
 
 // Gives us more control of "timeout" / cancellation behavior during testing
@@ -447,7 +449,7 @@ func (n *LivepeerNode) getSegmentChan(md *SegTranscodingMetadata) (SegmentChan, 
 	if len(n.SegmentChans) >= MaxSessions {
 		return nil, ErrOrchCap
 	}
-	sc := make(SegmentChan, 1)
+	sc := make(SegmentChan, maxSegmentChannels)
 	glog.V(common.DEBUG).Infof("Creating new segment chan for manifestID=%s sessionID=%s", md.ManifestID, md.AuthToken.SessionId)
 	if err := n.transcodeSegmentLoop(md, sc); err != nil {
 		return nil, err

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -132,6 +132,7 @@ type (
 		mRecordingSaveLatency         *stats.Float64Measure
 		mRecordingSaveErrors          *stats.Int64Measure
 		mRecordingSavedSegments       *stats.Int64Measure
+		mOrchestratorSwaps            *stats.Int64Measure
 
 		// Metrics for sending payments
 		mTicketValueSent    *stats.Float64Measure
@@ -255,6 +256,7 @@ func InitCensus(nodeType NodeType, version string) {
 		"How long it takes to save segment to the OS", "sec")
 	census.mRecordingSaveErrors = stats.Int64("recording_save_errors", "Number of errors during save to the recording OS", "tot")
 	census.mRecordingSavedSegments = stats.Int64("recording_saved_segments", "Number of segments saved to the recording OS", "tot")
+	census.mOrchestratorSwaps = stats.Int64("orchestrator_swaps", "Number of orchestrator swaps mid-stream", "tot")
 
 	// Metrics for sending payments
 	census.mTicketValueSent = stats.Float64("ticket_value_sent", "TicketValueSent", "gwei")
@@ -591,6 +593,13 @@ func InitCensus(nodeType NodeType, version string) {
 			TagKeys:     baseTags,
 			Aggregation: view.LastValue(),
 		},
+		{
+			Name:        "orchestrator_swaps",
+			Measure:     census.mOrchestratorSwaps,
+			Description: "Number of orchestrator swaps mid-stream",
+			TagKeys:     baseTags,
+			Aggregation: view.Count(),
+		},
 
 		// Metrics for sending payments
 		{
@@ -888,6 +897,12 @@ func MaxSessions(maxSessions int) {
 	census.lock.Lock()
 	defer census.lock.Unlock()
 	stats.Record(census.ctx, census.mMaxSessions.M(int64(maxSessions)))
+}
+
+func OrchestratorSwapped() {
+	census.lock.Lock()
+	defer census.lock.Unlock()
+	stats.Record(census.ctx, census.mOrchestratorSwaps.M(1))
 }
 
 func CurrentSessions(currentSessions int) {

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -152,6 +152,8 @@ func TestPush_MultipartReturn(t *testing.T) {
 	assert.Equal("", strings.TrimSpace(string(body)))
 
 	// Binary data should be returned
+	bsm.sel.Clear()
+	bsm.sel.Add([]*BroadcastSession{sess})
 	reader.Seek(0, 0)
 	reader = strings.NewReader("InsteadOf.TS")
 	req = httptest.NewRequest("POST", "/live/mani/12.ts", reader)
@@ -191,6 +193,8 @@ func TestPush_MultipartReturn(t *testing.T) {
 
 	// No sessions error
 	cxn.sessManager.sel.Clear()
+	cxn.sessManager.lastSess = nil
+	cxn.sessManager.sessMap = make(map[string]*BroadcastSession)
 	reader.Seek(0, 0)
 	req = httptest.NewRequest("POST", "/live/mani/13.ts", reader)
 	w = httptest.NewRecorder()

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -103,6 +103,7 @@ type BroadcastSession struct {
 	Balances         *core.AddressBalances
 	Balance          Balance
 	LatencyScore     float64
+	SegsInFlight     []SegFlightMetadata
 }
 
 // ReceivedTranscodeResult contains received transcode result data and related metadata

--- a/server/selection.go
+++ b/server/selection.go
@@ -234,6 +234,9 @@ func (s *LIFOSelector) Complete(sess *BroadcastSession) {
 func (s *LIFOSelector) Select() *BroadcastSession {
 	sessList := *s
 	last := len(sessList) - 1
+	if last < 0 {
+		return nil
+	}
 	sess, sessions := sessList[last], sessList[:last]
 	*s = sessions
 	return sess

--- a/test.sh
+++ b/test.sh
@@ -22,6 +22,7 @@ cd ..
 # Be more strict with HTTP push tests: run with race detector enabled
 cd server
 go test -run Push_ -race
+go test -run TestSelectSession_ -race
 go test -run RegisterConnection -race
 cd ..
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Implements flexible segment-in-flight handling between a B and an O as described in https://github.com/livepeer/go-livepeer/issues/1658. Previously only a single segment could be in flight on a particular B<>O session.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- https://github.com/livepeer/go-livepeer/pull/1735/commits/23a7532fc858f23e105a6922b4139fddfaf1dde5 - Add a new metric to count Orchestrator Swaps (needed by https://github.com/livepeer/docker-livepeer/pull/50)
- https://github.com/livepeer/go-livepeer/pull/1735/commits/5dc0b25f1f58043f8bc6a66072b2a6098c08941d 
    - Track the last used BroadcasterSession in a `lastSession` variable and also track all segments-in-flight for a particular session in a queue.
    - Re-use the last session whenever possible - as specified in https://github.com/livepeer/go-livepeer/issues/1658
    - Increment the new metric for "Orchestrator Swaps" whenever new session's O URI is different from last session's O URI

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

A lot of manual testing -
1. Ensuring session re-use when simultaneous segments arriving at the same session (i.e. get a 200 response for all segments when sent as described in https://github.com/livepeer/go-livepeer/issues/1665 even when B knows only one O)
2. Ensuring Segments-In-Flight queue is cleaned up when all segments return for a particular session
3. Check the new `mOrchestratorSwaps` metric is updated whenever a swap occurs

**TODO**
- [x] Fix existing Unit Tests
- [x] Write unit tests for new code
- [x] Remove Log lines
- [x] Race condition checks

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #1658 and #1719

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
