### PR TITLE
windows: fully-static build, bump to go1.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,9 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: MSYS
-    - name: Install prerequisites
+    - name: Prepare mingw64 environment
       shell: msys2 {0}
-      run: pacman -S --noconfirm --noprogressbar --ask=20 perl binutils git make autoconf zip mingw-w64-x86_64-gcc mingw-w64-x86_64-libtool mingw-w64-x86_64-gnutls mingw-w64-x86_64-pkg-config mingw-w64-x86_64-clang
-    - name: Install Go 1.13
-      shell: msys2 {0}
-      run: pacman -U --noconfirm --noprogressbar --disable-download-timeout --ask=20 https://storage.googleapis.com/lp_testharness_assets/mingw-w64-x86_64-go-1.13.8-1-any.pkg.tar.xz
+      run: ./prepare_mingw64.sh
     - name: Build ffmpeg
       shell: msys2 {0}
       run: ./install_ffmpeg.sh

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ eth/protocol
 #windows build env
 /msys2
 /msys2-install
+/.build

--- a/ci_env.sh
+++ b/ci_env.sh
@@ -8,8 +8,8 @@ set -e
 # Populate necessary Windows build path stuff
 if [[ $(uname) == *"MSYS"* ]]; then
   export PATH="/usr/bin:/mingw64/bin:$PATH"
-  export C_INCLUDE_PATH="/mingw64/lib:${C_INCLUDE_PATH:-}"
   export HOME="/build"
+  export C_INCLUDE_PATH="$HOME/compiled/lib:/mingw64/lib:/mingw64/lib:${C_INCLUDE_PATH:-}"
   mkdir -p $HOME
 
   export PATH="$HOME/compiled/bin":$PATH

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -14,6 +14,7 @@ if [[ $(uname) == *"MSYS"* ]]; then
 
   export TARGET_OS="--target-os=mingw64"
   export HOST_OS="--host=x86_64-w64-mingw32"
+  export BUILD_OS="--build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32"
 
   # Needed for mbedtls
   export WINDOWS_BUILD=1
@@ -33,32 +34,22 @@ if [ $(uname) != "Darwin" ]; then
   fi
 fi
 
-if [ ! -e "$HOME/nasm-2.14.02" ]; then
-  # sudo apt-get -y install asciidoc xmlto # this fails :(
-  cd "$HOME"
-  curl -o nasm-2.14.02.tar.gz https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz
-  echo 'b34bae344a3f2ed93b2ca7bf25f1ed3fb12da89eeda6096e3551fd66adeae9fc  nasm-2.14.02.tar.gz' > nasm-2.14.02.tar.gz.sha256
-  sha256sum -c nasm-2.14.02.tar.gz.sha256
-  tar xf nasm-2.14.02.tar.gz
-  rm nasm-2.14.02.tar.gz nasm-2.14.02.tar.gz.sha256
-  cd "$HOME/nasm-2.14.02"
-  ./configure --prefix="$HOME/compiled"
-  make
-  make install || echo "Installing docs fails but should be OK otherwise"
-fi
-
-if [ ! -e "$HOME/x264" ]; then
-  git clone http://git.videolan.org/git/x264.git "$HOME/x264"
-  cd "$HOME/x264"
-  # git master as of this writing
-  git checkout 545de2ffec6ae9a80738de1b2c8cf820249a2530
-  ./configure --prefix="$HOME/compiled" --enable-pic --enable-static ${HOST_OS:-} --disable-cli
-  make
-  make install-lib-static
-fi
-
 # Static linking of gnutls on Linux/Mac
 if [[ $(uname) != *"MSYS"* ]]; then
+  if [ ! -e "$HOME/nasm-2.14.02" ]; then
+    # sudo apt-get -y install asciidoc xmlto # this fails :(
+    cd "$HOME"
+    curl -o nasm-2.14.02.tar.gz https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz
+    echo 'b34bae344a3f2ed93b2ca7bf25f1ed3fb12da89eeda6096e3551fd66adeae9fc  nasm-2.14.02.tar.gz' > nasm-2.14.02.tar.gz.sha256
+    sha256sum -c nasm-2.14.02.tar.gz.sha256
+    tar xf nasm-2.14.02.tar.gz
+    rm nasm-2.14.02.tar.gz nasm-2.14.02.tar.gz.sha256
+    cd "$HOME/nasm-2.14.02"
+    ./configure --prefix="$HOME/compiled"
+    make
+    make install || echo "Installing docs fails but should be OK otherwise"
+  fi
+
   # rm -rf "$HOME/gmp-6.1.2"
   if [ ! -e "$HOME/gmp-6.1.2" ]; then
     cd "$HOME"
