### PR TITLE
install_ffmpeg: Allow specifying ffmpeg installation root dir

### DIFF
--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -101,7 +101,7 @@ if [ ! -e "$ROOT/gnutls-3.7.0" ]; then
   make install
   # gnutls doesn't properly set up its pkg-config or something? without this line ffmpeg and go
   # don't know that they need gmp, nettle, and hogweed
-  sed -i'' -e "s/-lgnutls/-lgnutls -lhogweed -lnettle -lgmp $EXTRA_GNUTLS_LIBS/g" ~/compiled/lib/pkgconfig/gnutls.pc
+  sed -i'' -e "s/-lgnutls/-lgnutls -lhogweed -lnettle -lgmp $EXTRA_GNUTLS_LIBS/g" $ROOT/compiled/lib/pkgconfig/gnutls.pc
 fi
 
 EXTRA_FFMPEG_FLAGS=""

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -2,14 +2,17 @@
 
 set -ex
 
+DEFAULT_ROOT="${HOME:-/build}"
+ROOT="${1:-$DEFAULT_ROOT}"
+mkdir -p $ROOT
+
 # Windows (MSYS2) needs a few tweaks
 if [[ $(uname) == *"MSYS"* ]]; then
   export PATH="$PATH:/usr/bin:/mingw64/bin"
   export C_INCLUDE_PATH="${C_INCLUDE_PATH:-}:/mingw64/lib"
-  export HOME="/build"
-  mkdir -p $HOME
+  export HOME="$ROOT"
 
-  export PATH="$HOME/compiled/bin":$PATH
+  export PATH="$ROOT/compiled/bin":$PATH
   export PKG_CONFIG_PATH=/mingw64/lib/pkgconfig
 
   export TARGET_OS="--target-os=mingw64"
@@ -20,80 +23,80 @@ if [[ $(uname) == *"MSYS"* ]]; then
   export WINDOWS_BUILD=1
 fi
 
-export PATH="$HOME/compiled/bin":$PATH
-export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}:$HOME/compiled/lib/pkgconfig"
+export PATH="$ROOT/compiled/bin":$PATH
+export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}:$ROOT/compiled/lib/pkgconfig"
 
 # NVENC only works on Windows/Linux
 if [ $(uname) != "Darwin" ]; then
-  if [ ! -e "$HOME/nv-codec-headers" ]; then
-    git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git "$HOME/nv-codec-headers"
-    cd $HOME/nv-codec-headers
+  if [ ! -e "$ROOT/nv-codec-headers" ]; then
+    git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git "$ROOT/nv-codec-headers"
+    cd $ROOT/nv-codec-headers
     git checkout 250292dd20af60edc6e0d07f1d6e489a2f8e1c44
-    make -e PREFIX="$HOME/compiled"
-    make install -e PREFIX="$HOME/compiled"
+    make -e PREFIX="$ROOT/compiled"
+    make install -e PREFIX="$ROOT/compiled"
   fi
 fi
 
 # Static linking of gnutls on Linux/Mac
 if [[ $(uname) != *"MSYS"* ]]; then
-  if [ ! -e "$HOME/nasm-2.14.02" ]; then
+  if [ ! -e "$ROOT/nasm-2.14.02" ]; then
     # sudo apt-get -y install asciidoc xmlto # this fails :(
-    cd "$HOME"
+    cd "$ROOT"
     curl -o nasm-2.14.02.tar.gz https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.gz
     echo 'b34bae344a3f2ed93b2ca7bf25f1ed3fb12da89eeda6096e3551fd66adeae9fc  nasm-2.14.02.tar.gz' > nasm-2.14.02.tar.gz.sha256
     sha256sum -c nasm-2.14.02.tar.gz.sha256
     tar xf nasm-2.14.02.tar.gz
     rm nasm-2.14.02.tar.gz nasm-2.14.02.tar.gz.sha256
-    cd "$HOME/nasm-2.14.02"
-    ./configure --prefix="$HOME/compiled"
+    cd "$ROOT/nasm-2.14.02"
+    ./configure --prefix="$ROOT/compiled"
     make
     make install || echo "Installing docs fails but should be OK otherwise"
   fi
 
