### PR TITLE
darwin: Fix builds with libtasn1 patch for gnutls

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -8,6 +8,7 @@ FROM livepeerci/build-platform:latest
 ARG HIGHEST_CHAIN_TAG
 ENV HIGHEST_CHAIN_TAG ${HIGHEST_CHAIN_TAG}
 
+COPY patches patches
 COPY ./install_ffmpeg.sh ./install_ffmpeg.sh
 RUN ./install_ffmpeg.sh
 

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -22,6 +22,7 @@ fi
 
 export PATH="$HOME/compiled/bin":$PATH
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}:$HOME/compiled/lib/pkgconfig"
+export GO_LIVEPEER_PATH=$(pwd)
 
 # NVENC only works on Windows/Linux
 if [ $(uname) != "Darwin" ]; then
@@ -93,6 +94,9 @@ if [ ! -e "$HOME/gnutls-3.7.0" ]; then
   curl -LO https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.0.tar.xz
   tar xf gnutls-3.7.0.tar.xz
   cd gnutls-3.7.0
+  # Patch linking issue with isdigit
+  # Patch by Ross Nicholson: https://gitlab.com/gnutls/gnutls/-/issues/1033#note_451585569 
+  patch -Np1 -i $GO_LIVEPEER_PATH/patches/undo-libtasn1-cisdigit.patch
   LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" LIBS="-lhogweed -lnettle -lgmp $EXTRA_GNUTLS_LIBS" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools --disable-hardware-acceleration --disable-guile --disable-libdane --disable-tests --disable-rpath --disable-nls
   make
   make install

