### PR TITLE
core,discovery: add checks for PriceInfo.pixelsPerUnit==0

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,8 @@
 
 #### General
 
+- \#1813 Check that priceInfo.pixelsPerUnit is not 0 (@kyriediculous)
+
 #### Broadcaster
 
 - \#1782 Fix SegsInFlight data-loss on refreshing O sessions (@darkdragon)

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1280,6 +1280,15 @@ func TestTicketParams_GivenNilNode_ReturnsNil(t *testing.T) {
 	assert.Nil(t, params)
 }
 
+func TestTicketParams_GivenZeroPriceInfoDenom_ReturnsErr(t *testing.T) {
+	n, _ := NewLivepeerNode(nil, "", nil)
+	orch := NewOrchestrator(n, nil)
+	n.Recipient = new(pm.MockRecipient)
+	params, err := orch.TicketParams(ethcommon.Address{}, &net.PriceInfo{PricePerUnit: 0, PixelsPerUnit: 0})
+	assert.Nil(t, params)
+	assert.EqualError(t, err, "pixels per unit is 0")
+}
+
 func TestTicketParams_GivenNilRecipient_ReturnsNil(t *testing.T) {
 	n, _ := NewLivepeerNode(nil, "", nil)
 	orch := NewOrchestrator(n, nil)

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -233,7 +233,12 @@ func (orch *orchestrator) TicketParams(sender ethcommon.Address, priceInfo *net.
 		return nil, nil
 	}
 
-	params, err := orch.node.Recipient.TicketParams(sender, big.NewRat(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit))
+	ratPriceInfo, err := common.RatPriceInfo(priceInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	params, err := orch.node.Recipient.TicketParams(sender, ratPriceInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -109,12 +109,12 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int, suspe
 		// check if O's price is below B's max price
 		maxPrice := server.BroadcastCfg.MaxPrice()
 		price, err := common.RatPriceInfo(info.PriceInfo)
-		if price == nil {
-			glog.V(common.DEBUG).Infof("no price info received for orch=%v", info.GetTranscoder())
-			return false
-		}
 		if err != nil {
 			glog.V(common.DEBUG).Infof("invalid price info orch=%v err=%v", info.GetTranscoder(), err)
+			return false
+		}
+		if price == nil {
+			glog.V(common.DEBUG).Infof("no price info received for orch=%v", info.GetTranscoder())
 			return false
 		}
 		if maxPrice != nil && price.Cmp(maxPrice) > 0 {

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -99,7 +99,7 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int, suspe
 	pred := func(info *net.OrchestratorInfo) bool {
 
 		if err := dbo.ticketParamsValidator.ValidateTicketParams(pmTicketParams(info.TicketParams)); err != nil {
-			glog.V(common.DEBUG).Infof("invalid ticket params - orch=%v err=%v",
+			glog.V(common.DEBUG).Infof("invalid ticket params orch=%v err=%v",
 				info.GetTranscoder(),
 				err,
 			)
@@ -108,9 +108,17 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int, suspe
 
 		// check if O's price is below B's max price
 		maxPrice := server.BroadcastCfg.MaxPrice()
-		price := big.NewRat(info.PriceInfo.PricePerUnit, info.PriceInfo.PixelsPerUnit)
+		price, err := common.RatPriceInfo(info.PriceInfo)
+		if price == nil {
+			glog.V(common.DEBUG).Infof("no price info received for orch=%v", info.GetTranscoder())
+			return false
+		}
+		if err != nil {
+			glog.V(common.DEBUG).Infof("invalid price info orch=%v err=%v", info.GetTranscoder(), err)
+			return false
+		}
 		if maxPrice != nil && price.Cmp(maxPrice) > 0 {
-			glog.V(common.DEBUG).Infof("orchestrator's price is too high - orch=%v price=%v wei/pixel maxPrice=%v wei/pixel",
+			glog.V(common.DEBUG).Infof("orchestrator's price is too high orch=%v price=%v wei/pixel maxPrice=%v wei/pixel",
 				info.GetTranscoder(),
 				price.FloatString(3),
 				maxPrice.FloatString(3),


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Using `common.RatPrinceInfo` for converting `net.PrinceInfo` -> `big.Rat` and handling the error case. 

This function already does a check for the `PriceInfo` denominator being 0 

**Specific updates (required)**
- Using common.RatPriceInfo 
- Add unit tests


Didn't explicitly test the predicate function, would require us to move it to global scope I believe. Can always do this still. 

**How did you test each of these updates (required)**


**Does this pull request close any open issues?**


**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
