### PR TITLE
Make filtering orchestrators that haven't been updated in last day optional

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,7 @@
 #### General
 
 - \#2013 Add support for EIP-1559 transactions (@yondonfu)
+- \#2073 Make filtering orchestrators in the DB that haven't been updated in last day optional (@yondonfu)
 
 #### Broadcaster
 

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -798,7 +798,7 @@ func TestProcessPayment_ActiveOrchestrator(t *testing.T) {
 
 	// orchestrator inactive -> error
 	err := orch.ProcessPayment(defaultPayment(t), ManifestID("some manifest"))
-	expErr := fmt.Sprintf("orchestrator is inactive, cannot process payments")
+	expErr := fmt.Sprintf("orchestrator %v is inactive in round %v, cannot process payments", addr.Hex(), 10)
 	assert.EqualError(err, expErr)
 
 	// orchestrator is active -> no error

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -122,13 +122,14 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 
 	sender := ethcommon.BytesToAddress(payment.Sender)
 
-	ok, err := orch.isActive(ethcommon.BytesToAddress(payment.TicketParams.Recipient))
+	recipientAddr := ethcommon.BytesToAddress(payment.TicketParams.Recipient)
+	ok, err := orch.isActive(recipientAddr)
 	if err != nil {
 		return err
 	}
 
 	if !ok {
-		return fmt.Errorf("orchestrator is inactive, cannot process payments")
+		return fmt.Errorf("orchestrator %v is inactive in round %v, cannot process payments", recipientAddr.Hex(), orch.rm.LastInitializedRound())
 	}
 
 	priceInfo := payment.GetExpectedPrice()

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -68,8 +68,9 @@ func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm
 func (dbo *DBOrchestratorPoolCache) getURLs() ([]*url.URL, error) {
 	orchs, err := dbo.store.SelectOrchs(
 		&common.DBOrchFilter{
-			MaxPrice:     server.BroadcastCfg.MaxPrice(),
-			CurrentRound: dbo.rm.LastInitializedRound(),
+			MaxPrice:       server.BroadcastCfg.MaxPrice(),
+			CurrentRound:   dbo.rm.LastInitializedRound(),
+			UpdatedLastDay: true,
 		},
 	)
 	if err != nil || len(orchs) <= 0 {
@@ -144,8 +145,9 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(numOrchestrators int, suspe
 func (dbo *DBOrchestratorPoolCache) Size() int {
 	count, _ := dbo.store.OrchCount(
 		&common.DBOrchFilter{
-			MaxPrice:     server.BroadcastCfg.MaxPrice(),
-			CurrentRound: dbo.rm.LastInitializedRound(),
+			MaxPrice:       server.BroadcastCfg.MaxPrice(),
+			CurrentRound:   dbo.rm.LastInitializedRound(),
+			UpdatedLastDay: true,
 		},
 	)
 	return count


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR addresses https://github.com/livepeer/go-livepeer/issues/1482.

Based on the OP in the above issue and [this comment](https://github.com/livepeer/go-livepeer/issues/1482#issuecomment-943323704) I suspect the problem is that all orchestrator table queries will filter out any orchestrator entries that have not been updated in the last day. I had previously thought that existing orchestrator entries would be updated at least once a day when a new round is initialized as mentioned [here](https://github.com/livepeer/go-livepeer/issues/1482#issuecomment-943323704). I'm still not sure why this wouldn't be happening. But, the screenshot provided in the OP of https://github.com/livepeer/go-livepeer/issues/1482 does indicate a `updatedAt` timestamp that is more than 1 day in the past which would explain the failed active check - the `updatedAt` timestamp was from 4/30/20 and the active check started failing on 5/5/20. Note: I'm assuming that the DB dump in that post was created on or after 5/5/20.

So, the `updatedAt` check is my best guess of the problem right now and this PR disables the `updatedAt` check unless it is explicitly enabled using `DBOrchFilter.UpdatedLastDay`. The check is explicitly enabled in `DBOrchestratorPoolCache` when deciding which orchestrators to query in order to preserve existing behavior for now - changes to this behavior can be considered separately. 

Also included some additional logging around the active check for informational purposes in case there is an additional problem in addition to the `updatedAt` check.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Added unit tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #1482

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