@@ -76,24 +67,38 @@ if [[ $(uname) != *"MSYS"* ]]; then
     curl -LO https://github.com/livepeer/livepeer-builddeps/raw/34900f2b1be4e366c5270e3ee5b0d001f12bd8a4/nettle-3.4.1.tar.gz
     tar xf nettle-3.4.1.tar.gz
     cd nettle-3.4.1
-    LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --disable-shared --enable-pic
+    LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" ./configure --prefix="$HOME/compiled" --disable-shared --enable-pic
     make
     make install
   fi
 
-  # rm -rf "$HOME/gnutls-3.5.18"
-  if [ ! -e "$HOME/gnutls-3.5.18" ]; then
-    cd $HOME
-    curl -LO https://www.gnupg.org/ftp/gcrypt/gnutls/v3.5/gnutls-3.5.18.tar.xz
-    tar xf gnutls-3.5.18.tar.xz
-    cd gnutls-3.5.18
-    LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" LIBS="-lhogweed -lnettle -lgmp" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools
-    make
-    make install
-    # gnutls doesn't properly set up its pkg-config or something? without this line ffmpeg and go
-    # don't know that they need gmp, nettle, and hogweed
-    sed -i'' -e 's/-lgnutls/-lgnutls -lhogweed -lnettle -lgmp/g' ~/compiled/lib/pkgconfig/gnutls.pc
+fi
+
+if [ ! -e "$HOME/x264" ]; then
+  git clone http://git.videolan.org/git/x264.git "$HOME/x264"
+  cd "$HOME/x264"
+  # git master as of this writing
+  git checkout 545de2ffec6ae9a80738de1b2c8cf820249a2530
+  ./configure --prefix="$HOME/compiled" --enable-pic --enable-static ${HOST_OS:-} --disable-cli
+  make
+  make install-lib-static
+fi
+
+if [ ! -e "$HOME/gnutls-3.7.0" ]; then
+  EXTRA_GNUTLS_LIBS=""
+  if [[ $(uname) == *"MSYS"* ]]; then
+    EXTRA_GNUTLS_LIBS="-lncrypt -lcrypt32 -lwsock32 -lws2_32 -lwinpthread"
   fi
+  cd $HOME
+  curl -LO https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.0.tar.xz
+  tar xf gnutls-3.7.0.tar.xz
+  cd gnutls-3.7.0
+  LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" LIBS="-lhogweed -lnettle -lgmp $EXTRA_GNUTLS_LIBS" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools --disable-hardware-acceleration --disable-guile --disable-libdane --disable-tests --disable-rpath --disable-nls
+  make
+  make install
+  # gnutls doesn't properly set up its pkg-config or something? without this line ffmpeg and go
+  # don't know that they need gmp, nettle, and hogweed
+  sed -i'' -e "s/-lgnutls/-lgnutls -lhogweed -lnettle -lgmp $EXTRA_GNUTLS_LIBS/g" ~/compiled/lib/pkgconfig/gnutls.pc
 fi
 
 EXTRA_FFMPEG_FLAGS=""
@@ -110,7 +115,7 @@ else
 fi
 
 if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
-  git clone https://git.ffmpeg.org/ffmpeg.git "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
+  git clone https://github.com/livepeer/ffmpeg.git "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$HOME/ffmpeg"
   git checkout 3ea705767720033754e8d85566460390191ae27d
   ./configure ${TARGET_OS:-} --fatal-warnings \

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -61,12 +61,12 @@ if [[ $(uname) != *"MSYS"* ]]; then
     make install
   fi
 
