### PR TITLE
docker: use content classification model from ML repo releases

### DIFF
--- a/docker/Dockerfile.build-linux
+++ b/docker/Dockerfile.build-linux
@@ -30,4 +30,4 @@ ENV GOPATH /go
 RUN mkdir -p /go
 WORKDIR /build
 
-RUN curl -LO https://github.com/livepeer/livepeer-ml/releases/download/v0.1/tasmodel.pb
+RUN curl -LO https://github.com/livepeer/livepeer-ml/releases/download/v0.3/tasmodel.pb

--- a/docker/Dockerfile.build-linux
+++ b/docker/Dockerfile.build-linux
@@ -30,4 +30,4 @@ ENV GOPATH /go
 RUN mkdir -p /go
 WORKDIR /build
 
-RUN curl -LO https://storage.googleapis.com/lp_testharness_assets/tasmodel.pb
+RUN curl -LO https://github.com/livepeer/livepeer-ml/releases/download/v0.1/tasmodel.pb

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/jaypipes/ghw v0.7.0
 	github.com/livepeer/livepeer-data v0.2.0
-	github.com/livepeer/lpms v0.0.0-20211022165630-1d91ede415fa
+	github.com/livepeer/lpms v0.0.0-20211112122814-e2ac92166d0c
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -365,6 +365,8 @@ github.com/livepeer/livepeer-data v0.2.0 h1:8ELEri/sWd6fAHT3anAgoKe9Z+XgbW0oLg5q
 github.com/livepeer/livepeer-data v0.2.0/go.mod h1:vkW1PJ24gOJgx1hHUo07cXkR1b409n+dGpyWJsHKI3s=
 github.com/livepeer/lpms v0.0.0-20211022165630-1d91ede415fa h1:tgEYFcJIUbpgEDXYHYEVVklG+QUVGZwg4KHC9OcsRyo=
 github.com/livepeer/lpms v0.0.0-20211022165630-1d91ede415fa/go.mod h1:iIvqFRRSIcouTWFheH2/TeDAq7xTVOJNR0eAS84o754=
+github.com/livepeer/lpms v0.0.0-20211112122814-e2ac92166d0c h1:4Ivom0fVEPL3henXLUrvP+teYu2Su9JJMwmAwJCjQfI=
+github.com/livepeer/lpms v0.0.0-20211112122814-e2ac92166d0c/go.mod h1:iIvqFRRSIcouTWFheH2/TeDAq7xTVOJNR0eAS84o754=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Change detection model URL in Dockerfile to point to livepeer-ml repo release


**Specific updates (required)**
- 

**How did you test each of these updates (required)**
Tested with [LPMS](https://github.com/livepeer/lpms/pull/269) scenedetection 

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
