### PR TITLE
eth,pm: avoid watchPoolSizeChange nil pointer error

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,6 +10,7 @@
 - \#1827 Limit the maximum size of a segment read over HTTP (@jailuthra)
 - \#1809 Don't log statement that blocks have been backfilled when no blocks have elapsed (@kyriediculous)
 - \#1809 Avoid nil pointer error in SyncToLatestBlock when no blocks are present in the database (@kyriediculous)
+- \#1833 Prevent nil pointer errors when fetching transcoder pool size (@kyriediculous)
 
 #### Orchestrator
 

--- a/eth/watchers/orchestratorwatcher_test.go
+++ b/eth/watchers/orchestratorwatcher_test.go
@@ -150,6 +150,7 @@ func TestOrchWatcher_HandleRoundEvent_CacheOrchestratorStake(t *testing.T) {
 	stubStore := &stubOrchestratorStore{}
 	lpEth := &eth.StubClient{
 		TotalStake: expStake,
+		Errors:     make(map[string]error),
 	}
 	tw := &stubTimeWatcher{}
 
@@ -170,13 +171,13 @@ func TestOrchWatcher_HandleRoundEvent_CacheOrchestratorStake(t *testing.T) {
 	assert.Equal(stubStore.stake, int64(500000000))
 
 	// LivepeerEthClient.CurrentRound() error
-	lpEth.RoundsErr = errors.New("CurrentRound error")
+	lpEth.Errors["CurrentRound"] = errors.New("CurrentRound error")
 	errorLogsBefore := glog.Stats.Error.Lines()
 	tw.sink <- newRoundEvent
 	time.Sleep(20 * time.Millisecond)
 	errorLogsAfter := glog.Stats.Error.Lines()
 	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
-	lpEth.RoundsErr = nil
+	lpEth.Errors["CurrentRound"] = nil
 
 	// OrchestratorStore.SelectOrchs error
 	stubStore.selectErr = errors.New("SelectOrchs error")

--- a/eth/watchers/timewatcher.go
+++ b/eth/watchers/timewatcher.go
@@ -71,7 +71,7 @@ func NewTimeWatcher(roundsManagerAddr ethcommon.Address, watcher BlockWatcher, l
 	}
 	num, err := tw.lpEth.CurrentRoundStartBlock()
 	if err != nil {
-		return nil, fmt.Errorf("error fetching current round start block %v=", err)
+		return nil, fmt.Errorf("error fetching current round start block err=%v", err)
 	}
 	tw.setLastInitializedRound(lr, bh, num)
 
@@ -85,9 +85,11 @@ func NewTimeWatcher(roundsManagerAddr ethcommon.Address, watcher BlockWatcher, l
 	}
 	tw.setLastSeenBlock(blockNum)
 
-	if err := tw.fetchAndSetTranscoderPoolSize(); err != nil {
+	size, err := tw.lpEth.GetTranscoderPoolSize()
+	if err != nil {
 		return nil, fmt.Errorf("error fetching initial transcoderPoolSize err=%v", err)
 	}
+	tw.setTranscoderPoolSize(size)
 
 	return tw, nil
 }
@@ -245,20 +247,13 @@ func (tw *TimeWatcher) handleLog(log types.Log) error {
 	}
 
 	// Get the active transcoder pool size when we receive a NewRound event
-	if err := tw.fetchAndSetTranscoderPoolSize(); err != nil {
-		return err
-	}
-
-	tw.roundSubFeed.Send(log)
-
-	return nil
-}
-
-func (tw *TimeWatcher) fetchAndSetTranscoderPoolSize() error {
 	size, err := tw.lpEth.GetTranscoderPoolSize()
 	if err != nil {
 		return err
 	}
 	tw.setTranscoderPoolSize(size)
+
+	tw.roundSubFeed.Send(log)
+
 	return nil
 }

--- a/eth/watchers/timewatcher.go
+++ b/eth/watchers/timewatcher.go
@@ -54,12 +54,42 @@ func NewTimeWatcher(roundsManagerAddr ethcommon.Address, watcher BlockWatcher, l
 		return nil, fmt.Errorf("error creating decoder: %v", err)
 	}
 
-	return &TimeWatcher{
+	tw := &TimeWatcher{
 		quit:    make(chan struct{}),
 		watcher: watcher,
 		lpEth:   lpEth,
 		dec:     dec,
-	}, nil
+	}
+
+	lr, err := tw.lpEth.LastInitializedRound()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching initial lastInitializedRound value err=%v", err)
+	}
+	bh, err := tw.lpEth.BlockHashForRound(lr)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching initial lastInitializedBlockHash value err=%v", err)
+	}
+	num, err := tw.lpEth.CurrentRoundStartBlock()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching current round start block %v=", err)
+	}
+	tw.setLastInitializedRound(lr, bh, num)
+
+	lastSeenBlock, err := tw.watcher.GetLatestBlock()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching last seen block err=%v", err)
+	}
+	blockNum := big.NewInt(0)
+	if lastSeenBlock != nil {
+		blockNum = lastSeenBlock.Number
+	}
+	tw.setLastSeenBlock(blockNum)
+
+	if err := tw.fetchAndSetTranscoderPoolSize(); err != nil {
+		return nil, fmt.Errorf("error fetching initial transcoderPoolSize err=%v", err)
+	}
+
+	return tw, nil
 }
 
 // LastInitializedRound gets the last initialized round from cache
