### PR TITLE
db: return Miniheader with zero values rather than nil from FindLatestMiniheader when no headers are found

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,8 @@
 
 - \#1810 Display "n/a" in CLI when max gas price isn't specified (@kyriediculous)
 - \#1827 Limit the maximum size of a segment read over HTTP (@jailuthra)
+- \#1809 Don't log statement that blocks have been backfilled when no blocks have elapsed
+- \#1809 Avoid nil pointer error in SyncToLatestBlock when no blocks are present in the database (@kyriediculous)
 
 #### Orchestrator
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,7 +8,7 @@
 
 - \#1810 Display "n/a" in CLI when max gas price isn't specified (@kyriediculous)
 - \#1827 Limit the maximum size of a segment read over HTTP (@jailuthra)
-- \#1809 Don't log statement that blocks have been backfilled when no blocks have elapsed
+- \#1809 Don't log statement that blocks have been backfilled when no blocks have elapsed (@kyriediculous)
 - \#1809 Avoid nil pointer error in SyncToLatestBlock when no blocks are present in the database (@kyriediculous)
 
 #### Orchestrator

--- a/eth/blockwatch/block_watcher.go
+++ b/eth/blockwatch/block_watcher.go
@@ -159,6 +159,10 @@ func (w *Watcher) syncToLatestBlock() error {
 		return err
 	}
 
+	if lastSeenHeader == nil {
+		return w.pollNextBlock()
+	}
+
 	for i := lastSeenHeader.Number; i.Cmp(newestHeader.Number) < 0; i = i.Add(i, big.NewInt(1)) {
 		if err := w.pollNextBlock(); err != nil {
 			return err
@@ -332,7 +336,7 @@ func (w *Watcher) getMissedEventsToBackfill(ctx context.Context) ([]*Event, erro
 		return events, nil
 	}
 
-	if blocksElapsed = latestBlockNum - startBlockNum; blocksElapsed == 0 {
+	if blocksElapsed = latestBlockNum - startBlockNum; blocksElapsed <= 0 {
 		return events, nil
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Instead of returning `nil` from `db.FindLatestMiniHeader` when no entries are found in the database we return a zero-value to avoid unexpected behaviour whereby no error and no value is returned.  

This behaviour is similar to the underlying `ethClient.HeaderByNumber` implementation. 

**note**
Consider changing `blockWatch.Miniheader.Number` to an `int64` or `big.Int` instead of a pointer reference `*big.Int` to avoid explicit initialisation of this field. 

```
&blockwatch.MiniHeader{
  Number: big.NewInt(0)
}
```

**Specific updates (required)**
- Added a test case
- Return zero value when no results found in FindLatestMiniHeader
- fixed other test cases for functions that use FindLatestMiniHeader
- Changed the check for `blocksElapsed` to be `<=0` to avoid verbose logging when no blocks have elapsed. 

**How did you test each of these updates (required)**
Ran unit tests

**Does this pull request close any open issues?**
Fixes #1803 
Fixes #1780 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
