### PR TITLE
Count bytes of video data received/sent by broadcaster per stream

### DIFF
--- a/net/interface.go
+++ b/net/interface.go
@@ -9,11 +9,17 @@ type RemoteTranscoderInfo struct {
 	Capacity int
 }
 
+type StreamInfo struct {
+	SourceBytes     uint64
+	TranscodedBytes uint64
+}
+
 type NodeStatus struct {
 	Manifests map[string]*m3u8.MasterPlaylist
 	// maps external manifest (provided in HTTP push URL to the internal one
 	// (returned from webhook))
 	InternalManifests           map[string]string
+	StreamInfo                  map[string]StreamInfo
 	OrchestratorPool            []string
 	Version                     string
 	GolangRuntimeVersion        string

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -363,6 +364,7 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, erro
 	if monitor.Enabled {
 		monitor.SegmentEmerged(nonce, seg.SeqNo, len(BroadcastJobVideoProfiles), seg.Duration)
 	}
+	atomic.AddUint64(&cxn.sourceBytes, uint64(len(seg.Data)))
 
 	seg.Name = "" // hijack seg.Name to convey the uploaded URI
 	ext, err := common.ProfileFormatExtension(vProfile.Format)
@@ -570,6 +572,7 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 			}
 
 			data = d
+			atomic.AddUint64(&cxn.transcodedBytes, uint64(len(data)))
 		}
 
 		if bros != nil {

--- a/server/cliserver_test.go
+++ b/server/cliserver_test.go
@@ -202,7 +202,7 @@ func TestGetStatus(t *testing.T) {
 	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 	req.Nil(err)
-	expected := fmt.Sprintf(`{"Manifests":{},"InternalManifests":{},"OrchestratorPool":[],"Version":"undefined","GolangRuntimeVersion":"%s","GOArch":"%s","GOOS":"%s","RegisteredTranscodersNumber":1,"RegisteredTranscoders":[{"Address":"TestAddress","Capacity":5}],"LocalTranscoding":false}`,
+	expected := fmt.Sprintf(`{"Manifests":{},"InternalManifests":{},"StreamInfo":{},"OrchestratorPool":[],"Version":"undefined","GolangRuntimeVersion":"%s","GOArch":"%s","GOOS":"%s","RegisteredTranscodersNumber":1,"RegisteredTranscoders":[{"Address":"TestAddress","Capacity":5}],"LocalTranscoding":false}`,
 		runtime.Version(), runtime.GOARCH, runtime.GOOS)
 	assert.Equal(expected, string(body))
 }

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -135,6 +135,8 @@ func TestPush_MultipartReturn(t *testing.T) {
 		i++
 	}
 	assert.Equal(1, i)
+	assert.Equal(uint64(12), cxn.sourceBytes)
+	assert.Equal(uint64(0), cxn.transcodedBytes)
 
 	bsm.sel.Clear()
 	bsm.sel.Add([]*BroadcastSession{sess})
@@ -190,6 +192,8 @@ func TestPush_MultipartReturn(t *testing.T) {
 		i++
 	}
 	assert.Equal(1, i)
+	assert.Equal(uint64(36), cxn.sourceBytes)
+	assert.Equal(uint64(44), cxn.transcodedBytes)
 
 	// No sessions error
 	cxn.sessManager.sel.Clear()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Count bytes of video data received/sent by broadcaster per stream
and expose that in /status endpoint.
These allows to calculate ingest rate.

**Specific updates (required)**
- Added two fields to the `rtmpConnection` structure and exposed them in the /status endpoint

**How did you test each of these updates (required)**
unit test


**Does this pull request close any open issues?**
Fixes #1752 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