@@ -93,6 +123,9 @@ func (tw *TimeWatcher) setLastInitializedRound(round *big.Int, hash [32]byte, st
 func (tw *TimeWatcher) GetTranscoderPoolSize() *big.Int {
 	tw.mu.RLock()
 	defer tw.mu.RUnlock()
+	if tw.transcoderPoolSize == nil {
+		return big.NewInt(0)
+	}
 	return tw.transcoderPoolSize
 }
 
@@ -116,34 +149,6 @@ func (tw *TimeWatcher) setLastSeenBlock(blockNum *big.Int) {
 
 // Watch the blockwatch subscription for NewRound events
 func (tw *TimeWatcher) Watch() error {
-	lr, err := tw.lpEth.LastInitializedRound()
-	if err != nil {
-		return fmt.Errorf("error fetching initial lastInitializedRound value err=%v", err)
-	}
-	bh, err := tw.lpEth.BlockHashForRound(lr)
-	if err != nil {
-		return fmt.Errorf("error fetching initial lastInitializedBlockHash value err=%v", err)
-	}
-	num, err := tw.lpEth.CurrentRoundStartBlock()
-	if err != nil {
-		return fmt.Errorf("error fetching current round start block %v=", err)
-	}
-	tw.setLastInitializedRound(lr, bh, num)
-
-	if err := tw.fetchAndSetTranscoderPoolSize(); err != nil {
-		return fmt.Errorf("error fetching initial transcoderPoolSize err=%v", err)
-	}
-
-	lastSeenBlock, err := tw.watcher.GetLatestBlock()
-	if err != nil {
-		return fmt.Errorf("error fetching last seen block err=%v", err)
-	}
-	blockNum := big.NewInt(0)
-	if lastSeenBlock != nil {
-		blockNum = lastSeenBlock.Number
-	}
-	tw.setLastSeenBlock(blockNum)
-
 	events := make(chan []*blockwatch.Event, 10)
 	sub := tw.watcher.Subscribe(events)
 	defer sub.Unsubscribe()
@@ -252,7 +257,7 @@ func (tw *TimeWatcher) handleLog(log types.Log) error {
 func (tw *TimeWatcher) fetchAndSetTranscoderPoolSize() error {
 	size, err := tw.lpEth.GetTranscoderPoolSize()
 	if err != nil {
-		return fmt.Errorf("error fetching initial transcoderPoolSize: %v", err)
+		return err
 	}
 	tw.setTranscoderPoolSize(size)
 	return nil

--- a/eth/watchers/timewatcher_test.go
+++ b/eth/watchers/timewatcher_test.go
@@ -1,7 +1,7 @@
 package watchers
 
 import (
-	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -40,6 +40,89 @@ func TestSetAndGet_TranscoderPoolSize(t *testing.T) {
 	tw.setTranscoderPoolSize(size)
 	assert.Equal(size, tw.transcoderPoolSize)
 	assert.Equal(size, tw.GetTranscoderPoolSize())
+
+	// return big.Int(0) when nil
+	tw.setTranscoderPoolSize(nil)
+	assert.Nil(tw.transcoderPoolSize)
+	assert.Equal(big.NewInt(0), tw.GetTranscoderPoolSize())
+}
+
+func TestTimeWatcher_NewTimeWatcher(t *testing.T) {
+	assert := assert.New(t)
+	size := big.NewInt(50)
+	block := big.NewInt(10)
+	round := big.NewInt(1)
+	hash := ethcommon.HexToHash("foo")
+	lpEth := &eth.StubClient{
+		PoolSize:          size,
+		BlockNum:          block,
+		BlockHashToReturn: hash,
+		Round:             round,
+		Errors:            make(map[string]error),
+	}
+	watcher := &stubBlockWatcher{
+		latestHeader: &blockwatch.MiniHeader{Number: block},
+	}
+
+	testErr := fmt.Errorf("error")
+
+	// Last InitializedRound error
+	lpEth.Errors["LastInitializedRound"] = testErr
+	expErr := fmt.Sprintf("error fetching initial lastInitializedRound value err=%v", testErr)
+	tw, err := NewTimeWatcher(stubRoundsManagerAddr, watcher, lpEth)
+	assert.Nil(tw)
+	assert.EqualError(err, expErr)
+	lpEth.Errors["LastInitializedRound"] = nil
+
+	// BlockHashForRound error
+	lpEth.Errors["BlockHashForRound"] = testErr
+	expErr = fmt.Sprintf("error fetching initial lastInitializedBlockHash value err=%v", testErr)
+	tw, err = NewTimeWatcher(stubRoundsManagerAddr, watcher, lpEth)
+	assert.Nil(tw)
+	assert.EqualError(err, expErr)
+	lpEth.Errors["BlockHashForRound"] = nil
+
+	// CurrentRoundStartBlock error
+	lpEth.Errors["CurrentRoundStartBlock"] = testErr
+	expErr = fmt.Sprintf("error fetching current round start block %v=", testErr)
+	tw, err = NewTimeWatcher(stubRoundsManagerAddr, watcher, lpEth)
+	assert.Nil(tw)
+	assert.EqualError(err, expErr)
+	lpEth.Errors["CurrentRoundStartBlock"] = nil
+
+	// GetLastestBlock error
+	watcher.err = fmt.Errorf("GetLatestBlock error")
+	expErr = fmt.Sprintf("error fetching last seen block err=%v", watcher.err)
+	tw, err = NewTimeWatcher(stubRoundsManagerAddr, watcher, lpEth)
+	assert.Nil(tw)
+	assert.EqualError(err, expErr)
+	watcher.err = nil
+
+	// TranscoderPoolSize error
+	lpEth.Errors["GetTranscoderPoolSize"] = testErr
+	expErr = fmt.Sprintf("error fetching initial transcoderPoolSize err=%v", testErr)
+	tw, err = NewTimeWatcher(stubRoundsManagerAddr, watcher, lpEth)
+	assert.Nil(tw)
+	assert.EqualError(err, expErr)
+	lpEth.Errors["GetTranscoderPoolSize"] = nil
+
+	tw, err = NewTimeWatcher(stubRoundsManagerAddr, watcher, lpEth)
+	assert.Nil(err)
+	bh := tw.LastInitializedBlockHash()
+	assert.Equal(hash, common.BytesToHash(bh[:]))
+	assert.Equal(round, tw.LastInitializedRound())
+	assert.Equal(size, tw.GetTranscoderPoolSize())
+	assert.Equal(block, tw.LastSeenBlock())
+
+	// if watcher.GetLatestBlock() == nil, initialise lastSeenBlock to big.NewInt(0)
+	watcher.latestHeader = nil
+	tw, err = NewTimeWatcher(stubRoundsManagerAddr, watcher, lpEth)
+	assert.Nil(err)
+	bh = tw.LastInitializedBlockHash()
+	assert.Equal(hash, common.BytesToHash(bh[:]))
+	assert.Equal(round, tw.LastInitializedRound())
+	assert.Equal(size, tw.GetTranscoderPoolSize())
+	assert.Equal(big.NewInt(0), tw.LastSeenBlock())
 }
 
 func TestTimeWatcher_WatchAndStop(t *testing.T) {
@@ -53,12 +136,13 @@ func TestTimeWatcher_WatchAndStop(t *testing.T) {
 		BlockNum:          block,
 		BlockHashToReturn: hash,
 		Round:             round,
+		Errors:            make(map[string]error),
 	}
 	watcher := &stubBlockWatcher{
 		latestHeader: &blockwatch.MiniHeader{Number: block},
 	}
 	tw, err := NewTimeWatcher(stubRoundsManagerAddr, watcher, lpEth)
-	assert.Nil(err)
+	require.Nil(t, err)
 
 	header := defaultMiniHeader()
 	newRoundEvent := newStubNewRoundLog()
@@ -71,26 +155,6 @@ func TestTimeWatcher_WatchAndStop(t *testing.T) {
 
 	go tw.Watch()
 	time.Sleep(2 * time.Millisecond)
-	// Check state initialization
-	bh := tw.LastInitializedBlockHash()
-	assert.Equal(hash, common.BytesToHash(bh[:]))
-	assert.Equal(round, tw.LastInitializedRound())
-	assert.Equal(size, tw.GetTranscoderPoolSize())
-	assert.Equal(block, tw.LastSeenBlock())
-	tw.Stop()
-
-	// if watcher.GetLatestBlock() == nil, initialise lastSeenBlock to big.NewInt(0)
-	watcher.latestHeader = nil
-	tw, err = NewTimeWatcher(stubRoundsManagerAddr, watcher, lpEth)
-	assert.Nil(err)
-	go tw.Watch()
-	time.Sleep(2 * time.Millisecond)
-	// Check state initialization
-	bh = tw.LastInitializedBlockHash()
-	assert.Equal(hash, common.BytesToHash(bh[:]))
-	assert.Equal(round, tw.LastInitializedRound())
-	assert.Equal(size, tw.GetTranscoderPoolSize())
-	assert.Equal(big.NewInt(0), tw.LastSeenBlock())
 
 	// New Round event
 	watcher.sink <- []*blockwatch.Event{blockEvent}
@@ -123,7 +187,7 @@ func TestTimeWatcher_WatchAndStop(t *testing.T) {
 	watcher.sink <- []*blockwatch.Event{blockEvent}
 	time.Sleep(2 * time.Millisecond)
 	bhForRound = tw.LastInitializedBlockHash()
-	assert.Equal(hash, common.BytesToHash(bh[:]))
+	assert.Equal(hash, common.BytesToHash(bhForRound[:]))
 	assert.Equal(round, tw.LastInitializedRound())
 	assert.Equal(size, tw.GetTranscoderPoolSize())
 	assert.Equal(header.Number, tw.LastSeenBlock())
@@ -132,16 +196,6 @@ func TestTimeWatcher_WatchAndStop(t *testing.T) {
 	tw.Stop()
 	time.Sleep(2 * time.Millisecond)
 	assert.True(watcher.sub.unsubscribed)
-
-	// Test watch error when RPC calls fail
-	tw = &TimeWatcher{
-		lpEth: &eth.StubClient{
-			RoundsErr: errors.New("timewatcher error"),
-		},
-	}
-	err = tw.Watch()
-	assert.NotNil(err)
-	assert.Contains(err.Error(), "timewatcher error")
 }
 
 func TestTimeWatcher_HandleLog(t *testing.T) {

--- a/eth/watchers/timewatcher_test.go
+++ b/eth/watchers/timewatcher_test.go
@@ -84,7 +84,7 @@ func TestTimeWatcher_NewTimeWatcher(t *testing.T) {
 
 	// CurrentRoundStartBlock error
 	lpEth.Errors["CurrentRoundStartBlock"] = testErr
-	expErr = fmt.Sprintf("error fetching current round start block %v=", testErr)
+	expErr = fmt.Sprintf("error fetching current round start block err=%v", testErr)
 	tw, err = NewTimeWatcher(stubRoundsManagerAddr, watcher, lpEth)
 	assert.Nil(tw)
 	assert.EqualError(err, expErr)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This issue might be caused by an unexpected return value from the ETH provider. 

The error is caused by the following expression 

```go
if poolSize := sm.tm.GetTranscoderPoolSize(); poolSize.Cmp(lastPoolSize) != 0
```

Both values are fetched from `TimeWatcher.GetTranscoderPoolSize()`

The value of `TimeWatcher.transcoderPoolSize` is initialised on node startup and refetched from the ETH provider when events are received. 

The contract binding `BondingManagerSession.GetTranscoderPoolSize()` returns the following `return *(new(*big.Int)), err`. 
This means that even though the return value (a pointer) can't be nil because it is initialised , but value the pointer refers to can still be and this is what is returned. If for some reason there is a nil error and an unexpected value from the contract call a nil pointer could still occur. 

**Specific updates (required)**
- Wrap the contract call in case it returns `nil, nil`

**How did you test each of these updates (required)**


**Does this pull request close any open issues?**
Fixes #1828 


**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
