### PR TITLE
Randomization for unknown sessions at a random frequency

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -102,6 +102,7 @@ func main() {
 	orchSecret := flag.String("orchSecret", "", "Shared secret with the orchestrator as a standalone transcoder")
 	transcodingOptions := flag.String("transcodingOptions", "P240p30fps16x9,P360p30fps16x9", "Transcoding options for broadcast job, or path to json config")
 	maxAttempts := flag.Int("maxAttempts", 3, "Maximum transcode attempts")
+	selectRandFreq := flag.Float64("selectRandFreq", 0.3, "Frequency to randomly select unknown orchestrators (on-chain mode only)")
 	maxSessions := flag.Int("maxSessions", 10, "Maximum number of concurrent transcoding sessions for Orchestrator, maximum number or RTMP streams for Broadcaster, or maximum capacity for transcoder")
 	currentManifest := flag.Bool("currentManifest", false, "Expose the currently active ManifestID as \"/stream/current.m3u8\"")
 	nvidia := flag.String("nvidia", "", "Comma-separated list of Nvidia GPU device IDs (or \"all\" for all available devices)")
@@ -880,6 +881,7 @@ func main() {
 
 		// Set max transcode attempts. <=0 is OK; it just means "don't transcode"
 		server.MaxAttempts = *maxAttempts
+		server.SelectRandFreq = *selectRandFreq
 
 	} else if n.NodeType == core.OrchestratorNode {
 		suri, err := getServiceURI(n, *serviceAddr)

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -18,6 +18,7 @@ import (
 )
 
 var getOrchestratorsTimeoutLoop = 3 * time.Second
+var getOrchestratorsCutoffTimeout = 500 * time.Millisecond
 
 var serverGetOrchInfo = server.GetOrchestratorInfo
 
@@ -75,7 +76,7 @@ func (o *orchestratorPool) GetOrchestrators(numOrchestrators int, suspender comm
 
 	numAvailableOrchs := len(linfos)
 	numOrchestrators = int(math.Min(float64(numAvailableOrchs), float64(numOrchestrators)))
-	ctx, cancel := context.WithTimeout(context.Background(), getOrchestratorsTimeoutLoop)
+	ctx, cancel := context.WithTimeout(context.Background(), getOrchestratorsCutoffTimeout)
 
 	infoCh := make(chan *net.OrchestratorInfo, numAvailableOrchs)
 	errCh := make(chan error, numAvailableOrchs)

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -111,7 +111,10 @@ func NewSessionPool(mid core.ManifestID, poolSize, numOrchs int, sus *suspender,
 }
 
 func (sp *SessionPool) suspend(orch string) {
-	sp.sus.suspend(orch, sp.poolSize/sp.numOrchs)
+	poolSize := math.Max(1, float64(sp.poolSize))
+	numOrchs := math.Max(1, float64(sp.numOrchs))
+	penalty := int(math.Ceil(poolSize / numOrchs))
+	sp.sus.suspend(orch, penalty)
 }
 
 func (sp *SessionPool) refreshSessions() {
@@ -358,7 +361,7 @@ func NewSessionManager(node *core.LivepeerNode, params *core.StreamParameters, s
 	}
 	maxInflight := common.HTTPTimeout.Seconds() / SegLen.Seconds()
 	trustedNumOrchs := int(math.Min(trustedPoolSize, maxInflight*2))
-	untrustedNumOrchs := int(math.Min(untrustedPoolSize, maxInflight*2)) * 2
+	untrustedNumOrchs := int(untrustedPoolSize)
 	susTrusted := newSuspender()
 	susUntrusted := newSuspender()
 	createSessionsTrusted := func() ([]*BroadcastSession, error) {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -63,6 +63,8 @@ var AuthWebhookURL *url.URL
 var DetectionWebhookURL *url.URL
 var DetectionWhClient = &http.Client{Timeout: 2 * time.Second}
 
+var SelectRandFreq float64
+
 // For HTTP push watchdog
 var httpPushTimeout = 1 * time.Minute
 var httpPushResetTimer = func() (context.Context, context.CancelFunc) {
@@ -574,7 +576,7 @@ func (s *LivepeerServer) registerConnection(rtmpStrm stream.RTMPVideoStream) (*r
 		stakeRdr = &storeStakeReader{store: s.LivepeerNode.Database}
 	}
 	selFactory := func() BroadcastSessionsSelector {
-		return NewMinLSSelector(stakeRdr, 1.0)
+		return NewMinLSSelectorWithRandFreq(stakeRdr, 1.0, SelectRandFreq)
 	}
 	cxn := &rtmpConnection{
 		mid:     mid,

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -411,7 +411,7 @@ func TestSelectOrchestrator(t *testing.T) {
 	// Skip orchestrator if missing auth token
 	sd.infos[0].AuthToken = nil
 
-	sess, err = selectOrchestrator(s.LivepeerNode, sp, 4, newSuspender())
+	sess, err = selectOrchestrator(s.LivepeerNode, sp, 4, newSuspender(), func(float32) bool { return true })
 	require.Nil(err)
 
 	assert.Len(sess, 1)
@@ -421,7 +421,7 @@ func TestSelectOrchestrator(t *testing.T) {
 	sd.infos[0].AuthToken = &net.AuthToken{}
 	sd.infos[0].TicketParams = nil
 
-	sess, err = selectOrchestrator(s.LivepeerNode, sp, 4, newSuspender())
+	sess, err = selectOrchestrator(s.LivepeerNode, sp, 4, newSuspender(), func(float32) bool { return true })
 	require.Nil(err)
 
 	assert.Len(sess, 1)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds a randFreq field to MinLSSelector which defines a random frequency at which to randomize the selection of unknown sessions instead of running stake weighted selection when in on-chain mode.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests, but only for simple scenarios as unit testing randomization is a bit tricky so my plan is to also do some manual testing with non-trivial values of randFreq i.e. not 0.0 or 1.0.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
