### PR TITLE
monitor+server: Record million pixels processed metric

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,6 +10,7 @@
 
 - \#1877 Refresh TicketParams for the active session before expiry (@kyriediculous)
 - \#1879 Add mp4 download of recorded stream (@darkdarkdragon)
+- \#1899 Record million pixels processed metric (@yondonfu)
 
 #### Orchestrator
 

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -528,6 +528,10 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64)
 		}
 
 		balUpdate.Debit.Mul(new(big.Rat).SetInt64(pixelCount), priceInfo)
+
+		if monitor.Enabled {
+			monitor.MilPixelsProcessed(float64(pixelCount) / 1000000.0)
+		}
 	}
 
 	// transcode succeeded; continue processing response


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Adds a million pixels processed metric. For now, this is only recorded on B by taking the total pixel count for a set of transcoded results, dividing it by 1m and then recording the result. This metric is helpful for monitoring pixel throughput on a B while also monitoring payment/ticket throughput since the latter should be based on the former.

The risk of overflow while using a float64 to record the metric should be minimal. Consider the following example:

- 179729280000 pixels per hour for a stream with 240p30fps, 360p30fps, 480p30fps, 720p30fps outputs (does not factor in decoded pixels from the input)
- 179729280000 / 1000000 = 179729.28 million pixels per hour
- 179729.28 million pixels per hour * 24 hours * 365 days = 1574428492.8 million pixels per year
- 1574428492.8 million pixels per year * 1000000 streams = 1574428492800000.0

So, with 1000000 streams running 24/7 for an entire year the million pixels value should still be below the max float64 value.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add `mil_pixels_processed` metric in the `monitor` package
- Record `mil_pixels_processed` metric on B after counting the pixels in the transcoded results

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Manually.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
