### PR TITLE
ci/windows: Add GPG keyserver

### DIFF
--- a/prepare_mingw64.sh
+++ b/prepare_mingw64.sh
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export MINGW_INSTALLS=mingw64
 pacman -S --noconfirm --noprogressbar --ask=20 --needed mingw-w64-x86_64-binutils mingw-w64-x86_64-gcc mingw-w64-x86_64-pkg-config mingw-w64-x86_64-go mingw-w64-x86_64-nasm mingw-w64-x86_64-clang git make autoconf automake patch libtool texinfo gtk-doc zip
-gpg --recv-keys F3599FF828C67298 249B39D24F25E3B6 2071B08A33BD3F06 29EE58B996865171 D605848ED7E69871
+gpg --keyserver keyserver.ubuntu.com --recv-keys F3599FF828C67298 249B39D24F25E3B6 2071B08A33BD3F06 29EE58B996865171 D605848ED7E69871
 
 # winpthreads needs git config for some reason
 git config --get user.email || git config --global user.email "fakeemail@example.com"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Use `keyserver.ubuntu.com` for fetching GPG keys used in the windows build. The default SKS keyservers used by GPG [are down](https://stackoverflow.com/a/68132500).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Windows CI works now

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
