### PR TITLE
Fix LB transcoder race condition around session-cleanup

### DIFF
--- a/core/lb_test.go
+++ b/core/lb_test.go
@@ -142,7 +142,8 @@ func TestLB_SessionCancel(t *testing.T) {
 
 	sess := &transcoderSession{
 		transcoder:  newStubTranscoder(""),
-		sender:      make(chan *transcoderParams, 1),
+		done:        make(chan struct{}),
+		sender:      make(chan *transcoderParams, maxSegmentChannels),
 		makeContext: ctxFunc,
 	}
 
@@ -154,7 +155,7 @@ func TestLB_SessionCancel(t *testing.T) {
 	stubCancel()
 	wgWait(wg)
 	_, err := sess.Transcode(&SegTranscodingMetadata{})
-	assert.Equal(t, ErrTranscoderBusy, err)
+	assert.Equal(t, ErrTranscoderStopped, err)
 }
 
 func TestLB_SessionConcurrency(t *testing.T) {
@@ -164,7 +165,8 @@ func TestLB_SessionConcurrency(t *testing.T) {
 
 	sess := &transcoderSession{
 		transcoder:  newStubTranscoder(""),
-		sender:      make(chan *transcoderParams, 1),
+		done:        make(chan struct{}),
+		sender:      make(chan *transcoderParams, maxSegmentChannels),
 		makeContext: ctxFunc,
 	}
 
@@ -212,7 +214,8 @@ func TestLB_ConcurrentSessionErrors(t *testing.T) {
 			sess := &transcoderSession{
 				key:         "",
 				transcoder:  transcoder,
-				sender:      make(chan *transcoderParams, 1),
+				done:        make(chan struct{}),
+				sender:      make(chan *transcoderParams, maxSegmentChannels),
 				makeContext: transcodeLoopContext,
 			}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Ensure that no segments are left hanging since we increased the LB channel size in https://github.com/livepeer/go-livepeer/commit/882ed38fc1383dd8ae25e6abd20fd9e5a4a104c9

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- https://github.com/livepeer/go-livepeer/commit/415c1c02b1f39525ab08d003c119b26fe6f6eede - Add a test case to check the case where Seg 1 fails, causing session loop to return, and Seg 2 comes in before the session channels are cleaned up https://github.com/livepeer/go-livepeer/issues/1750#issuecomment-773651383
- https://github.com/livepeer/go-livepeer/commit/8c6f5b43b11e05822f917b07813262180ef59800 - Fix the race condition by adding a separate `done` channel to signal the sender that the session loop has closed (and return `ErrTranscoderStopped` to the caller)
- https://github.com/livepeer/go-livepeer/pull/1775/commits/ffd4505117f5fdbc7f3a15fa9becfa92d25ec98e - Fix some old unit tests to use `maxSegmentChannels` and initialize the done channel


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Run the test case in https://github.com/livepeer/go-livepeer/commit/415c1c02b1f39525ab08d003c119b26fe6f6eede to reproduce hanging behaviour
- Run the test case again after the fix to verify hanging behaviour does not happen anymore

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes https://github.com/livepeer/go-livepeer/issues/1750

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
