### PR TITLE
drivers,server: Cap data read for a seg

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,7 @@
 #### General
 
 - \#1810 Display "n/a" in CLI when max gas price isn't specified (@kyriediculous)
+- \#1827 Limit the maximum size of a segment read over HTTP (@jailuthra)
 
 #### Orchestrator
 

--- a/common/util.go
+++ b/common/util.go
@@ -26,6 +26,9 @@ import (
 // HTTPTimeout timeout used in HTTP connections between nodes
 var HTTPTimeout = 8 * time.Second
 
+// Max Segment Size (cap reading HTTP response body at this size)
+const MaxSegSize = 20 * 1024 * 1024 // 20 MiB - 20s of 1080p30fps video @ 8000kbps
+
 const maxInt64 = int64(math.MaxInt64)
 
 // using a scaleFactor of 1000 for orchestrator prices

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -213,8 +213,7 @@ func getSegmentDataHTTP(uri string) ([]byte, error) {
 		glog.Errorf("Non-200 response for status=%v uri=%s", resp.Status, uri)
 		return nil, fmt.Errorf(resp.Status)
 	}
-	bodyReader := io.LimitReader(resp.Body, common.MaxSegSize)
-	body, err := ioutil.ReadAll(bodyReader)
+	body, err := common.ReadAtMost(resp.Body, common.MaxSegSize)
 	if err != nil {
 		glog.Errorf("Error reading body uri=%s err=%v", uri, err)
 		return nil, err

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -213,7 +213,8 @@ func getSegmentDataHTTP(uri string) ([]byte, error) {
 		glog.Errorf("Non-200 response for status=%v uri=%s", resp.Status, uri)
 		return nil, fmt.Errorf(resp.Status)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	bodyReader := io.LimitReader(resp.Body, common.MaxSegSize)
+	body, err := ioutil.ReadAll(bodyReader)
 	if err != nil {
 		glog.Errorf("Error reading body uri=%s err=%v", uri, err)
 		return nil, err

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -29,8 +29,7 @@ import (
 )
 
 var refreshTimeout = 2500 * time.Millisecond
-var maxDuration = (5 * time.Minute)
-var maxDurationSec = maxDuration.Seconds()
+var maxDurationSec = common.MaxDuration.Seconds()
 
 var Policy *verification.Policy
 var BroadcastCfg = &BroadcastConfig{}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -692,9 +692,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, httpErr, http.StatusMethodNotAllowed)
 		return
 	}
-	// we read this unconditionally, mostly for ffmpeg
-	bodyReader := io.LimitReader(r.Body, common.MaxSegSize)
-	body, err := ioutil.ReadAll(bodyReader)
+	body, err := common.ReadAtMost(r.Body, common.MaxSegSize)
 
 	if err != nil {
 		httpErr := fmt.Sprintf(`Error reading http request body: %s`, err.Error())

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -693,7 +693,8 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// we read this unconditionally, mostly for ffmpeg
-	body, err := ioutil.ReadAll(r.Body)
+	bodyReader := io.LimitReader(r.Body, common.MaxSegSize)
+	body, err := ioutil.ReadAll(bodyReader)
 
 	if err != nil {
 		httpErr := fmt.Sprintf(`Error reading http request body: %s`, err.Error())

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -295,7 +295,8 @@ func (h *lphttp) TranscodeResults(w http.ResponseWriter, r *http.Request) {
 				res.Err = err
 				break
 			}
-			body, err := ioutil.ReadAll(p)
+			limitReader := io.LimitReader(p, common.MaxSegSize)
+			body, err := ioutil.ReadAll(limitReader)
 			if err != nil {
 				glog.Error("Error reading body ", err)
 				res.Err = err

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -295,8 +295,7 @@ func (h *lphttp) TranscodeResults(w http.ResponseWriter, r *http.Request) {
 				res.Err = err
 				break
 			}
-			limitReader := io.LimitReader(p, common.MaxSegSize)
-			body, err := ioutil.ReadAll(limitReader)
+			body, err := common.ReadAtMost(p, common.MaxSegSize)
 			if err != nil {
 				glog.Error("Error reading body ", err)
 				res.Err = err

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -432,7 +432,7 @@ func coreSegMetadata(segData *net.SegData) (*core.SegTranscodingMetadata, error)
 	}
 
 	dur := time.Duration(segData.Duration) * time.Millisecond
-	if dur < 0 || dur > maxDuration {
+	if dur < 0 || dur > common.MaxDuration {
 		glog.Error("Invalid duration")
 		return nil, errDuration
 	}

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -1212,7 +1212,7 @@ func TestGenVerify_RoundTrip_Duration(t *testing.T) {
 	// check invariant : verifySegCreds(genSegCreds(dur)).Duration == dur
 	rapid.Check(t, func(t *rapid.T) {
 		assert := assert.New(t) // in order to pick up the rapid rng
-		randDur := rapid.IntRange(1, int(maxDuration.Milliseconds())).Draw(t, "dur").(int)
+		randDur := rapid.IntRange(1, int(common.MaxDuration.Milliseconds())).Draw(t, "dur").(int)
 		dur := time.Duration(randDur * int(time.Millisecond))
 		seg := &stream.HLSSegment{Duration: dur.Seconds()}
 		creds, err := genSegCreds(sess, seg)
@@ -1231,7 +1231,7 @@ func TestCoreNetSegData_RoundTrip_Duration(t *testing.T) {
 	// and vice versa.
 	rapid.Check(t, func(t *rapid.T) {
 		assert := assert.New(t) // in order to pick up the rapid rng
-		randDur := rapid.IntRange(1, int(maxDuration.Milliseconds())).Draw(t, "dur").(int)
+		randDur := rapid.IntRange(1, int(common.MaxDuration.Milliseconds())).Draw(t, "dur").(int)
 		dur := time.Duration(randDur * int(time.Millisecond))
 		segData := &net.SegData{Duration: int32(randDur)}
 		md := &core.SegTranscodingMetadata{Duration: dur, Profiles: []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9}}

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"math"
 	"math/big"
@@ -112,7 +113,8 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 
 	// download the segment and check the hash
 	dlStart := time.Now()
-	data, err := ioutil.ReadAll(r.Body)
+	bodyReader := io.LimitReader(r.Body, common.MaxSegSize)
+	data, err := ioutil.ReadAll(bodyReader)
 	if err != nil {
 		glog.Errorf("Could not read request body - err=%v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"math"
 	"math/big"
@@ -113,8 +112,7 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 
 	// download the segment and check the hash
 	dlStart := time.Now()
-	bodyReader := io.LimitReader(r.Body, common.MaxSegSize)
-	data, err := ioutil.ReadAll(bodyReader)
+	data, err := common.ReadAtMost(r.Body, common.MaxSegSize)
 	if err != nil {
 		glog.Errorf("Could not read request body - err=%v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -213,7 +213,7 @@ func TestVerifySegCreds_Duration(t *testing.T) {
 	assert.Nil(md)
 
 	// check invalid value : greater than max duration
-	md, err = runVerify(&net.SegData{Duration: int32(maxDuration.Milliseconds() + 1), AuthToken: stubAuthToken})
+	md, err = runVerify(&net.SegData{Duration: int32(common.MaxDuration.Milliseconds() + 1), AuthToken: stubAuthToken})
 	assert.Equal(errDuration, err)
 	assert.Nil(md)
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Cap the data read for a segment to prevent bad segments eating up a lot of memory.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
*see the commit history*

Currently the max segment size is set to ~300MB (at 8000kbps using the current max duration of 5minutes)

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Manually tested on a local B/OT setup with a smaller limit set (2MB) and a bigger segment (2.4MB). The segment data read was being capped at the defined size.


With Limit Set:
B: `I0404 22:11:10.044429 2542338 broadcast.go:372] Processing segment nonce=17696729379380681746 manifestID=test seqNo=1 dur=2 bytes=2097152`
OT: `[h264 @ 0x7f810403d640] error while decoding MB 60 59, bytestream -12`
Transcoded Rendition Duration: 1.23 s

Without Limit Set:
B: `I0404 22:12:42.698367 2543964 broadcast.go:372] Processing segment nonce=13032173926343571666 manifestID=test seqNo=1 dur=2 bytes=2405084`
OT: *No error*
Transcoded Rendition Duration: 2.7 s

2. Added unit tests for Push API and B<->O serve segment in https://github.com/livepeer/go-livepeer/pull/1827/commits/9d23156dc5aa076b4e8ec0becb5d777eede42eba

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #1523 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
