### PR TITLE
install_ffmpeg: Now works when $HOME is not set

### DIFF
--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -24,7 +24,7 @@ fi
 export PATH="$ROOT/compiled/bin":$PATH
 export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}:$ROOT/compiled/lib/pkgconfig"
 
-mkdir -p $ROOT
+mkdir -p "$ROOT/"
 
 # NVENC only works on Windows/Linux
 if [ $(uname) != "Darwin" ]; then


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Sometimes the `$HOME` environment variable is not set for `root` unix user, causing the script to terminate. Adding the trailing slash ensures

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
*See commit history*

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Tested on root by manually setting `$HOME` to `""` and `"/tmp/"`

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #1967 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