-  # rm -rf "$HOME/nettle-3.4.1"
-  if [ ! -e "$HOME/nettle-3.4.1" ]; then
+  # rm -rf "$HOME/nettle-3.7"
+  if [ ! -e "$HOME/nettle-3.7" ]; then
     cd $HOME
-    curl -LO https://github.com/livepeer/livepeer-builddeps/raw/34900f2b1be4e366c5270e3ee5b0d001f12bd8a4/nettle-3.4.1.tar.gz
-    tar xf nettle-3.4.1.tar.gz
-    cd nettle-3.4.1
+    curl -LO https://github.com/livepeer/livepeer-builddeps/raw/657a86b78759b1ab36dae227253c26ff50cb4b0a/nettle-3.7.tar.gz
+    tar xf nettle-3.7.tar.gz
+    cd nettle-3.7
     LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" ./configure --prefix="$HOME/compiled" --disable-shared --enable-pic
     make
     make install

--- a/prepare_mingw64.sh
+++ b/prepare_mingw64.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -eo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+export MINGW_INSTALLS=mingw64
+pacman -S --noconfirm --noprogressbar --ask=20 --needed mingw-w64-x86_64-binutils mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config mingw-w64-x86_64-go mingw-w64-x86_64-nasm mingw-w64-x86_64-clang git make autoconf automake patch libtool texinfo gtk-doc zip
+gpg --recv-keys F3599FF828C67298 249B39D24F25E3B6 2071B08A33BD3F06 29EE58B996865171 D605848ED7E69871
+
+# winpthreads needs git config for some reason
+git config --get user.email || git config --global user.email "fakeemail@example.com"
+git config --get user.name || git config --global user.name "Livepeer Windows Build"
+
+rm -rf "$DIR/.build"
+mkdir -p "$DIR/.build"
+git clone https://github.com/msys2/MINGW-packages.git "$DIR/.build/MINGW-packages"
+cd "$DIR/.build/MINGW-packages"
+git checkout f4c989755fdbca217e0c53c01a6206d36a9c3e0d
+
+for x in zlib gmp nettle winpthreads-git; do
+  echo ""
+  echo "---------"
+  echo "building $x"
+  echo "---------"
+  echo ""
+  cd "$DIR/.build/MINGW-packages/mingw-w64-$x"
+  set +e
+  makepkg-mingw -CL --nocheck
+  EXIT=$?
+  set -e
+  if [[ $EXIT != "13" ]] && [[ $EXIT != "0" ]]; then
+    echo "exiting $EXIT"
+    exit $EXIT
+  fi
+  pacman -U --noconfirm *.zst
+  echo "prepare_mingw64: deleting shared libraries"
+  # https://narkive.com/Fjlrbrjg:20.646.48
+  find /mingw64/lib -name "*.dll.a" -exec rm -v {} \;
+done
+# And one more dynamic library to remove, this one in the system itself...
+rm -rfv /mingw64/x86_64-w64-mingw32/lib/libwinpthread.dll.a

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -51,12 +51,6 @@ cp $ROUTER $BASE
 # do a basic upload so we know if stuff's working prior to doing everything else
 if [[ $ARCH == "windows" ]]; then
   FILE=$BASE.zip
-  ls /mingw64/bin/
-  # This list was produced by `ldd livepeer.exe`
-  LIBS="libffi-7.dll libgcc_s_seh-1.dll libgmp-10.dll libgnutls-30.dll libhogweed-6.dll libiconv-2.dll libidn2-0.dll libintl-8.dll libnettle-8.dll libp11-kit-0.dll libtasn1-6.dll libunistring-2.dll libwinpthread-1.dll zlib1.dll"
-  for LIB in $LIBS; do
-    cp -r /mingw64/bin/$LIB ./$BASE
-  done
   zip -r ./$FILE ./$BASE
 else
   FILE=$BASE.tar.gz


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
* Bump Windows go build to go1.15
* Implement a fully-static livepeer.exe file with no more bundled DLLs. And it only took me two years.

**How did you test each of these updates (required)**
It works!
![image](https://user-images.githubusercontent.com/257909/110077311-bf8a0200-7d3a-11eb-9b25-8e66a580aedf.png)

Checked with both GPU and CPU transcoding. I didn't check on-chain mode but presumably anything that's mostly Go code is fine.