### PR TITLE
http push: return 422 for non-retryable errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,7 @@
 - \#1899 Record million pixels processed metric (@yondonfu)
 - \#1888 Should not save (when recording) segments with zero video frames (@darkdarkdragon)
 - \#1908 Prevent Broadcaster from sending low face value PM tickets (@kyriediculous)
+- \#1934 http push: return 422 for non-retryable errors (@darkdarkdragon)
 
 #### Orchestrator
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -916,10 +916,13 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	// Do the transcoding!
 	urls, err := processSegment(cxn, seg)
 	if err != nil {
-		// TODO distinguish between user errors (400) and server errors (500)
 		httpErr := fmt.Sprintf("http push error processing segment url=%s manifestID=%s err=%v", r.URL, mid, err)
 		glog.Error(httpErr)
-		http.Error(w, httpErr, http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if isNonRetryableError(err) {
+			status = http.StatusUnprocessableEntity
+		}
+		http.Error(w, httpErr, status)
 		return
 	}
 	select {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
In HTTP push handler returns 422 status code for non-retryable errors

**Specific updates (required)**
- Return 422 statuc code


**How did you test each of these updates (required)**
unit test

**Does this pull request close any open issues?**
Fixes #1927 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
