### PR TITLE
eth: Ensure `maxFeePerGas` in all transactions never exceed `-masGasPrice` defined by the user

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,7 @@
 #### General
 
 - \#2114 Add option to repeat the benchmarking process (@jailuthra)
+- \#2111 Ensure `maxFeePerGas` in all transactions never exceed `-masGasPrice` defined by the user (@leszko)
 
 #### Broadcaster
 

--- a/doc/ethereum.md
+++ b/doc/ethereum.md
@@ -14,12 +14,13 @@ The round initialization service is disabled by default and can be enabled by st
 
 ## Gas Prices
 
-After the EIP-1559 upgrade on Ethereum, the node uses `maxFeePerGas` parameter to limit the maximum fee paid for the transaction execution:
-
-- If max gas price is specified, then use its value as `maxFeePerGas`
-- If max gas price is not specified, then use the default `maxFeePerGas` and gradually increase it with the replacement transactions
+After the EIP-1559 upgrade on Ethereum, the node treats the gas price as priority fee + base fee.
 
 ### Max gas price
+
+The `maxGasPrice` parameter makes sure the transaction fee never exceeds the specified limit.
+- If the current network gas price is higher than `maxGasPrice`, the transaction is not sent
+- The transaction parameter `maxFeePerGas` is set to `maxGasPrice`
 
 The following options can be used to get the max gas price:
 

--- a/doc/ethereum.md
+++ b/doc/ethereum.md
@@ -14,7 +14,10 @@ The round initialization service is disabled by default and can be enabled by st
 
 ## Gas Prices
 
-After the EIP-1559 upgrade on Ethereum, the node treats the gas price as priority fee + base fee.
+After the EIP-1559 upgrade on Ethereum, the node uses `maxFeePerGas` parameter to limit the maximum fee paid for the transaction execution:
+
+- If max gas price is specified, then use its value as `maxFeePerGas`
+- If max gas price is not specified, then use the default `maxFeePerGas` and gradually increase it with the replacement transactions
 
 ### Max gas price
 
@@ -23,7 +26,7 @@ The following options can be used to get the max gas price:
 - `curl localhost:7935/maxGasPrice`
 - Run `livepeer_cli` and observe the max gas price in the node stats
 
-The following options can be used to set the m gas price to `<MAX_GAS_PRICE>`, a Wei denominated value:
+The following options can be used to set the max gas price to `<MAX_GAS_PRICE>`, a Wei denominated value:
 
 - Start the node with `-maxGasPrice <MAX_GAS_PRICE>`
 - `curl localhost:7935/setMaxGasPrice?maxGasPrice=<MAX_GAS_PRICE>`

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -79,7 +79,7 @@ func TestSendTransaction_SendErr_DontUpdateNonce(t *testing.T) {
 	}, 1*time.Second, big.NewInt(0), nil)
 	gpm.gasPrice = big.NewInt(1)
 
-	tm := NewTransactionManager(client, gpm, &accountManager{}, 3*time.Second, 0)
+	tm := NewTransactionManager(client, gpm, &stubTransactionSigner{}, 3*time.Second, 0)
 
 	bi := NewBackend(client, signer, gpm, tm)
 

