### PR TITLE
exposes `glog`'s library flags that allow to enable logging to files

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -79,8 +79,16 @@ func main() {
 		glog.Fatalf("Cannot find current user: %v", err)
 	}
 	vFlag := flag.Lookup("v")
-	//We preserve this flag before resetting all the flags.  Not a scalable approach, but it'll do for now.  More discussions here - https://github.com/livepeer/go-livepeer/pull/617
+	vToStderr := flag.Lookup("logtostderr")
+	vAlsoToStderr := flag.Lookup("alsologtostderr")
+	vLogDir := flag.Lookup("log_dir")
+	//We preserve these flags before resetting all the flags.  Not a scalable approach, but it'll do for now.  More discussions here - https://github.com/livepeer/go-livepeer/pull/617
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	toStderr := flag.Bool("logtostderr", true, "log to standard error instead of files (enabled by default)")
+	alsoToStderr := flag.Bool("alsologtostderr", false, "log to standard error as well as files (logtostderr should be set to false)")
+	logDir := flag.String("log_dir", "", "If non-empty, write log files in this directory (should exist)")
+	flag.Uint64Var(&glog.MaxSize, "log_max_size", glog.MaxSize, "If non-empty, write log files in this directory (should exist)")
 
 	// Network & Addresses:
 	network := flag.String("network", "offchain", "Network to connect to")
@@ -161,6 +169,10 @@ func main() {
 
 	flag.Parse()
 	vFlag.Value.Set(*verbosity)
+
+	vToStderr.Value.Set(fmt.Sprintf("%v", *toStderr))
+	vAlsoToStderr.Value.Set(fmt.Sprintf("%v", *alsoToStderr))
+	vLogDir.Value.Set(*logDir)
 
 	isFlagSet := make(map[string]bool)
 	flag.Visit(func(f *flag.Flag) { isFlagSet[f.Name] = true })


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Exposes `glog`'s library flags that allows enabling logging to files.

Allows to enable logging to files instead of stderr or to both stderr and files.

**Specific updates (required)**


**How did you test each of these updates (required)**
Manually

**Does this pull request close any open issues?**
Relates to #2104 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
