### PR TITLE
pm: refresh ticket params before expiry from sender side

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,8 @@
 
 #### Broadcaster
 
+- \#1877 Refresh TicketParams for the active session before expiry (@kyriediculous)
+
 #### Orchestrator
 
 #### Transcoder

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -22,6 +22,7 @@ var errInsufficientSenderReserve = errors.New("insufficient sender reserve")
 var maxWinProb = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1))
 
 var paramsExpirationBlock = big.NewInt(10)
+var paramsExpiryBuffer = int64(1)
 
 // Recipient is an interface which describes an object capable
 // of receiving tickets

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -155,7 +155,9 @@ func (s *sender) validateTicketParams(ticketParams *TicketParams, numTickets int
 	}
 
 	latestBlock := s.timeManager.LastSeenBlock()
-	if ticketParams.ExpirationBlock.Cmp(latestBlock) <= 0 {
+
+	currentBuffer := new(big.Int).Sub(ticketParams.ExpirationBlock, latestBlock).Int64()
+	if currentBuffer <= paramsExpiryBuffer {
 		return ErrTicketParamsExpired
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Refresh TicketParams for the active orchestrator session on the broadcaster at 10% before they expire. 

**Specific updates (required)**
- Updated the expiry check in `sender.ValidateTicketParams`


**How did you test each of these updates (required)**
- Added unit tests

**Does this pull request close any open issues?**
Fixes #1852 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
