### PR TITLE
common,pm: redeem winning tickets on node startup

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,3 +7,9 @@
 #### General
 
 - \#1810 Display "n/a" in CLI when max gas price isn't specified (@kyriediculous)
+
+### Features ⚒
+
+#### Orchestrator
+
+- \#1792 Redeem winning tickets on node startup

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -68,6 +68,23 @@ func (ts *stubTicketStore) SelectEarliestWinningTicket(sender ethcommon.Address,
 	return nil, nil
 }
 
+func (ts *stubTicketStore) SelectWinningTickets(sender ethcommon.Address, minCreationRound int64) ([]*SignedTicket, error) {
+	ts.lock.Lock()
+	defer ts.lock.Unlock()
+
+	if ts.loadShouldFail {
+		return nil, fmt.Errorf("stub TicketStore load error")
+	}
+	var tickets []*SignedTicket
+	for _, t := range ts.tickets[sender] {
+		if !ts.submitted[fmt.Sprintf("%x", t.Sig)] {
+			tickets = append(tickets, t)
+		}
+	}
+
+	return tickets, nil
+}
+
 func (ts *stubTicketStore) MarkWinningTicketRedeemed(ticket *SignedTicket, txHash ethcommon.Hash) error {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()

--- a/pm/ticketstore.go
+++ b/pm/ticketstore.go
@@ -11,6 +11,8 @@ type TicketStore interface {
 	// which is not yet redeemed
 	SelectEarliestWinningTicket(sender ethcommon.Address, minCreationRound int64) (*SignedTicket, error)
 
+	SelectWinningTickets(sender ethcommon.Address, minCreationRound int64) ([]*SignedTicket, error)
+
 	// RemoveWinningTicket removes a ticket
 	RemoveWinningTicket(ticket *SignedTicket) error
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Redeems all non-expired winning tickets upon node startup

**Specific updates (required)**
- Added `SelectWinningTickets` to `db`
- Added helpers in `LocalSenderMonitor` to redeem tickets on startup


**How did you test each of these updates (required)**
unit tests

**Does this pull request close any open issues?**
Fixes #632 

**Checklist:**
- [ ] README and other documentation updated
- [x] Node runs in OSX and devenv
- [x] All tests in `./test.sh` pass
