### PR TITLE
cmd+server: Redact webhook basic auth info from log

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -812,7 +812,7 @@ func main() {
 			glog.Errorf("Error checking for local -httpAddr: %v", err)
 			return
 		}
-		if !isFlagSet["httpIngest"] && !isLocalHTTP && server.AuthWebhookURL == "" {
+		if !isFlagSet["httpIngest"] && !isLocalHTTP && server.AuthWebhookURL == nil {
 			glog.Warning("HTTP ingest is disabled because -httpAddr is publicly accessible. To enable, configure -authWebhookUrl or use the -httpIngest flag")
 			*httpIngest = false
 		}

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -751,20 +751,26 @@ func main() {
 	}
 
 	if *authWebhookURL != "" {
-		_, err := validateURL(*authWebhookURL)
+		parsedUrl, err := validateURL(*authWebhookURL)
 		if err != nil {
 			glog.Fatal("Error setting auth webhook URL ", err)
 		}
-		glog.Info("Using auth webhook URL ", *authWebhookURL)
+		if parsedUrl.User != nil {
+			parsedUrl.User = url.User("REDACTED")
+		}
+		glog.Info("Using auth webhook URL ", parsedUrl)
 		server.AuthWebhookURL = *authWebhookURL
 	}
 
 	if *detectionWebhookURL != "" {
-		_, err := validateURL(*detectionWebhookURL)
+		parsedUrl, err := validateURL(*detectionWebhookURL)
 		if err != nil {
 			glog.Fatal("Error setting detection webhook URL ", err)
 		}
-		glog.Info("Using detection webhook URL ", *detectionWebhookURL)
+		if parsedUrl.User != nil {
+			parsedUrl.User = url.User("REDACTED")
+		}
+		glog.Info("Using detection webhook URL ", parsedUrl)
 		server.DetectionWebhookURL = *detectionWebhookURL
 	}
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -755,11 +755,8 @@ func main() {
 		if err != nil {
 			glog.Fatal("Error setting auth webhook URL ", err)
 		}
-		if parsedUrl.User != nil {
-			parsedUrl.User = url.User("REDACTED")
-		}
-		glog.Info("Using auth webhook URL ", parsedUrl)
-		server.AuthWebhookURL = *authWebhookURL
+		glog.Info("Using auth webhook URL ", parsedUrl.Redacted())
+		server.AuthWebhookURL = parsedUrl
 	}
 
 	if *detectionWebhookURL != "" {
@@ -767,11 +764,8 @@ func main() {
 		if err != nil {
 			glog.Fatal("Error setting detection webhook URL ", err)
 		}
-		if parsedUrl.User != nil {
-			parsedUrl.User = url.User("REDACTED")
-		}
-		glog.Info("Using detection webhook URL ", parsedUrl)
-		server.DetectionWebhookURL = *detectionWebhookURL
+		glog.Info("Using detection webhook URL ", parsedUrl.Redacted())
+		server.DetectionWebhookURL = parsedUrl
 	}
 
 	if n.NodeType == core.BroadcasterNode {

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -561,7 +561,7 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 	}
 
 	// [EXPERIMENTAL] send content detection results to callback webhook
-	if DetectionWebhookURL != "" && len(res.Detections) > 0 {
+	if DetectionWebhookURL != nil && len(res.Detections) > 0 {
 		glog.V(common.DEBUG).Infof("Got detection result %v", res.Detections)
 		go func(mid core.ManifestID, config core.DetectionConfig, seqNo uint64, detections []*net.DetectData) {
 			type SceneClassificationResult struct {
@@ -597,10 +597,10 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 				glog.Errorf("Unable to marshal detection result into JSON manifestID=%v seqNo=%v", mid, seqNo)
 				return
 			}
-			resp, err := DetectionWhClient.Post(DetectionWebhookURL, "application/json", bytes.NewBuffer(jsonValue))
+			resp, err := DetectionWhClient.Post(DetectionWebhookURL.String(), "application/json", bytes.NewBuffer(jsonValue))
 			if err != nil {
 				glog.Errorf("Unable to POST detection result on webhook url=%v manifestID=%v seqNo=%v, err=%v",
-					DetectionWebhookURL, mid, seqNo, err)
+					DetectionWebhookURL.Redacted(), mid, seqNo, err)
 			} else if resp.StatusCode != 200 {
 				rbody, rerr := ioutil.ReadAll(resp.Body)
 				resp.Body.Close()

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -60,8 +60,8 @@ const BroadcastRetry = 15 * time.Second
 
 var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmpeg.P360p30fps16x9}
 
-var AuthWebhookURL string
-var DetectionWebhookURL string
+var AuthWebhookURL *url.URL
+var DetectionWebhookURL *url.URL
 var DetectionWhClient = &http.Client{Timeout: 2 * time.Second}
 
 // For HTTP push watchdog
@@ -327,7 +327,7 @@ func createRTMPStreamIDHandler(s *LivepeerServer) func(url *url.URL) (strmID str
 }
 
 func authenticateStream(url string) (*authWebhookResponse, error) {
-	if AuthWebhookURL == "" {
+	if AuthWebhookURL == nil {
 		return nil, nil
 	}
 	started := time.Now()
@@ -336,7 +336,7 @@ func authenticateStream(url string) (*authWebhookResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.Post(AuthWebhookURL, "application/json", bytes.NewBuffer(jsonValue))
+	resp, err := http.Post(AuthWebhookURL.String(), "application/json", bytes.NewBuffer(jsonValue))
 
 	if err != nil {
 		return nil, err

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -319,7 +319,7 @@ func TestCreateRTMPStreamHandlerCap(t *testing.T) {
 		rtmpConnections: make(map[core.ManifestID]*rtmpConnection),
 	}
 	createSid := createRTMPStreamIDHandler(s)
-	u, _ := url.Parse("http://hot/id1/secret")
+	u := mustParseUrl("http://hot/id1/secret")
 	oldMaxSessions := core.MaxSessions
 	core.MaxSessions = 1
 	// happy case
@@ -579,26 +579,26 @@ func TestCreateRTMPStreamHandler(t *testing.T) {
 
 	// Test default path structure
 	expectedSid := core.MakeStreamIDFromString("ghijkl", "secretkey")
-	u, _ := url.Parse("rtmp://localhost/" + expectedSid.String()) // with key
+	u := mustParseUrl("rtmp://localhost/" + expectedSid.String()) // with key
 	if sid := createSid(u); sid.StreamID() != expectedSid.String() {
 		t.Error("Unexpected streamid", sid.StreamID())
 	}
-	u, _ = url.Parse("rtmp://localhost/stream/" + expectedSid.String()) // with stream
+	u = mustParseUrl("rtmp://localhost/stream/" + expectedSid.String()) // with stream
 	if sid := createSid(u); sid.StreamID() != expectedSid.String() {
 		t.Error("Unexpected streamid")
 	}
 	expectedMid := "mnopq"
 	key := common.RandomIDGenerator(StreamKeyBytes)
-	u, _ = url.Parse("rtmp://localhost/" + string(expectedMid)) // without key
+	u = mustParseUrl("rtmp://localhost/" + string(expectedMid)) // without key
 	if sid := createSid(u); sid.StreamID() != string(expectedMid)+"/"+key {
 		t.Error("Unexpected streamid", sid.StreamID())
 	}
-	u, _ = url.Parse("rtmp://localhost/stream/" + string(expectedMid)) // with stream, without key
+	u = mustParseUrl("rtmp://localhost/stream/" + string(expectedMid)) // with stream, without key
 	if sid := createSid(u); sid.StreamID() != string(expectedMid)+"/"+key {
 		t.Error("Unexpected streamid", sid.StreamID())
 	}
 	// Test normal case
-	u, _ = url.Parse("rtmp://localhost")
+	u = mustParseUrl("rtmp://localhost")
 	st := stream.NewBasicRTMPVideoStream(createSid(u))
 	if st.GetStreamID() == "" {
 		t.Error("Empty streamid")
@@ -625,7 +625,7 @@ func TestCreateRTMPStreamHandler(t *testing.T) {
 	testManifestIDQueryParam := func(inp string) {
 		// This isn't a great test because if the query param ever changes,
 		// this test will still pass
-		u, _ := url.Parse("rtmp://localhost/" + inp)
+		u := mustParseUrl("rtmp://localhost/" + inp)
 		if sid := createSid(u); sid.StreamID() != st.GetStreamID() {
 			t.Errorf("Unexpected StreamID for '%v' ; expected '%v' for input '%v'", sid, st.GetStreamID(), inp)
 		}
@@ -643,7 +643,7 @@ func TestEndRTMPStreamHandler(t *testing.T) {
 	createSid := createRTMPStreamIDHandler(s)
 	handler := gotRTMPStreamHandler(s)
 	endHandler := endRTMPStreamHandler(s)
-	u, _ := url.Parse("rtmp://localhost")
+	u := mustParseUrl("rtmp://localhost")
 	sid := createSid(u)
 	st := stream.NewBasicRTMPVideoStream(sid)
 
@@ -673,7 +673,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 
 	vProfile := ffmpeg.P720p30fps16x9
 	hlsStrmID := core.MakeStreamID(core.ManifestID("ghijkl"), &vProfile)
-	u, _ := url.Parse("rtmp://localhost:1935/movie")
+	u := mustParseUrl("rtmp://localhost:1935/movie")
 	strm := stream.NewBasicRTMPVideoStream(&core.StreamParameters{ManifestID: hlsStrmID.ManifestID})
 	expectedSid := core.MakeStreamIDFromString(string(hlsStrmID.ManifestID), "source")
 
@@ -748,7 +748,7 @@ func TestMultiStream(t *testing.T) {
 	s.RTMPSegmenter = &StubSegmenter{skip: true}
 	handler := gotRTMPStreamHandler(s)
 	createSid := createRTMPStreamIDHandler(s)
-	u, _ := url.Parse("rtmp://localhost")
+	u := mustParseUrl("rtmp://localhost")
 
 	handleStream := func(i int) {
 		st := stream.NewBasicRTMPVideoStream(createSid(u))
@@ -805,7 +805,7 @@ func TestGetHLSMasterPlaylistHandler(t *testing.T) {
 
 	vProfile := ffmpeg.P720p30fps16x9
 	hlsStrmID := core.MakeStreamID(core.RandomManifestID(), &vProfile)
-	url, _ := url.Parse("rtmp://localhost:1935/movie")
+	url := mustParseUrl("rtmp://localhost:1935/movie")
 	strm := stream.NewBasicRTMPVideoStream(newStreamParams(hlsStrmID.ManifestID, "source"))
 
 	if err := handler(url, strm); err != nil {
@@ -820,7 +820,7 @@ func TestGetHLSMasterPlaylistHandler(t *testing.T) {
 	mid := hlsStrmID.ManifestID
 
 	mlHandler := getHLSMasterPlaylistHandler(s)
-	url2, _ := url.Parse(fmt.Sprintf("http://localhost/stream/%s.m3u8", mid))
+	url2 := mustParseUrl(fmt.Sprintf("http://localhost/stream/%s.m3u8", mid))
 
 	//Test get master playlist
 	pl, err := mlHandler(url2)
@@ -944,7 +944,7 @@ func TestBroadcastSessionManagerWithStreamStartStop(t *testing.T) {
 	endHandler := endRTMPStreamHandler(s)
 
 	// create BasicRTMPVideoStream and extract ManifestID
-	u, _ := url.Parse("rtmp://localhost")
+	u := mustParseUrl("rtmp://localhost")
 	sid := createSid(u)
 	st := stream.NewBasicRTMPVideoStream(sid)
 	mid := streamParams(st.AppData()).ManifestID
@@ -988,7 +988,7 @@ func TestBroadcastSessionManagerWithStreamStartStop(t *testing.T) {
 }
 
 func TestCleanStreamPrefix(t *testing.T) {
-	u, _ := url.Parse("http://localhost/stream/1220c50f8bc4d2a807aace1e1376496a9d7f7c1408dec2512763c3ca16fe828f6631_01.ts")
+	u := mustParseUrl("http://localhost/stream/1220c50f8bc4d2a807aace1e1376496a9d7f7c1408dec2512763c3ca16fe828f6631_01.ts")
 	segName := cleanStreamPrefix(u.Path)
 	if segName != "1220c50f8bc4d2a807aace1e1376496a9d7f7c1408dec2512763c3ca16fe828f6631_01.ts" {
 		t.Errorf("Expecting %v, but %v", "1220c50f8bc4d2a807aace1e1376496a9d7f7c1408dec2512763c3ca16fe828f6631_01.ts", segName)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -351,8 +351,8 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	s.RTMPSegmenter = &StubSegmenter{skip: true}
 	createSid := createRTMPStreamIDHandler(s)
 
-	AuthWebhookURL = "http://localhost:8938/notexisting"
-	u, _ := url.Parse("http://hot/something/id1")
+	AuthWebhookURL = mustParseUrl("http://localhost:8938/notexisting")
+	u := mustParseUrl("http://hot/something/id1")
 	sid := createSid(u)
 	assert.Nil(sid, "Webhook auth failed")
 
@@ -369,7 +369,7 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 		w.Write(nil)
 	}))
 	defer ts.Close()
-	AuthWebhookURL = ts.URL
+	AuthWebhookURL = mustParseUrl(ts.URL)
 	sid = createSid(u)
 	assert.NotNil(sid, "On empty response with 200 code should pass")
 
@@ -378,10 +378,10 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 		t := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(resp))
 		}))
-		AuthWebhookURL = t.URL
+		AuthWebhookURL = mustParseUrl(t.URL)
 		return t
 	}
-	defer func() { AuthWebhookURL = "" }()
+	defer func() { AuthWebhookURL = nil }()
 	BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P360p30fps16x9}
 
 	// empty manifestID
@@ -1160,4 +1160,12 @@ func TestJsonProfileToVideoProfiles(t *testing.T) {
 	p, err = jsonProfileToVideoProfile(resp)
 	assert.Nil(p)
 	assert.Equal(common.ErrProfName, err)
+}
+
+func mustParseUrl(str string) *url.URL {
+	url, err := url.Parse(str)
+	if err != nil {
+		panic(err)
+	}
+	return url
 }

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -319,7 +319,7 @@ func TestCreateRTMPStreamHandlerCap(t *testing.T) {
 		rtmpConnections: make(map[core.ManifestID]*rtmpConnection),
 	}
 	createSid := createRTMPStreamIDHandler(s)
-	u := mustParseUrl("http://hot/id1/secret")
+	u := mustParseUrl(t, "http://hot/id1/secret")
 	oldMaxSessions := core.MaxSessions
 	core.MaxSessions = 1
 	// happy case
@@ -351,8 +351,8 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	s.RTMPSegmenter = &StubSegmenter{skip: true}
 	createSid := createRTMPStreamIDHandler(s)
 
-	AuthWebhookURL = mustParseUrl("http://localhost:8938/notexisting")
-	u := mustParseUrl("http://hot/something/id1")
+	AuthWebhookURL = mustParseUrl(t, "http://localhost:8938/notexisting")
+	u := mustParseUrl(t, "http://hot/something/id1")
 	sid := createSid(u)
 	assert.Nil(sid, "Webhook auth failed")
 
@@ -369,17 +369,17 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 		w.Write(nil)
 	}))
 	defer ts.Close()
-	AuthWebhookURL = mustParseUrl(ts.URL)
+	AuthWebhookURL = mustParseUrl(t, ts.URL)
 	sid = createSid(u)
 	assert.NotNil(sid, "On empty response with 200 code should pass")
 
 	// local helper to reduce boilerplate
 	makeServer := func(resp string) *httptest.Server {
-		t := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte(resp))
 		}))
-		AuthWebhookURL = mustParseUrl(t.URL)
-		return t
+		AuthWebhookURL = mustParseUrl(t, ts.URL)
+		return ts
 	}
 	defer func() { AuthWebhookURL = nil }()
 	BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P360p30fps16x9}
@@ -579,26 +579,26 @@ func TestCreateRTMPStreamHandler(t *testing.T) {
 
 	// Test default path structure
 	expectedSid := core.MakeStreamIDFromString("ghijkl", "secretkey")
-	u := mustParseUrl("rtmp://localhost/" + expectedSid.String()) // with key
+	u := mustParseUrl(t, "rtmp://localhost/"+expectedSid.String()) // with key
 	if sid := createSid(u); sid.StreamID() != expectedSid.String() {
 		t.Error("Unexpected streamid", sid.StreamID())
 	}
-	u = mustParseUrl("rtmp://localhost/stream/" + expectedSid.String()) // with stream
+	u = mustParseUrl(t, "rtmp://localhost/stream/"+expectedSid.String()) // with stream
 	if sid := createSid(u); sid.StreamID() != expectedSid.String() {
 		t.Error("Unexpected streamid")
 	}
 	expectedMid := "mnopq"
 	key := common.RandomIDGenerator(StreamKeyBytes)
-	u = mustParseUrl("rtmp://localhost/" + string(expectedMid)) // without key
+	u = mustParseUrl(t, "rtmp://localhost/"+string(expectedMid)) // without key
 	if sid := createSid(u); sid.StreamID() != string(expectedMid)+"/"+key {
 		t.Error("Unexpected streamid", sid.StreamID())
 	}
-	u = mustParseUrl("rtmp://localhost/stream/" + string(expectedMid)) // with stream, without key
+	u = mustParseUrl(t, "rtmp://localhost/stream/"+string(expectedMid)) // with stream, without key
 	if sid := createSid(u); sid.StreamID() != string(expectedMid)+"/"+key {
 		t.Error("Unexpected streamid", sid.StreamID())
 	}
 	// Test normal case
-	u = mustParseUrl("rtmp://localhost")
+	u = mustParseUrl(t, "rtmp://localhost")
 	st := stream.NewBasicRTMPVideoStream(createSid(u))
 	if st.GetStreamID() == "" {
 		t.Error("Empty streamid")
@@ -625,7 +625,7 @@ func TestCreateRTMPStreamHandler(t *testing.T) {
 	testManifestIDQueryParam := func(inp string) {
 		// This isn't a great test because if the query param ever changes,
 		// this test will still pass
-		u := mustParseUrl("rtmp://localhost/" + inp)
+		u := mustParseUrl(t, "rtmp://localhost/"+inp)
 		if sid := createSid(u); sid.StreamID() != st.GetStreamID() {
 			t.Errorf("Unexpected StreamID for '%v' ; expected '%v' for input '%v'", sid, st.GetStreamID(), inp)
 		}
@@ -643,7 +643,7 @@ func TestEndRTMPStreamHandler(t *testing.T) {
 	createSid := createRTMPStreamIDHandler(s)
 	handler := gotRTMPStreamHandler(s)
 	endHandler := endRTMPStreamHandler(s)
-	u := mustParseUrl("rtmp://localhost")
+	u := mustParseUrl(t, "rtmp://localhost")
 	sid := createSid(u)
 	st := stream.NewBasicRTMPVideoStream(sid)
 
@@ -673,7 +673,7 @@ func TestGotRTMPStreamHandler(t *testing.T) {
 
 	vProfile := ffmpeg.P720p30fps16x9
 	hlsStrmID := core.MakeStreamID(core.ManifestID("ghijkl"), &vProfile)
-	u := mustParseUrl("rtmp://localhost:1935/movie")
+	u := mustParseUrl(t, "rtmp://localhost:1935/movie")
 	strm := stream.NewBasicRTMPVideoStream(&core.StreamParameters{ManifestID: hlsStrmID.ManifestID})
 	expectedSid := core.MakeStreamIDFromString(string(hlsStrmID.ManifestID), "source")
 
@@ -748,7 +748,7 @@ func TestMultiStream(t *testing.T) {
 	s.RTMPSegmenter = &StubSegmenter{skip: true}
 	handler := gotRTMPStreamHandler(s)
 	createSid := createRTMPStreamIDHandler(s)
-	u := mustParseUrl("rtmp://localhost")
+	u := mustParseUrl(t, "rtmp://localhost")
 
 	handleStream := func(i int) {
 		st := stream.NewBasicRTMPVideoStream(createSid(u))
@@ -805,7 +805,7 @@ func TestGetHLSMasterPlaylistHandler(t *testing.T) {
 
 	vProfile := ffmpeg.P720p30fps16x9
 	hlsStrmID := core.MakeStreamID(core.RandomManifestID(), &vProfile)
-	url := mustParseUrl("rtmp://localhost:1935/movie")
+	url := mustParseUrl(t, "rtmp://localhost:1935/movie")
 	strm := stream.NewBasicRTMPVideoStream(newStreamParams(hlsStrmID.ManifestID, "source"))
 
 	if err := handler(url, strm); err != nil {
@@ -820,7 +820,7 @@ func TestGetHLSMasterPlaylistHandler(t *testing.T) {
 	mid := hlsStrmID.ManifestID
 
 	mlHandler := getHLSMasterPlaylistHandler(s)
-	url2 := mustParseUrl(fmt.Sprintf("http://localhost/stream/%s.m3u8", mid))
+	url2 := mustParseUrl(t, fmt.Sprintf("http://localhost/stream/%s.m3u8", mid))
 
 	//Test get master playlist
 	pl, err := mlHandler(url2)
@@ -944,7 +944,7 @@ func TestBroadcastSessionManagerWithStreamStartStop(t *testing.T) {
 	endHandler := endRTMPStreamHandler(s)
 
 	// create BasicRTMPVideoStream and extract ManifestID
-	u := mustParseUrl("rtmp://localhost")
+	u := mustParseUrl(t, "rtmp://localhost")
 	sid := createSid(u)
 	st := stream.NewBasicRTMPVideoStream(sid)
 	mid := streamParams(st.AppData()).ManifestID
@@ -988,7 +988,7 @@ func TestBroadcastSessionManagerWithStreamStartStop(t *testing.T) {
 }
 
 func TestCleanStreamPrefix(t *testing.T) {
-	u := mustParseUrl("http://localhost/stream/1220c50f8bc4d2a807aace1e1376496a9d7f7c1408dec2512763c3ca16fe828f6631_01.ts")
+	u := mustParseUrl(t, "http://localhost/stream/1220c50f8bc4d2a807aace1e1376496a9d7f7c1408dec2512763c3ca16fe828f6631_01.ts")
 	segName := cleanStreamPrefix(u.Path)
 	if segName != "1220c50f8bc4d2a807aace1e1376496a9d7f7c1408dec2512763c3ca16fe828f6631_01.ts" {
 		t.Errorf("Expecting %v, but %v", "1220c50f8bc4d2a807aace1e1376496a9d7f7c1408dec2512763c3ca16fe828f6631_01.ts", segName)
@@ -1162,10 +1162,10 @@ func TestJsonProfileToVideoProfiles(t *testing.T) {
 	assert.Equal(common.ErrProfName, err)
 }
 
-func mustParseUrl(str string) *url.URL {
+func mustParseUrl(t *testing.T, str string) *url.URL {
 	url, err := url.Parse(str)
 	if err != nil {
-		panic(err)
+		t.Fatalf(`Bad url "%s": %v`, str, err)
 	}
 	return url
 }

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -612,7 +612,7 @@ func TestPush_SetVideoProfileFormats(t *testing.T) {
 	defer ts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = mustParseUrl(ts.URL)
+	AuthWebhookURL = mustParseUrl(t, ts.URL)
 
 	h, r, w = requestSetup(s)
 	req = httptest.NewRequest("POST", "/live/web/0.mp4", r)
@@ -672,7 +672,7 @@ func TestPush_ShouldRemoveSessionAfterTimeoutIfInternalMIDIsUsed(t *testing.T) {
 	defer ts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = mustParseUrl(ts.URL)
+	AuthWebhookURL = mustParseUrl(t, ts.URL)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/live/extmid1/1.ts", nil)
@@ -1005,7 +1005,7 @@ func TestPush_WebhookRequestURL(t *testing.T) {
 
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = mustParseUrl(ts.URL)
+	AuthWebhookURL = mustParseUrl(t, ts.URL)
 	handler, reader, w := requestSetup(s)
 	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
 	handler.ServeHTTP(w, req)
@@ -1041,7 +1041,7 @@ func TestPush_OSPerStream(t *testing.T) {
 	defer whts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = mustParseUrl(whts.URL)
+	AuthWebhookURL = mustParseUrl(t, whts.URL)
 
 	ts, mux := stubTLSServer()
 	defer ts.Close()
@@ -1210,7 +1210,7 @@ func TestPush_ReuseIntmidWithDiffExtmid(t *testing.T) {
 	defer ts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = mustParseUrl(ts.URL)
+	AuthWebhookURL = mustParseUrl(t, ts.URL)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/live/extmid1/0.ts", reader)

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -612,7 +612,7 @@ func TestPush_SetVideoProfileFormats(t *testing.T) {
 	defer ts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = ts.URL
+	AuthWebhookURL = mustParseUrl(ts.URL)
 
 	h, r, w = requestSetup(s)
 	req = httptest.NewRequest("POST", "/live/web/0.mp4", r)
@@ -672,7 +672,7 @@ func TestPush_ShouldRemoveSessionAfterTimeoutIfInternalMIDIsUsed(t *testing.T) {
 	defer ts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = ts.URL
+	AuthWebhookURL = mustParseUrl(ts.URL)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/live/extmid1/1.ts", nil)
@@ -927,7 +927,7 @@ func TestPush_ForAuthWebhookFailure(t *testing.T) {
 
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = "notaurl"
+	AuthWebhookURL = &url.URL{Path: "notaurl"}
 	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
 
 	handler.ServeHTTP(w, req)
@@ -1005,7 +1005,7 @@ func TestPush_WebhookRequestURL(t *testing.T) {
 
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = ts.URL
+	AuthWebhookURL = mustParseUrl(ts.URL)
 	handler, reader, w := requestSetup(s)
 	req := httptest.NewRequest("POST", "/live/seg.ts", reader)
 	handler.ServeHTTP(w, req)
@@ -1041,7 +1041,7 @@ func TestPush_OSPerStream(t *testing.T) {
 	defer whts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = whts.URL
+	AuthWebhookURL = mustParseUrl(whts.URL)
 
 	ts, mux := stubTLSServer()
 	defer ts.Close()
@@ -1158,7 +1158,7 @@ func TestPush_ConcurrentSegments(t *testing.T) {
 	s, _ := NewLivepeerServer("127.0.0.1:1938", n, true, "")
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = ""
+	AuthWebhookURL = nil
 
 	var wg sync.WaitGroup
 	start := make(chan struct{})
@@ -1210,7 +1210,7 @@ func TestPush_ReuseIntmidWithDiffExtmid(t *testing.T) {
 	defer ts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = ts.URL
+	AuthWebhookURL = mustParseUrl(ts.URL)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/live/extmid1/0.ts", reader)

--- a/server/recordings_test.go
+++ b/server/recordings_test.go
@@ -38,7 +38,7 @@ func TestRecordingHandler(t *testing.T) {
 	defer whts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = whts.URL
+	AuthWebhookURL = mustParseUrl(whts.URL)
 
 	makeReq := func(method, uri string) *http.Response {
 		writer := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestRecording(t *testing.T) {
 	defer whts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = whts.URL
+	AuthWebhookURL = mustParseUrl(whts.URL)
 	makeReq := func(method, uri string) *http.Response {
 		writer := httptest.NewRecorder()
 		req := httptest.NewRequest(method, uri, nil)

--- a/server/recordings_test.go
+++ b/server/recordings_test.go
@@ -38,7 +38,7 @@ func TestRecordingHandler(t *testing.T) {
 	defer whts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = mustParseUrl(whts.URL)
+	AuthWebhookURL = mustParseUrl(t, whts.URL)
 
 	makeReq := func(method, uri string) *http.Response {
 		writer := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestRecording(t *testing.T) {
 	defer whts.Close()
 	oldURL := AuthWebhookURL
 	defer func() { AuthWebhookURL = oldURL }()
-	AuthWebhookURL = mustParseUrl(whts.URL)
+	AuthWebhookURL = mustParseUrl(t, whts.URL)
 	makeReq := func(method, uri string) *http.Response {
 		writer := httptest.NewRecorder()
 		req := httptest.NewRequest(method, uri, nil)

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -268,7 +268,7 @@ func getOrchestrator(orch Orchestrator, req *net.OrchestratorRequest) (*net.Orch
 }
 
 func getPriceInfo(orch Orchestrator, addr ethcommon.Address) (*net.PriceInfo, error) {
-	if AuthWebhookURL != "" {
+	if AuthWebhookURL != nil {
 		webhookRes := getFromDiscoveryAuthWebhookCache(addr.Hex())
 		if webhookRes != nil && webhookRes.PriceInfo != nil {
 			return webhookRes.PriceInfo, nil
@@ -330,7 +330,7 @@ type discoveryAuthWebhookRes struct {
 // authenticateBroadcaster returns an error if authentication fails
 // on success it caches the webhook response
 func authenticateBroadcaster(id string) (*discoveryAuthWebhookRes, error) {
-	if AuthWebhookURL == "" {
+	if AuthWebhookURL == nil {
 		return nil, nil
 	}
 
@@ -339,7 +339,7 @@ func authenticateBroadcaster(id string) (*discoveryAuthWebhookRes, error) {
 	if err != nil {
 		return nil, err
 	}
-	res, err := http.Post(AuthWebhookURL, "application/json", bytes.NewBuffer(jsonValues))
+	res, err := http.Post(AuthWebhookURL.String(), "application/json", bytes.NewBuffer(jsonValues))
 	if err != nil {
 		return nil, err
 	}

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -852,7 +852,7 @@ func TestGetOrchestrator_GivenValidSig_ReturnsOrchTicketParams(t *testing.T) {
 
 func TestGetOrchestrator_WebhookAuth_Error(t *testing.T) {
 	orch := &mockOrchestrator{}
-	AuthWebhookURL = mustParseUrl("http://fail")
+	AuthWebhookURL = mustParseUrl(t, "http://fail")
 	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 
@@ -873,7 +873,7 @@ func TestGetOrchestrator_WebhookAuth_ReturnsNotOK(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	AuthWebhookURL = mustParseUrl(ts.URL)
+	AuthWebhookURL = mustParseUrl(t, ts.URL)
 	defer func() {
 		AuthWebhookURL = nil
 	}()
@@ -902,7 +902,7 @@ func TestGetOrchestratorWebhookAuth_ReturnsOK(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	AuthWebhookURL = mustParseUrl(ts.URL)
+	AuthWebhookURL = mustParseUrl(t, ts.URL)
 	defer func() {
 		AuthWebhookURL = nil
 	}()

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -852,7 +852,7 @@ func TestGetOrchestrator_GivenValidSig_ReturnsOrchTicketParams(t *testing.T) {
 
 func TestGetOrchestrator_WebhookAuth_Error(t *testing.T) {
 	orch := &mockOrchestrator{}
-	AuthWebhookURL = "http://fail"
+	AuthWebhookURL = mustParseUrl("http://fail")
 	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	orch.On("VerifySig", mock.Anything, mock.Anything, mock.Anything).Return(true)
 
@@ -873,9 +873,9 @@ func TestGetOrchestrator_WebhookAuth_ReturnsNotOK(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	AuthWebhookURL = ts.URL
+	AuthWebhookURL = mustParseUrl(ts.URL)
 	defer func() {
-		AuthWebhookURL = ""
+		AuthWebhookURL = nil
 	}()
 
 	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
@@ -902,9 +902,9 @@ func TestGetOrchestratorWebhookAuth_ReturnsOK(t *testing.T) {
 	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
-	AuthWebhookURL = ts.URL
+	AuthWebhookURL = mustParseUrl(ts.URL)
 	defer func() {
-		AuthWebhookURL = ""
+		AuthWebhookURL = nil
 	}()
 
 	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
@@ -1066,9 +1066,9 @@ func TestGetPriceInfo_Webhook_NoCache_ReturnsDefaultPrice(t *testing.T) {
 	assert := assert.New(t)
 	orch := &mockOrchestrator{}
 
-	AuthWebhookURL = "i'm enabled"
+	AuthWebhookURL = &url.URL{Path: "i'm enabled"}
 	defer func() {
-		AuthWebhookURL = ""
+		AuthWebhookURL = nil
 	}()
 
 	addr := ethcommon.HexToAddress("foo")
@@ -1090,9 +1090,9 @@ func TestGetPriceInfo_Webhook_Cache_WrongType_ReturnsDefaultPrice(t *testing.T) 
 	assert := assert.New(t)
 	orch := &mockOrchestrator{}
 
-	AuthWebhookURL = "i'm enabled"
+	AuthWebhookURL = &url.URL{Path: "i'm enabled"}
 	defer func() {
-		AuthWebhookURL = ""
+		AuthWebhookURL = nil
 	}()
 
 	addr := ethcommon.HexToAddress("foo")
@@ -1116,9 +1116,9 @@ func TestGetPriceInfo_Webhook_Cache_ReturnsCachePrice(t *testing.T) {
 	assert := assert.New(t)
 	orch := &mockOrchestrator{}
 
-	AuthWebhookURL = "i'm enabled"
+	AuthWebhookURL = &url.URL{Path: "i'm enabled"}
 	defer func() {
-		AuthWebhookURL = ""
+		AuthWebhookURL = nil
 	}()
 
 	addr := ethcommon.HexToAddress("foo")

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -1177,9 +1177,9 @@ func TestServeSegment_UpdateOrchestratorInfo_WebhookCache_PriceInfo(t *testing.T
 
 	require := require.New(t)
 
-	AuthWebhookURL = "i'm enabled"
+	AuthWebhookURL = &url.URL{Path: "i'm enabled"}
 	defer func() {
-		AuthWebhookURL = ""
+		AuthWebhookURL = nil
 	}()
 
 	origRandomIDGenerator := common.RandomIDGenerator


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Redacts basic auth credentials from webhook URLs before logging them.

This gave me second thoughts about using basic auth in the first place, but I
think it's still better than before especially after we ship the access rules for
API tokens. In the future we may want to switch to a separate flag with the
token so we can then use regular `Bearer` authorization header.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Remove parsed basic auth user info before logging cli flag

**How did you test each of these updates (required)**
https://play.golang.org/p/fqGr9eufH5A

**Does this pull request close any open issues?**
Closes https://github.com/livepeer/go-livepeer/issues/1936

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [-] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
