### PR TITLE
pm: tx cost checks

### DIFF
--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -242,8 +242,8 @@ func (r *recipient) faceValue(sender ethcommon.Address) (*big.Int, error) {
 	}
 
 	if faceValue.Cmp(maxFloat) > 0 {
-		if maxFloat.Cmp(r.cfg.EV) < 0 {
-			// If maxFloat < EV, then there is no
+		if maxFloat.Cmp(r.cfg.EV) < 0 || maxFloat.Cmp(r.txCost()) <= 0 {
+			// If maxFloat < EV or <= tx cost, then there is no
 			// acceptable faceValue
 			return nil, errInsufficientSenderReserve
 		}

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -383,6 +383,9 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 	if availableFunds.Cmp(txCost) <= 0 {
 		return nil, errors.New("insufficient sender funds for redeem tx cost")
 	}
+	if ticket.FaceValue.Cmp(txCost) <= 0 {
+		return nil, errors.New("insufficient ticket face value for redeem tx cost")
+	}
 
 	// Subtract the ticket face value from the sender's current max float
 	// This amount will be considered pending until the ticket redemption


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds checks on the orchestrator to:

- Ensure that the estimated ticket redemption tx cost can be covered by the advertised ticket face value. At the moment, when the default ticket face value is higher than the broadcaster's max float (derived from its reserve), the ticket face value is adjusted to match the broadcaster's max float. A check is added to require that the broadcaster's max float >= the estimated ticket redemption tx cost
- Ensure that tickets are only redeemed if their face value would cover the estimated ticket redemption tx cost

This PR focuses on adding the above missing checks and leaves further configuration to be addressed separately.

See #1603 for more details.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
