### PR TITLE
eth: Fix active total stake calc in RewardWithHint

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -33,5 +33,6 @@
 #### Orchestrator
 
 - \#2018 Only mark tickets for failed transactions as redeemed when there is an error checking the transaction (@yondonfu)
+- \#2029 Fix active total stake calculation when generating hints for rewardWithHint (@yondonfu)
 
 #### Transcoder

--- a/eth/client_test.go
+++ b/eth/client_test.go
@@ -114,6 +114,10 @@ func TestSimulateTranscoderPool(t *testing.T) {
 	assert.Equal(hints, lpTypes.TranscoderPoolHints{
 		PosPrev: ethcommon.HexToAddress("eee"),
 	})
+
+	// when new stake is 0 and transcoder pool is full return empty hints
+	hints = simulateTranscoderPoolUpdate(ethcommon.HexToAddress("aaa"), big.NewInt(0), copyTranscoders(transcoders), true)
+	assert.Equal(hints, lpTypes.TranscoderPoolHints{})
 }
 
 func TestFindTranscoderHints(t *testing.T) {

--- a/eth/types/contracts.go
+++ b/eth/types/contracts.go
@@ -13,17 +13,18 @@ var (
 )
 
 type Transcoder struct {
-	Address           common.Address
-	ServiceURI        string
-	LastRewardRound   *big.Int
-	RewardCut         *big.Int
-	FeeShare          *big.Int
-	DelegatedStake    *big.Int
-	ActivationRound   *big.Int
-	DeactivationRound *big.Int
-	Active            bool
-	Status            string
-	PricePerPixel     *big.Rat
+	Address                    common.Address
+	ServiceURI                 string
+	LastRewardRound            *big.Int
+	RewardCut                  *big.Int
+	FeeShare                   *big.Int
+	DelegatedStake             *big.Int
+	ActivationRound            *big.Int
+	DeactivationRound          *big.Int
+	LastActiveStakeUpdateRound *big.Int
+	Active                     bool
+	Status                     string
+	PricePerPixel              *big.Rat
 }
 
 func ParseTranscoderStatus(s uint8) (string, error) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR fixes a bug in the total stake calculations used for hint generation in `eth.client.Reward()`. I've added in-line PR comments to explain the bug and the solutions used.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested manually using devtool.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #2015

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
