### PR TITLE
WIP: Adding binary signing to github workflows 

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}        
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -117,6 +117,14 @@ jobs:
         with:
           path: ~/build
           key: ${{ runner.os }}-binaries-${{ github.sha }}
+      - name: Install gpgv2 
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y gpgv2
+      - name: Import gpg key
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Upload build
         run: cp ~/build/* . && ./upload_build.sh
         env:
@@ -124,5 +132,7 @@ jobs:
           GCLOUD_KEY: ${{ secrets.GCLOUD_KEY }}
           GCLOUD_SECRET: ${{ secrets.GCLOUD_SECRET }}
           DISCORD_URL: ${{ secrets.DISCORD_URL }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       - name: Notify new build upload
         run: curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,0 +1,40 @@
+name: Mac build
+on: push
+    
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install dependent packages
+      run: brew install coreutils
+
+    - name: Install ffmpeg
+      run: ./install_ffmpeg.sh
+
+    - name: Install go modules
+      run: go mod download
+
+    - name: Set CI environment variables
+      run: ./ci_env.sh make livepeer livepeer_cli livepeer_bench livepeer_router
+
+    - name: Import gpg key
+      uses: crazy-max/ghaction-import-gpg@v3
+      with:
+        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+    - name: Upload build
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        GITHUB_REF: ${{ github.ref }}
+        GCLOUD_KEY: ${{ secrets.GCLOUD_KEY }}
+        GCLOUD_SECRET: ${{ secrets.GCLOUD_SECRET }}
+        DISCORD_URL: ${{ secrets.DISCORD_URL }}
+      run: ./upload_build.sh
+

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,10 +28,20 @@ jobs:
     - name: Build Livepeer
       shell: msys2 {0}
       run: ./ci_env.sh make livepeer livepeer_cli livepeer_bench livepeer_router
+    - name: Import gpg key 
+      shell: msys2 {0}
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      run: |
+        echo "$GPG_PRIVATE_KEY" > ~/privatekey.asc
+        gpg --pinentry-mode loopback --passphrase $GPG_PASSPHRASE --import ~/privatekey.asc
     - name: Upload build
       if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       shell: msys2 {0}
-      env: 
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         GHA_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
         GCLOUD_KEY: ${{ secrets.GCLOUD_KEY }}
         GCLOUD_SECRET: ${{ secrets.GCLOUD_SECRET }}

--- a/ci_env.sh
+++ b/ci_env.sh
@@ -16,6 +16,16 @@ if [[ $(uname) == *"MSYS"* ]]; then
   export PKG_CONFIG_PATH="/mingw64/lib/pkgconfig:$HOME/compiled/lib/pkgconfig"
   export GOROOT=/mingw64/lib/go
   export GOPATH=/mingw64
+else
+  export PKG_CONFIG_PATH="$HOME/compiled/lib/pkgconfig"
+fi
+
+echo "PKG_CONFIG_PATH: ${PKG_CONFIG_PATH}"
+if [ -d $PKG_CONFIG_PATH ]; then
+  echo "Contents of ${PKG_CONFIG_PATH}"
+  ls -1 $PKG_CONFIG_PATH
+else
+  echo "PKG_CONFIG_PATH: ${PKG_CONFIG_PATH} does not exist" 
 fi
 
 # If we want to build with branch --> network support for any other networks, add them here!

--- a/print_version.sh
+++ b/print_version.sh
@@ -11,7 +11,7 @@ set -o nounset
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-currentTag="$(git describe --tags)"
+currentTag="$(git describe --always --tags)"
 currentVersion="$(cat "$DIR/VERSION")"
 currentSha="$(git describe --always --long --dirty --abbrev=8)"
 if [[ "$currentTag" == "v$currentVersion" ]]; then


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR is in reference to fixing the issues mentioned in the [security advisory](https://github.com/livepeer/go-livepeer/security/advisories/GHSA-mx24-x6f2-5ppp) 

**Specific updates (required)**
- Moved Darwin build from travisci to github actions
- GPG signed binary and push signature to gcloud bucket
- Add signature verification of packages that are installed by install_ffmpeg.sh
- Push to new gcloud ci bucket

**How did you test each of these updates (required)**
I've tested the actions by running the github workflows to verify the signed binary is being uploaded 

The files of interest that I have changed are:
- .github/workflows/linux.yml
- .github/workflows/mac.yml
- .github/workflows/windows.yml
- install_ffmpeg.sh
- upload_build.sh


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
