### PR TITLE
pm: Only mark failed tx as redeemed for check tx err

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -28,4 +28,6 @@
 
 #### Orchestrator
 
+- \#2018 Only mark tickets for failed transactions as redeemed when there is an error checking the transaction (@yondonfu)
+
 #### Transcoder

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -25,8 +25,6 @@ var unixNow = func() int64 {
 	return time.Now().Unix()
 }
 
-type errCheckTx error
-
 // SenderMonitor is an interface that describes methods used to
 // monitor remote senders
 type SenderMonitor interface {
@@ -429,7 +427,7 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 			monitor.TicketRedemptionError()
 		}
 		// Return tx so caller can utilize the tx if it fails
-		return tx, errCheckTx(err)
+		return tx, err
 	}
 
 	if monitor.Enabled {

--- a/pm/sendermonitor_test.go
+++ b/pm/sendermonitor_test.go
@@ -794,7 +794,7 @@ func TestRedeemWinningTicket_SingleTicket_CheckTxError(t *testing.T) {
 	signedT := defaultSignedTicket(addr, uint32(0))
 
 	tx, err := sm.redeemWinningTicket(signedT)
-	assert.Nil(tx)
+	assert.NotNil(tx)
 	assert.IsType(expErr, err)
 }
 

--- a/pm/sendermonitor_test.go
+++ b/pm/sendermonitor_test.go
@@ -787,7 +787,7 @@ func TestRedeemWinningTicket_SingleTicket_CheckTxError(t *testing.T) {
 	sm := NewSenderMonitor(cfg, b, smgr, tm, ts)
 	sm.Start()
 	defer sm.Stop()
-	expErr := errCheckTx(errors.New("checktx error"))
+	expErr := errors.New("checktx error")
 	b.checkTxErr = expErr
 	assert := assert.New(t)
 
@@ -795,7 +795,7 @@ func TestRedeemWinningTicket_SingleTicket_CheckTxError(t *testing.T) {
 
 	tx, err := sm.redeemWinningTicket(signedT)
 	assert.NotNil(tx)
-	assert.IsType(expErr, err)
+	assert.Equal(expErr, err)
 }
 
 func TestRedeemWinningTicket_SingleTicket(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

At the moment, if an error is encountered while calling `eth.client.CheckTx()` for a ticket redemption tx, the ticket is marked as redeemed with the tx hash set to the null hash (i.e. 0x000...). This behavior is a problem because `eth.client.CheckTx()` could return an error even if the tx did not fail. For example, an error is returned in the scenario where the tx needs to be replaced, but the required gas price for a replacement exceeds the node's configured max gas price. The consequence of this behavior is that the node incorrectly marks the ticket as redeemed in the node's DB which prevents the node from retrying the ticket and also makes it more difficult to query the DB for redeemable tickets in other tools such as the script in https://github.com/livepeer/go-livepeer/pull/2014.

This PR introduces logic to only mark tickets for failed redeemed (i.e. revert, OOG) txs as redeemed.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history and in-line code comments.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Ran unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #2016 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
