### PR TITLE
cmd/livepeer: Set default maxTicketEV to 3000 gwei

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -25,6 +25,7 @@
 - \#1950 Fix extremely long delay before uploaded segment gets transcoded (@darkdarkdragon)
 - \#1933 server: Return 0 video frame segments unchanged (@darkdarkdragon)
 - \#1932 Serialize writes of JSON playlist (@darkdarkdragon)
+- \#1985 Set default -maxTicketEV to 3000 gwei (@yondonfu)
 
 #### Orchestrator
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -122,7 +122,7 @@ func main() {
 	initializeRound := flag.Bool("initializeRound", false, "Set to true if running as a transcoder and the node should automatically initialize new rounds")
 	ticketEV := flag.String("ticketEV", "1000000000000", "The expected value for PM tickets")
 	// Broadcaster max acceptable ticket EV
-	maxTicketEV := flag.String("maxTicketEV", "100000000000000", "The maximum acceptable expected value for PM tickets")
+	maxTicketEV := flag.String("maxTicketEV", "3000000000000", "The maximum acceptable expected value for PM tickets")
 	// Broadcaster deposit multiplier to determine max acceptable ticket faceValue
 	depositMultiplier := flag.Int("depositMultiplier", 1, "The deposit multiplier used to determine max acceptable faceValue for PM tickets")
 	// Orchestrator base pricing info


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Sets the default value for `-maxTicketEV` on broadcasters to 3000 gwei to establish a safer default for broadcasters (i.e. set a lower cap on the value that a broadcaster will send to an orchestrator up front before receiving any results).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Ran manually.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