-  # rm -rf "$HOME/gmp-6.1.2"
-  if [ ! -e "$HOME/gmp-6.1.2" ]; then
-    cd "$HOME"
+  # rm -rf "$ROOT/gmp-6.1.2"
+  if [ ! -e "$ROOT/gmp-6.1.2" ]; then
+    cd "$ROOT"
     curl -LO https://github.com/livepeer/livepeer-builddeps/raw/34900f2b1be4e366c5270e3ee5b0d001f12bd8a4/gmp-6.1.2.tar.xz
     tar xf gmp-6.1.2.tar.xz
-    cd "$HOME/gmp-6.1.2"
-    ./configure --prefix="$HOME/compiled" --disable-shared  --with-pic --enable-fat
+    cd "$ROOT/gmp-6.1.2"
+    ./configure --prefix="$ROOT/compiled" --disable-shared  --with-pic --enable-fat
     make
     make install
   fi
 
-  # rm -rf "$HOME/nettle-3.7"
-  if [ ! -e "$HOME/nettle-3.7" ]; then
-    cd $HOME
+  # rm -rf "$ROOT/nettle-3.7"
+  if [ ! -e "$ROOT/nettle-3.7" ]; then
+    cd $ROOT
     curl -LO https://github.com/livepeer/livepeer-builddeps/raw/657a86b78759b1ab36dae227253c26ff50cb4b0a/nettle-3.7.tar.gz
     tar xf nettle-3.7.tar.gz
     cd nettle-3.7
-    LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include" ./configure --prefix="$HOME/compiled" --disable-shared --enable-pic
+    LDFLAGS="-L${ROOT}/compiled/lib" CFLAGS="-I${ROOT}/compiled/include" ./configure --prefix="$ROOT/compiled" --disable-shared --enable-pic
     make
     make install
   fi
 
 fi
 
-if [ ! -e "$HOME/x264" ]; then
-  git clone http://git.videolan.org/git/x264.git "$HOME/x264"
-  cd "$HOME/x264"
+if [ ! -e "$ROOT/x264" ]; then
+  git clone http://git.videolan.org/git/x264.git "$ROOT/x264"
+  cd "$ROOT/x264"
   # git master as of this writing
   git checkout 545de2ffec6ae9a80738de1b2c8cf820249a2530
-  ./configure --prefix="$HOME/compiled" --enable-pic --enable-static ${HOST_OS:-} --disable-cli
+  ./configure --prefix="$ROOT/compiled" --enable-pic --enable-static ${HOST_OS:-} --disable-cli
   make
   make install-lib-static
 fi
 
-if [ ! -e "$HOME/gnutls-3.7.0" ]; then
+if [ ! -e "$ROOT/gnutls-3.7.0" ]; then
   EXTRA_GNUTLS_LIBS=""
   if [[ $(uname) == *"MSYS"* ]]; then
     EXTRA_GNUTLS_LIBS="-lncrypt -lcrypt32 -lwsock32 -lws2_32 -lwinpthread"
   fi
-  cd $HOME
+  cd $ROOT
   curl -LO https://www.gnupg.org/ftp/gcrypt/gnutls/v3.7/gnutls-3.7.0.tar.xz
   tar xf gnutls-3.7.0.tar.xz
   cd gnutls-3.7.0
-  LDFLAGS="-L${HOME}/compiled/lib" CFLAGS="-I${HOME}/compiled/include -O2" LIBS="-lhogweed -lnettle -lgmp $EXTRA_GNUTLS_LIBS" ./configure ${BUILD_OS:-} --prefix="$HOME/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools --disable-hardware-acceleration --disable-guile --disable-libdane --disable-tests --disable-rpath --disable-nls
+  LDFLAGS="-L${ROOT}/compiled/lib" CFLAGS="-I${ROOT}/compiled/include -O2" LIBS="-lhogweed -lnettle -lgmp $EXTRA_GNUTLS_LIBS" ./configure ${BUILD_OS:-} --prefix="$ROOT/compiled" --enable-static --disable-shared --with-pic --with-included-libtasn1 --with-included-unistring --without-p11-kit --without-idn --without-zlib --disable-doc --disable-cxx --disable-tools --disable-hardware-acceleration --disable-guile --disable-libdane --disable-tests --disable-rpath --disable-nls
   make
   make install
   # gnutls doesn't properly set up its pkg-config or something? without this line ffmpeg and go
