### PR TITLE
server/broadcast: don't retry segments after max attempts

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,6 +11,7 @@
 #### Broadcaster
 
 - \#2085 Set max refresh sessions threshold to 8 (@yondonfu)
+- \#2083 Return 422 to the push client after max retry attempts for a segment (@jailuthra)
 
 #### Orchestrator
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -1403,5 +1403,8 @@ func isNonRetryableError(err error) bool {
 			return true
 		}
 	}
+	if strings.HasPrefix(err.Error(), "Hit max transcode attempts:") {
+		return true
+	}
 	return false
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
 Return 422 to push-api clients once the B has retried a segment `MaxAttempts` times.
 
**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
See commit history 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
1. Unit test to ensure 422 is returned when retried a segment `MaxAttempts` times
2. Manual testing of Push API after returning an error for transcoding:
```diff
diff --git a/server/broadcast.go b/server/broadcast.go
index ff17a0d5..34c89e37 100644
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -612,6 +612,9 @@ func transcodeSegment(cxn *rtmpConnection, seg *stream.HLSSegment, name string,
                        err = errors.New("empty response")
                }
                return nil, info, err
+       } else if sess != nil {
+               cxn.sessManager.completeSession(sess)
+               return nil, info, errors.New("Unknown error")
        }

        // download transcoded segments from the transcoder
```

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #2069 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
