### PR TITLE
Check verified session first while choosing the result from multiple untrusted sessions

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,6 +14,7 @@
 - \#2085 Set max refresh sessions threshold to 8 (@yondonfu)
 - \#2083 Return 422 to the push client after max retry attempts for a segment (@jailuthra)
 - \#2022 Randomize selection of orchestrators in untrusted pool at a random frequency (@yondonfu)
+- \#2100 Check verified session first while choosing the result from multiple untrusted sessions (@leszko) 
 
 #### Orchestrator
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -544,6 +544,9 @@ func (bsm *BroadcastSessionsManager) collectResults(submitResultsCh chan *Submit
 		if res.Err == nil && res.TranscodeResult != nil {
 			if res.Session.OrchestratorScore == common.Score_Trusted {
 				trustedResults = res
+			} else if res.Session == bsm.verifiedSession {
+				// verified result should always come first and therefore take the priority
+				untrustedResults = append([]*SubmitResult{res}, untrustedResults...)
 			} else {
 				untrustedResults = append(untrustedResults, res)
 			}

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -1679,3 +1679,26 @@ func stubTestTranscoder(ctx context.Context, handler http.HandlerFunc) string {
 	mux.HandleFunc("/segment", handler)
 	return ts.URL
 }
+
+func TestCollectResults(t *testing.T) {
+	assert := assert.New(t)
+
+	trustedSess := StubBroadcastSession("trustedTranscoder")
+	trustedSess.OrchestratorScore = common.Score_Trusted
+	untrustedSess1 := StubBroadcastSession("untrustedTranscoder1")
+	untrustedSess1.OrchestratorScore = common.Score_Untrusted
+	untrustedSess2 := StubBroadcastSession("untrustedTranscoder2")
+	untrustedSess2.OrchestratorScore = common.Score_Untrusted
+	bsm := bsmWithSessList([]*BroadcastSession{trustedSess, untrustedSess1, untrustedSess2})
+
+	resChan := make(chan *SubmitResult, 3)
+	resChan <- &SubmitResult{Session: untrustedSess1, TranscodeResult: &ReceivedTranscodeResult{}}
+	resChan <- &SubmitResult{Session: untrustedSess2, TranscodeResult: &ReceivedTranscodeResult{}}
+	resChan <- &SubmitResult{Session: trustedSess, TranscodeResult: &ReceivedTranscodeResult{}}
+
+	trustedResult, untrustedResults, err := bsm.collectResults(resChan, 3)
+
+	assert.NoError(err)
+	assert.Equal(trustedSess, trustedResult.Session)
+	assert.Len(untrustedResults, 2)
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
When there are multiple untrusted sessions (orchestrators), then check first the result from the verified session. This is one of the changes that will prevent bouncing between different orchestrators while transcoding a stream.

related to #2097

**Note**: This change alone does not completely prevent bouncing between different sessions. Swapping sessions also occur [here](https://github.com/livepeer/go-livepeer/blob/aef74f6a05c0e273947e7915bafa21e69bc41c43/server/broadcast.go#L291).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Refactor `broadcast.go`: extract `collectResults()` function to make it testable
- Add unit test for `collectResults()`
- Make verified session returned first from `collectResults()`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

1. Add printing the currently verified session and the result session
2. Build the project
3. Run the local setup with 1 trusted orchestrator and 3 untrusted orchestrator
4. Check that the currently verified session is always the one selected from multiple results


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
