### PR TITLE
server: Use http.Transport for HTTP client

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,7 @@
 - \#2022 Randomize selection of orchestrators in untrusted pool at a random frequency (@yondonfu)
 - \#2100 Check verified session first while choosing the result from multiple untrusted sessions (@leszko)
 - \#2103 Suspend sessions that did not pass p-hash verification (@leszko)
+- \#2110 Transparently support HTTP/2 for segment requests while allowing HTTP/1 via GODEBUG runtime flags (@yondonfu)
 
 #### Orchestrator
 

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -56,6 +56,11 @@ var httpClient = &http.Client{
 			tlsDialer := &tls.Dialer{Config: tlsConfig}
 			return tlsDialer.DialContext(cctx, network, addr)
 		},
+		// Required for the transport to try to upgrade to HTTP/2 if TLSClientConfig is non-nil or
+		// if custom dialers (i.e. via DialTLSContext) are used. This allows us to by default
+		// transparently support HTTP/2 while maintaining the flexibility to use HTTP/1 by running
+		// with GODEBUG=http2client=0
+		ForceAttemptHTTP2: true,
 	},
 	// Don't set a timeout here; pass a context to the request
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Replace http2.Transport to have option to downgrade from http2 if needed.

We've observed what appears to be dead locks with multiple concurrent HTTP requests during segment submission from a B to O. According to https://github.com/golang/go/issues/32388 there was a dead lock bug fixed in the http2 package that was backported into the latest go1.16 and go1.17. go-livepeer is currently built using go1.15. While we could upgrade to one of the go versions with this fix, we should probably do more testing when bumping to those go versions. So, this PR instead allows http2 to be disabled which should in theory bypass the dead lock http2 bug.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Ran a B with `GODEBUG=http2debug=2` and observed http2 logs when B submits a segment to O.
- Ran a B with `GODEBUG=http2debug=2,http2client=0` and did not observe http2 logs when B submits a segment to O.

Note: We've yet to test whether running with `GODEBUG=http2client=0` with these changes actually resolves the issue we observed with dead locking concurrent HTTP requests and it is difficult to repro that.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
