### PR TITLE
core: reuse remote transcoder for stream

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,7 @@
 
 - \#1845 Staking actions with hints (@kyriediculous)
 - \#1873 Increase TicketParams expiration to 10 blocks (@kyriediculous)
+- \#1849 Re-use remote transcoders for a stream sessions (@reubenr0d)
 
 #### Transcoder
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds map to keep track of transcoders assigned to sessions
- Updated selectTranscoder to return and set transcoders to sessions
- Removed transcoder from map in case of session end/transcoder errors


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
On local offchain setup:
- Setup 1 O, 2 T, 1 B
- Start stream and observed that only one transcoder is processing stream
- Killed that transcoder and stream moves to other transcoder
- Created Unit Tests

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #1842 
Fixes #1712 
Fixes #1273 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
