### PR TITLE
server,core: Improve in-flight segment handling

### DIFF
--- a/core/lb.go
+++ b/core/lb.go
@@ -82,7 +82,7 @@ func (lb *LoadBalancingTranscoder) createSession(md *SegTranscodingMetadata) (*t
 	session := &transcoderSession{
 		transcoder:  lb.newT(transcoder),
 		key:         key,
-		sender:      make(chan *transcoderParams, 1),
+		sender:      make(chan *transcoderParams, maxSegmentChannels),
 		makeContext: transcodeLoopContext,
 	}
 	lb.sessions[job] = session


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Fix the bugs in, and clean up the logic of the recently introduced flexible segment-in-flight feature between the B & O.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Remove segments from the in-flight queue only after downloading
- Add goroutines in the test to check for race conditions around `selectSession()` and `completeSession()`
- Simplify `completeSession` logic, and always make sure bsm.lastSess is set to the updated session (with the updated SegsInFlight queue)
- Increase channel buffer count of LB transcoder to match that of the O set previously

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Manual testing with simultaneous curl calls
- Unit tests with stubbed sessions

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #1742 and Fixes #1743

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
