### PR TITLE
Allow to pass region in the custom s3 storage url 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,7 @@
 #### General
 
 - \#1848 Use fee cut instead of fee share for user facing language in the CLI (@kyriediculous)
+- \#1854 Allow to pass region in the custom s3 storage URL (@darkdarkdragon)
 
 #### Broadcaster
 

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -133,7 +133,7 @@ func ParseOSURL(input string, useFullAPI bool) (OSDriver, error) {
 	}
 	if u.Scheme == "s3" {
 		pw, ok := u.User.Password()
-		if ok == false {
+		if !ok {
 			return nil, fmt.Errorf("password is required with s3:// OS")
 		}
 		base := path.Base(u.Path)
@@ -145,7 +145,12 @@ func ParseOSURL(input string, useFullAPI bool) (OSDriver, error) {
 		if u.Scheme == "s3+https" {
 			scheme = "https"
 		}
-		_, bucket := path.Split(u.Path)
+		region := "ignored"
+		base, bucket := path.Split(u.Path)
+		if len(base) > 1 && base[len(base)-1] == '/' {
+			base = base[:len(base)-1]
+			_, region = path.Split(base)
+		}
 		hosturl, err := url.Parse(input)
 		if err != nil {
 			return nil, err
@@ -154,10 +159,10 @@ func ParseOSURL(input string, useFullAPI bool) (OSDriver, error) {
 		hosturl.Scheme = scheme
 		hosturl.Path = ""
 		pw, ok := u.User.Password()
-		if ok == false {
+		if !ok {
 			return nil, fmt.Errorf("password is required with s3:// OS")
 		}
-		return NewCustomS3Driver(hosturl.String(), bucket, u.User.Username(), pw, useFullAPI), nil
+		return NewCustomS3Driver(hosturl.String(), bucket, region, u.User.Username(), pw, useFullAPI), nil
 	}
 	if u.Scheme == "gs" {
 		file := u.User.Username()

--- a/drivers/drivers_test.go
+++ b/drivers/drivers_test.go
@@ -26,12 +26,26 @@ func TestS3URL(t *testing.T) {
 
 func TestCustomS3URL(t *testing.T) {
 	assert := assert.New(t)
-	os, err := ParseOSURL("s3+http://user:password@example.com:9000/path/to/bucket-name", true)
+	os, err := ParseOSURL("s3+http://user:password@example.com:9000/bucket-name", true)
 	s3, iss3 := os.(*s3OS)
 	assert.Equal(true, iss3)
 	assert.Equal(nil, err)
 	assert.Equal("http://example.com:9000", s3.host)
 	assert.Equal("bucket-name", s3.bucket)
+	assert.Equal("user", s3.awsAccessKeyID)
+	assert.Equal("password", s3.awsSecretAccessKey)
+	assert.Equal("ignored", s3.region)
+}
+
+func TestCustomS3URLWithRegion(t *testing.T) {
+	assert := assert.New(t)
+	os, err := ParseOSURL("s3+http://user:password@example.com:9000/path/to/region-name/bucket-name", true)
+	s3, iss3 := os.(*s3OS)
+	assert.Equal(true, iss3)
+	assert.Equal(nil, err)
+	assert.Equal("http://example.com:9000", s3.host)
+	assert.Equal("bucket-name", s3.bucket)
+	assert.Equal("region-name", s3.region)
 	assert.Equal("user", s3.awsAccessKeyID)
 	assert.Equal("password", s3.awsSecretAccessKey)
 }

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -96,14 +96,14 @@ func NewS3Driver(region, bucket, accessKey, accessKeySecret string, useFullAPI b
 }
 
 // NewCustomS3Driver for creating S3-compatible stores other than S3 itself
-func NewCustomS3Driver(host, bucket, accessKey, accessKeySecret string, useFullAPI bool) OSDriver {
-	glog.Infof("using custom s3 with url: %s, bucket %s use full API %v", host, bucket, useFullAPI)
+func NewCustomS3Driver(host, bucket, region, accessKey, accessKeySecret string, useFullAPI bool) OSDriver {
+	glog.Infof("using custom s3 with url: %s, bucket %s region %s use full API %v", host, bucket, region, useFullAPI)
 	os := &s3OS{
 		host:               host,
 		bucket:             bucket,
 		awsAccessKeyID:     accessKey,
 		awsSecretAccessKey: accessKeySecret,
-		region:             "ignored",
+		region:             region,
 		useFullAPI:         useFullAPI,
 	}
 	if !useFullAPI {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
All the previous S3-compatible storages we've tested was ignoring 'region' part of configuration.
So in our code it was hardcoded as value 'ignored'.
But filebase.com does want it to be set to specific value.
This updates allows to pass region as the part of the custom URL, like this:

`s3+http://user:password@example.com:9000/path/to/region-name/bucket-name`


**Specific updates (required)**
Change parsing of custom s3 url


**How did you test each of these updates (required)**
unit test

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
