### PR TITLE
server+discovery: Only log errors if request was not cancelled

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,7 @@
 #### Broadcaster
 
 - \#1875 Update 'trying to transcode' log statement with manifestID (@kyriediculous)
+- \#1837 Only log discovery errors when request is not cancelled (@yondonfu)
 
 #### Orchestrator
 

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"container/heap"
 	"context"
+	"errors"
 	"math"
 	"math/rand"
 	"net/url"
@@ -85,8 +86,11 @@ func (o *orchestratorPool) GetOrchestrators(numOrchestrators int, suspender comm
 			infoCh <- info
 			return
 		}
-		if err != nil && monitor.Enabled {
-			monitor.LogDiscoveryError(err.Error())
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			glog.Error(err)
+			if monitor.Enabled {
+				monitor.LogDiscoveryError(err.Error())
+			}
 		}
 		errCh <- err
 	}

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -86,7 +86,7 @@ func (o *orchestratorPool) GetOrchestrators(numOrchestrators int, suspender comm
 			infoCh <- info
 			return
 		}
-		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			glog.Error(err)
 			if monitor.Enabled {
 				monitor.LogDiscoveryError(err.Error())

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -224,8 +224,7 @@ func GetOrchestratorInfo(ctx context.Context, bcast common.Broadcaster, orchestr
 	req, err := genOrchestratorReq(bcast)
 	r, err := c.GetOrchestrator(ctx, req)
 	if err != nil {
-		glog.Errorf("Could not get orchestrator orch=%v err=%v", orchestratorServer, err)
-		return nil, errors.New("Could not get orchestrator err=" + err.Error())
+		return nil, fmt.Errorf("Could not get orchestrator orch=%v err=%v", orchestratorServer, err)
 	}
 
 	return r, nil

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -224,7 +224,7 @@ func GetOrchestratorInfo(ctx context.Context, bcast common.Broadcaster, orchestr
 	req, err := genOrchestratorReq(bcast)
 	r, err := c.GetOrchestrator(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("Could not get orchestrator orch=%v err=%v", orchestratorServer, err)
+		return nil, errors.Wrapf(err, "Could not get orchestrator orch=%v", orchestratorServer)
 	}
 
 	return r, nil
@@ -237,8 +237,8 @@ func startOrchestratorClient(uri *url.URL) (net.OrchestratorClient, *grpc.Client
 		grpc.WithBlock(),
 		grpc.WithTimeout(GRPCConnectTimeout))
 	if err != nil {
-		glog.Errorf("Did not connect to orch=%v err=%v", uri, err)
-		return nil, nil, fmt.Errorf("Did not connect to orch=%v err=%v", uri, err)
+		return nil, nil, errors.Wrapf(err, "Did not connect to orch=%v", uri)
+
 	}
 	c := net.NewOrchestratorClient(conn)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
- Wrap discovery related errors in the `server` package instead of concatenating the error message strings. This allows usage of `errors.Is()` because it can now unwrap error messages.
- Add a check to see if an error from discovery doesn't contain `context.Canceled` or `context.Exceeded` and only log the error if it doesn't

**How did you test each of these updates (required)**
Ran a broadcaster on rinkeby

**Does this pull request close any open issues?**
Fixes #1846 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
