### PR TITLE
Gracefully notify orchestrator in case of a panic in transcoder

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,7 +16,7 @@
 #### Orchestrator
 
 #### Transcoder
-- \#2088 Gracefully notify orchestrator in case of panic in transcoding (@leszko)
+- \#2088 Gracefully notify orchestrator in case of a panic in transcoder (@leszko)
 
 ### Bug Fixes 🐞
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,7 @@
 #### Orchestrator
 
 #### Transcoder
+- \#2088 Gracefully notify orchestrator in case of panic in transcoding (@leszko)
 
 ### Bug Fixes 🐞
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,7 +16,7 @@
 #### Orchestrator
 
 #### Transcoder
-- \#2088 Gracefully notify orchestrator in case of a panic in transcoder (@leszko)
+- \#2094 Gracefully notify orchestrator in case of a panic in transcoder (@leszko)
 
 ### Bug Fixes 🐞
 

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -27,12 +27,18 @@ type LocalTranscoder struct {
 	workDir string
 }
 
-type UnrecoverableError error
+type UnrecoverableError struct {
+	error
+}
+
+func NewUnrecoverableError(err error) UnrecoverableError {
+	return UnrecoverableError{err}
+}
 
 var WorkDir string
 
 func (lt *LocalTranscoder) Transcode(md *SegTranscodingMetadata) (td *TranscodeData, retErr error) {
-	// Returns UnrecoverableError instead of panic to gracefully notify orchestrator about transcoder's failure
+	// Returns UnrecoverableError instead of panicking to gracefully notify orchestrator about transcoder's failure
 	defer recoverFromPanic(&retErr)
 
 	// Set up in / out config
@@ -75,7 +81,7 @@ type NvidiaTranscoder struct {
 }
 
 func (nv *NvidiaTranscoder) Transcode(md *SegTranscodingMetadata) (td *TranscodeData, retErr error) {
-	// Returns UnrecoverableError instead of panic to gracefully notify orchestrator about transcoder's failure
+	// Returns UnrecoverableError instead of panicking to gracefully notify orchestrator about transcoder's failure
 	defer recoverFromPanic(&retErr)
 
 	in := &ffmpeg.TranscodeOptionsIn{
@@ -265,6 +271,6 @@ func recoverFromPanic(retErr *error) {
 		if !ok {
 			err = errors.New("unrecoverable transcoding failure")
 		}
-		*retErr = UnrecoverableError(err)
+		*retErr = NewUnrecoverableError(err)
 	}
 }

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -27,9 +27,14 @@ type LocalTranscoder struct {
 	workDir string
 }
 
+type UnrecoverableError error
+
 var WorkDir string
 
-func (lt *LocalTranscoder) Transcode(md *SegTranscodingMetadata) (*TranscodeData, error) {
+func (lt *LocalTranscoder) Transcode(md *SegTranscodingMetadata) (td *TranscodeData, retErr error) {
+	// Returns UnrecoverableError instead of panic to gracefully notify orchestrator about transcoder's failure
+	defer recoverFromPanic(&retErr)
+
 	// Set up in / out config
 	in := &ffmpeg.TranscodeOptionsIn{
 		Fname: md.Fname,
@@ -69,7 +74,9 @@ type NvidiaTranscoder struct {
 	session *ffmpeg.Transcoder
 }
 
-func (nv *NvidiaTranscoder) Transcode(md *SegTranscodingMetadata) (*TranscodeData, error) {
+func (nv *NvidiaTranscoder) Transcode(md *SegTranscodingMetadata) (td *TranscodeData, retErr error) {
+	// Returns UnrecoverableError instead of panic to gracefully notify orchestrator about transcoder's failure
+	defer recoverFromPanic(&retErr)
 
 	in := &ffmpeg.TranscodeOptionsIn{
 		Fname:  md.Fname,
@@ -250,4 +257,14 @@ func detectorsToTranscodeOptions(workDir string, accel ffmpeg.Acceleration, prof
 		opts[i] = o
 	}
 	return opts
+}
+
+func recoverFromPanic(retErr *error) {
+	if r := recover(); r != nil {
+		err, ok := r.(error)
+		if !ok {
+			err = errors.New("unrecoverable transcoding failure")
+		}
+		*retErr = UnrecoverableError(err)
+	}
 }

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -300,6 +300,7 @@ func TestRecoverFromPanic(t *testing.T) {
 
 	assert.NotNil(err)
 	assert.Equal("unrecoverable transcoding failure", err.Error())
+	assert.IsType(UnrecoverableError{}, err)
 }
 
 func TestRecoverFromPanic_WithError(t *testing.T) {

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -38,7 +39,6 @@ func TestLocalTranscoder(t *testing.T) {
 		t.Errorf("Wrong data %v", len(res.Segments[1].Data))
 	}
 }
-
 func TestNvidia_Transcoder(t *testing.T) {
 	dev := os.Getenv("NV_DEVICE")
 	if dev == "" {
@@ -286,4 +286,32 @@ func TestTranscoder_Formats(t *testing.T) {
 	}
 	// sanity check the base format wasn't overwritten (has happened before!)
 	assert.Equal(ffmpeg.FormatNone, ffmpeg.P144p30fps16x9.Format)
+}
+
+func TestRecoverFromPanic(t *testing.T) {
+	assert := assert.New(t)
+
+	f := func() (err error) {
+		defer recoverFromPanic(&err)
+		panic(struct{}{})
+	}
+
+	err := f()
+
+	assert.NotNil(err)
+	assert.Equal("unrecoverable transcoding failure", err.Error())
+}
+
+func TestRecoverFromPanic_WithError(t *testing.T) {
+	assert := assert.New(t)
+	sampleErr := errors.New("sample error")
+
+	f := func() (err error) {
+		defer recoverFromPanic(&err)
+		panic(sampleErr)
+	}
+
+	err := f()
+
+	assert.Equal(sampleErr, err)
 }

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -313,5 +313,5 @@ func TestRecoverFromPanic_WithError(t *testing.T) {
 
 	err := f()
 
-	assert.Equal(sampleErr, err)
+	assert.Equal(NewUnrecoverableError(sampleErr), err)
 }

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -152,6 +152,9 @@ func runTranscode(n *core.LivepeerNode, orchAddr string, httpc *http.Client, not
 		err = errors.New("segment / profile mismatch")
 	}
 	if err != nil {
+		if _, ok := err.(core.UnrecoverableError); ok {
+			defer panic(err)
+		}
 		glog.Error("Unable to transcode ", err)
 		body.Write([]byte(err.Error()))
 		contentType = transcodingErrorMimeType


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Fix transcoder to send an error to orchestrator before crashing. Before, when the transcoder crashed after `panic()`, the orchestrator had to time out before trying another transcoder. The change is related only to the split O+T topology.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add `recover()` in to the `transcoder` functions (both for Nvidia and the standard CPU transcoding)
- Add handling `UnrecoverableError` in `ot_rpc.go` to send the error message to orchestrator and only then to panic and crash

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

1. Add an artificial `panic(errors.New("Some error"))` inside `transcoder.go#Transcode()` function
2. Build the project
3. Start orchestrator + 2 transcoders
4. Start broadcaster and a start streaming a video
5. The first transcoder crashes, orchestrator is notified and selects the second transcoder without the timeout

The same test without this PR, makes orchestrator wait for the timeout before selecting the second transcoder.

**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2088 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
