### PR TITLE
cmd/livepeer: Bump redeem gas estimate to 350k

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,8 @@
 
 #### Orchestrator
 
+- \#1931 Bump ticket redemption gas estimate to 350k to account for occasional higher gas usage (@yondonfu)
+
 #### Transcoder
 
 ### Bug Fixes 🐞

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -54,7 +54,7 @@ var (
 	blockWatcherRetentionLimit = 20
 
 	// Estimate of the gas required to redeem a PM ticket
-	redeemGas = 250000
+	redeemGas = 350000
 	// The multiplier on the transaction cost to use for PM ticket faceValue
 	txCostMultiplier = 100
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Bump redeem gas estimate to 350k to account for occasional scenarios where the gas used for redemption exceeds the current gas estimate of 250k.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

N/A

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1904

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
