### PR TITLE
pm: low ticket facevalue safeguard

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,7 @@
 - \#1879 Add mp4 download of recorded stream (@darkdarkdragon)
 - \#1899 Record million pixels processed metric (@yondonfu)
 - \#1888 Should not save (when recording) segments with zero video frames (@darkdarkdragon)
+- \#1908 Prevent Broadcaster from sending low face value PM tickets (@kyriediculous)
 
 #### Orchestrator
 

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1251,7 +1251,7 @@ func TestSufficientBalance_IsSufficient_ReturnsTrue(t *testing.T) {
 
 	err := orch.ProcessPayment(payment, manifestID)
 	assert.Nil(err)
-	recipient.On("EV").Return(big.NewRat(100, 1))
+	recipient.On("EV").Return(big.NewRat(100, 100))
 	assert.True(orch.SufficientBalance(ethcommon.BytesToAddress(payment.Sender), manifestID))
 }
 

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -24,6 +24,8 @@ var maxWinProb = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewI
 var paramsExpirationBlock = big.NewInt(10)
 var paramsExpiryBuffer = int64(1)
 
+var evMultiplier = big.NewInt(100)
+
 // Recipient is an interface which describes an object capable
 // of receiving tickets
 type Recipient interface {
@@ -229,14 +231,8 @@ func (r *recipient) faceValue(sender ethcommon.Address) (*big.Int, error) {
 	// faceValue = txCost * txCostMultiplier
 	faceValue := new(big.Int).Mul(r.txCost(), big.NewInt(int64(r.cfg.TxCostMultiplier)))
 
-	// TODO: Consider setting faceValue to some value higher than
-	// EV in this case where the default faceValue < the desired EV.
-	// At the moment, for simplicity we just adjust faceValue to the
-	// desired EV in this case (which would result in winProb = 100%).
-	// In practice, EV should be smaller than the default faceValue
-	// so this shouldn't be a problem in most cases
 	if faceValue.Cmp(r.cfg.EV) < 0 {
-		faceValue = r.cfg.EV
+		faceValue = new(big.Int).Mul(r.cfg.EV, evMultiplier)
 	}
 
 	// Fetch current max float for sender

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -166,6 +166,10 @@ func (s *sender) validateTicketParams(ticketParams *TicketParams, numTickets int
 		return nil
 	}
 
+	if ev.Cmp(new(big.Rat).SetInt(ticketParams.FaceValue)) >= 0 {
+		return fmt.Errorf("ticket faceValue too low faceValue=%v", ticketParams.FaceValue)
+	}
+
 	info, err := s.senderManager.GetSenderInfo(s.signer.Account().Address)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds a safeguard to protect against low ticket faceValues whereby the ticket faceValue has to be greater than EV x N 


**How did you test each of these updates (required)**
- Added unit test

**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/internal-project-tracking/issues/142

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
