### PR TITLE
1656 upload timeouts

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,7 @@
 - \#2103 Suspend sessions that did not pass p-hash verification (@leszko)
 - \#2110 Transparently support HTTP/2 for segment requests while allowing HTTP/1 via GODEBUG runtime flags (@yondonfu)
 - \#2124 Do not retry transcoding if HTTP client closed/canceled the connection (@leszko)
+- \#2122 Add the upload segment timeout to improve failing fast (@leszko)
 
 #### Orchestrator
 

--- a/common/util.go
+++ b/common/util.go
@@ -29,6 +29,9 @@ import (
 // HTTPTimeout timeout used in HTTP connections between nodes
 var HTTPTimeout = 8 * time.Second
 
+// SegmentUploadTimeout timeout used in HTTP connections for uploading the segment
+var SegmentUploadTimeout = 2 * time.Second
+
 // Max Segment Duration
 var MaxDuration = (5 * time.Minute)
 

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -447,7 +447,7 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64,
 	// timeout for the segment upload, until HTTP returns OK 200
 	uploadTimeout := time.Duration(segUploadTimeoutMultiplier * seg.Duration * float64(time.Second))
 	if uploadTimeout <= 0 {
-		uploadTimeout = httpTimeout
+		uploadTimeout = common.SegmentUploadTimeout
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -45,7 +45,6 @@ var errFormat = errors.New("unrecognized profile output format")
 var errProfile = errors.New("unrecognized encoder profile")
 var errDuration = errors.New("invalid duration")
 var errCapCompat = errors.New("incompatible capabilities")
-var errTimeout = errors.New("timeout")
 
 var dialTimeout = 2 * time.Second
 

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -36,6 +36,9 @@ const segmentHeader = "Livepeer-Segment"
 
 const pixelEstimateMultiplier = 1.02
 
+const segUploadTimeoutMultiplier = 0.5
+const segHttpPushTimeoutMultiplier = 4.0
+
 var errSegEncoding = errors.New("ErrorSegEncoding")
 var errSegSig = errors.New("ErrSegSig")
 var errFormat = errors.New("unrecognized profile output format")
@@ -438,12 +441,12 @@ func SubmitSegment(sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64,
 	// timeout for the whole HTTP call: segment upload, transcoding, reading response
 	httpTimeout := common.HTTPTimeout
 	// set a minimum timeout to accommodate transport / processing overhead
-	paddedDur := 4.0 * seg.Duration // use a multiplier of 4 for now
+	paddedDur := segHttpPushTimeoutMultiplier * seg.Duration
 	if paddedDur > httpTimeout.Seconds() {
 		httpTimeout = time.Duration(paddedDur * float64(time.Second))
 	}
-	// timeout fot the segment upload, until HTTP returns OK 200
-	uploadTimeout := time.Duration(0.5 * seg.Duration * float64(time.Second)) // use 0.5 multiplier
+	// timeout for the segment upload, until HTTP returns OK 200
+	uploadTimeout := time.Duration(segUploadTimeoutMultiplier * seg.Duration * float64(time.Second))
 	if uploadTimeout <= 0 {
 		uploadTimeout = httpTimeout
 	}

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -2001,7 +2001,7 @@ func TestSubmitSegment_Timeout(t *testing.T) {
 	headerTimeout = 100 * time.Millisecond
 	lock.Unlock()
 	_, err = SubmitSegment(sess, seg, 0, false, true)
-	assert.Contains(err.Error(), "header timeout: timeout")
+	assert.Contains(err.Error(), "context canceled")
 
 	// time out body
 	lock.Lock()
@@ -2282,7 +2282,7 @@ func TestSendReqWithTimeout(t *testing.T) {
 	resp, err = sendReqWithTimeout(req, time.Millisecond)
 	wg.Done()
 	assert.Nil(resp)
-	assert.ErrorIs(err, errTimeout)
+	assert.ErrorIs(err, context.Canceled)
 }
 
 func stubTLSServer() (*httptest.Server, *http.ServeMux) {

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -2001,8 +2001,7 @@ func TestSubmitSegment_Timeout(t *testing.T) {
 	headerTimeout = 100 * time.Millisecond
 	lock.Unlock()
 	_, err = SubmitSegment(sess, seg, 0, false, true)
-	assert.Contains(err.Error(), "header timeout")
-	assert.Contains(err.Error(), "context deadline exceeded")
+	assert.Contains(err.Error(), "header timeout: timeout")
 
 	// time out body
 	lock.Lock()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
While making an HTTP request from B -> O, introduce a separate timeout for the segment data upload. Before there was one timeout for the whole request.

**Specific updates (required)**
- Add timeout for segment upload + unit tests

**How did you test each of these updates (required)**
Check locally if transcoding (still) works. Then, introduced an artificial sleep in O and tried again. Note the timeout error message in B.

**Does this pull request close any open issues?**
fix #1656 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
