### PR TITLE
Add link to Arch linux binary package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ network built on the Ethereum blockchain.
 
 Follow the [installation guide](https://livepeer.org/docs/installation/install-livepeer).
 
+Packages for Arch Linux can be found on the [AUR](https://aur.archlinux.org/packages/go-livepeer-bin/).
+
 ## Run Livepeer
 
 If you are interested in participating using the network as a video developer, check out the [video developer docs](https://livepeer.org/docs/video-developers/overview).


### PR DESCRIPTION
If someone would ping the person who maintains https://livepeer.org/docs/installation/install-livepeer#install-a-binary-release and add the same line there, it might speed up adoption on Arch linux which is a very popular distro with Linux gamers and also the distro the new Steam machine is based on.

**What does this pull request do? Explain your changes. (required)**
Update README.md with link to package on Arch's AUR.

**Specific updates (required)**

N/A

**How did you test each of these updates (required)**
N/A

**Does this pull request close any open issues?**
<!-- Fixes # -->
N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
