### PR TITLE
server: Add safety checks in selectOrchestrator

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,8 @@
 
 #### Broadcaster
 
+- \#2067 Add safety checks in selectOrchestrator for auth token and ticket params in OrchestratorInfo (@yondonfu)
+
 #### Orchestrator
 
 #### Transcoder

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -330,13 +330,23 @@ func selectOrchestrator(n *core.LivepeerNode, params *core.StreamParameters, cou
 			ticketParams *pm.TicketParams
 		)
 
-		if n.Sender != nil && tinfo.TicketParams != nil {
-			ticketParams = pmTicketParams(tinfo.TicketParams)
-			sessionID = n.Sender.StartSession(*ticketParams)
+		if tinfo.AuthToken == nil {
+			glog.Errorf("Missing auth token orch=%v", tinfo.Transcoder)
+			continue
 		}
 
-		if n.Balances != nil {
-			balance = core.NewBalance(ticketParams.Recipient, core.ManifestID(tinfo.AuthToken.SessionId), n.Balances)
+		if n.Sender != nil {
+			if tinfo.TicketParams == nil {
+				glog.Errorf("Missing ticket params orch=%v", tinfo.Transcoder)
+				continue
+			}
+
+			ticketParams = pmTicketParams(tinfo.TicketParams)
+			sessionID = n.Sender.StartSession(*ticketParams)
+
+			if n.Balances != nil {
+				balance = core.NewBalance(ticketParams.Recipient, core.ManifestID(tinfo.AuthToken.SessionId), n.Balances)
+			}
 		}
 
 		var orchOS drivers.OSSession


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds safety checks in `selectOrchestrator()` that will skip the broadcast session creation for an O if it is either missing an auth token or ticket params (only if the B is running in on-chain mode) in its OrchestratorInfo message.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
