### PR TITLE
verification: Run sig verification even without a policy

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,6 +26,8 @@
 
 #### Broadcaster
 
+- \#2026 Run signature verification even without a verification policy specified (@yondonfu)
+
 #### Orchestrator
 
 - \#2018 Only mark tickets for failed transactions as redeemed when there is an error checking the transaction (@yondonfu)

--- a/verification/verify.go
+++ b/verification/verify.go
@@ -115,12 +115,12 @@ func NewSegmentVerifier(p *Policy) *SegmentVerifier {
 }
 
 func (sv *SegmentVerifier) Verify(params *Params) (*Params, error) {
-	if sv.policy == nil {
-		return nil, nil
-	}
-
 	if err := sv.sigVerification(params); err != nil {
 		return nil, err
+	}
+
+	if sv.policy == nil {
+		return nil, nil
 	}
 
 	var err error

--- a/verification/verify_test.go
+++ b/verification/verify_test.go
@@ -214,6 +214,12 @@ func TestVerify(t *testing.T) {
 	assert.Equal(errPMCheckFailed, err)
 	assert.Nil(res)
 
+	// Check sig verifier runs and fails (due to missing sig) even when policy is nil
+	sv = NewSegmentVerifier(nil)
+	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{TicketParams: &net.TicketParams{}}, Renditions: renditions})
+	assert.Equal(errPMCheckFailed, err)
+	assert.Nil(res)
+
 	// Check retryable: 3 attempts
 	sv = NewSegmentVerifier(&Policy{Verifier: verifier, Retries: 2}) // reset
 	verifier.err = Retryable{errors.New("Stub Verifier Retryable Error")}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

At the moment, signature verification for results returned by an orchestrators will only run if a verification policy is specified which is only the case if `-localVerify=true`. As a result, if `-localVerify=false` when running a broadcaster, signature verification is skipped.

This PR ensures that signature verification is always run regardless of the value of `-localVerify` because the broadcaster should always verify signatures returned by an orchestrator.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
