### PR TITLE
discovery,pm,server: Additional checks to avoid nil pointer errors caused by unexpected orchestrator configurations

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,7 @@
 
 - \#1782 Fix SegsInFlight data-loss on refreshing O sessions (@darkdragon)
 - \#1814 Add price checks when caching orchestrator responses during discovery (@yondonfu)
+- \#1818 Additional checks to avoid nil pointer errors caused by unexpected orchestrator configurations (@kyriediculous)
 
 #### Transcoder
 

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -146,6 +146,10 @@ func (s *sender) ValidateTicketParams(ticketParams *TicketParams) error {
 
 // validateTicketParams checks if ticket params are acceptable for a specific number of tickets
 func (s *sender) validateTicketParams(ticketParams *TicketParams, numTickets int) error {
+	if ticketParams == nil {
+		return fmt.Errorf("ticketParams is nil")
+	}
+
 	if ticketParams.ExpirationBlock.Int64() == 0 {
 		return nil
 	}

--- a/pm/sender_test.go
+++ b/pm/sender_test.go
@@ -428,6 +428,11 @@ func TestCreateTicketBatch_ConcurrentCallsForSameSession_SenderNonceIncrementsCo
 	assert.Equal(totalTickets, len(uniqueNonces))
 }
 
+func TestValidateTicketParams_NilTicketParams_ReturnsError(t *testing.T) {
+	sender := defaultSender(t)
+	assert.EqualError(t, sender.validateTicketParams(nil, 1), "ticketParams is nil")
+}
+
 func TestValidateParams_ValidateSender(t *testing.T) {
 	sender := defaultSender(t)
 	sm := sender.senderManager.(*stubSenderManager)

--- a/server/selection.go
+++ b/server/selection.go
@@ -162,6 +162,9 @@ func (s *MinLSSelector) selectUnknownSession() *BroadcastSession {
 	var addrs []ethcommon.Address
 	addrCount := make(map[ethcommon.Address]int)
 	for _, sess := range s.unknownSessions {
+		if sess.OrchestratorInfo.GetTicketParams() == nil {
+			continue
+		}
 		addr := ethcommon.BytesToAddress(sess.OrchestratorInfo.TicketParams.Recipient)
 		if _, ok := addrCount[addr]; !ok {
 			addrs = append(addrs, addr)
@@ -195,6 +198,9 @@ func (s *MinLSSelector) selectUnknownSession() *BroadcastSession {
 	// The greater the stake weight of a session, the more likely that it will be selected because subtracting its stake weight from r
 	// will result in a value <= 0
 	for i, sess := range s.unknownSessions {
+		if sess.OrchestratorInfo.GetTicketParams() == nil {
+			continue
+		}
 		addr := ethcommon.BytesToAddress(sess.OrchestratorInfo.TicketParams.Recipient)
 		// If we could not fetch the stake weight for addr then its stake weight defaults to 0
 		r -= stakes[addr]

--- a/server/selection_test.go
+++ b/server/selection_test.go
@@ -299,6 +299,9 @@ func TestMinLSSelector_SelectUnknownSession_UniformWeights(t *testing.T) {
 		stakeMap[addr] = 1000
 	}
 
+	addrNoInfo := ethcommon.BytesToAddress([]byte(strconv.Itoa(len(sessions) + 1)))
+	sessions = append(sessions, &BroadcastSession{OrchestratorInfo: &net.OrchestratorInfo{}})
+	stakeMap[addrNoInfo] = 1000
 	stakeRdr.SetStakes(stakeMap)
 	sel.Add(sessions)
 
@@ -314,12 +317,13 @@ func TestMinLSSelector_SelectUnknownSession_UniformWeights(t *testing.T) {
 
 	// Check that the difference between the selection count of each session is less than some small delta
 	maxDelta := .015
-	for i, sess := range sessions[:len(sessions)-1] {
+	for i, sess := range sessions[:len(sessions)-2] {
 		nextSess := sessions[i+1]
 		diff := math.Abs(float64(sessCount[sess] - sessCount[nextSess]))
 		delta := diff / float64(sessCount[sess])
 		assert.Less(t, delta, maxDelta)
 	}
+	assert.Zero(t, sessCount[sessions[len(sessions)-1]])
 }
 
 func TestMinLSSelector_SelectUnknownSession_SameAddress(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

**Specific updates (required)**
- Return an error from `validateTicketParams()` if the provided `ticketParams` argument is `nil`
- Skip an orchestrator during latency / stake weight selection if it has no ticket params 
- Skip caching an orchestrator to the DB if it has no ETH address 

**How did you test each of these updates (required)**
- Unit tests
- Reproduce crash cases and check they don't happen again. 

**Does this pull request close any open issues?**


**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
