### PR TITLE
CLI option to disable recording

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -164,6 +164,7 @@ func main() {
 	datadir := flag.String("datadir", "", "data directory")
 	objectstore := flag.String("objectStore", "", "url of primary object store")
 	recordstore := flag.String("recordStore", "", "url of object store for recodings")
+	disableRecording := flag.Bool("disableRecording", false, "Turns of recoding, even if record store is specified by webhook")
 
 	// All deprecated
 	s3bucket := flag.String("s3bucket", "", "S3 region/bucket (e.g. eu-central-1/testbucket)")
@@ -822,6 +823,7 @@ func main() {
 			// Not a fatal error; may continue operating in segment-only mode
 			glog.Error("No orchestrator specified; transcoding will not happen")
 		}
+		server.DisableRecording = *disableRecording
 		if *authWebhookURL != "" {
 			_, err := validateURL(*authWebhookURL)
 			if err != nil {

--- a/core/util.go
+++ b/core/util.go
@@ -1,0 +1,26 @@
+package core
+
+import (
+	"io"
+	"net/http"
+	"os"
+)
+
+var hostName = "undefinde"
+
+func init() {
+	hostName, _ = os.Hostname()
+}
+
+// NewPostRequest creates POST HTTP request with User Agent header set to
+// Livepeer version
+func NewPostRequest(url, contentType string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Add("User-Agent", "Livepeer/"+LivepeerVersion)
+	req.Header.Add("Livepeer-Host", hostName)
+	return req, nil
+}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -64,6 +64,9 @@ var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmp
 
 var AuthWebhookURL string
 
+// DisableRecording if true then recordStore field from Webhook response ignored
+var DisableRecording bool
+
 // For HTTP push watchdog
 var httpPushTimeout = 1 * time.Minute
 var httpPushResetTimer = func() (context.Context, context.CancelFunc) {
@@ -255,7 +258,7 @@ func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID str
 				}
 			}
 			// set Recording OS if it was provided
-			if resp.RecordObjectStore != "" {
+			if resp.RecordObjectStore != "" && !DisableRecording {
 				ros, err = drivers.ParseOSURL(resp.RecordObjectStore, true)
 				if err != nil {
 					glog.Errorf("Failed to parse recording object store url for streamID url=%s err=%v", url.String(), err)

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -320,8 +320,11 @@ func authenticateStream(url string) (*authWebhookResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.Post(AuthWebhookURL, "application/json", bytes.NewBuffer(jsonValue))
-
+	req, err := core.NewPostRequest(AuthWebhookURL, "application/json", bytes.NewBuffer(jsonValue))
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -1048,6 +1048,9 @@ func TestPush_DisableRecording(t *testing.T) {
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
+		ua := r.Header.Get("User-Agent")
+		assert.Contains(ua, "Livepeer/")
+		assert.Equal("Livepeer/"+core.LivepeerVersion, ua)
 		assert.Equal(req.URL, "http://example.com/live/sess3/3.ts")
 		w.Write([]byte(`{"manifestID":"OSTEST01", "objectStore": "memory://store3", "recordObjectStore": "memory://store4"}`))
 	}))


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Allows to disable recording, even if enabled by Webhook response.


**Specific updates (required)**
Add CLI option `-disableRecording`

**How did you test each of these updates (required)**
Unit test


**Does this pull request close any open issues?**
Fixes #1767


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