@@ -120,9 +123,9 @@ else
   fi
 fi
 
-if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
-  git clone https://github.com/livepeer/FFmpeg.git "$HOME/ffmpeg" || echo "FFmpeg dir already exists"
-  cd "$HOME/ffmpeg"
+if [ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]; then
+  git clone https://github.com/livepeer/FFmpeg.git "$ROOT/ffmpeg" || echo "FFmpeg dir already exists"
+  cd "$ROOT/ffmpeg"
   git checkout b344789a31a2d806be702239d7614f7a9f51f941
   ./configure ${TARGET_OS:-} --fatal-warnings \
     --disable-programs --disable-doc --disable-sdl2 --disable-iconv \
@@ -138,9 +141,9 @@ if [ ! -e "$HOME/ffmpeg/libavcodec/libavcodec.a" ]; then
     --enable-filter=aresample,asetnsamples,fps,scale,lvpdnn \
     --enable-encoder=aac,libx264 \
     --enable-decoder=aac,h264 \
-    --extra-cflags="-I${HOME}/compiled/include" \
-    --extra-ldflags="-L${HOME}/compiled/lib ${EXTRA_LDFLAGS}" \
-    --prefix="$HOME/compiled" \
+    --extra-cflags="-I${ROOT}/compiled/include" \
+    --extra-ldflags="-L${ROOT}/compiled/lib ${EXTRA_LDFLAGS}" \
+    --prefix="$ROOT/compiled" \
     $EXTRA_FFMPEG_FLAGS
   make
   make install

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -2,15 +2,13 @@
 
 set -ex
 
-DEFAULT_ROOT="${HOME:-/build}"
-ROOT="${1:-$DEFAULT_ROOT}"
-mkdir -p $ROOT
+ROOT="${1:-$HOME}"
 
 # Windows (MSYS2) needs a few tweaks
 if [[ $(uname) == *"MSYS"* ]]; then
+  ROOT="/build"
   export PATH="$PATH:/usr/bin:/mingw64/bin"
   export C_INCLUDE_PATH="${C_INCLUDE_PATH:-}:/mingw64/lib"
-  export HOME="$ROOT"
 
   export PATH="$ROOT/compiled/bin":$PATH
   export PKG_CONFIG_PATH=/mingw64/lib/pkgconfig
@@ -25,6 +23,8 @@ fi
 
 export PATH="$ROOT/compiled/bin":$PATH
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}:$ROOT/compiled/lib/pkgconfig"
+
+mkdir -p $ROOT
 
 # NVENC only works on Windows/Linux
 if [ $(uname) != "Darwin" ]; then


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
My local build only really worked after I ran the `./install_ffmpeg.sh`
script, even though I already had _some_ `ffmpeg` version installed
via `brew`.

The issue I had with it though was that it wrote a bunch of directories
in my home path, which felt intrusive. 

The point of this change was to allow specifying some different path
to the script, to be used as the root dir for installation instead. Simply
pass an argument to it like `./install_ffmpeg.sh ~/workspace/pkg/ffmeg`
and it should install everything to that path instead.

**Specific updates (required)**
 - Create `$ROOT` var to use instead of `$HOME`
 - Set `$ROOT`: from cli arg, or; `$HOME`, or; `/build` (windows*)
 - `s/HOME/ROOT/g`
 - `s/~\//`$ROOT\//`

* I'll see if this works for the windows build or if we need to force a
different `$HOME` even if it exists.

**How did you test each of these updates (required)**
Ran script both with custom and no argument and made sure it installed everything.

**Does this pull request close any open issues?**
No.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [-] [Pending changelog](./CHANGELOG_PENDING.md) updated
