### PR TITLE
Capture and log error on webserver crash

### DIFF
--- a/server/webserver.go
+++ b/server/webserver.go
@@ -70,7 +70,8 @@ func (s *LivepeerServer) StartCliWebserver(bindAddr string) {
 	}
 
 	glog.Info("CLI server listening on ", bindAddr)
-	srv.ListenAndServe()
+	err := srv.ListenAndServe()
+	glog.Error(err)
 }
 
 func (s *LivepeerServer) setOnChainConfig() {}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
I wrote up some more info on this problem in https://github.com/livepeer/go-livepeer/issues/1758.

We're running into some issues in `v0.5.14` with the webserver silently crashing, and figured having the underlying error logged would help a lot with usability.

**Specific updates (required)**
- Captures the error returned from https://github.com/livepeer/go-livepeer/blob/master/server/webserver.go#L73
- Logs this error using `glog.Error()`

**How did you test each of these updates (required)**
I didn't test these, the change is small enough I assume it should work alright.
Up to the livepeer devs if they think this is reasonable, or if I should do some more testing myself.

Here's an example 20 lines down where we use this same pattern: https://github.com/livepeer/go-livepeer/blob/master/server/webserver.go#L92-L93


**Does this pull request close any open issues?**
<!-- Fixes # -->
https://github.com/livepeer/go-livepeer/issues/1758

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass

I skipped over these as well^, am so used to running livepeer in alpine linux I'll admit I'm not too versed manually building for this binary for OSX.
I can follow through with these steps if we'd like, just let me know!

Didn't see any relevant documentation that we'd want to update for this.
