### PR TITLE
CLI: fix max gas price when not specified

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,9 @@
 # Unreleased Changes
 
 ## vX.X
+
+### Bug Fixes 🐞
+
+#### General
+
+- \#1810 Display "n/a" in CLI when max gas price isn't specified (@kyriediculous)

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -45,7 +45,11 @@ func (w *wizard) stats(showOrchestrator bool) {
 
 	lptBal, _ := new(big.Int).SetString(w.getTokenBalance(), 10)
 	ethBal, _ := new(big.Int).SetString(w.getEthBalance(), 10)
+	maxGasPriceStr := "n/a"
 	maxGasPrice, _ := new(big.Int).SetString(w.maxGasPrice(), 10)
+	if maxGasPrice != nil && maxGasPrice.Cmp(big.NewInt(0)) > 0 {
+		maxGasPriceStr = fmt.Sprintf("%v GWei", eth.FromWei(maxGasPrice, params.GWei))
+	}
 
 	table := tablewriter.NewWriter(os.Stdout)
 	data := [][]string{
@@ -60,7 +64,7 @@ func (w *wizard) stats(showOrchestrator bool) {
 		{"ETH Account", w.getEthAddr()},
 		{"LPT Balance", eth.FormatUnits(lptBal, "LPT")},
 		{"ETH Balance", eth.FormatUnits(ethBal, "ETH")},
-		{"Max Gas Price", fmt.Sprintf("%v GWei", eth.FromWei(maxGasPrice, params.GWei))},
+		{"Max Gas Price", maxGasPriceStr},
 	}
 
 	for _, v := range data {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes displaying max gas price in the CLI when it's not specified. Now shows "n/a". 


**How did you test each of these updates (required)**
Tested on rinkeby 

![image](https://user-images.githubusercontent.com/22256858/112194955-b38eb300-8c09-11eb-84af-e183847368f5.png)

![image](https://user-images.githubusercontent.com/22256858/112195009-c0aba200-8c09-11eb-9851-dff17880b085.png)

**Does this pull request close any open issues?**
Fixes #1807 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
