### PR TITLE
Add 'Content-Disposition' header to the /recordings  mp4 response. Us…

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -1038,11 +1038,12 @@ func getPlaylistsFromStore(ctx context.Context, sess drivers.OSSession, manifest
 	return filesMap, jsonFiles, latestPlaylistTime, nil
 }
 
-func (s *LivepeerServer) streamMP4(w http.ResponseWriter, r *http.Request, jpl *core.JsonPlaylist, manifestID, track string) {
+func (s *LivepeerServer) streamMP4(w http.ResponseWriter, r *http.Request, jpl *core.JsonPlaylist, manifestID, track, fileName string) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	contentType, _ := common.TypeByExtension(".mp4")
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%s;`, fileName))
 	var sourceBytesSent, resultBytesSent int64
 
 	or, ow, err := os.Pipe()
@@ -1308,7 +1309,7 @@ func (s *LivepeerServer) HandleRecordings(w http.ResponseWriter, r *http.Request
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		s.streamMP4(w, r, mainJspl, manifestID, track)
+		s.streamMP4(w, r, mainJspl, manifestID, track, pp[len(pp)-1])
 		return
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
`Content-Disposition` header forces browsers to download file instead of trying to play it.
Usage of last part of request URL as filename allows to form URLs like this:
`livepeer.com/recordings/sessionId/source/someFileName.mp4`
That way we can form URL (on frontend) that will contain user defined stream name and session creation timestamp without need to pass this information to go-livepeer node by other means.


**Specific updates (required)**
Add 'Content-Disposition' header to the /recordings  mp4 response. Use last part
of the request URL as file name in 'Content-Disposition' response.


**How did you test each of these updates (required)**
Manually


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
