### PR TITLE
cmd: add missing signer to eth client config

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,6 +11,7 @@
 - \#1930 Support custom minimum gas price (@yondonfu)
 - \#1942 Log min and max gas price when monitoring is enabled (@kyriediculous)
 - \#1923 Use a transaction manager with better transaction handling and optional replacement transactions instead of the default JSON-RPC client (@kyriediculous)
+- \#1954 Add signer to Ethereum client config (@kyriediculous)
 
 #### Broadcaster
 

--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -200,6 +200,7 @@ func ethSetup(ethAcctAddr, keystoreDir string, isBroadcaster bool) {
 		EthClient:          backend,
 		GasPriceMonitor:    gpm,
 		TransactionManager: tm,
+		Signer:             signer,
 	}
 
 	client, err := eth.NewClient(ethCfg)

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -418,6 +418,7 @@ func main() {
 			EthClient:          backend,
 			GasPriceMonitor:    gpm,
 			TransactionManager: tm,
+			Signer:             signer,
 		}
 
 		client, err := eth.NewClient(ethCfg)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds signer to `LivepeerEthConfig` when initialising the `LivepeerEthClient`


**Does this pull request close any open issues?**
Fixes #1953

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
