### PR TITLE
monitor: Create realtime ratio histogram metric

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,6 +24,8 @@
 
 #### Broadcaster
 
+- \#1989 Record realtime ratio metric as a histogram (@victorges)
+
 #### Orchestrator
 
 #### Transcoder

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -383,7 +383,7 @@ func InitCensus(nodeType NodeType, version string) {
 		{
 			Name:        "http_client_segment_transcoded_realtime_ratio",
 			Measure:     census.mRealtimeRatio,
-			Description: "Ratio of source segment duration / transcode time as measured on broadcaster API",
+			Description: "Ratio of source segment duration / transcode time as measured on HTTP client",
 			TagKeys:     baseTags,
 			Aggregation: view.Distribution(0.5, 1, 2, 3, 5, 10, 50, 100),
 		},

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -230,7 +230,7 @@ func InitCensus(nodeType NodeType, version string) {
 	}
 	census.mHTTPClientTimeout1 = stats.Int64("http_client_timeout_1", "Number of times HTTP connection was dropped before transcoding complete", "tot")
 	census.mHTTPClientTimeout2 = stats.Int64("http_client_timeout_2", "Number of times HTTP connection was dropped before transcoded segments was sent back to client", "tot")
-	census.mRealtimeRatio = stats.Float64("http_client_segment_transcoded_realtime_ratio", "Ratio of source segment duration / transcode time as measured on broadcaster API", "rat")
+	census.mRealtimeRatio = stats.Float64("http_client_segment_transcoded_realtime_ratio", "Ratio of source segment duration / transcode time as measured on HTTP client", "rat")
 	census.mRealtime3x = stats.Int64("http_client_segment_transcoded_realtime_3x", "Number of segment transcoded 3x faster than realtime", "tot")
 	census.mRealtime2x = stats.Int64("http_client_segment_transcoded_realtime_2x", "Number of segment transcoded 2x faster than realtime", "tot")
 	census.mRealtime1x = stats.Int64("http_client_segment_transcoded_realtime_1x", "Number of segment transcoded 1x faster than realtime", "tot")

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -126,6 +126,7 @@ type (
 		mSourceSegmentDuration        *stats.Float64Measure
 		mHTTPClientTimeout1           *stats.Int64Measure
 		mHTTPClientTimeout2           *stats.Int64Measure
+		mRealtimeRatio                *stats.Float64Measure
 		mRealtime3x                   *stats.Int64Measure
 		mRealtime2x                   *stats.Int64Measure
 		mRealtime1x                   *stats.Int64Measure
@@ -229,6 +230,7 @@ func InitCensus(nodeType NodeType, version string) {
 	}
 	census.mHTTPClientTimeout1 = stats.Int64("http_client_timeout_1", "Number of times HTTP connection was dropped before transcoding complete", "tot")
 	census.mHTTPClientTimeout2 = stats.Int64("http_client_timeout_2", "Number of times HTTP connection was dropped before transcoded segments was sent back to client", "tot")
+	census.mRealtimeRatio = stats.Float64("http_client_segment_transcoded_realtime_ratio", "Ratio of source segment duration / transcode time as measured on broadcaster API", "rat")
 	census.mRealtime3x = stats.Int64("http_client_segment_transcoded_realtime_3x", "Number of segment transcoded 3x faster than realtime", "tot")
 	census.mRealtime2x = stats.Int64("http_client_segment_transcoded_realtime_2x", "Number of segment transcoded 2x faster than realtime", "tot")
 	census.mRealtime1x = stats.Int64("http_client_segment_transcoded_realtime_1x", "Number of segment transcoded 1x faster than realtime", "tot")
@@ -377,6 +379,13 @@ func InitCensus(nodeType NodeType, version string) {
 			Description: "Number of times HTTP connection was dropped before transcoded segments was sent back to client",
 			TagKeys:     baseTags,
 			Aggregation: view.Count(),
+		},
+		{
+			Name:        "http_client_segment_transcoded_realtime_ratio",
+			Measure:     census.mRealtimeRatio,
+			Description: "Ratio of source segment duration / transcode time as measured on broadcaster API",
+			TagKeys:     baseTags,
+			Aggregation: view.Distribution(0.5, 1, 2, 3, 5, 10),
 		},
 		{
 			Name:        "http_client_segment_transcoded_realtime_3x",
@@ -1118,19 +1127,21 @@ func SegmentFullyProcessed(segDur, processDur float64) {
 	if processDur == 0 {
 		return
 	}
-	xRealtime := processDur / segDur
+	ratio := segDur / processDur
+	var bucketM stats.Measurement
 	switch {
-	case xRealtime < 1.0/3.0:
-		stats.Record(census.ctx, census.mRealtime3x.M(1))
-	case xRealtime < 1.0/2.0:
-		stats.Record(census.ctx, census.mRealtime2x.M(1))
-	case xRealtime < 1.0:
-		stats.Record(census.ctx, census.mRealtime1x.M(1))
-	case xRealtime < 2.0:
-		stats.Record(census.ctx, census.mRealtimeHalf.M(1))
+	case ratio > 3:
+		bucketM = census.mRealtime3x.M(1)
+	case ratio > 2:
+		bucketM = census.mRealtime2x.M(1)
+	case ratio > 1:
+		bucketM = census.mRealtime1x.M(1)
+	case ratio > 0.5:
+		bucketM = census.mRealtimeHalf.M(1)
 	default:
-		stats.Record(census.ctx, census.mRealtimeSlow.M(1))
+		bucketM = census.mRealtimeSlow.M(1)
 	}
+	stats.Record(census.ctx, bucketM, census.mRealtimeRatio.M(ratio))
 }
 
 func AuthWebhookFinished(dur time.Duration) {

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -385,7 +385,7 @@ func InitCensus(nodeType NodeType, version string) {
 			Measure:     census.mRealtimeRatio,
 			Description: "Ratio of source segment duration / transcode time as measured on broadcaster API",
 			TagKeys:     baseTags,
-			Aggregation: view.Distribution(0.5, 1, 2, 3, 5, 10),
+			Aggregation: view.Distribution(0.5, 1, 2, 3, 5, 10, 50, 100),
 		},
 		{
 			Name:        "http_client_segment_transcoded_realtime_3x",


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This will allow for simpler queries to be performed to evaluate our transcoding
performance. Using Prometheus' [histogram_quantile()](https://prometheus.io/docs/prometheus/latest/querying/functions/#histogram_quantile) function, we can actually
plot and alert on a concrete p99 value for the transcoding realtime ratio.

e.g.: "p99" (actually p01 since higher is better) of transcode real-time ratio as
seen by `ewr` orchs: [[query]](https://ewr-monitoring.livepeer.live/prometheus/graph?g0.expr=histogram_quantile(0.01%2C%20sum%20by%20(le)%20(rate(livepeer_transcode_score_bucket%5B1m%5D)))&g0.tab=0&g0.stacked=0&g0.range_input=1w)

Ended up coding this when digging deeper on the real-time alert, to make it less noisy. 

**Specific updates (required)**
- Add `http_client_segment_transcoded_realtime_ratio` metric to `monitor/census.go`

**How did you test each of these updates (required)**
Not really sure how to test the Prometheus logic locally, but the change is pretty simple.
Also cross-checked the implementation with the `transcode_score` metric which is almost 
the same idea (it's only measured on a different step in the code, on orchs and transcoders afaict)

**Does this pull request close any open issues?**
Closes https://github.com/livepeer/livepeer-infra/issues/627 (still need to update the actual alert definitions though)

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [-] README and other documentation updated
- [-] [Pending changelog](./CHANGELOG_PENDING.md) updated
