### PR TITLE
.github/workflows: checkout action use head commit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,7 @@ jobs:
       with:
         # Needed for commands that depend on git tags
         fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Set global environment variables
       run: |
         echo "PKG_CONFIG_PATH=/root/compiled/lib/pkgconfig" >> $GITHUB_ENV

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,7 @@ jobs:
       with:
         # Needed for commands that depend on git tags
         fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
@@ -68,6 +69,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -108,6 +111,7 @@ jobs:
         with:
           # Needed for commands that depend on git tags
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Cache binaries
         uses: actions/cache@v2.1.5
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: configure git line endings
       run: git config --global core.autocrlf false
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Setup Msys2 environment

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,6 +12,8 @@ jobs:
       run: git config --global core.autocrlf false
     - uses: actions/checkout@v2
       with:
+        # Needed for commands that depend on git tags
+        fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
     - name: Setup Msys2 environment
       uses: msys2/setup-msys2@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,6 +11,8 @@ jobs:
     - name: configure git line endings
       run: git config --global core.autocrlf false
     - uses: actions/checkout@v1
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Setup Msys2 environment
       uses: msys2/setup-msys2@v2
       with:


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Always checkout the head commit for GH actions.

When a `pull_request` event triggers a GH action, the `@actions/checkout` action will checkout from the repo using the value of `github.ref`. The value of `github.ref` in this scenario is the SHA hash of the merge commit that is created by merging the base to the head. The problem with this is that the merge commit hash will be referenced in the go-livepeer version string, but the merge commit might not be present in the commit history (see #1887) which makes it difficult to debug builds.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

Set `github.ref` to the SHA of the head commit when checking out.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Ran CI.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1887 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] ~[Pending changelog](./CHANGELOG_PENDING.md) updated~
