### PR TITLE
eth: gas price monitor stability improvements

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,8 @@
 
 #### Orchestrator
 
+- \#1856 Use mean of last seen gas prices in the gas price monitor (@kyriediculous)
+
 #### Transcoder
 
 - \#1840 Automatically use all GPUs when -nvidia=all flag is set (@jailuthra)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Uses the mean of N last seen gas prices to calculate a gas price suggestion. 

If the gas price oracle suggest a gas price that is not within 3 standard deviations of the current N prices in the list, the newly seen price will be discarded.

**How did you test each of these updates (required)**
- [x] unit tests
- [ ] manual tests

**Does this pull request close any open issues?**
Fixes #1851 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
