### PR TITLE
mod,install_ffmpeg: update to ffmpeg with `signature_cuda` filter sup…

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,8 @@
 
 #### Transcoder
 
+- \#2036 Generate mpeg7 perceptual hashes for fast verification (@jailuthra)
+
 ### Bug Fixes 🐞
 
 #### General

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/jaypipes/ghw v0.7.0
 	github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 // indirect
 	github.com/livepeer/livepeer-data v0.2.0
-	github.com/livepeer/lpms v0.0.0-20210913114201-60d071ce5550
+	github.com/livepeer/lpms v0.0.0-20210924125113-6ccecaaad72c
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cO
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.2.0 h1:8ELEri/sWd6fAHT3anAgoKe9Z+XgbW0oLg5qODdhvm8=
 github.com/livepeer/livepeer-data v0.2.0/go.mod h1:vkW1PJ24gOJgx1hHUo07cXkR1b409n+dGpyWJsHKI3s=
-github.com/livepeer/lpms v0.0.0-20210913114201-60d071ce5550 h1:hOoDoinr6GWvYVX8X1Bia65ok3hiDnaL3nj2EfZbVT8=
-github.com/livepeer/lpms v0.0.0-20210913114201-60d071ce5550/go.mod h1:iIvqFRRSIcouTWFheH2/TeDAq7xTVOJNR0eAS84o754=
+github.com/livepeer/lpms v0.0.0-20210924125113-6ccecaaad72c h1:PbxntZucwHnegSUUst2788mo7E3KuGw2EYuwyTbGGLA=
+github.com/livepeer/lpms v0.0.0-20210924125113-6ccecaaad72c/go.mod h1:iIvqFRRSIcouTWFheH2/TeDAq7xTVOJNR0eAS84o754=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -114,7 +114,7 @@ else
   if which clang > /dev/null; then
     echo "clang detected, building with GPU support"
 
-    EXTRA_FFMPEG_FLAGS="--enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid --enable-filter=scale_cuda --enable-encoder=h264_nvenc"
+    EXTRA_FFMPEG_FLAGS="--enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid --enable-filter=scale_cuda,signature_cuda --enable-encoder=h264_nvenc"
 
     if [[ $BUILD_TAGS == *"experimental"* ]]; then
         echo "experimental tag detected, building with Tensorflow support"
@@ -126,7 +126,7 @@ fi
 if [ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]; then
   git clone https://github.com/livepeer/FFmpeg.git "$ROOT/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$ROOT/ffmpeg"
-  git checkout 16b8686687413ef99fa398ca63585ff438737378
+  git checkout daa98cba7a82d0f1612aa36d9a0cbd9ba1a603ff
   ./configure ${TARGET_OS:-} --fatal-warnings \
     --disable-programs --disable-doc --disable-sdl2 --disable-iconv \
     --disable-muxers --disable-demuxers --disable-parsers --disable-protocols \


### PR DESCRIPTION
…port

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Use `signature_cuda` filter for mpeg7 perceptual hash generation when the transcoder node is initialized on a GPU (via `-nvidia <device>`).

Otherwise stick to the CPU based `signature` filter.

See https://github.com/livepeer/lpms/pull/263 and https://github.com/livepeer/FFmpeg/pull/14 for details.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
*See Commit History*

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Manually tested the following scenarios with a B build that asks for perceptual hashes for each segment https://github.com/livepeer/go-livepeer/tree/jai/mpeg7-test-orch:

1. Correct filter out of `signature` and `signature_cuda` is used when transcoder is initialized on CPU vs GPU
2. Verified that the perceptual hash URLs are received by the B
3. Running an old O or T node without the capability introduced in #2036 doesn't lead to any errors, but no perceptual hash is returned on the B
4. Other edge cases like newer O + old T in a split setup doesn't lead to errors or crashes, only error logs

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #2039 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
