### PR TITLE
pm: check winning ticket transactions until confirm or error

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -32,6 +32,7 @@
 
 - \#1860 Discard low gas prices to prevent insufficient ticket faceValue errors (@kyriediculous)
 - \#1859 Handle error for invalid inferred orchestrator public IP on node startup (@reubenr0d)
+- \#1880 Don't mark a winning ticket as redeemed if a transaction is submitted but pending (@kyriediculous)
 
 #### Transcoder
 

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -418,11 +418,16 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 	}
 
 	// Wait for transaction to confirm
-	if err := sm.broker.CheckTx(tx); err != nil {
+	var txErr error
+	for txErr = sm.broker.CheckTx(tx); !errors.Is(txErr, context.Canceled) || !errors.Is(txErr, context.DeadlineExceeded); {
+
+	}
+
+	if txErr != nil {
 		if monitor.Enabled {
 			monitor.TicketRedemptionError(ticket.Ticket.Sender.String())
 		}
-		return nil, err
+		return nil, txErr
 	}
 
 	if monitor.Enabled {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Don't return from `senderMonitor.redeemWinningTicket` when context times out, loop instead until a concrete response is returned (other error or non-nil tx)

**How did you test each of these updates (required)**


**Does this pull request close any open issues?**
Fixes #1806 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
