### PR TITLE
Support custom minimum gas price

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,7 @@
 
 - \#1911 [Experimental] Enable scene classification for Adult/Soccer (@jailuthra, @yondonfu)
 - \#1915 Use gas price monitor for gas price suggestions for all Ethereum transactions (@kyriediculous)
+- \#1930 Support custom minimum gas price (@yondonfu)
 
 #### Broadcaster
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -509,7 +509,7 @@ func main() {
 			CleanupInterval: cleanupInterval,
 			TTL:             smTTL,
 			RedeemGas:       redeemGas,
-			SuggestGasPrice: backend.SuggestGasPrice,
+			SuggestGasPrice: client.Backend().SuggestGasPrice,
 			RPCTimeout:      ethRPCTimeout,
 		}
 

--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -101,6 +101,7 @@ func (w *wizard) initializeOptions() []wizardOpt {
 		{desc: "Invoke \"withdraw broadcasting funds\"", invoke: w.withdraw, notOrchestrator: true},
 		{desc: "Set broadcast config", invoke: w.setBroadcastConfig, notOrchestrator: true},
 		{desc: "Set maximum Ethereum gas price", invoke: w.setMaxGasPrice},
+		{desc: "Set minimum Ethereum gas price", invoke: w.setMinGasPrice},
 		{desc: "Get test LPT", invoke: w.requestTokens, testnet: true},
 		{desc: "Get test ETH", invoke: func() {
 			fmt.Print("For Rinkeby Eth, go to the Rinkeby faucet (https://faucet.rinkeby.io/).")

--- a/cmd/livepeer_cli/wizard_eth.go
+++ b/cmd/livepeer_cli/wizard_eth.go
@@ -17,6 +17,18 @@ func (w *wizard) setMaxGasPrice() {
 	httpPostWithParams(fmt.Sprintf("http://%v:%v/setMaxGasPrice", w.host, w.httpPort), val)
 }
 
+func (w *wizard) setMinGasPrice() {
+	fmt.Printf("Current minimum gas price: %v\n", w.minGasPrice())
+	fmt.Printf("Enter new minimum gas price in Wei")
+	minGasPrice := w.readBigInt()
+
+	val := url.Values{
+		"minGasPrice": {fmt.Sprintf("%v", minGasPrice.String())},
+	}
+
+	httpPostWithParams(fmt.Sprintf("http://%v:%v/setMinGasPrice", w.host, w.httpPort), val)
+}
+
 func (w *wizard) signMessage() {
 	fmt.Printf("Enter or paste the message to sign: \n")
 	msg := w.readMultilineString()

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -51,6 +51,12 @@ func (w *wizard) stats(showOrchestrator bool) {
 		maxGasPriceStr = fmt.Sprintf("%v GWei", eth.FromWei(maxGasPrice, params.GWei))
 	}
 
+	minGasPriceStr := "n/a"
+	minGasPrice, _ := new(big.Int).SetString(w.minGasPrice(), 10)
+	if minGasPrice != nil {
+		minGasPriceStr = fmt.Sprintf("%v GWei", eth.FromWei(minGasPrice, params.GWei))
+	}
+
 	table := tablewriter.NewWriter(os.Stdout)
 	data := [][]string{
 		{"Node's version", status.Version},
@@ -65,6 +71,7 @@ func (w *wizard) stats(showOrchestrator bool) {
 		{"LPT Balance", eth.FormatUnits(lptBal, "LPT")},
 		{"ETH Balance", eth.FormatUnits(ethBal, "ETH")},
 		{"Max Gas Price", maxGasPriceStr},
+		{"Min Gas Price", minGasPriceStr},
 	}
 
 	for _, v := range data {
@@ -420,6 +427,10 @@ func (w *wizard) maxGasPrice() string {
 		max = "n/a"
 	}
 	return max
+}
+
+func (w *wizard) minGasPrice() string {
+	return httpGet(fmt.Sprintf("http://%v:%v/minGasPrice", w.host, w.httpPort))
 }
 
 func (w *wizard) currentBlock() (*big.Int, error) {

--- a/doc/ethereum.md
+++ b/doc/ethereum.md
@@ -11,3 +11,31 @@ If the node detects that its address is registered on-chain, it will automatical
 The node can run a round initialization service that will automatically call a smart contract function to initialize the current round.
 
 The round initialization service is disabled by default and can be enabled by starting the node with `-initializeRound`.
+
+## Gas Prices
+
+### Max gas price
+
+The following options can be used to get the max gas price:
+
+- `curl localhost:7935/maxGasPrice`
+- Run `livepeer_cli` and observe the max gas price in the node stats
+
+The following options can be used to set the m gas price to `<MAX_GAS_PRICE>`, a Wei denominated value:
+
+- Start the node with `-maxGasPrice <MAX_GAS_PRICE>`
+- `curl localhost:7935/setMaxGasPrice?maxGasPrice=<MAX_GAS_PRICE>`
+- Run `livepeer_cli` and select the set max gas price option
+
+### Min gas price
+
+The following options can be used to get the min gas price:
+
+- `curl localhost:7935/minGasPrice`
+- Run `livepeer_cli` and observe the min gas price in the node statts
+
+The following options can be used to set the min gas price to `<MIN_GAS_PRICE>`, a Wei denominated value:
+
+- Start the node with `-minGasPrice <MIN_GAS_PRICE>`
+- `curl localhost:7935/setMinGasPrice?minGasPrice=<MIN_GAS_PRICE>`
+- Run `livepeer_cli` and select the set min gas price option

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -44,6 +44,8 @@ type Backend interface {
 	ChainID(ctx context.Context) (*big.Int, error)
 	MaxGasPrice() *big.Int
 	SetMaxGasPrice(gp *big.Int)
+	MinGasPrice() *big.Int
+	SetMinGasPrice(gp *big.Int)
 }
 
 type backend struct {
@@ -133,6 +135,14 @@ func (b *backend) MaxGasPrice() *big.Int {
 	b.RLock()
 	defer b.RUnlock()
 	return b.maxGasPrice
+}
+
+func (b *backend) SetMinGasPrice(gp *big.Int) {
+	b.gpm.SetMinGasPrice(gp)
+}
+
+func (b *backend) MinGasPrice() *big.Int {
+	return b.gpm.MinGasPrice()
 }
 
 type txLog struct {

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -112,9 +112,12 @@ func TestBackend_SetMaxGasPrice(t *testing.T) {
 func TestBackend_SuggestGasPrice(t *testing.T) {
 	assert := assert.New(t)
 	gp := big.NewInt(10)
-	gpm := &GasPriceMonitor{
-		gasPrice: gp,
-	}
+	gpo := &stubGasPriceOracle{gasPrice: gp}
+
+	gpm := NewGasPriceMonitor(gpo, 1*time.Hour, big.NewInt(0))
+	_, err := gpm.Start(context.Background())
+	assert.Nil(err)
+	defer gpm.Stop()
 
 	b := &backend{
 		gpm: gpm,

--- a/eth/client.go
+++ b/eth/client.go
@@ -43,7 +43,7 @@ var (
 
 type LivepeerEthClient interface {
 	Account() accounts.Account
-	Backend() (Backend, error)
+	Backend() Backend
 
 	// Rounds
 	InitializeRound() (*types.Transaction, error)
@@ -361,12 +361,8 @@ func (c *client) Account() accounts.Account {
 	return c.accountManager.Account()
 }
 
-func (c *client) Backend() (Backend, error) {
-	if c.backend == nil {
-		return nil, ErrMissingBackend
-	} else {
-		return c.backend, nil
-	}
+func (c *client) Backend() Backend {
+	return c.backend
 }
 
 // Rounds

--- a/eth/gaspricemonitor.go
+++ b/eth/gaspricemonitor.go
@@ -59,6 +59,10 @@ func (gpm *GasPriceMonitor) GasPrice() *big.Int {
 	gpm.gasPriceMu.RLock()
 	defer gpm.gasPriceMu.RUnlock()
 
+	if gpm.gasPrice.Cmp(gpm.minGasPrice) < 0 {
+		return gpm.minGasPrice
+	}
+
 	return gpm.gasPrice
 }
 

--- a/eth/gaspricemonitor.go
+++ b/eth/gaspricemonitor.go
@@ -28,7 +28,7 @@ type GasPriceMonitor struct {
 	// pollingMu protects access to polling related fields
 	pollingMu sync.Mutex
 
-	// gasPriceMu protects access to gasPrice
+	// gasPriceMu protects access to gasPrice and minGasPrice
 	gasPriceMu sync.RWMutex
 	// gasPrice is the current gas price to be returned to users
 	gasPrice *big.Int
@@ -64,6 +64,18 @@ func (gpm *GasPriceMonitor) GasPrice() *big.Int {
 	}
 
 	return gpm.gasPrice
+}
+
+func (gpm *GasPriceMonitor) SetMinGasPrice(minGasPrice *big.Int) {
+	gpm.gasPriceMu.Lock()
+	defer gpm.gasPriceMu.Unlock()
+	gpm.minGasPrice = minGasPrice
+}
+
+func (gpm *GasPriceMonitor) MinGasPrice() *big.Int {
+	gpm.gasPriceMu.RLock()
+	defer gpm.gasPriceMu.RUnlock()
+	return gpm.minGasPrice
 }
 
 // Start starts polling for gas price updates and returns a channel to receive

--- a/eth/gaspricemonitor_test.go
+++ b/eth/gaspricemonitor_test.go
@@ -217,3 +217,17 @@ func TestStop(t *testing.T) {
 	_, ok := (<-gpm.update)
 	assert.False(ok)
 }
+
+func TestMinGasPrice(t *testing.T) {
+	gasPrice := big.NewInt(777)
+	gpo := newStubGasPriceOracle(gasPrice)
+	gpo.SetGasPrice(gasPrice)
+
+	assert := assert.New(t)
+
+	gpm := NewGasPriceMonitor(gpo, 1*time.Hour, big.NewInt(0))
+	assert.Equal(big.NewInt(0), gpm.MinGasPrice())
+
+	gpm.SetMinGasPrice(big.NewInt(1))
+	assert.Equal(big.NewInt(1), gpm.MinGasPrice())
+}

--- a/eth/gaspricemonitor_test.go
+++ b/eth/gaspricemonitor_test.go
@@ -82,7 +82,6 @@ func TestStart(t *testing.T) {
 	update, err = gpm.Start(context.Background())
 	assert.NotNil(update)
 	assert.Nil(err)
-	defer gpm.Stop()
 
 	assert.Equal(gasPrice, gpm.GasPrice())
 
@@ -91,6 +90,20 @@ func TestStart(t *testing.T) {
 	update, err = gpm.Start(context.Background())
 	assert.Nil(update)
 	assert.EqualError(err, "already polling")
+	gpm.Stop()
+
+	// Test initial gas price less than minGasPrice
+
+	minGasPrice := new(big.Int).Add(gasPrice, big.NewInt(1))
+	gpm = NewGasPriceMonitor(gpo, 1*time.Hour, minGasPrice)
+
+	update, err = gpm.Start(context.Background())
+	assert.NotNil(update)
+	assert.Nil(err)
+	defer gpm.Stop()
+
+	assert.NotEqual(big.NewInt(0), gpm.GasPrice())
+	assert.Equal(minGasPrice, gpm.GasPrice())
 }
 
 func TestStart_Polling(t *testing.T) {

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -223,7 +223,7 @@ func (e *StubClient) Setup(password string, gasLimit uint64, gasPrice *big.Int) 
 func (e *StubClient) Account() accounts.Account {
 	return accounts.Account{Address: e.TranscoderAddress}
 }
-func (e *StubClient) Backend() (Backend, error) { return nil, nil }
+func (e *StubClient) Backend() Backend { return nil }
 
 // Rounds
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -364,3 +364,34 @@ func voteHandler(client eth.LivepeerEthClient) http.Handler {
 		w.Write(tx.Hash().Bytes())
 	})
 }
+
+func minGasPriceHandler(client eth.LivepeerEthClient) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if client == nil {
+			respondWith500(w, "missing ETH client")
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(client.Backend().MinGasPrice().String()))
+	})
+}
+
+func setMinGasPriceHandler(client eth.LivepeerEthClient) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if client == nil {
+			respondWith500(w, "missing ETH client")
+			return
+		}
+
+		minGasPrice, err := common.ParseBigInt(r.FormValue("minGasPrice"))
+		if err != nil {
+			respondWith400(w, fmt.Sprintf("invalid minGasPrice: %v", err))
+			return
+		}
+		client.Backend().SetMinGasPrice(minGasPrice)
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("setMinGasPrice success"))
+	})
+}

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -954,12 +954,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 
 	mux.HandleFunc("/ethBalance", func(w http.ResponseWriter, r *http.Request) {
 		if s.LivepeerNode.Eth != nil {
-			b, err := s.LivepeerNode.Eth.Backend()
-			if err != nil {
-				glog.Error(err)
-				return
-			}
-
+			b := s.LivepeerNode.Eth.Backend()
 			balance, err := b.BalanceAt(r.Context(), s.LivepeerNode.Eth.Account().Address, nil)
 			if err != nil {
 				glog.Error(err)
@@ -1075,12 +1070,8 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 				glog.Errorf("Unable to get the time for the next valid request from faucet: %v", err)
 				return
 			}
-			backend, err := s.LivepeerNode.Eth.Backend()
-			if err != nil {
-				glog.Errorf("Unable to get LivepeerEthClient backend: %v", err)
-				return
-			}
 
+			backend := s.LivepeerNode.Eth.Backend()
 			blk, err := backend.BlockByNumber(r.Context(), nil)
 			if err != nil {
 				glog.Errorf("Unable to get latest block")
@@ -1142,11 +1133,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 	})
 
 	mux.HandleFunc("/maxGasPrice", func(w http.ResponseWriter, r *http.Request) {
-		b, err := s.LivepeerNode.Eth.Backend()
-		if err != nil {
-			respondWith400(w, err.Error())
-			return
-		}
+		b := s.LivepeerNode.Eth.Backend()
 		gprice := b.MaxGasPrice()
 		if gprice == nil {
 			w.Write([]byte(""))
@@ -1170,11 +1157,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 		if amount == "0" {
 			gprice = nil
 		}
-		b, err := s.LivepeerNode.Eth.Backend()
-		if err != nil {
-			respondWith400(w, err.Error())
-			return
-		}
+		b := s.LivepeerNode.Eth.Backend()
 		b.SetMaxGasPrice(gprice)
 	})
 

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -1133,6 +1133,11 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 	})
 
 	mux.HandleFunc("/maxGasPrice", func(w http.ResponseWriter, r *http.Request) {
+		if s.LivepeerNode.Eth == nil {
+			respondWith500(w, "missing ETH client")
+			return
+		}
+
 		b := s.LivepeerNode.Eth.Backend()
 		gprice := b.MaxGasPrice()
 		if gprice == nil {

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -1161,6 +1161,9 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 		b.SetMaxGasPrice(gprice)
 	})
 
+	mux.Handle("/minGasPrice", minGasPriceHandler(s.LivepeerNode.Eth))
+	mux.Handle("/setMinGasPrice", mustHaveFormParams(setMinGasPriceHandler(s.LivepeerNode.Eth), "minGasPrice"))
+
 	mux.Handle("/currentBlock", currentBlockHandler(s.LivepeerNode.Database))
 
 	// TicketBroker


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Adds support for configuring a custom minimum gas price using the `-minGasPrice` flag, requests to the `/setMinGasPrice` webserver endpoint and `livepeer_cli`.

This PR is based off of https://github.com/livepeer/go-livepeer/pull/1915 which injects GasPriceMonitor into the backend type defined in `eth` so in this PR we define setters/getters for minGasPrice for GasPriceMonitor which are used by the backend.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests and tested manually using devtool to confirm that if the last polled gas price < minGasPrice, txs will be submitted with minGasPrice.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1914

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
