### PR TITLE
core/lb: use SessionID as map index

### DIFF
--- a/core/lb.go
+++ b/core/lb.go
@@ -48,7 +48,7 @@ func NewLoadBalancingTranscoder(devices string, newTranscoderFn newTranscoderFn)
 func (lb *LoadBalancingTranscoder) Transcode(md *SegTranscodingMetadata) (*TranscodeData, error) {
 
 	lb.mu.RLock()
-	session, exists := lb.sessions[string(md.ManifestID)]
+	session, exists := lb.sessions[string(md.AuthToken.SessionId)]
 	lb.mu.RUnlock()
 	if exists {
 		glog.V(common.DEBUG).Info("LB: Using existing transcode session for ", session.key)
@@ -67,7 +67,7 @@ func (lb *LoadBalancingTranscoder) createSession(md *SegTranscodingMetadata) (*t
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
-	job := string(md.ManifestID)
+	job := string(md.AuthToken.SessionId)
 	if session, exists := lb.sessions[job]; exists {
 		glog.V(common.DEBUG).Info("Attempted to create session but already exists ", session.key)
 		return session, nil

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func stubMetadata(sess string, profile ...ffmpeg.VideoProfile) *SegTranscodingMetadata {
-	return &SegTranscodingMetadata{ManifestID: ManifestID(sess), Profiles: profile}
+	return &SegTranscodingMetadata{AuthToken: &net.AuthToken{SessionId: sess}, Profiles: profile}
 }
 
 func TestLocalTranscoder(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Use SessionID instead of ManifestID to index the loadbalancer sessions.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- https://github.com/livepeer/go-livepeer/commit/a3862f17202b383ec4bb639f0019472a9c1f9b85 Use SessionID as map index

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Run the lb unit tests
- Verify that SessionId is now used within the log lines on a local O
```
I0305 01:40:55.807153   31849 orchestrator.go:474] Submitted segment to transcode loop manifestID=movmovv sessionID=a7a6b2b9 seqNo=1
I0305 01:40:55.807386   31849 lb.go:54] LB: Using existing transcode session for a7a6b2b9_0
```

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #1748

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [ ] Node runs in OSX and devenv
- [ ] All tests in `./test.sh` pass
