### PR TITLE
Fix for multi-seg-in-flight

### DIFF
--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -568,7 +568,9 @@ func TestSelectSession_MultipleInFlight(t *testing.T) {
 	bsm.suspendOrch(expectedSess1)
 	bsm.removeSession(expectedSess0)
 	bsm.removeSession(expectedSess1)
+	bsm.sessLock.Lock() // refresh session could be running in parallel and modifying sessMap
 	assert.Len(bsm.sessMap, 0)
+	bsm.sessLock.Unlock()
 
 	sess0 = sendSegStub()
 	assert.Nil(sess0)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes case where data in `SegsInFlight` array gets lost after session refresh


**Specific updates (required)**
- Add unit test showing bug
- Add fix - after session update new session object should be assigned to `lastSess` field.

**How did you test each of these updates (required)**
Unit test.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
