### PR TITLE
server: discovery auth webhook priceInfo setting

### DIFF
--- a/doc/rtmpwebhookauth.md
+++ b/doc/rtmpwebhookauth.md
@@ -54,11 +54,24 @@ There is simple webhook authentication server [example](https://github.com/livep
 
 ## Orchestrators
 
-Webhooks can be used to authenticate discovery requests. When a webhook URL is provided on node startup using the `-authWebhookUrl` flag the Livepeer node will make a `POST` request to the specified URL on each `GetOrchestratorInfo` call. 
+Webhooks can be used to authenticate discovery requests. When a webhook URL is provided on node startup using the `-authWebhookUrl` flag the Livepeer node will make a `POST` request to the specified URL on each `GetOrchestratorInfo` call.
+
+If a valid `priceInfo` object is provided in the response the orchestrator will use it instead of its default price. A valid price requires `pricePerUnit >= 0` and `pixelsPerUnit > 0`.
 
 #### Request Object
 ```json
 {
-    "id": ""
+    "id": string
+}
+```
+
+#### Response Object
+
+```json
+{
+    "priceInfo": {
+        "pricePerUnit": number,
+        "pixelsPerUnit": number
+    }
 }
 ```


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Implements a `PriceInfo` field on the discovery auth webhook response to be used for further price settings when sending `TicketParams` instead of the Orchestrator's default set price + overhead. 

**Specific updates (required)**
- Rename `authBroadcasterRes` to `discoveryAuthWebhookRes`
- Add `PriceInfo` field to `discoveryAuthWebhookRes` 
- Add a `cache.Cache` , `discoveryAuthWebhookCache` to store webhook responses 
- Add a function `getPriceInfo()` in `server/rpc.go` that reads PriceInfo from the `discoveryAuthWebhookCache` for a broadcaster, if none exists returns default orchestrator price + overhead instead.
- use the new `getPriceInfo()` to get price in `orchestratorInfo()`
- Add unit tests 

**How did you test each of these updates (required)**
unit tests

**Does this pull request close any open issues?**
Fixes #1723 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
