### PR TITLE
server,discovery: fetch as many Os as possible during discovery before a shorter timeout

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,6 +13,8 @@
 
 #### Broadcaster
 
+- \#1874 Fetch as many orchestrators as possible during discovery before a shorter timeout (@kyriediculous)
+
 #### Orchestrator
 
 #### Transcoder

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -177,7 +177,7 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchestratorStake() error {
 	}
 
 	resc, errc := make(chan *common.DBOrch, len(orchs)), make(chan error, len(orchs))
-	ctx, cancel := context.WithTimeout(context.Background(), getOrchestratorsTimeoutLoop)
+	ctx, cancel := context.WithTimeout(context.Background(), getOrchestratorCutoffTime)
 	defer cancel()
 
 	currentRound := dbo.rm.LastInitializedRound()
@@ -253,7 +253,7 @@ func (dbo *DBOrchestratorPoolCache) cacheDBOrchs() error {
 	}
 
 	resc, errc := make(chan *common.DBOrch, len(orchs)), make(chan error, len(orchs))
-	ctx, cancel := context.WithTimeout(context.Background(), getOrchestratorsTimeoutLoop)
+	ctx, cancel := context.WithTimeout(context.Background(), common.HTTPTimeout)
 	defer cancel()
 
 	getOrchInfo := func(dbOrch *common.DBOrch) {

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -19,7 +19,7 @@ import (
 
 const MinWorkingSetSize = 8
 
-var getOrchestratorCutoffTime = 1 * time.Second
+var getOrchestratorCutoffTime = 250 * time.Millisecond
 
 var serverGetOrchInfo = server.GetOrchestratorInfo
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR changes discovery to take into account all possible orchestrators as long as they respond to a discovery request within 1 second. Previously we would stop gathering responses once we received a small subset of responses. 

**Specific updates (required)**
- change `numOrchs` to be equal to the Orchestrator pool size 
- Decreased the timeout to 1 second
- Changed the suspension time to poolSize/numSessions (not sure if this is better but at least this avoids poolSize/numOrchs which would always be 1)
- Changed the cut-off point at which we do a refresh to be at less than 20% of the original selected set.

**How did you test each of these updates (required)**
https://github.com/livepeer/internal-project-tracking/issues/124

**Does this pull request close any open issues?**
Fixes #1853 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