--- a/patches/undo-libtasn1-cisdigit.patch
+++ b/patches/undo-libtasn1-cisdigit.patch
@@ -1,0 +1,143 @@
+--- a/lib/minitasn1/decoding.c
++++ b/lib/minitasn1/decoding.c
+@@ -32,7 +32,6 @@
+ #include <element.h>
+ #include <limits.h>
+ #include <intprops.h>
+-#include <c-ctype.h>
+ 
+ #ifdef DEBUG
+ # define warn() fprintf(stderr, "%s: %d\n", __func__, __LINE__)
+@@ -353,7 +352,7 @@
+       p = &der[len_len];
+       for (i=0;i<(unsigned)(str_len-1);i++)
+          {
+-           if (c_isdigit(p[i]) == 0)
++           if (isdigit(p[i]) == 0)
+              {
+                if (type == ASN1_ETYPE_GENERALIZED_TIME)
+                  {
+--- a/lib/minitasn1/element.c
++++ b/lib/minitasn1/element.c
+@@ -30,7 +30,6 @@
+ #include "parser_aux.h"
+ #include <gstr.h>
+ #include "structure.h"
+-#include "c-ctype.h"
+ #include "element.h"
+ 
+ void
+@@ -380,7 +379,7 @@
+     case ASN1_ETYPE_ENUMERATED:
+       if (len == 0)
+ 	{
+-	  if ((c_isdigit (value[0])) || (value[0] == '-'))
++	  if ((isdigit (value[0])) || (value[0] == '-'))
+ 	    {
+ 	      value_temp = malloc (SIZEOF_UNSIGNED_LONG_INT);
+ 	      if (value_temp == NULL)
+@@ -453,7 +452,7 @@
+ 	  p = node->down;
+ 	  while (type_field (p->type) != ASN1_ETYPE_DEFAULT)
+ 	    p = p->right;
+-	  if ((c_isdigit (p->value[0])) || (p->value[0] == '-'))
++	  if ((isdigit (p->value[0])) || (p->value[0] == '-'))
+ 	    {
+ 	      default_temp = malloc (SIZEOF_UNSIGNED_LONG_INT);
+ 	      if (default_temp == NULL)
+@@ -519,7 +518,7 @@
+       break;
+     case ASN1_ETYPE_OBJECT_ID:
+       for (i = 0; i < _asn1_strlen (value); i++)
+-	if ((!c_isdigit (value[i])) && (value[i] != '.') && (value[i] != '+'))
++	if ((!isdigit (value[i])) && (value[i] != '.') && (value[i] != '+'))
+ 	  return ASN1_VALUE_NOT_VALID;
+       if (node->type & CONST_DEFAULT)
+ 	{
+@@ -540,7 +539,7 @@
+ 	if (len < 11)
+ 	  return ASN1_VALUE_NOT_VALID;
+ 	for (k = 0; k < 10; k++)
+-	  if (!c_isdigit (value[k]))
++	  if (!isdigit (value[k]))
+ 	    return ASN1_VALUE_NOT_VALID;
+ 	switch (len)
+ 	  {
+@@ -549,7 +548,7 @@
+ 	      return ASN1_VALUE_NOT_VALID;
+ 	    break;
+ 	  case 13:
+-	    if ((!c_isdigit (value[10])) || (!c_isdigit (value[11])) ||
++	    if ((!isdigit (value[10])) || (!isdigit (value[11])) ||
+ 		(value[12] != 'Z'))
+ 	      return ASN1_VALUE_NOT_VALID;
+ 	    break;
+@@ -557,16 +556,16 @@
+ 	    if ((value[10] != '+') && (value[10] != '-'))
+ 	      return ASN1_VALUE_NOT_VALID;
+ 	    for (k = 11; k < 15; k++)
+-	      if (!c_isdigit (value[k]))
++	      if (!isdigit (value[k]))
+ 		return ASN1_VALUE_NOT_VALID;
+ 	    break;
+ 	  case 17:
+-	    if ((!c_isdigit (value[10])) || (!c_isdigit (value[11])))
++	    if ((!isdigit (value[10])) || (!isdigit (value[11])))
+ 	      return ASN1_VALUE_NOT_VALID;
+ 	    if ((value[12] != '+') && (value[12] != '-'))
+ 	      return ASN1_VALUE_NOT_VALID;
+ 	    for (k = 13; k < 17; k++)
+-	      if (!c_isdigit (value[k]))
++	      if (!isdigit (value[k]))
+ 		return ASN1_VALUE_NOT_VALID;
+ 	    break;
+ 	  default:
+@@ -890,7 +889,7 @@
+ 	  p = node->down;
+ 	  while (type_field (p->type) != ASN1_ETYPE_DEFAULT)
+ 	    p = p->right;
+-	  if ((c_isdigit (p->value[0])) || (p->value[0] == '-')
++	  if ((isdigit (p->value[0])) || (p->value[0] == '-')
+ 	      || (p->value[0] == '+'))
+ 	    {
+ 	      result = _asn1_convert_integer
+
+--- a/lib/minitasn1/int.h
++++ b/lib/minitasn1/int.h
+@@ -29,6 +29,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ #include <stdio.h>
++#include <ctype.h>
+ #include <stdint.h>
+ 
+ #ifdef HAVE_SYS_TYPES_H
+--- a/lib/minitasn1/parser_aux.c
++++ b/lib/minitasn1/parser_aux.c
+@@ -26,7 +26,6 @@
+ #include "gstr.h"
+ #include "structure.h"
+ #include "element.h"
+-#include "c-ctype.h"
+ 
+ char _asn1_identifierMissing[ASN1_MAX_NAME_SIZE + 1];	/* identifier name not found */
+ 
+@@ -755,7 +754,7 @@
+ 	      p2 = p->down;
+ 	      if (p2 && (type_field (p2->type) == ASN1_ETYPE_CONSTANT))
+ 		{
+-		  if (p2->value && !c_isdigit (p2->value[0]))
++		  if (p2->value && !isdigit (p2->value[0]))
+ 		    {
+ 		      _asn1_str_cpy (name2, sizeof (name2), name_root);
+ 		      _asn1_str_cat (name2, sizeof (name2), ".");
+@@ -1067,7 +1066,7 @@
+ 	  p2 = p->down;
+ 	  if (p2 && (type_field (p2->type) == ASN1_ETYPE_CONSTANT))
+ 	    {
+-	      if (p2->value && !c_isdigit (p2->value[0]))
++	      if (p2->value && !isdigit (p2->value[0]))
+ 		{
+ 		  _asn1_str_cpy (name2, sizeof (name2), node->name);
+ 		  _asn1_str_cat (name2, sizeof (name2), ".");
+


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Fixes the broken Darwin build by applying a libtasn1 patch for gnutls.

Darwin builds started failing after the gnutls version was bumped in #1785. The failure did not occur at compile time for gnutls because `install_ffmpeg.sh` compiles gnutls using the `--disable-doc` flag and instead it occurred when attempting to link ffmpeg with gnutls. The ffmpeg build then fails with:

```
ERROR: gnutls not found using pkg-config
```

`tail -n 100 ~/ffmpeg/ffbuild/config.log` showed more information about the error.

The error encountered is captured by this [gnutls issue](https://gitlab.com/gnutls/gnutls/-/issues/1033). The issue is closed, but the fix does not appear to be shipped with gnutls 3.7.0 yet though. But, a patch was [shared](https://gitlab.com/gnutls/gnutls/-/issues/1033#note_451585569) in that issue thread and an example of that patch being applied can be found [here](https://code.wildfiregames.com/source/0ad/browse/ps/trunk/libraries/osx/build-osx-libs.sh$666).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Successfully created a Darwin build locally.

Now let's see if the [Travis build succeeds](https://travis-ci.org/github/livepeer/go-livepeer/builds/762468222)...

Update: It did! 🥳 

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1788 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
