### PR TITLE
.github/workflows: Run steps with creds on push to master

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
       - master
 jobs:
   build:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-16.04
     steps:
     - name: Checkout

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -104,7 +104,7 @@ jobs:
   upload:
     runs-on: ubuntu-18.04
     needs: [build, test]
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
       shell: msys2 {0}
       run: ./ci_env.sh make livepeer livepeer_cli livepeer_bench livepeer_router
     - name: Upload build
-      if: github.event.pull_request.head.repo.full_name == github.repository
+      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       shell: msys2 {0}
       env: 
         GHA_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Currently, certain steps (i.e. steps that require Docker auth or build uploads) of the GH actions are run [conditionally](https://github.com/livepeer/go-livepeer/blob/d58ed200bedd77b0cc9d64100f2f7ac34bb3b260/.github/workflows/docker.yml#L9) based on whether the PR originates from the main repo or a fork. The problem with this conditional is that it will evaluate to false when a PR is merged to master because `github.event.pull_request.head.repo.full_name` will not be populated since the GH action would be triggered by a push to master as opposed to the opening of a PR.

Examples [here](https://github.com/livepeer/go-livepeer/runs/2614634624) and [here](https://github.com/livepeer/go-livepeer/runs/2614582241).

This PR updates the conditionals to evaluate to true if the GH action is triggered by a push as well.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] ~[Pending changelog](./CHANGELOG_PENDING.md) updated~
