### PR TITLE
eth: fix max gas price nil pointer error in replace transaction

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,7 +22,7 @@
 
 #### General
 
-- \#2001  fix max gas price nil pointer error in replace transaction (@kyriediculous)
+- \#2001 Fix max gas price nil pointer error in replace transaction (@kyriediculous)
 
 #### Broadcaster
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,8 @@
 
 #### General
 
+- \#2001  fix max gas price nil pointer error in replace transaction (@kyriediculous)
+
 #### Broadcaster
 
 #### Orchestrator

--- a/eth/transactionManager.go
+++ b/eth/transactionManager.go
@@ -166,7 +166,7 @@ func (tm *TransactionManager) replace(tx *types.Transaction) (*types.Transaction
 
 	// Bump gas price exceeds max gas price, return early
 	max := tm.gpm.MaxGasPrice()
-	if gasPrice.Cmp(max) > 0 {
+	if max != nil && gasPrice.Cmp(max) > 0 {
 		return nil, fmt.Errorf("replacement gas price exceeds max gas price suggested=%v max=%v", gasPrice, max)
 	}
 

--- a/eth/transactionManager_test.go
+++ b/eth/transactionManager_test.go
@@ -219,6 +219,12 @@ func TestTransactionManager_Replace(t *testing.T) {
 	tx, err = tm.replace(stubTx)
 	assert.Nil(tx)
 	assert.EqualError(err, expErr.Error())
+
+	// Test when max gas price is nil - should still return signing replacement tx error
+	gpm.maxGasPrice = nil
+	tx, err = tm.replace(stubTx)
+	assert.Nil(tx)
+	assert.EqualError(err, expErr.Error())
 	sig.err = nil
 
 	// Error sending replacement tx


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Check that `gpm.MaxGasPrice` isn't nil in `TransctionManager.replace()`

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x7ff626d592eb]

goroutine 44 [running]:
math/big.(*Int).Cmp(0xc00107b5a0, 0x0, 0x1)
        D:/a/_temp/msys/msys64/mingw64/lib/go/src/math/big/int.go:328 +0x4b
github.com/livepeer/go-livepeer/eth.(*TransactionManager).replace(0xc0004340f0, 0xc001760750, 0x7ff6292630c0, 0x7ff628912a01, 0x7ff6292630c0)
        D:/a/go-livepeer/go-livepeer/eth/transactionManager.go:169 +0x1e8
github.com/livepeer/go-livepeer/eth.(*TransactionManager).checkTxLoop(0xc0004340f0)
        D:/a/go-livepeer/go-livepeer/eth/transactionManager.go:222 +0x2a9
github.com/livepeer/go-livepeer/eth.(*TransactionManager).Start(0xc0004340f0)
        D:/a/go-livepeer/go-livepeer/eth/transactionManager.go:124 +0x32
created by main.main
        D:/a/go-livepeer/go-livepeer/cmd/livepeer/livepeer.go:412 +0x2a9a
```

**Specific updates (required)**
added nil check

**How did you test each of these updates (required)**
Removed max gas price initial value from unit tests

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated