### PR TITLE
cmd,eth: use gas price monitor for all transactions instead of 'eth_gasPrice' from the ethereum JSON-RPC provider

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,7 @@
 #### General
 
 - \#1911 [Experimental] Enable scene classification for Adult/Soccer (@jailuthra, @yondonfu)
+- \#1915 Use gas price monitor for gas price suggestions for all Ethereum transactions (@kyriediculous)
 
 #### Broadcaster
 

--- a/eth/client.go
+++ b/eth/client.go
@@ -148,7 +148,7 @@ type client struct {
 	txTimeout time.Duration
 }
 
-func NewClient(accountAddr ethcommon.Address, keystoreDir, password string, eth *ethclient.Client, controllerAddr ethcommon.Address, txTimeout time.Duration, maxGasPrice *big.Int) (LivepeerEthClient, error) {
+func NewClient(accountAddr ethcommon.Address, keystoreDir, password string, eth *ethclient.Client, gpm *GasPriceMonitor, controllerAddr ethcommon.Address, txTimeout time.Duration, maxGasPrice *big.Int) (LivepeerEthClient, error) {
 	chainID, err := eth.ChainID(context.Background())
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func NewClient(accountAddr ethcommon.Address, keystoreDir, password string, eth 
 
 	signer := types.NewEIP155Signer(chainID)
 
-	backend, err := NewBackend(eth, signer)
+	backend, err := NewBackend(eth, signer, gpm)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/gaspricemonitor_test.go
+++ b/eth/gaspricemonitor_test.go
@@ -41,6 +41,10 @@ func (s *stubGasPriceOracle) Queries() int {
 	return s.queries
 }
 
+func (s *stubGasPriceOracle) GasPrice() *big.Int {
+	return s.gasPrice
+}
+
 func (s *stubGasPriceOracle) SuggestGasPrice(ctx context.Context) (*big.Int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Improve transaction management with better UX 

- [x] use gas price monitor for all transactions instead of 'eth_gasPrice' from the ethereum JSON-RPC provider

**Specific updates (required)**
- Use `GasPriceMonitor.GasPrice()` instead of `ethClient.SuggestGasPrice()` in `Backend.SuggestGasPrice()`. Since `Backend` overwrites the `eth.Transactor` interface all transactions, also contract calls through the contract bindings, will use the gas price stored by the `GasPriceMonitor`. 
- Use the `GasPriceMonitor` regardless of the node being in O or B mode


**How did you test each of these updates (required)**
- Unit tests

**Does this pull request close any open issues?**
Fixes #1906 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
