### PR TITLE
install_ffmpeg.sh: add -O2 to gnutls build

### DIFF
--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -93,7 +93,7 @@ if [ ! -e "$HOME/gnutls-3.7.0" ]; then
   curl -LO https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.0.tar.xz
   tar xf gnutls-3.7.0.tar.xz
   cd gnutls-3.7.0
-  LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" LIBS="-lhogweed -lnettle -lgmp $EXTRA_GNUTLS_LIBS" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools --disable-hardware-acceleration --disable-guile --disable-libdane --disable-tests --disable-rpath --disable-nls
+  LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include -O2" LIBS="-lhogweed -lnettle -lgmp $EXTRA_GNUTLS_LIBS" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools --disable-hardware-acceleration --disable-guile --disable-libdane --disable-tests --disable-rpath --disable-nls
   make
   make install
   # gnutls doesn't properly set up its pkg-config or something? without this line ffmpeg and go


### PR DESCRIPTION
Apparently `-O2` optimizations change the macros around enough that the Darwin bug doesn't exist anymore

fixes #1788 