### PR TITLE
core,pm: handle zero/nil gas price from gas price monitor

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,10 @@
 
 - \#1810 Display "n/a" in CLI when max gas price isn't specified (@kyriediculous)
 
+#### Orchestrator
+
+- \#1830 handle "zero" or "nil" gas price from gas price monitor (@kyriediculous)
+
 ### Features ⚒
 
 #### Broadcaster

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -289,7 +289,10 @@ func (orch *orchestrator) priceInfo(sender ethcommon.Address) (*big.Rat, error) 
 			return nil, err
 		}
 
-		overhead = overhead.Add(overhead, new(big.Rat).Inv(txCostMultiplier))
+		if txCostMultiplier.Cmp(big.NewRat(0, 1)) > 0 {
+			overhead = overhead.Add(overhead, new(big.Rat).Inv(txCostMultiplier))
+		}
+
 	}
 	// pricePerPixel = basePrice * overhead
 	fixedPrice, err := common.PriceToFixed(new(big.Rat).Mul(basePrice, overhead))

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -589,6 +589,27 @@ func TestTxCostMultiplier_InsufficientReserve_ReturnsError(t *testing.T) {
 	assert.EqualError(t, err, errInsufficientSenderReserve.Error())
 }
 
+func TestTxCostMultiplier_ZeroTxCost_Returns_Zero(t *testing.T) {
+	sender, b, v, gm, sm, tm, cfg, _ := newRecipientFixtureOrFatal(t)
+	gm.gasPrice = big.NewInt(0)
+	recipient := RandAddress()
+	secret := [32]byte{3}
+	r := NewRecipientWithSecret(recipient, b, v, gm, sm, tm, secret, cfg)
+
+	mul, err := r.TxCostMultiplier(sender)
+	assert.Nil(t, err)
+	assert.Equal(t, big.NewRat(0, 1), mul)
+}
+
+func TestTxCost_NilGasPrice_ReturnsZero(t *testing.T) {
+	_, b, v, gm, sm, tm, cfg, _ := newRecipientFixtureOrFatal(t)
+	gm.gasPrice = nil
+	secret := [32]byte{3}
+	r := NewRecipientWithSecret(RandAddress(), b, v, gm, sm, tm, secret, cfg)
+	txCost := r.(*recipient).txCost()
+	assert.Equal(t, big.NewInt(0), txCost)
+}
+
 func TestSenderNoncesCleanupLoop(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
 When the gas price monitor returns a gas price of  `0` or `nil` in on-chain mode the node will crash with a division-by-zero error.  This bug caused a majority of the orchestrators on the public network to all crash simultaneously when a common hosted ethereum provider, infura, could have potentially returned a gas price of `0`. (see below). 
 
**Specific updates (required)**
- In `recipient.txCost()` if the `gasPriceMonitor` returns `0` (or `nil`  , but this _should_ be impossible due to the above update) `txCost` will return `0`
- In `recipient.TxCostMultiplier()` if the value returned from `recipient.txCost()` is `0` , return `big.NewRat(0,1)`
- In `orchestrator.priceInfo()` if the `txCostMultiplier` return from `recipient.TxCostMultiplier()` is `0/1` use a price multiplier of `1` (no overhead charged because of no tx cost). 

**How did you test each of these updates (required)**
- [x] Added unit tests 
- [x] Manual test on private network with 0 gas price 

**Motivation**
Decided to add extra checks to deal with cases of `nil` and `0` values down the call chain. While this is a more elaborate fix it would prevent breaking the software on private networks with a gas price of 0 or running against an ethereum node that also mines with a gas price of 0. 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated


**Context**

```
panic: division by zero

goroutine 336441272 [running]:
math/big.(*Rat).SetFrac(0xc003369480, 0xc00019aea0, 0xc000ccfb20, 0x1ee6364f)
        /usr/local/go/src/math/big/rat.go:307 +0x465
github.com/livepeer/go-livepeer/pm.(*recipient).TxCostMultiplier(0xc0001780c0, 0x7d1b06f7c8c4c7c3, 0xfe5953ee6e76726a, 0xc01ee6364f, 0x8361c8, 0xc001bee460, 0xc001bee440)
        /root/go-livepool/pm/recipient.go:289 +0xce
github.com/livepeer/go-livepeer/core.(*orchestrator).priceInfo(0xc000512910, 0x7d1b06f7c8c4c7c3, 0xfe5953ee6e76726a, 0x1ee6364f, 0x0, 0xc001156a20, 0xc0023b58b0)
        /root/go-livepool/core/orchestrator.go:283 +0x22d
github.com/livepeer/go-livepeer/core.(*orchestrator).PriceInfo(0xc000512910, 0x7d1b06f7c8c4c7c3, 0xfe5953ee6e76726a, 0x1ee6364f, 0x0, 0x20, 0xc001bee4c0)
        /root/go-livepool/core/orchestrator.go:261 +0x96
github.com/livepeer/go-livepeer/server.getPriceInfo(0x1fccc58, 0xc000512910, 0x7d1b06f7c8c4c7c3, 0xfe5953ee6e76726a, 0xc01ee6364f, 0xc0023b5988, 0x690ba7, 0x0)
        /root/go-livepool/server/rpc.go:282 +0x53
github.com/livepeer/go-livepeer/server.orchestratorInfo(0x1fccc58, 0xc000512910, 0x7d1b06f7c8c4c7c3, 0xfe5953ee6e76726a, 0x1ee6364f, 0xc001bee4c0, 0x1c, 0x50, 0x0, 0x0)
        /root/go-livepool/server/rpc.go:286 +0x6a
github.com/livepeer/go-livepeer/server.getOrchestrator(0x1fccc58, 0xc000512910, 0xc0042c35e0, 0x1c51840, 0xc004ed9600, 0x1fad5d0)
        /root/go-livepool/server/rpc.go:272 +0x305
github.com/livepeer/go-livepeer/server.(*lphttp).GetOrchestrator(0xc0001418e0, 0x1fbc0f0, 0xc004ed9680, 0xc0042c35e0, 0xc0001418e0, 0xc004ed9680, 0xc000067b88)
        /root/go-livepool/server/rpc.go:140 +0x45
github.com/livepeer/go-livepeer/net._Orchestrator_GetOrchestrator_Handler(0x1c51840, 0xc0001418e0, 0x1fbc0f0, 0xc004ed9680, 0xc0050104e0, 0x0, 0x1fbc0f0, 0xc004ed9680, 0xc0067d9860, 0x59)
        /root/go-livepool/net/lp_rpc.pb.go:1688 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00011aea0, 0x1fc7658, 0xc003d01320, 0xc00ffa0a00, 0xc00011cf00, 0x2a60960, 0x0, 0x0, 0x0)
        /root/go/pkg/mod/google.golang.org/grpc@v1.28.0/server.go:1082 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc00011aea0, 0x1fc7658, 0xc003d01320, 0xc00ffa0a00, 0x0)
        /root/go/pkg/mod/google.golang.org/grpc@v1.28.0/server.go:1405 +0xccf
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000500a20, 0xc00011aea0, 0x1fc7658, 0xc003d01320, 0xc00ffa0a00)
        /root/go/pkg/mod/google.golang.org/grpc@v1.28.0/server.go:746 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /root/go/pkg/mod/google.golang.org/grpc@v1.28.0/server.go:744 +0xa5
       ```
