### PR TITLE
eth,misc: Use transaction manager with confirmation and optional replacement queue

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,6 +10,7 @@
 - \#1915 Use gas price monitor for gas price suggestions for all Ethereum transactions (@kyriediculous)
 - \#1930 Support custom minimum gas price (@yondonfu)
 - \#1942 Log min and max gas price when monitoring is enabled (@kyriediculous)
+- \#1923 Use a transaction manager with better transaction handling and optional replacement transactions instead of the default JSON-RPC client (@kyriediculous)
 
 #### Broadcaster
 

--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -161,6 +161,7 @@ func ethSetup(ethAcctAddr, keystoreDir string, isBroadcaster bool) {
 	glog.Infof("Using controller address %s", ethController)
 
 	gpm := eth.NewGasPriceMonitor(backend, 5*time.Second, big.NewInt(0))
+
 	// Start gas price monitor
 	_, err = gpm.Start(context.Background())
 	if err != nil {
@@ -169,8 +170,17 @@ func ethSetup(ethAcctAddr, keystoreDir string, isBroadcaster bool) {
 	}
 	defer gpm.Stop()
 
-	client, err := eth.NewClient(ethcommon.HexToAddress(ethAcctAddr), keystoreDir, passphrase, backend, gpm,
-		ethcommon.HexToAddress(ethController), ethTxTimeout, nil)
+	clientCfg := eth.LivepeerEthClientConfig{
+		AccountAddr:         ethcommon.HexToAddress(ethAcctAddr),
+		KeystoreDir:         keystoreDir,
+		Password:            passphrase,
+		ControllerAddr:      ethcommon.HexToAddress(ethController),
+		TxTimeout:           ethTxTimeout,
+		MaxGasPrice:         nil,
+		ReplaceTransactions: false,
+	}
+
+	client, err := eth.NewClient(backend, gpm, clientCfg)
 	if err != nil {
 		glog.Errorf("Failed to create client: %v", err)
 		return

--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/console"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/livepeer/go-livepeer/eth"
@@ -160,7 +161,7 @@ func ethSetup(ethAcctAddr, keystoreDir string, isBroadcaster bool) {
 	}
 	glog.Infof("Using controller address %s", ethController)
 
-	gpm := eth.NewGasPriceMonitor(backend, 5*time.Second, big.NewInt(0))
+	gpm := eth.NewGasPriceMonitor(backend, 5*time.Second, big.NewInt(0), nil)
 
 	// Start gas price monitor
 	_, err = gpm.Start(context.Background())
@@ -170,19 +171,40 @@ func ethSetup(ethAcctAddr, keystoreDir string, isBroadcaster bool) {
 	}
 	defer gpm.Stop()
 
-	clientCfg := eth.LivepeerEthClientConfig{
-		AccountAddr:         ethcommon.HexToAddress(ethAcctAddr),
-		KeystoreDir:         keystoreDir,
-		Password:            passphrase,
-		ControllerAddr:      ethcommon.HexToAddress(ethController),
-		TxTimeout:           ethTxTimeout,
-		MaxGasPrice:         nil,
-		ReplaceTransactions: false,
+	chainID, err := backend.ChainID(context.Background())
+	if err != nil {
+		glog.Errorf("Failed to get chain ID from remote ethereum node: %v", err)
+		return
 	}
 
-	client, err := eth.NewClient(backend, gpm, clientCfg)
+	signer := types.NewEIP155Signer(chainID)
+
+	am, err := eth.NewAccountManager(ethcommon.HexToAddress(ethAcctAddr), keystoreDir, signer)
 	if err != nil {
-		glog.Errorf("Failed to create client: %v", err)
+		glog.Errorf("Error creating Ethereum account manager: %v", err)
+		return
+	}
+
+	if err := am.Unlock(passphrase); err != nil {
+		glog.Errorf("Error unlocking Ethereum account: %v", err)
+		return
+	}
+
+	tm := eth.NewTransactionManager(backend, gpm, am, 5*time.Minute, 0)
+	go tm.Start()
+	defer tm.Stop()
+
+	ethCfg := eth.LivepeerEthClientConfig{
+		AccountManager:     am,
+		ControllerAddr:     ethcommon.HexToAddress(ethController),
+		EthClient:          backend,
+		GasPriceMonitor:    gpm,
+		TransactionManager: tm,
+	}
+
+	client, err := eth.NewClient(ethCfg)
+	if err != nil {
+		glog.Errorf("Failed to create Livepeer Ethereum client: %v", err)
 		return
 	}
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -393,7 +393,17 @@ func main() {
 		}
 		defer gpm.Stop()
 
-		client, err := eth.NewClient(ethcommon.HexToAddress(*ethAcctAddr), keystoreDir, *ethPassword, backend, gpm, ethcommon.HexToAddress(*ethController), EthTxTimeout, bigMaxGasPrice)
+		ethCfg := eth.LivepeerEthClientConfig{
+			AccountAddr:         ethcommon.HexToAddress(*ethAcctAddr),
+			KeystoreDir:         keystoreDir,
+			Password:            *ethPassword,
+			ControllerAddr:      ethcommon.HexToAddress(*ethController),
+			TxTimeout:           EthTxTimeout,
+			MaxGasPrice:         bigMaxGasPrice,
+			ReplaceTransactions: *replaceTx,
+		}
+
+		client, err := eth.NewClient(backend, gpm, ethCfg)
 		if err != nil {
 			glog.Errorf("Failed to create Livepeer Ethereum client: %v", err)
 			return

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/livepeer/go-livepeer/build"
@@ -45,8 +46,7 @@ import (
 )
 
 var (
-	ErrKeygen    = errors.New("ErrKeygen")
-	EthTxTimeout = 600 * time.Second
+	ErrKeygen = errors.New("ErrKeygen")
 
 	// The timeout for ETH RPC calls
 	ethRPCTimeout = 20 * time.Second
@@ -113,6 +113,8 @@ func main() {
 	ethKeystorePath := flag.String("ethKeystorePath", "", "Path for the Eth Key")
 	ethOrchAddr := flag.String("ethOrchAddr", "", "ETH address of an on-chain registered orchestrator")
 	ethUrl := flag.String("ethUrl", "", "Ethereum node JSON-RPC URL")
+	txTimeout := flag.Duration("transactionTimeout", 5*time.Minute, "Amount of time to wait for an Ethereum transaction to confirm before timing out")
+	maxTxReplacements := flag.Int("maxTransactionReplacements", 1, "Number of times to automatically replace pending Ethereum transactions")
 	gasLimit := flag.Int("gasLimit", 0, "Gas limit for ETH transactions")
 	minGasPrice := flag.Int64("minGasPrice", 0, "Minimum gas price for ETH transactions")
 	maxGasPrice := flag.Int("maxGasPrice", 0, "Maximum gas price for ETH transactions")
@@ -384,7 +386,7 @@ func main() {
 			bigMaxGasPrice = big.NewInt(int64(*maxGasPrice))
 		}
 
-		gpm := eth.NewGasPriceMonitor(backend, blockPollingTime, big.NewInt(*minGasPrice))
+		gpm := eth.NewGasPriceMonitor(backend, blockPollingTime, big.NewInt(*minGasPrice), bigMaxGasPrice)
 		// Start gas price monitor
 		_, err = gpm.Start(ctx)
 		if err != nil {
@@ -393,17 +395,32 @@ func main() {
 		}
 		defer gpm.Stop()
 
-		ethCfg := eth.LivepeerEthClientConfig{
-			AccountAddr:         ethcommon.HexToAddress(*ethAcctAddr),
-			KeystoreDir:         keystoreDir,
-			Password:            *ethPassword,
-			ControllerAddr:      ethcommon.HexToAddress(*ethController),
-			TxTimeout:           EthTxTimeout,
-			MaxGasPrice:         bigMaxGasPrice,
-			ReplaceTransactions: *replaceTx,
+		signer := types.NewEIP155Signer(chainID)
+
+		am, err := eth.NewAccountManager(ethcommon.HexToAddress(*ethAcctAddr), keystoreDir, signer)
+		if err != nil {
+			glog.Errorf("Error creating Ethereum account manager: %v", err)
+			return
 		}
 
-		client, err := eth.NewClient(backend, gpm, ethCfg)
+		if err := am.Unlock(*ethPassword); err != nil {
+			glog.Errorf("Error unlocking Ethereum account: %v", err)
+			return
+		}
+
+		tm := eth.NewTransactionManager(backend, gpm, am, *txTimeout, *maxTxReplacements)
+		go tm.Start()
+		defer tm.Stop()
+
+		ethCfg := eth.LivepeerEthClientConfig{
+			AccountManager:     am,
+			ControllerAddr:     ethcommon.HexToAddress(*ethController),
+			EthClient:          backend,
+			GasPriceMonitor:    gpm,
+			TransactionManager: tm,
+		}
+
+		client, err := eth.NewClient(ethCfg)
 		if err != nil {
 			glog.Errorf("Failed to create Livepeer Ethereum client: %v", err)
 			return

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -3,7 +3,6 @@ package eth
 import (
 	"context"
 	"crypto/ecdsa"
-	"fmt"
 	"log"
 	"math/big"
 	"testing"
@@ -13,13 +12,11 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewTxLog(t *testing.T) {
-	require := require.New(t)
 	assert := assert.New(t)
 
 	// https://etherscan.io/tx/0x6afffe4d95789e7a27bf0ec8adb8324b2e481a5a6df468366e6efffad15746a6
@@ -33,24 +30,18 @@ func TestNewTxLog(t *testing.T) {
 		common.Hex2Bytes("ec8b3cb6000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001a02ec8398aed129f376c296c8b999d2f9ee61494110f9a752494d2ef1b89a4c9d30000000000000000000000009c10672cee058fd658103d90872fe431bb6c0afa0000000000000000000000003ee860a4aba830af84ebbce2b381fc11db8493e20000000000000000000000000000000000000000000000000057c3cdc9be11ec0a5ce4361d251fc5d71ba8fa55eef46b5a59a967145c79aa4cdbe1f943ad00000000000000000000000000000000000000000000000000000000000000000001d00ef48a6825d9ae93097ad55bc76057fb50afc203aa98fd4e01aa6576d7129800000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000689a9f81d59be53a90a12cb12f627aa9e87c505320bad20a98fd98d5ed23bfe9a5400000000000000000000000000000000000000000000000000000000000000415ff5265992f1a6563851d085f363b16ad65416baaee090ee368b59082437df7a0237214659511fc188d6a4ef57c988bb18faa3e99826c78e9e75eb29366745891b00000000000000000000000000000000000000000000000000000000000000"),
 	)
 
-	abis, err := makeABIMap()
-	require.Nil(err)
-	b := &backend{
-		abiMap: abis,
-	}
-
-	txLog, err := b.newTxLog(tx)
+	txLog, err := newTxLog(tx)
 	assert.Equal("redeemWinningTicket", txLog.method)
 	assert.Equal(inputs, txLog.inputs)
 
 	// test unknown ABI
 	tx = types.NewTransaction(2, common.HexToAddress("foo"), big.NewInt(0), 200000, big.NewInt(1000000), common.Hex2Bytes("aaaabbbb"))
-	txLog, err = b.newTxLog(tx)
+	txLog, err = newTxLog(tx)
 	assert.EqualError(err, "unknown ABI")
 
 	// test no method signature
 	tx = types.NewTransaction(2, common.HexToAddress("foo"), big.NewInt(0), 200000, big.NewInt(1000000), nil)
-	txLog, err = b.newTxLog(tx)
+	txLog, err = newTxLog(tx)
 	assert.EqualError(err, "no method signature")
 }
 
@@ -85,11 +76,12 @@ func TestSendTransaction_SendErr_DontUpdateNonce(t *testing.T) {
 
 	gpm := NewGasPriceMonitor(&stubGasPriceOracle{
 		gasPrice: big.NewInt(1),
-	}, 1*time.Second, big.NewInt(0))
+	}, 1*time.Second, big.NewInt(0), nil)
 	gpm.gasPrice = big.NewInt(1)
 
-	bi, err := NewBackend(client, signer, gpm)
-	require.Nil(t, err)
+	tm := NewTransactionManager(client, gpm, &accountManager{}, 3*time.Second, 0)
+
+	bi := NewBackend(client, signer, gpm, tm)
 
 	nonceLockBefore := bi.(*backend).nonceManager.getNonceLock(fromAddress)
 
@@ -100,43 +92,4 @@ func TestSendTransaction_SendErr_DontUpdateNonce(t *testing.T) {
 	nonceLockAfter := bi.(*backend).nonceManager.getNonceLock(fromAddress)
 
 	assert.Equal(t, nonceLockBefore.nonce, nonceLockAfter.nonce)
-}
-
-func TestBackend_SetMaxGasPrice(t *testing.T) {
-	gp := big.NewInt(10)
-	backend := &backend{}
-	backend.SetMaxGasPrice(gp)
-	assert.Equal(t, gp, backend.MaxGasPrice())
-}
-
-func TestBackend_SuggestGasPrice(t *testing.T) {
-	assert := assert.New(t)
-	gp := big.NewInt(10)
-	gpo := &stubGasPriceOracle{gasPrice: gp}
-
-	gpm := NewGasPriceMonitor(gpo, 1*time.Hour, big.NewInt(0))
-	_, err := gpm.Start(context.Background())
-	assert.Nil(err)
-	defer gpm.Stop()
-
-	b := &backend{
-		gpm: gpm,
-	}
-
-	actualGp, err := b.SuggestGasPrice(context.Background())
-	assert.Nil(err)
-	assert.Equal(gp, actualGp)
-
-	b.maxGasPrice = big.NewInt(9)
-
-	actualGp, err = b.SuggestGasPrice(context.Background())
-	assert.EqualError(
-		err,
-		fmt.Sprintf(
-			"current gas price exceeds maximum gas price max=%v GWei current=%v GWei",
-			FromWei(b.maxGasPrice, params.GWei),
-			FromWei(gp, params.GWei),
-		),
-	)
-	assert.Nil(actualGp)
 }

--- a/eth/client.go
+++ b/eth/client.go
@@ -13,7 +13,6 @@ package eth
 //go:generate abigen --abi protocol/abi/LivepeerTokenFaucet.abi --pkg contracts --type LivepeerTokenFaucet --out contracts/livepeerTokenFaucet.go
 //go:generate abigen --abi protocol/abi/Poll.abi --pkg contracts --type Poll --out contracts/poll.go
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"sort"
@@ -118,6 +117,7 @@ type LivepeerEthClient interface {
 type client struct {
 	accountManager AccountManager
 	backend        Backend
+	tm             *TransactionManager
 
 	controllerAddr      ethcommon.Address
 	tokenAddr           ethcommon.Address
@@ -146,41 +146,23 @@ type client struct {
 }
 
 type LivepeerEthClientConfig struct {
-	AccountAddr         ethcommon.Address
-	KeystoreDir         string
-	Password            string
-	ControllerAddr      ethcommon.Address
-	TxTimeout           time.Duration
-	MaxGasPrice         *big.Int
-	ReplaceTransactions bool
+	AccountManager     AccountManager
+	GasPriceMonitor    *GasPriceMonitor
+	EthClient          *ethclient.Client
+	TransactionManager *TransactionManager
+	Signer             types.Signer
+	ControllerAddr     ethcommon.Address
 }
 
-func NewClient(eth *ethclient.Client, gpm *GasPriceMonitor, cfg LivepeerEthClientConfig) (LivepeerEthClient, error) {
-	chainID, err := eth.ChainID(context.Background())
-	if err != nil {
-		return nil, err
-	}
+func NewClient(cfg LivepeerEthClientConfig) (LivepeerEthClient, error) {
 
-	signer := types.NewEIP155Signer(chainID)
-
-	am, err := NewAccountManager(cfg.AccountAddr, cfg.KeystoreDir, signer)
-	if err != nil {
-		return nil, err
-	}
-
-	tm := NewTransactionManager(eth, gpm, am, cfg.TxTimeout, true)
-
-	backend := NewBackend(eth, signer, gpm, tm)
-
-	if err := am.Unlock(cfg.Password); err != nil {
-		return nil, err
-	}
+	backend := NewBackend(cfg.EthClient, cfg.Signer, cfg.GasPriceMonitor, cfg.TransactionManager)
 
 	return &client{
-		accountManager: am,
+		accountManager: cfg.AccountManager,
 		backend:        backend,
+		tm:             cfg.TransactionManager,
 		controllerAddr: cfg.ControllerAddr,
-		txTimeout:      cfg.TxTimeout,
 	}, nil
 }
 
@@ -884,84 +866,28 @@ func (c *client) ContractAddresses() map[string]ethcommon.Address {
 }
 
 func (c *client) CheckTx(tx *types.Transaction) error {
-	ctx, cancel := context.WithTimeout(context.Background(), c.txTimeout)
-	defer cancel()
+	receipts := make(chan *transactionReceipt, 10)
+	txSub := c.tm.Subscribe(receipts)
+	defer txSub.Unsubscribe()
 
-	receipt, err := bind.WaitMined(ctx, c.backend, tx)
-	if err != nil {
-		return err
-	}
-
-	if receipt.Status == uint64(0) {
-		return fmt.Errorf("tx %v failed", tx.Hash().Hex())
-	} else {
-		return nil
+	for {
+		select {
+		case err := <-txSub.Err():
+			return err
+		case receipt := <-receipts:
+			if tx.Hash() == receipt.TxHash {
+				if receipt.err != nil {
+					return receipt.err
+				}
+				if receipt.Status == uint64(0) {
+					return fmt.Errorf("transaction failed txHash=%v", receipt.TxHash.Hex())
+				}
+				return nil
+			}
+		}
 	}
 }
 
 func (c *client) Sign(msg []byte) ([]byte, error) {
 	return c.accountManager.Sign(msg)
-}
-
-func (c *client) ReplaceTransaction(tx *types.Transaction, method string, gasPrice *big.Int) (*types.Transaction, error) {
-	_, pending, err := c.backend.TransactionByHash(context.Background(), tx.Hash())
-	// Only return here if the error is not related to the tx not being found
-	// Presumably the provided tx was already broadcasted at some point, so even if for some reason the
-	// node being used cannot find it, the originally broadcasted tx is still valid and might be sitting somewhere
-	if err != nil && err != ethereum.NotFound {
-		return nil, err
-	}
-	// If tx was found
-	// If `pending` is true, the tx was mined and included in a block
-	if err == nil && !pending {
-		return nil, ErrReplacingMinedTx
-	}
-
-	// Updated gas price must be at least 10% greater than the gas price used for the original transaction in order
-	// to submit a replacement transaction with the same nonce. 10% is not defined by the protocol, but is the default required price bump
-	// used by many clients: https://github.com/ethereum/go-ethereum/blob/01a7e267dc6d7bbef94882542bbd01bd712f5548/core/tx_pool.go#L148
-	// We add a little extra in addition to the 10% price bump just to be sure
-	minGasPrice := big.NewInt(0).Add(big.NewInt(0).Add(tx.GasPrice(), big.NewInt(0).Div(tx.GasPrice(), big.NewInt(10))), big.NewInt(10))
-
-	// If gas price is not provided, use minimum gas price that satisfies the 10% required price bump
-	if gasPrice == nil {
-		gasPrice = minGasPrice
-
-		suggestedGasPrice, err := c.backend.SuggestGasPrice(context.Background())
-		if err != nil {
-			return nil, err
-		}
-
-		// If the suggested gas price is higher than the bumped gas price, use the suggested gas price
-		// This is to account for any wild market gas price increases between the time of the original tx submission and time
-		// of replacement tx submission
-		// Note: If the suggested gas price is lower than the bumped gas price because market gas prices have dropped
-		// since the time of the original tx submission we cannot use the lower suggested gas price and we still need to use
-		// the bumped gas price in order to properly replace a still pending tx
-		if suggestedGasPrice.Cmp(gasPrice) == 1 {
-			gasPrice = suggestedGasPrice
-		}
-	}
-
-	// Check that gas price meets minimum price bump requirement
-	if gasPrice.Cmp(minGasPrice) == -1 {
-		return nil, fmt.Errorf("Provided gas price does not satisfy required price bump to replace transaction %v", tx.Hash())
-	}
-
-	// Replacement raw tx uses same fields as old tx (reusing the same nonce is crucial) except the gas price is updated
-	newRawTx := types.NewTransaction(tx.Nonce(), *tx.To(), tx.Value(), tx.Gas(), gasPrice, tx.Data())
-
-	newSignedTx, err := c.accountManager.SignTx(newRawTx)
-	if err != nil {
-		return nil, err
-	}
-
-	err = c.backend.SendTransaction(context.Background(), newSignedTx)
-	if err == nil {
-		glog.Infof("\n%vEth Transaction%v\n\nReplacement transaction: \"%v\".  Hash: \"%v\".  Gas Price: %v \n\n%v\n", strings.Repeat("*", 30), strings.Repeat("*", 30), method, newSignedTx.Hash().String(), newSignedTx.GasPrice().String(), strings.Repeat("*", 75))
-	} else {
-		glog.Infof("\n%vEth Transaction%v\n\nReplacement transaction: \"%v\".  Gas Price: %v \nTransaction Failed: %v\n\n%v\n", strings.Repeat("*", 30), strings.Repeat("*", 30), method, newSignedTx.GasPrice().String(), err, strings.Repeat("*", 75))
-	}
-
-	return newSignedTx, err
 }

--- a/eth/gaspricemonitor_test.go
+++ b/eth/gaspricemonitor_test.go
@@ -62,7 +62,7 @@ func TestStart(t *testing.T) {
 	gasPrice := big.NewInt(777)
 	gpo := newStubGasPriceOracle(gasPrice)
 
-	gpm := NewGasPriceMonitor(gpo, 1*time.Hour, big.NewInt(0))
+	gpm := NewGasPriceMonitor(gpo, 1*time.Hour, big.NewInt(0), nil)
 
 	assert := assert.New(t)
 
@@ -95,7 +95,7 @@ func TestStart(t *testing.T) {
 	// Test initial gas price less than minGasPrice
 
 	minGasPrice := new(big.Int).Add(gasPrice, big.NewInt(1))
-	gpm = NewGasPriceMonitor(gpo, 1*time.Hour, minGasPrice)
+	gpm = NewGasPriceMonitor(gpo, 1*time.Hour, minGasPrice, nil)
 
 	update, err = gpm.Start(context.Background())
 	assert.NotNil(update)
@@ -114,7 +114,7 @@ func TestStart_Polling(t *testing.T) {
 	gpo := newStubGasPriceOracle(gasPrice1)
 
 	pollingInterval := 1 * time.Millisecond
-	gpm := NewGasPriceMonitor(gpo, pollingInterval, big.NewInt(10))
+	gpm := NewGasPriceMonitor(gpo, pollingInterval, big.NewInt(10), nil)
 
 	assert := assert.New(t)
 
@@ -165,7 +165,7 @@ func TestStart_Polling_ContextCancel(t *testing.T) {
 	gpo := newStubGasPriceOracle(gasPrice1)
 
 	pollingInterval := 1 * time.Second
-	gpm := NewGasPriceMonitor(gpo, pollingInterval, big.NewInt(0))
+	gpm := NewGasPriceMonitor(gpo, pollingInterval, big.NewInt(0), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	update, err := gpm.Start(ctx)
@@ -188,7 +188,7 @@ func TestStop(t *testing.T) {
 	gpo := newStubGasPriceOracle(gasPrice)
 	gpo.SetGasPrice(gasPrice)
 
-	gpm := NewGasPriceMonitor(gpo, 1*time.Hour, big.NewInt(0))
+	gpm := NewGasPriceMonitor(gpo, 1*time.Hour, big.NewInt(0), nil)
 
 	assert := assert.New(t)
 
@@ -225,9 +225,16 @@ func TestMinGasPrice(t *testing.T) {
 
 	assert := assert.New(t)
 
-	gpm := NewGasPriceMonitor(gpo, 1*time.Hour, big.NewInt(0))
+	gpm := NewGasPriceMonitor(gpo, 1*time.Hour, big.NewInt(0), nil)
 	assert.Equal(big.NewInt(0), gpm.MinGasPrice())
 
 	gpm.SetMinGasPrice(big.NewInt(1))
 	assert.Equal(big.NewInt(1), gpm.MinGasPrice())
+}
+
+func TestSetMaxGasPrice(t *testing.T) {
+	gp := big.NewInt(10)
+	gpm := &GasPriceMonitor{}
+	gpm.SetMaxGasPrice(gp)
+	assert.Equal(t, gp, gpm.MaxGasPrice())
 }

--- a/eth/rewardservice.go
+++ b/eth/rewardservice.go
@@ -91,30 +91,11 @@ func (s *RewardService) tryReward() error {
 			return err
 		}
 
-		err = s.client.CheckTx(tx)
-		if err != nil {
-			if err == context.DeadlineExceeded {
-				glog.Infof("Reward tx did not confirm within defined time window - will try to replace pending tx once")
-				// Previous attempt to call reward() still pending
-				// Replace pending tx by bumping gas price
-				tx, err = s.client.ReplaceTransaction(tx, "reward", nil)
-				if err != nil {
-					return err
-				}
-				if err := s.client.CheckTx(tx); err != nil {
-					return err
-				}
-			} else {
-				return err
-			}
-		}
-
-		tp, err := s.client.GetTranscoderEarningsPoolForRound(s.client.Account().Address, currentRound)
-		if err != nil {
+		if err := s.client.CheckTx(tx); err != nil {
 			return err
 		}
 
-		glog.Infof("Called reward for round %v - %v rewards minted", currentRound, FormatUnits(tp.RewardPool, "LPTU"))
+		glog.Infof("Called reward for round %v", currentRound)
 
 		return nil
 	}

--- a/eth/rewardservice_test.go
+++ b/eth/rewardservice_test.go
@@ -101,7 +101,6 @@ func TestRewardService_ReceiveRoundEvent_TryReward(t *testing.T) {
 
 	eth.AssertNumberOfCalls(t, "Reward", 1)
 	eth.AssertNumberOfCalls(t, "CheckTx", 1)
-	eth.AssertNotCalled(t, "ReplaceTransaction")
 
 	errorLogsAfter := glog.Stats.Error.Lines()
 	infoLogsAfter := glog.Stats.Info.Lines()
@@ -109,11 +108,8 @@ func TestRewardService_ReceiveRoundEvent_TryReward(t *testing.T) {
 	assert.Equal(int64(1), infoLogsAfter-infoLogsBefore)
 
 	// Test for transaction time out error
-	// Call replace transaction
 	eth.On("Reward").Return(&types.Transaction{}, nil).Once()
 	eth.On("CheckTx").Return(context.DeadlineExceeded).Once()
-	eth.On("ReplaceTransaction").Return(&types.Transaction{}, nil)
-	eth.On("CheckTx").Return(nil).Once()
 
 	errorLogsBefore = glog.Stats.Error.Lines()
 	infoLogsBefore = glog.Stats.Info.Lines()
@@ -122,31 +118,10 @@ func TestRewardService_ReceiveRoundEvent_TryReward(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	eth.AssertNumberOfCalls(t, "Reward", 2)
-	eth.AssertNumberOfCalls(t, "CheckTx", 3)
-	eth.AssertNumberOfCalls(t, "ReplaceTransaction", 1)
-
-	errorLogsAfter = glog.Stats.Error.Lines()
-	infoLogsAfter = glog.Stats.Info.Lines()
-	assert.Equal(int64(0), errorLogsAfter-errorLogsBefore)
-	assert.Equal(int64(2), infoLogsAfter-infoLogsBefore)
-
-	// Test replacement timeout error
-	eth.On("Reward").Return(&types.Transaction{}, nil).Once()
-	eth.On("CheckTx").Return(context.DeadlineExceeded)
-	eth.On("ReplaceTransaction").Return(&types.Transaction{}, nil)
-
-	errorLogsBefore = glog.Stats.Error.Lines()
-	infoLogsBefore = glog.Stats.Info.Lines()
-
-	tw.roundSink <- types.Log{}
-	time.Sleep(1 * time.Second)
-
-	eth.AssertNumberOfCalls(t, "Reward", 3)
-	eth.AssertNumberOfCalls(t, "CheckTx", 5)
-	eth.AssertNumberOfCalls(t, "ReplaceTransaction", 2)
+	eth.AssertNumberOfCalls(t, "CheckTx", 2)
 
 	errorLogsAfter = glog.Stats.Error.Lines()
 	infoLogsAfter = glog.Stats.Info.Lines()
 	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
-	assert.Equal(int64(1), infoLogsAfter-infoLogsBefore)
+	assert.Equal(int64(0), infoLogsAfter-infoLogsBefore)
 }

--- a/eth/transactionManager.go
+++ b/eth/transactionManager.go
@@ -216,7 +216,6 @@ func (tm *TransactionManager) checkTxLoop() {
 
 		receipt, err = tm.wait(tx)
 
-		fmt.Println("max replacements", tm.maxReplacements)
 		// context.DeadlineExceeded indicates that we hit the txTimeout
 		// If we hit the txTimeout, replace the tx up to maxReplacements times
 		for i := 0; err == context.DeadlineExceeded && i < tm.maxReplacements; i++ {

--- a/eth/transactionManager.go
+++ b/eth/transactionManager.go
@@ -1,0 +1,255 @@
+package eth
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
+)
+
+type transactionSenderReader interface {
+	ethereum.TransactionSender
+	ethereum.TransactionReader
+	// Required for bind.DeployBackend argument in bind.WaitMined
+	CodeAt(context.Context, ethcommon.Address, *big.Int) ([]byte, error)
+}
+
+type transactionSigner interface {
+	SignTx(tx *types.Transaction) (*types.Transaction, error)
+}
+
+type TransactionManager struct {
+	txTimeout       time.Duration
+	maxReplacements int
+
+	queue transactionQueue
+
+	// subscriptions
+	feed  event.Feed
+	scope event.SubscriptionScope
+
+	eth transactionSenderReader
+	gpm *GasPriceMonitor
+	sig transactionSigner
+
+	cond *sync.Cond
+
+	quit chan struct{}
+}
+
+type transactionQueue []*types.Transaction
+
+type transactionReceipt struct {
+	*types.Receipt
+	err error
+}
+
+func (tq *transactionQueue) add(tx *types.Transaction) {
+	*tq = append(*tq, tx)
+}
+
+func (tq *transactionQueue) pop() *types.Transaction {
+	if tq.length() == 0 {
+		return nil
+	}
+	tx := (*tq)[0]
+	*tq = (*tq)[1:]
+	return tx
+}
+
+func (tq transactionQueue) length() int {
+	return len(tq)
+}
+
+func (tq transactionQueue) peek() *types.Transaction {
+	if tq.length() == 0 {
+		return nil
+	}
+	return tq[0]
+}
+
+func NewTransactionManager(eth transactionSenderReader, gpm *GasPriceMonitor, signer transactionSigner, txTimeout time.Duration, maxReplacements int) *TransactionManager {
+	return &TransactionManager{
+		cond:            sync.NewCond(&sync.Mutex{}),
+		txTimeout:       txTimeout,
+		maxReplacements: maxReplacements,
+		eth:             eth,
+		gpm:             gpm,
+		sig:             signer,
+		queue:           transactionQueue{},
+		quit:            make(chan struct{}),
+	}
+}
+
+func (tm *TransactionManager) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	sendErr := tm.eth.SendTransaction(ctx, tx)
+
+	txLog, err := newTxLog(tx)
+	if err != nil {
+		txLog.method = "unknown"
+	}
+
+	if sendErr != nil {
+		glog.Infof("\n%vEth Transaction%v\n\nInvoking transaction: \"%v\". Inputs: \"%v\"   \nTransaction Failed: %v\n\n%v\n", strings.Repeat("*", 30), strings.Repeat("*", 30), txLog.method, txLog.inputs, sendErr, strings.Repeat("*", 75))
+		return sendErr
+	}
+
+	// Add transaction to queue
+	tm.cond.L.Lock()
+	tm.queue.add(tx)
+	tm.cond.L.Unlock()
+	tm.cond.Signal()
+
+	glog.Infof("\n%vEth Transaction%v\n\nInvoking transaction: \"%v\". Inputs: \"%v\"  Hash: \"%v\". \n\n%v\n", strings.Repeat("*", 30), strings.Repeat("*", 30), txLog.method, txLog.inputs, tx.Hash().String(), strings.Repeat("*", 75))
+
+	return nil
+}
+
+func (tm *TransactionManager) Subscribe(sink chan<- *transactionReceipt) event.Subscription {
+	return tm.scope.Track(tm.feed.Subscribe(sink))
+}
+
+func (tm *TransactionManager) Start() {
+	tm.checkTxLoop()
+}
+
+func (tm *TransactionManager) Stop() {
+	tm.scope.Close()
+	close(tm.quit)
+}
+
+func (tm *TransactionManager) wait(tx *types.Transaction) (*types.Receipt, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), tm.txTimeout)
+	defer cancel()
+
+	return bind.WaitMined(ctx, tm.eth, tx)
+}
+
+func (tm *TransactionManager) replace(tx *types.Transaction) (*types.Transaction, error) {
+	_, pending, err := tm.eth.TransactionByHash(context.Background(), tx.Hash())
+	// Only return here if the error is not related to the tx not being found
+	// Presumably the provided tx was already broadcasted at some point, so even if for some reason the
+	// node being used cannot find it, the originally broadcasted tx is still valid and might be sitting somewhere
+	if err != nil && err != ethereum.NotFound {
+		return nil, err
+	}
+	// If tx was found
+	// If `pending` is false, the tx was mined and included in a block
+	if err == nil && !pending {
+		return nil, ErrReplacingMinedTx
+	}
+
+	gasPrice := calcReplacementGasPrice(tx)
+
+	suggestedGasPrice := tm.gpm.GasPrice()
+
+	// If the suggested gas price is higher than the bumped gas price, use the suggested gas price
+	// This is to account for any wild market gas price increases between the time of the original tx submission and time
+	// of replacement tx submission
+	// Note: If the suggested gas price is lower than the bumped gas price because market gas prices have dropped
+	// since the time of the original tx submission we cannot use the lower suggested gas price and we still need to use
+	// the bumped gas price in order to properly replace a still pending tx
+	if suggestedGasPrice.Cmp(gasPrice) == 1 {
+		gasPrice = suggestedGasPrice
+	}
+
+	// Bump gas price exceeds max gas price, return early
+	max := tm.gpm.MaxGasPrice()
+	if gasPrice.Cmp(max) > 0 {
+		return nil, fmt.Errorf("replacement gas price exceeds max gas price suggested=%v max=%v", gasPrice, max)
+	}
+
+	// Replacement raw tx uses same fields as old tx (reusing the same nonce is crucial) except the gas price is updated
+	newRawTx := types.NewTransaction(tx.Nonce(), *tx.To(), tx.Value(), tx.Gas(), gasPrice, tx.Data())
+
+	newSignedTx, err := tm.sig.SignTx(newRawTx)
+	if err != nil {
+		return nil, err
+	}
+
+	sendErr := tm.eth.SendTransaction(context.Background(), newSignedTx)
+	txLog, err := newTxLog(tx)
+	if err != nil {
+		txLog.method = "unknown"
+	}
+	if sendErr == nil {
+		glog.Infof("\n%vEth Transaction%v\n\nReplacement transaction: \"%v\".  Gas Price: %v \nTransaction Failed: %v\n\n%v\n", strings.Repeat("*", 30), strings.Repeat("*", 30), txLog.method, newSignedTx.GasPrice().String(), err, strings.Repeat("*", 75))
+	} else {
+		glog.Infof("\n%vEth Transaction%v\n\nReplacement transaction: \"%v\".  Hash: \"%v\".  Gas Price: %v \n\n%v\n", strings.Repeat("*", 30), strings.Repeat("*", 30), txLog.method, newSignedTx.Hash().String(), newSignedTx.GasPrice().String(), strings.Repeat("*", 75))
+	}
+
+	return newSignedTx, sendErr
+}
+
+func (tm *TransactionManager) checkTxLoop() {
+	for {
+		tm.cond.L.Lock()
+		for tm.queue.length() == 0 {
+			tm.cond.Wait()
+
+			select {
+			case <-tm.quit:
+				tm.cond.L.Unlock()
+				glog.V(common.DEBUG).Info("Stopping transaction manager")
+				return
+			default:
+			}
+		}
+
+		tx := tm.queue.pop()
+		tm.cond.L.Unlock()
+
+		var (
+			receipt *types.Receipt
+			err     error
+		)
+
+		receipt, err = tm.wait(tx)
+
+		fmt.Println("max replacements", tm.maxReplacements)
+		// context.DeadlineExceeded indicates that we hit the txTimeout
+		// If we hit the txTimeout, replace the tx up to maxReplacements times
+		for i := 0; err == context.DeadlineExceeded && i < tm.maxReplacements; i++ {
+			tx, err = tm.replace(tx)
+			// Do not attempt additional replacements if there was an error submitting this
+			// replacement tx
+			if err != nil {
+				break
+			}
+			receipt, err = tm.wait(tx)
+		}
+
+		tm.feed.Send(&transactionReceipt{
+			Receipt: receipt,
+			err:     err,
+		})
+
+	}
+}
+
+// Updated gas price must be at least 10% greater than the gas price used for the original transaction in order
+// to submit a replacement transaction with the same nonce. 10% is not defined by the protocol, but is the default required price bump
+// used by many clients: https://github.com/ethereum/go-ethereum/blob/01a7e267dc6d7bbef94882542bbd01bd712f5548/core/tx_pool.go#L148
+// We add a little extra in addition to the 10% price bump just to be sure
+func calcReplacementGasPrice(tx *types.Transaction) *big.Int {
+	return new(big.Int).Add(
+		new(big.Int).Add(
+			tx.GasPrice(),
+			new(big.Int).Div(
+				tx.GasPrice(),
+				big.NewInt(10),
+			),
+		),
+		big.NewInt(10),
+	)
+}

--- a/eth/transactionManager_test.go
+++ b/eth/transactionManager_test.go
@@ -1,0 +1,355 @@
+package eth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/pm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubTransactionSenderReader struct {
+	err             map[string]error
+	pending         bool
+	tx              *types.Transaction
+	receipt         *types.Receipt
+	callsToTxByHash int //reflects number of calls to replace()
+}
+
+func (stm *stubTransactionSenderReader) SendTransaction(ctx context.Context, tx *types.Transaction) error {
+	return stm.err["SendTransaction"]
+}
+
+func (stm *stubTransactionSenderReader) TransactionByHash(ctx context.Context, txHash common.Hash) (tx *types.Transaction, isPending bool, err error) {
+	stm.callsToTxByHash++
+	return stm.tx, stm.pending, stm.err["TransactionByHash"]
+}
+
+func (stm *stubTransactionSenderReader) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	return stm.receipt, stm.err["TransactionReceipt"]
+}
+
+func (stm *stubTransactionSenderReader) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) ([]byte, error) {
+	return []byte{}, stm.err["CodeAt"]
+}
+
+type stubTransactionSigner struct {
+	err error
+}
+
+func (sig *stubTransactionSigner) SignTx(tx *types.Transaction) (*types.Transaction, error) {
+	if sig.err != nil {
+		return nil, sig.err
+	}
+	return tx, nil
+}
+
+func TestTxQueue(t *testing.T) {
+	assert := assert.New(t)
+	tx := types.NewTransaction(1, pm.RandAddress(), big.NewInt(100), 1, big.NewInt(100), pm.RandBytes(32))
+	q := transactionQueue{}
+	q.add(tx)
+	assert.Len(q, 1)
+	assert.Equal(tx, q.peek())
+	assert.Equal(tx, q.pop())
+	assert.Len(q, 0)
+
+	q = transactionQueue{}
+	assert.Nil(q.pop())
+	assert.Nil(q.peek())
+}
+
+func TestTransactionManager_SendTransaction(t *testing.T) {
+	assert := assert.New(t)
+
+	eth := &stubTransactionSenderReader{
+		err: make(map[string]error),
+	}
+	q := transactionQueue{}
+	tm := &TransactionManager{
+		cond:  sync.NewCond(&sync.Mutex{}),
+		eth:   eth,
+		queue: q,
+	}
+
+	// Test error
+	expErr := errors.New("SendTransaction error")
+	eth.err["SendTransaction"] = expErr
+
+	tx := types.NewTransaction(1, pm.RandAddress(), big.NewInt(100), 100000, big.NewInt(100), pm.RandBytes(68))
+
+	errLogsBefore := glog.Stats.Info.Lines()
+	assert.EqualError(
+		tm.SendTransaction(context.Background(), tx),
+		expErr.Error(),
+	)
+	errLogsAfter := glog.Stats.Info.Lines()
+	assert.Equal(errLogsAfter-errLogsBefore, int64(1))
+
+	// Test no error
+	// Adds tx to queue
+	qLenBefore := q.length()
+	errLogsBefore = glog.Stats.Info.Lines()
+	eth.err = nil
+	assert.NoError(
+		tm.SendTransaction(context.Background(), tx),
+	)
+	qLenAfter := q.length()
+	errLogsAfter = glog.Stats.Info.Lines()
+	assert.Equal(errLogsAfter-errLogsBefore, int64(1))
+	assert.Equal(qLenAfter, qLenBefore, 1)
+	assert.Equal(tm.queue.peek().Hash(), tx.Hash())
+}
+
+func TestTransactionManager_Wait(t *testing.T) {
+	assert := assert.New(t)
+
+	eth := &stubTransactionSenderReader{
+		err: make(map[string]error),
+	}
+	q := transactionQueue{}
+	tm := &TransactionManager{
+		cond:      sync.NewCond(&sync.Mutex{}),
+		eth:       eth,
+		queue:     q,
+		txTimeout: 2 * time.Second,
+	}
+
+	// Test error
+	// This calls bind.WaitMined() on the ethereum client, which will never actually return the actual underlying error and only log it using go-ethereum's custom logger
+	// The expected error should thus be 'context deadline exceeded'
+	// https://github.com/ethereum/go-ethereum/blob/aa637fd38a379db6da98df0d520fb1c5139a18ce/accounts/abi/bind/util.go#L41
+	expErr := errors.New("context deadline exceeded")
+	eth.err["TransactionByHash"] = expErr
+
+	tx := types.NewTransaction(1, pm.RandAddress(), big.NewInt(100), 100000, big.NewInt(100), pm.RandBytes(68))
+
+	receipt, err := tm.wait(tx)
+	assert.Nil(receipt)
+	assert.EqualError(err, expErr.Error())
+
+	// No error, stub a receipt
+	eth.receipt = types.NewReceipt(pm.RandHash().Bytes(), false, 100000)
+	eth.err = nil
+
+	receipt, err = tm.wait(tx)
+	assert.Equal(receipt.Status, uint64(1))
+	assert.Equal(receipt.CumulativeGasUsed, uint64(100000))
+	assert.Nil(err)
+}
+
+func TestTransactionManager_Replace(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	eth := &stubTransactionSenderReader{
+		err: make(map[string]error),
+	}
+	q := transactionQueue{}
+	gasPrice := big.NewInt(10)
+	gpm := &GasPriceMonitor{
+		minGasPrice: big.NewInt(0),
+		maxGasPrice: big.NewInt(0),
+		gasPrice:    big.NewInt(1),
+	}
+	tm := &TransactionManager{
+		cond:      sync.NewCond(&sync.Mutex{}),
+		eth:       eth,
+		queue:     q,
+		txTimeout: 2 * time.Second,
+		gpm:       gpm,
+	}
+
+	stubTx := types.NewTransaction(1, pm.RandAddress(), big.NewInt(100), 100000, gasPrice, pm.RandBytes(68))
+
+	// Test eth.TransactionByHash error
+	expErr := errors.New("TransactionByHash error")
+	eth.err["TransactionByHash"] = expErr
+
+	tx, err := tm.replace(stubTx)
+	assert.Nil(tx)
+	assert.EqualError(err, expErr.Error())
+	eth.err["TransactionByHash"] = nil
+
+	// Test no error - ErrReplacingMinedTx
+	eth.pending = false
+	tx, err = tm.replace(stubTx)
+	assert.Nil(tx)
+	assert.EqualError(err, ErrReplacingMinedTx.Error())
+
+	// Test error is ethereum.NotFound - fail at next step
+	eth.pending = true
+	gpm.maxGasPrice = big.NewInt(1)
+	eth.err["TransactionByHash"] = ethereum.NotFound
+	tx, err = tm.replace(stubTx)
+	assert.Nil(tx)
+	assert.EqualError(
+		err,
+		fmt.Sprintf("Replacement gas price exceeds max gas price suggested=%v max=%v", calcReplacementGasPrice(stubTx), gpm.maxGasPrice),
+	)
+	eth.err["TransactionByHash"] = nil
+
+	// Replacement gas price exceeds max gas price
+	// Throw error
+	tx, err = tm.replace(stubTx)
+	assert.Nil(tx)
+	assert.EqualError(
+		err,
+		fmt.Sprintf("Replacement gas price exceeds max gas price suggested=%v max=%v", calcReplacementGasPrice(stubTx), gpm.maxGasPrice),
+	)
+
+	// Error signing replacement tx
+	expErr = errors.New("SignTx error")
+	sig := &stubTransactionSigner{
+		err: nil,
+	}
+	tm.sig = sig
+	sig.err = expErr
+	gpm.maxGasPrice = big.NewInt(99999)
+	tx, err = tm.replace(stubTx)
+	assert.Nil(tx)
+	assert.EqualError(err, expErr.Error())
+	sig.err = nil
+
+	// Error sending replacement tx
+	expErr = errors.New("SendTx error")
+	eth.err["SendTransaction"] = expErr
+	logsBefore := glog.Stats.Info.Lines()
+	tx, err = tm.replace(stubTx)
+	logsAfter := glog.Stats.Info.Lines()
+	assert.EqualError(err, expErr.Error())
+	assert.Equal(logsAfter-logsBefore, int64(1))
+	eth.err["SendTransaction"] = nil
+
+	// Success
+	logsBefore = glog.Stats.Info.Lines()
+	tx, err = tm.replace(stubTx)
+	logsAfter = glog.Stats.Info.Lines()
+	assert.Nil(err)
+	expTx := types.NewTransaction(1, *stubTx.To(), stubTx.Value(), 100000, calcReplacementGasPrice(stubTx), stubTx.Data())
+	assert.Equal(tx, expTx)
+	assert.Equal(logsAfter-logsBefore, int64(1))
+
+	// Replacement gas price lower than suggest gas price
+	// Use market gas price
+	gpm.gasPrice = big.NewInt(999)
+	require.Greater(gpm.GasPrice(), calcReplacementGasPrice(stubTx))
+	logsBefore = glog.Stats.Info.Lines()
+	tx, err = tm.replace(stubTx)
+	logsAfter = glog.Stats.Info.Lines()
+	assert.Nil(err)
+	expTx = types.NewTransaction(1, *stubTx.To(), stubTx.Value(), 100000, gpm.gasPrice, stubTx.Data())
+	assert.Equal(tx, expTx)
+	assert.Equal(logsAfter-logsBefore, int64(1))
+}
+
+func TestTransactionManager_CheckTxLoop(t *testing.T) {
+	assert := assert.New(t)
+
+	eth := &stubTransactionSenderReader{
+		err: make(map[string]error),
+	}
+	q := transactionQueue{}
+	gasPrice := big.NewInt(10)
+	gpm := &GasPriceMonitor{
+		minGasPrice: big.NewInt(0),
+		maxGasPrice: big.NewInt(99999999),
+		gasPrice:    big.NewInt(1),
+	}
+	sig := &stubTransactionSigner{
+		err: nil,
+	}
+
+	tm := &TransactionManager{
+		maxReplacements: 0,
+		cond:            sync.NewCond(&sync.Mutex{}),
+		eth:             eth,
+		queue:           q,
+		txTimeout:       2 * time.Second,
+		gpm:             gpm,
+		sig:             sig,
+		quit:            make(chan struct{}),
+	}
+
+	eth.pending = true
+	receipt := types.NewReceipt(pm.RandHash().Bytes(), false, 100000)
+	eth.receipt = receipt
+
+	stubTx := types.NewTransaction(1, pm.RandAddress(), big.NewInt(100), 100000, gasPrice, pm.RandBytes(68))
+
+	go tm.Start()
+	defer tm.Stop()
+
+	sink := make(chan *transactionReceipt, 10)
+	sub := tm.Subscribe(sink)
+	tm.SendTransaction(context.Background(), stubTx)
+
+	event := <-sink
+	assert.NotNil(event)
+	assert.Nil(event.err)
+	sub.Unsubscribe()
+
+	// Wait error no replacements
+	eth.receipt = nil
+	eth.err["TransactionReceipt"] = context.DeadlineExceeded
+	sink = make(chan *transactionReceipt)
+	sub = tm.Subscribe(sink)
+	tm.SendTransaction(context.Background(), stubTx)
+	event = <-sink
+	assert.NotNil(event)
+	assert.EqualError(event.err, context.DeadlineExceeded.Error())
+	eth.err["TransactionReceipt"] = nil
+	sub.Unsubscribe()
+
+	// Wait error, replacements
+	// Replace tx error
+	tm.maxReplacements = 1
+	eth.err["TransactionReceipt"] = context.DeadlineExceeded
+	eth.err["TransactionByHash"] = errors.New("TransactionByHash error")
+	sink = make(chan *transactionReceipt)
+	sub = tm.Subscribe(sink)
+
+	tm.SendTransaction(context.Background(), stubTx)
+	event = <-sink
+	assert.EqualError(event.err, eth.err["TransactionByHash"].Error())
+	assert.Equal(eth.callsToTxByHash, 1)
+	sub.Unsubscribe()
+
+	// Replace multiple times, but fail replacement
+	// Should replace only once
+	eth.callsToTxByHash = 0
+	tm.maxReplacements = 3
+
+	sink = make(chan *transactionReceipt)
+	sub = tm.Subscribe(sink)
+
+	tm.SendTransaction(context.Background(), stubTx)
+	event = <-sink
+	assert.EqualError(event.err, eth.err["TransactionByHash"].Error())
+	assert.Equal(eth.callsToTxByHash, 1)
+	assert.LessOrEqual(eth.callsToTxByHash, tm.maxReplacements)
+	sub.Unsubscribe()
+
+	// replace multiple times, time out
+	// replace 'maxReplacements' times
+	eth.callsToTxByHash = 0
+	eth.err["TransactionByHash"] = nil
+	sink = make(chan *transactionReceipt)
+	sub = tm.Subscribe(sink)
+
+	tm.SendTransaction(context.Background(), stubTx)
+	event = <-sink
+	assert.EqualError(event.err, context.DeadlineExceeded.Error())
+	assert.Equal(eth.callsToTxByHash, tm.maxReplacements)
+	sub.Unsubscribe()
+}

--- a/eth/transactionManager_test.go
+++ b/eth/transactionManager_test.go
@@ -195,7 +195,7 @@ func TestTransactionManager_Replace(t *testing.T) {
 	assert.Nil(tx)
 	assert.EqualError(
 		err,
-		fmt.Sprintf("Replacement gas price exceeds max gas price suggested=%v max=%v", calcReplacementGasPrice(stubTx), gpm.maxGasPrice),
+		fmt.Sprintf("replacement gas price exceeds max gas price suggested=%v max=%v", calcReplacementGasPrice(stubTx), gpm.maxGasPrice),
 	)
 	eth.err["TransactionByHash"] = nil
 
@@ -205,7 +205,7 @@ func TestTransactionManager_Replace(t *testing.T) {
 	assert.Nil(tx)
 	assert.EqualError(
 		err,
-		fmt.Sprintf("Replacement gas price exceeds max gas price suggested=%v max=%v", calcReplacementGasPrice(stubTx), gpm.maxGasPrice),
+		fmt.Sprintf("replacement gas price exceeds max gas price suggested=%v max=%v", calcReplacementGasPrice(stubTx), gpm.maxGasPrice),
 	)
 
 	// Error signing replacement tx
@@ -243,7 +243,7 @@ func TestTransactionManager_Replace(t *testing.T) {
 	// Replacement gas price lower than suggest gas price
 	// Use market gas price
 	gpm.gasPrice = big.NewInt(999)
-	require.Greater(gpm.GasPrice(), calcReplacementGasPrice(stubTx))
+	require.True(gpm.GasPrice().Cmp(calcReplacementGasPrice(stubTx)) > 0)
 	logsBefore = glog.Stats.Info.Lines()
 	tx, err = tm.replace(stubTx)
 	logsAfter = glog.Stats.Info.Lines()

--- a/pm/queue.go
+++ b/pm/queue.go
@@ -131,7 +131,8 @@ ticketLoop:
 						// If the ticket is used, we can mark it as redeemed
 						if res.err != nil {
 							glog.Errorf("Error redeeming err=%v", res.err)
-							if res.err != errIsUsedTicket {
+							_, checkTxErr := res.err.(errCheckTx)
+							if res.err != errIsUsedTicket && !checkTxErr {
 								continue
 							}
 						}

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -25,6 +25,8 @@ var unixNow = func() int64 {
 	return time.Now().Unix()
 }
 
+type errCheckTx error
+
 // SenderMonitor is an interface that describes methods used to
 // monitor remote senders
 type SenderMonitor interface {
@@ -422,7 +424,7 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 		if monitor.Enabled {
 			monitor.TicketRedemptionError()
 		}
-		return nil, err
+		return nil, errCheckTx(err)
 	}
 
 	if monitor.Enabled {

--- a/pm/sendermonitor_test.go
+++ b/pm/sendermonitor_test.go
@@ -787,14 +787,15 @@ func TestRedeemWinningTicket_SingleTicket_CheckTxError(t *testing.T) {
 	sm := NewSenderMonitor(cfg, b, smgr, tm, ts)
 	sm.Start()
 	defer sm.Stop()
-	b.checkTxErr = errors.New("checktx error")
+	expErr := errCheckTx(errors.New("checktx error"))
+	b.checkTxErr = expErr
 	assert := assert.New(t)
 
 	signedT := defaultSignedTicket(addr, uint32(0))
 
 	tx, err := sm.redeemWinningTicket(signedT)
 	assert.Nil(tx)
-	assert.EqualError(err, b.checkTxErr.Error())
+	assert.IsType(expErr, err)
 }
 
 func TestRedeemWinningTicket_SingleTicket(t *testing.T) {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -373,7 +373,7 @@ func minGasPriceHandler(client eth.LivepeerEthClient) http.Handler {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(client.Backend().MinGasPrice().String()))
+		w.Write([]byte(client.Backend().GasPriceMonitor().MinGasPrice().String()))
 	})
 }
 
@@ -389,7 +389,7 @@ func setMinGasPriceHandler(client eth.LivepeerEthClient) http.Handler {
 			respondWith400(w, fmt.Sprintf("invalid minGasPrice: %v", err))
 			return
 		}
-		client.Backend().SetMinGasPrice(minGasPrice)
+		client.Backend().GasPriceMonitor().SetMinGasPrice(minGasPrice)
 
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("setMinGasPrice success"))

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -1139,7 +1139,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 		}
 
 		b := s.LivepeerNode.Eth.Backend()
-		gprice := b.MaxGasPrice()
+		gprice := b.GasPriceMonitor().MaxGasPrice()
 		if gprice == nil {
 			w.Write([]byte(""))
 		} else {
@@ -1162,8 +1162,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 		if amount == "0" {
 			gprice = nil
 		}
-		b := s.LivepeerNode.Eth.Backend()
-		b.SetMaxGasPrice(gprice)
+		s.LivepeerNode.Eth.Backend().GasPriceMonitor().SetMaxGasPrice(gprice)
 	})
 
 	mux.Handle("/minGasPrice", minGasPriceHandler(s.LivepeerNode.Eth))


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Use a `TransactionManager` to handle transactions. This service will forward transactions to the ethereum JSON-RPC, when a transaction is broadcasted to the ethereum network it will be added to the queue. Lowest non-confirmed transactions are popped off the queue to wait until they are mined and retrieve their transaction receipt. 

Once the transaction receipt is found it will be sent over a subscription of transaction receipts that services that want feedback on tx confirmation can subscribe to. This subscription service now powers `LivepeerEthClient.CheckTx()` under the hood. 

**Specific updates (required)**
- 75eed97c84e9d40194403996fc75443f7d375d9e  eth: transaction manager with confirmation queue and optional replacement transactions

-  60d33a0c763505098488050999b220f51ed740a3  pm: handle ticket revert error

- a7b7c5e46e7d406a0f6330f53751a53e20e217ac  eth: remove replacement transactions from reward service

- d4886f688b6edc8f25243d846872a8821ca9b16f  eth,server: move max gas price logic to gas price monitor

- b12a24dc6888ff94d6a68fe3f6628cc828a1e015 eth: make abiMap and txLog helpers in the eth package rather than Backend methods

- 1b89b5c37b1a57da231df387bb8f3d163ed412a0  cmd: replace transaction flag

- efa84b466cebc138501eb8dcb380abe7fbbfd539  cmd,eth: use struct for LivepeerEthClient constructor parameters that aren't other services


**How did you test each of these updates (required)**
- Unit tests

- [ ] TODO add `TransactionManager` unit tests

**Does this pull request close any open issues?**
Fixes #1906

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
