### PR TITLE
Generate valid MP4 files

### DIFF
--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -126,7 +126,7 @@ if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
     --enable-gnutls --enable-libx264 --enable-gpl \
     --enable-protocol=https,http,rtmp,file,pipe \
     --enable-muxer=mpegts,hls,segment,mp4,null --enable-demuxer=flv,mpegts,mp4,mov \
-    --enable-bsf=h264_mp4toannexb,aac_adtstoasc,h264_metadata,h264_redundant_pps \
+    --enable-bsf=h264_mp4toannexb,aac_adtstoasc,h264_metadata,h264_redundant_pps,extract_extradata \
     --enable-parser=aac,aac_latm,h264 \
     --enable-filter=abuffer,buffer,abuffersink,buffersink,afifo,fifo,aformat \
     --enable-filter=aresample,asetnsamples,fps,scale \

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -1066,6 +1066,8 @@ func (s *LivepeerServer) streamMP4(w http.ResponseWriter, r *http.Request, jpl *
 		tc.StopTranscoder()
 		ow.Close()
 		<-done
+		glog.Infof("Completed mp4 request=%s manifestID=%s sourceBytes=%d destBytes=%d", r.URL.String(),
+			manifestID, sourceBytesSent, resultBytesSent)
 	}()
 	oname := fmt.Sprintf("pipe:%d", ow.Fd())
 	out := []ffmpeg.TranscodeOptions{
@@ -1126,8 +1128,6 @@ func (s *LivepeerServer) streamMP4(w http.ResponseWriter, r *http.Request, jpl *
 			return
 		}
 	}
-	glog.Infof("Completed mp4 request=%s manifestID=%s sourceBytes=%d destBytes=%d", r.URL.String(),
-		manifestID, sourceBytesSent, resultBytesSent)
 }
 
 // HandleRecordings handle requests to /recordings/ endpoint


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes MP4 generation to generate MP4 playable in QuickTime/default Windows player.


**Specific updates (required)**
Enables `extract_extradata` filter in ffmpeg build. MPEG-TS format doesn't store SPS/PPS (information needed to initialize h264 decoder) in container itself - so this information is only passed inside h264 bitsream. But MP4 container also store this information in the separate container field. `extract_extradata` filter used by ffmpeg to extract that data from h264 bitstream when parsing MPEG-TS streams. This is not needed during transcoding, but without that information generated MP4 had empty field that should've contained SPS/PPS - and that what confused QuickTime/Windows player.

**How did you test each of these updates (required)**
Manually


**Does this pull request close any open issues?**
Fixes #1897 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
