### PR TITLE
cmd/livepeer_bench: add option to repeat benchmark

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,8 @@
 
 #### General
 
+- \#2114 Add option to repeat the benchmarking process (@jailuthra)
+
 #### Broadcaster
 
 - \#2086 Add support for fast verification (@jailuthra @darkdragon)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Add option to repeat the benchmark process for more than 1 times. This is helpful to reproduce if we want to monitor VRAM usage when closing and re-opening GPU sessions.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
*See commit history*

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Manually tested that setting `-repeat <N>` leads to the benchmark process running `#N` times.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
