### PR TITLE
eth: tx receipt as embedded value rather than pointer in transaction manager subscriptions

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -37,6 +37,7 @@
 ### Bug Fixes 🐞
 
 #### General
+- \#1968 Fix nil pointer error in embedded transaction receipts returned from the TransactionManager (@kyriediculous)
 
 #### Broadcaster
 

--- a/eth/client.go
+++ b/eth/client.go
@@ -875,7 +875,7 @@ func (c *client) CheckTx(tx *types.Transaction) error {
 		case err := <-txSub.Err():
 			return err
 		case receipt := <-receipts:
-			if tx.Hash() == receipt.TxHash {
+			if tx.Hash() == receipt.originTxHash {
 				if receipt.err != nil {
 					return receipt.err
 				}

--- a/eth/transactionManager_test.go
+++ b/eth/transactionManager_test.go
@@ -306,6 +306,8 @@ func TestTransactionManager_CheckTxLoop(t *testing.T) {
 	sub = tm.Subscribe(sink)
 	tm.SendTransaction(context.Background(), stubTx)
 	event = <-sink
+	assert.NotNil(event.Receipt)
+	assert.Equal(event.originTxHash, stubTx.Hash())
 	assert.NotNil(event)
 	assert.EqualError(event.err, context.DeadlineExceeded.Error())
 	eth.err["TransactionReceipt"] = nil
@@ -321,6 +323,8 @@ func TestTransactionManager_CheckTxLoop(t *testing.T) {
 
 	tm.SendTransaction(context.Background(), stubTx)
 	event = <-sink
+	assert.NotNil(event.Receipt)
+	assert.Equal(event.originTxHash, stubTx.Hash())
 	assert.EqualError(event.err, eth.err["TransactionByHash"].Error())
 	assert.Equal(eth.callsToTxByHash, 1)
 	sub.Unsubscribe()
@@ -335,6 +339,8 @@ func TestTransactionManager_CheckTxLoop(t *testing.T) {
 
 	tm.SendTransaction(context.Background(), stubTx)
 	event = <-sink
+	assert.NotNil(event.Receipt)
+	assert.Equal(event.originTxHash, stubTx.Hash())
 	assert.EqualError(event.err, eth.err["TransactionByHash"].Error())
 	assert.Equal(eth.callsToTxByHash, 1)
 	assert.LessOrEqual(eth.callsToTxByHash, tm.maxReplacements)
@@ -349,6 +355,8 @@ func TestTransactionManager_CheckTxLoop(t *testing.T) {
 
 	tm.SendTransaction(context.Background(), stubTx)
 	event = <-sink
+	assert.NotNil(event.Receipt)
+	assert.Equal(event.originTxHash, stubTx.Hash())
 	assert.EqualError(event.err, context.DeadlineExceeded.Error())
 	assert.Equal(eth.callsToTxByHash, tm.maxReplacements)
 	sub.Unsubscribe()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Embed the transaction receipt from the ethereum client as a value rather than a pointer in the `transactionReceipt`returned by `TransactionManager`subscriptions. 

**How did you test each of these updates (required)**
- added unit test

**Does this pull request close any open issues?**
Fixes #1964 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
