### PR TITLE
server: fix OT error handling

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,14 +26,13 @@
 
 #### General
 
-- \#1864 Fix OT error handling (@reubenr0d)
-
 #### Broadcaster
 
 #### Orchestrator
 
 - \#1860 Discard low gas prices to prevent insufficient ticket faceValue errors (@kyriediculous)
 - \#1859 Handle error for invalid inferred orchestrator public IP on node startup (@reubenr0d)
+- \#1864 Fix OT error handling (@reubenr0d)
 
 #### Transcoder
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,6 +26,8 @@
 
 #### General
 
+- \#1864 Fix OT error handling (@reubenr0d)
+
 #### Broadcaster
 
 #### Orchestrator

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -550,7 +550,7 @@ func (n *LivepeerNode) transcodeSeg(config transcodeConfig, seg *stream.HLSSegme
 	start := time.Now()
 	tData, err := transcoder.Transcode(md)
 	if err != nil {
-		glog.Errorf("Error transcoding manifestID=%s sessionID=%s segNo=%d segName=%s - %v", string(md.ManifestID), md.AuthToken.SessionId, seg.SeqNo, seg.Name, err)
+		glog.Errorf("Error transcoding manifestID=%s sessionID=%s segNo=%d segName=%s err=%v", string(md.ManifestID), md.AuthToken.SessionId, seg.SeqNo, seg.Name, err)
 		return terr(err)
 	}
 
@@ -741,8 +741,12 @@ func (rt *RemoteTranscoder) Transcode(md *SegTranscodingMetadata) (*TranscodeDat
 	case <-ctx.Done():
 		return signalEOF(ErrRemoteTranscoderTimeout)
 	case chanData := <-taskChan:
+		segmentLen := 0
+		if chanData.TranscodeData != nil {
+			segmentLen = len(chanData.TranscodeData.Segments)
+		}
 		glog.Infof("Successfully received results from remote transcoder=%s segments=%d taskId=%d fname=%s dur=%v err=%v",
-			rt.addr, len(chanData.TranscodeData.Segments), taskID, fname, time.Since(start), chanData.Err)
+			rt.addr, segmentLen, taskID, fname, time.Since(start), chanData.Err)
 		return chanData.TranscodeData, chanData.Err
 	}
 }

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -187,9 +187,11 @@ func runTranscode(n *core.LivepeerNode, orchAddr string, httpc *http.Client, not
 	req.Header.Set("Credentials", n.OrchSecret)
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("TaskId", strconv.FormatInt(notify.TaskId, 10))
+	pixels := int64(0)
 	if tData != nil {
-		req.Header.Set("Pixels", strconv.FormatInt(tData.Pixels, 10))
+		pixels = tData.Pixels
 	}
+	req.Header.Set("Pixels", strconv.FormatInt(pixels, 10))
 	uploadStart := time.Now()
 	resp, err := httpc.Do(req)
 	if err != nil {

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -259,13 +259,6 @@ func (h *lphttp) TranscodeResults(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	decodedPixels, err := strconv.ParseInt(r.Header.Get("Pixels"), 10, 64)
-	if err != nil {
-		glog.Error("Could not parse decoded pixels", err)
-		http.Error(w, "Invalid Pixels", http.StatusBadRequest)
-		return
-	}
-
 	var res core.RemoteTranscoderResult
 	if transcodingErrorMimeType == mediaType {
 		w.Write([]byte("OK"))
@@ -278,6 +271,13 @@ func (h *lphttp) TranscodeResults(w http.ResponseWriter, r *http.Request) {
 		}
 		glog.Errorf("Trascoding error for taskID=%v err=%v", tid, res.Err)
 		orch.TranscoderResults(tid, &res)
+		return
+	}
+
+	decodedPixels, err := strconv.ParseInt(r.Header.Get("Pixels"), 10, 64)
+	if err != nil {
+		glog.Error("Could not parse decoded pixels", err)
+		http.Error(w, "Invalid Pixels", http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Moved check for transcode errors on O before decodingPixels
- Added nil check for `chanData.TranscodeData`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Tested with errored out video segments, one without a keyframe, and another without Video
- Observed that proper error messages now show on the O
- Observed that EOF is not triggered in case of these errors

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #1843 
Fixes #1762

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
