### PR TITLE
broadcaster: fast verification frequency

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -372,6 +372,10 @@ func RandName() string {
 	return RandomIDGenerator(10)
 }
 
+var RandomUintUnder = func(max uint) uint {
+	return uint(rand.Uint32()) % max
+}
+
 func ToInt64(val *big.Int) int64 {
 	if val.Cmp(big.NewInt(maxInt64)) > 0 {
 		return maxInt64

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -419,7 +419,9 @@ func (bsm *BroadcastSessionsManager) selectSessions() ([]*BroadcastSession, bool
 
 		// Only return the last verified session if:
 		// - It is present in the 3 sessions returned by the selector
-		if bsm.verifiedSession != nil && includesSession(sessions, bsm.verifiedSession) {
+		// - With probability 1 - 1/VerificationFrequency
+		if bsm.verifiedSession != nil && includesSession(sessions, bsm.verifiedSession) &&
+			common.RandomUintUnder(bsm.VerificationFreq) > 0 {
 			glog.V(common.DEBUG).Infof("Reusing verified orch=%v", bsm.verifiedSession.OrchestratorInfo.Transcoder)
 			// Mark remaining unused sessions returned by selector as complete
 			remaining := removeSessionFromList(sessions, bsm.verifiedSession)

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -435,9 +435,10 @@ func (bsm *BroadcastSessionsManager) selectSessions() ([]*BroadcastSession, bool
 		return sessions, true
 	}
 
-	sessions := bsm.trustedPool.selectSessions(1)
+	// Default to selecting from untrusted pool
+	sessions := bsm.untrustedPool.selectSessions(1)
 	if len(sessions) == 0 {
-		sessions = bsm.untrustedPool.selectSessions(1)
+		sessions = bsm.trustedPool.selectSessions(1)
 	}
 
 	return sessions, false

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -413,7 +413,7 @@ func (bsm *BroadcastSessionsManager) selectSessions() ([]*BroadcastSession, bool
 
 		sessions := bsm.trustedPool.selectSessions(1)
 		untrustedSesions := bsm.untrustedPool.selectSessions(2)
-		calcPerceptualHash := len(sessions) > 0 && len(untrustedSesions) > 0
+		calcPerceptualHash := true
 		return append(sessions, untrustedSesions...), calcPerceptualHash
 	}
 
@@ -794,7 +794,7 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 		// cxn.sessManager.pushSegInFlight(sess, seg)
 		sess.pushSegInFlight(seg)
 		var res *ReceivedTranscodeResult
-		res, err = SubmitSegment(sess.Clone(), seg, nonce, false)
+		res, err = SubmitSegment(sess.Clone(), seg, nonce, calcPerceptualHash)
 		if err != nil || res == nil {
 			if isNonRetryableError(err) {
 				cxn.sessManager.completeSession(sess)
@@ -851,6 +851,16 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
 					}
 				}
 			}(cxn.mid, cxn.params.Detection, seg.SeqNo, res.Detections)
+		}
+		// Ensure perceptual hash is generated if we ask for it
+		if calcPerceptualHash {
+			segmToCheckIndex := rand.Intn(len(res.Segments))
+			segHash, err := drivers.GetSegmentData(res.Segments[segmToCheckIndex].PerceptualHashUrl)
+			if err != nil || len(segHash) <= 0 {
+				err = fmt.Errorf("error downloading perceptual hash from url=%s err=%w",
+					res.Segments[segmToCheckIndex].PerceptualHashUrl, err)
+				return nil, info, err
+			}
 		}
 		urls, err = downloadResults(cxn, seg, sess, res, verifier)
 		return urls, info, err


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- https://github.com/livepeer/go-livepeer/pull/2056/commits/59f43283b68dfd2734b9c578ea09b7026ecc9146 If the verificationFreq > 0 we should ask the Os to generate perceptual hashes, and download those hashes, regardless of how many Os are available or if we can even compare those hashes.
- https://github.com/livepeer/go-livepeer/pull/2056/commits/f2c156fee1ef59ed507a09cfc53cd644e0b98512 Once a session is verified, we use it for subsequent segments, as long as it is selected in the 3 sessions returned from the pools.
- https://github.com/livepeer/go-livepeer/pull/2056/commits/25373bda1fcd603b77892ba8ba2727a2b99ab684 Instead of sticking to a verified orchestrator throughout the stream, we run verification probabilistically on 1/VerificationFreq segments.
- https://github.com/livepeer/go-livepeer/pull/2056/commits/a73a85ec5c3da1ef95bb501554bb645113c83d97 If fast verification is disabled, default to selecting from untrusted pool first, only switching to trusted pool if no untrusted Os are available.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Local end-to-end testing as described in https://github.com/livepeer/internal-project-tracking/issues/183

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #2033 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