--- a/eth/transactionManager.go
+++ b/eth/transactionManager.go
@@ -101,7 +101,6 @@ func (tm *TransactionManager) SendTransaction(ctx context.Context, tx *types.Tra
 	adjustedRawTx := tm.newAdjustedTx(tx)
 	adjustedTx, err := tm.sig.SignTx(adjustedRawTx)
 	if err != nil {
-		glog.Infof("%s\n", err.Error())
 		return err
 	}
 

--- a/eth/transactionManager.go
+++ b/eth/transactionManager.go
@@ -98,9 +98,16 @@ func NewTransactionManager(eth transactionSenderReader, gpm *GasPriceMonitor, si
 }
 
 func (tm *TransactionManager) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-	sendErr := tm.eth.SendTransaction(ctx, tx)
+	adjustedRawTx := tm.newAdjustedTx(tx)
+	adjustedTx, err := tm.sig.SignTx(adjustedRawTx)
+	if err != nil {
+		glog.Infof("%s\n", err.Error())
+		return err
+	}
 
-	txLog, err := newTxLog(tx)
+	sendErr := tm.eth.SendTransaction(ctx, adjustedTx)
+
+	txLog, err := newTxLog(adjustedTx)
 	if err != nil {
 		txLog.method = "unknown"
 	}
@@ -112,11 +119,11 @@ func (tm *TransactionManager) SendTransaction(ctx context.Context, tx *types.Tra
 
 	// Add transaction to queue
 	tm.cond.L.Lock()
-	tm.queue.add(tx)
+	tm.queue.add(adjustedTx)
 	tm.cond.L.Unlock()
 	tm.cond.Signal()
 
-	glog.Infof("\n%vEth Transaction%v\n\nInvoking transaction: \"%v\". Inputs: \"%v\"  Hash: \"%v\". \n\n%v\n", strings.Repeat("*", 30), strings.Repeat("*", 30), txLog.method, txLog.inputs, tx.Hash().String(), strings.Repeat("*", 75))
+	glog.Infof("\n%vEth Transaction%v\n\nInvoking transaction: \"%v\". Inputs: \"%v\"  Hash: \"%v\". \n\n%v\n", strings.Repeat("*", 30), strings.Repeat("*", 30), txLog.method, txLog.inputs, adjustedTx.Hash().String(), strings.Repeat("*", 75))
 
 	return nil
 }
@@ -159,7 +166,7 @@ func (tm *TransactionManager) replace(tx *types.Transaction) (*types.Transaction
 
 	// Bump gas price exceeds max gas price, return early
 	max := tm.gpm.MaxGasPrice()
-	newGasPrice := calcGasPrice(newRawTx)
+	newGasPrice := newRawTx.GasFeeCap()
 	if max != nil && newGasPrice.Cmp(max) > 0 {
 		return nil, fmt.Errorf("replacement gas price exceeds max gas price suggested=%v max=%v", newGasPrice, max)
 	}
@@ -234,30 +241,37 @@ func (tm *TransactionManager) checkTxLoop() {
 	}
 }
 
+func (tm *TransactionManager) newAdjustedTx(tx *types.Transaction) *types.Transaction {
+	baseTx := newDynamicFeeTx(tx)
+	if tm.gpm.MaxGasPrice() != nil {
+		baseTx.GasFeeCap = tm.gpm.MaxGasPrice()
+	}
+
+	return types.NewTx(baseTx)
+}
+
 func applyPriceBump(val *big.Int, priceBump uint64) *big.Int {
 	a := big.NewInt(100 + int64(priceBump))
 	b := new(big.Int).Mul(a, val)
 	return b.Div(b, big.NewInt(100))
 }
 
-// Calculate the gas price as gas tip cap + base fee
-func calcGasPrice(tx *types.Transaction) *big.Int {
-	// Assume that the gas fee cap is calculated as gas tip cap + (baseFee * 2)
-	baseFee := new(big.Int).Div(new(big.Int).Sub(tx.GasFeeCap(), tx.GasTipCap()), big.NewInt(2))
-	return new(big.Int).Add(baseFee, tx.GasTipCap())
+func newReplacementTx(tx *types.Transaction) *types.Transaction {
+	baseTx := newDynamicFeeTx(tx)
+	baseTx.GasFeeCap = applyPriceBump(tx.GasFeeCap(), priceBump)
+	baseTx.GasTipCap = applyPriceBump(tx.GasTipCap(), priceBump)
+
+	return types.NewTx(baseTx)
 }
 
-func newReplacementTx(tx *types.Transaction) *types.Transaction {
-	baseTx := &types.DynamicFeeTx{
-		Nonce: tx.Nonce(),
-		// geth requires the price bump to be applied to both the gas tip cap and gas fee cap
-		GasFeeCap: applyPriceBump(tx.GasFeeCap(), priceBump),
-		GasTipCap: applyPriceBump(tx.GasTipCap(), priceBump),
+func newDynamicFeeTx(tx *types.Transaction) *types.DynamicFeeTx {
+	return &types.DynamicFeeTx{
+		To:        tx.To(),
+		Nonce:     tx.Nonce(),
+		GasFeeCap: tx.GasFeeCap(),
+		GasTipCap: tx.GasTipCap(),
 		Gas:       tx.Gas(),
 		Value:     tx.Value(),
 		Data:      tx.Data(),
-		To:        tx.To(),
 	}
-
-	return types.NewTx(baseTx)
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Limit the maxFeePerGas in the eth transaction to the `-maxGasPrice` value defined by the user. Before it was possible that the user paid more than they specified as `-maxGasPrice`.

Additionally, I removed the `calcGasPrice()` logic from `transactionManager.go`, because I believe it was incorrect. It assumed that `maxFeePerGas` will be calculated in the [go-ethereum code](https://github.com/ethereum/go-ethereum/blob/fa9671851272129c9cba90ed4385d5b0558d34a1/accounts/abi/bind/base.go#L254),  but I think we override it in our code [here](https://github.com/livepeer/go-livepeer/blob/master/eth/transactionManager.go#L254).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adjust `GasFeeCap` before sending the transaction
- Remove `calcGasPrice` function in `replace()`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I did test the change both locally and using Rinkeby.

**Local testing**

1. [Set up devtool environment](https://github.com/livepeer/go-livepeer/tree/master/cmd/devtool)
2. Start orchestrator and wait for the first transaction to happen

```
******************************Eth Transaction******************************

Invoking transaction: "rewardWithHint". Inputs: "_newPosPrev: 0x0000000000000000000000000000000000000000  _newPosNext: 0x0000000000000000000000000000000000000000"  Hash: "0x175ff3b3eaebbabc0014526a8dcac53d9505129cbec0f33122da3c9ee70eb509". 

***************************************************************************
```

3. Check the transaction, note the default value of `maxFeePerGas`: `1000000014` (`2 * base fee + priority fee`)

```
$ seth tx 0x175ff3b3eaebbabc0014526a8dcac53d9505129cbec0f33122da3c9ee70eb509
accessList              []
blockHash               0xc880bb7bb980bc6e5de23976a20b12d02ce8431c3af25cc4e35da0478bbf020e
...
maxFeePerGas            1000000014
...
```

4. Set `max gas price` (via livepeer CLI) to `1000000013`
5. Wait for the next transaction
6. Check the transaction, note the value `maxFeePerGas` is set to `1000000013`

```
$ seth tx 0x2222d3d7a1026fe0712352e482a55cac167d491b3f4b17b05467bd5a92de08b1
accessList              []
blockHash               0xf8729bb0ba9b6925ca77bf03817fb648985e304cde08bf6ab16814146ba4e12a
...
maxFeePerGas            1000000013
...
```

7. Set `max gas price` to a value which is too low, e.g. `5`
8. Note that the transaction is not sent

```
E1125 12:57:56.999314    8399 roundinitializer.go:87] current gas price exceeds maximum gas price max=0.000000005 GWei current=1.000000007 GWei
```

**Rinkeby testing**

1. Start livepeer connected to `rinkeby`
2. Invoke any transaction (e.g. in case of broadcaster, deposit ETH)

```
******************************Eth Transaction******************************

Invoking transaction: "fundDepositAndReserve". Inputs: "_depositAmount: 100000000000000000  _reserveAmount: 300000000000000000"  Hash: "0x382e9a5b7635862fd8a5ac64ddf7e1b1d6111c4b67cb1318c13d7fede3fa31f0". 

***************************************************************************
```

3. Check the transaction in Etherscan

https://rinkeby.etherscan.io/tx/0x382e9a5b7635862fd8a5ac64ddf7e1b1d6111c4b67cb1318c13d7fede3fa31f0

```
Base: 0.000000024 Gwei |Max: 1.000000044 Gwei |Max Priority: 1 Gwei
```

4. Set max gas price to `1000000055` and run the transaction again

```
******************************Eth Transaction******************************

Invoking transaction: "fundDepositAndReserve". Inputs: "_depositAmount: 1000000000000000  _reserveAmount: 0"  Hash: "0xc6cfc72bb7aef2e4f026332ebcf9eec00ba10b4a0a94290d7c59a3bc0d1f8e9f". 

***************************************************************************
```

5. Check the transaction in Etherscan

https://rinkeby.etherscan.io/tx/0xc6cfc72bb7aef2e4f026332ebcf9eec00ba10b4a0a94290d7c59a3bc0d1f8e9f

```
Base: 0.00000002 Gwei |Max: 1.000000055 Gwei |Max Priority: 1 Gwei
```



**Does this pull request close any open issues?**
<!-- Fixes # -->

fix #2084 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
