### PR TITLE
server: B should not retry transcoding if client closed/canceled the connection

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,6 +19,7 @@
 - \#2100 Check verified session first while choosing the result from multiple untrusted sessions (@leszko)
 - \#2103 Suspend sessions that did not pass p-hash verification (@leszko)
 - \#2110 Transparently support HTTP/2 for segment requests while allowing HTTP/1 via GODEBUG runtime flags (@yondonfu)
+- \#2124 Do not retry transcoding if HTTP client closed/canceled the connection (@leszko)
 
 #### Orchestrator
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -811,7 +811,8 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 			glog.Warningf("Not retrying current segment nonce=%d seqNo=%d due to non-retryable error err=%v", nonce, seg.SeqNo, err)
 			break
 		}
-		if err = ctx.Err(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
 			glog.Warningf("Not retrying current segment nonce=%d seqNo=%d due to error err=%v", nonce, seg.SeqNo, err)
 			break
 		}

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -813,7 +813,7 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 		}
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			err = ctxErr
-			glog.Warningf("Not retrying current segment nonce=%d seqNo=%d due to error err=%v", nonce, seg.SeqNo, err)
+			glog.Warningf("Not retrying current segment nonce=%d seqNo=%d due to context cancellation err=%v", nonce, seg.SeqNo, err)
 			break
 		}
 		// recoverable error, retry

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -677,7 +677,7 @@ func selectOrchestrator(n *core.LivepeerNode, params *core.StreamParameters, cou
 	return sessions, nil
 }
 
-func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, error) {
+func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, error) {
 
 	rtmpStrm := cxn.stream
 	nonce := cxn.nonce
@@ -809,6 +809,10 @@ func processSegment(cxn *rtmpConnection, seg *stream.HLSSegment) ([]string, erro
 		}
 		if isNonRetryableError(err) {
 			glog.Warningf("Not retrying current segment nonce=%d seqNo=%d due to non-retryable error err=%v", nonce, seg.SeqNo, err)
+			break
+		}
+		if err = ctx.Err(); err != nil {
+			glog.Warningf("Not retrying current segment nonce=%d seqNo=%d due to error err=%v", nonce, seg.SeqNo, err)
 			break
 		}
 		// recoverable error, retry

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -771,21 +771,21 @@ func TestProcessSegment_MaxAttempts(t *testing.T) {
 
 	// Sanity check: zero attempts should not transcode
 	MaxAttempts = 0
-	_, err := processSegment(cxn, seg)
+	_, err := processSegment(context.Background(), cxn, seg)
 	assert.Nil(err)
 	assert.Equal(0, transcodeCalls, "Unexpectedly submitted segment")
 	assert.Len(bsm.trustedPool.sessMap, 2)
 
 	// One failed transcode attempt. Should leave another in the map
 	MaxAttempts = 1
-	_, err = processSegment(cxn, seg)
+	_, err = processSegment(context.Background(), cxn, seg)
 	assert.NotNil(err)
 	assert.Equal("Hit max transcode attempts: UnknownResponse", err.Error())
 	assert.Equal(1, transcodeCalls, "Segment submission calls did not match")
 	assert.Len(bsm.trustedPool.sessMap, 1)
 
 	// Drain the swamp! Empty out the session list
-	_, err = processSegment(cxn, seg)
+	_, err = processSegment(context.Background(), cxn, seg)
 	assert.NotNil(err)
 	assert.Equal("Hit max transcode attempts: UnknownResponse", err.Error())
 	assert.Equal(2, transcodeCalls, "Segment submission calls did not match")
@@ -793,7 +793,7 @@ func TestProcessSegment_MaxAttempts(t *testing.T) {
 
 	// The session list is empty. TODO Should return an error indicating such
 	// (This test should fail and be corrected once this is actually implemented)
-	_, err = processSegment(cxn, seg)
+	_, err = processSegment(context.Background(), cxn, seg)
 	assert.Nil(err)
 	assert.Equal(2, transcodeCalls, "Segment submission calls did not match")
 	assert.Len(bsm.trustedPool.sessMap, 0)
@@ -875,7 +875,7 @@ func TestProcessSegment_MetadataQueueTranscodeEvent(t *testing.T) {
 	// Calls producer once with transcode event
 	cxn.sessManager = bsmWithSessList(stubSessionList(ctx, 2, handler))
 	transcodeResps <- dummyRes
-	_, err := processSegment(cxn, seg)
+	_, err := processSegment(context.Background(), cxn, seg)
 	assert.Nil(err)
 	assert.Len(cxn.sessManager.trustedPool.sessMap, 2)
 	evt, ok := queue.receive(ctx)
@@ -894,7 +894,7 @@ func TestProcessSegment_MetadataQueueTranscodeEvent(t *testing.T) {
 	cxn.sessManager = bsmWithSessList(stubSessionList(ctx, 2, handler))
 	transcodeResps <- nil
 	transcodeResps <- dummyRes
-	_, err = processSegment(cxn, seg)
+	_, err = processSegment(context.Background(), cxn, seg)
 	assert.Nil(err)
 	assert.Len(cxn.sessManager.trustedPool.sessMap, 1)
 	evt, ok = queue.receive(ctx)
@@ -911,7 +911,7 @@ func TestProcessSegment_MetadataQueueTranscodeEvent(t *testing.T) {
 	transcodeResps <- nil
 	transcodeResps <- nil
 	transcodeResps <- nil
-	_, err = processSegment(cxn, seg)
+	_, err = processSegment(context.Background(), cxn, seg)
 	assert.NotNil(err)
 	assert.Len(cxn.sessManager.trustedPool.sessMap, 0)
 	evt, ok = queue.receive(ctx)
@@ -927,7 +927,7 @@ func TestProcessSegment_MetadataQueueTranscodeEvent(t *testing.T) {
 
 	// Empty session list. Transcode event should still have success=false
 	cxn.sessManager = bsmWithSessList([]*BroadcastSession{})
-	_, err = processSegment(cxn, seg)
+	_, err = processSegment(context.Background(), cxn, seg)
 	assert.Nil(err)
 	assert.Len(cxn.sessManager.trustedPool.sessMap, 0)
 	evt, ok = queue.receive(ctx)
@@ -942,7 +942,7 @@ func TestProcessSegment_MetadataQueueTranscodeEvent(t *testing.T) {
 	queue.err = errors.New("publish failure")
 	cxn.sessManager = bsmWithSessList(stubSessionList(ctx, 1, handler))
 	transcodeResps <- dummyRes
-	_, err = processSegment(cxn, seg)
+	_, err = processSegment(context.Background(), cxn, seg)
 	assert.Nil(err)
 	assert.Len(cxn.sessManager.trustedPool.sessMap, 1)
 	evt, ok = queue.receive(ctx)
@@ -953,7 +953,7 @@ func TestProcessSegment_MetadataQueueTranscodeEvent(t *testing.T) {
 	// Uses manifest ID if external stream ID or params not present
 	testMissingStreamID := func() {
 		transcodeResps <- dummyRes
-		_, err = processSegment(cxn, seg)
+		_, err = processSegment(context.Background(), cxn, seg)
 		assert.Nil(err)
 		evt, ok = queue.receive(ctx)
 		require.True(ok)
@@ -1575,7 +1575,7 @@ func TestProcessSegment_VideoFormat(t *testing.T) {
 	downloadSeg = func(url string) ([]byte, error) { return []byte(url), nil }
 
 	// processSegment will also call transcodeSegment; also check that behavior
-	_, err := processSegment(cxn, seg)
+	_, err := processSegment(context.Background(), cxn, seg)
 
 	assert.Nil(err)
 	assert.Equal(ffmpeg.FormatNone, cxn.profile.Format)
@@ -1598,7 +1598,7 @@ func TestProcessSegment_VideoFormat(t *testing.T) {
 	}
 	cxn.sessManager = bsmWithSessList([]*BroadcastSession{sess})
 
-	_, err = processSegment(cxn, seg)
+	_, err = processSegment(context.Background(), cxn, seg)
 
 	assert.Nil(err)
 	for _, p := range sess.Params.Profiles {
@@ -1621,7 +1621,7 @@ func TestProcessSegment_VideoFormat(t *testing.T) {
 	}
 	cxn.sessManager = bsmWithSessList([]*BroadcastSession{sess})
 
-	_, err = processSegment(cxn, seg)
+	_, err = processSegment(context.Background(), cxn, seg)
 
 	assert.Nil(err)
 	for _, p := range sess.Params.Profiles {
@@ -1639,12 +1639,12 @@ func TestProcessSegment_CheckDuration(t *testing.T) {
 	cxn := &rtmpConnection{}
 
 	// Check less-than-zero
-	_, err := processSegment(cxn, seg)
+	_, err := processSegment(context.Background(), cxn, seg)
 	assert.Equal("Invalid duration -1", err.Error())
 
 	// CHeck greater than max duration
 	seg.Duration = maxDurationSec + 0.01
-	_, err = processSegment(cxn, seg)
+	_, err = processSegment(context.Background(), cxn, seg)
 	assert.Equal("Invalid duration 300.01", err.Error())
 }
 

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -778,6 +778,7 @@ func TestProcessSegment_MaxAttempts(t *testing.T) {
 
 	// One failed transcode attempt. Should leave another in the map
 	MaxAttempts = 1
+	transcodeCalls = 0
 	_, err = processSegment(context.Background(), cxn, seg)
 	assert.NotNil(err)
 	assert.Equal("Hit max transcode attempts: UnknownResponse", err.Error())
@@ -786,19 +787,21 @@ func TestProcessSegment_MaxAttempts(t *testing.T) {
 
 	// Context canceled. Execute once and not retry
 	MaxAttempts = 10
+	transcodeCalls = 0
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err = processSegment(ctx, cxn, seg)
 	assert.NotNil(err)
 	assert.Contains("context canceled", err.Error())
-	assert.Equal(2, transcodeCalls, "Segment submission calls did not match")
+	assert.Equal(1, transcodeCalls, "Segment submission calls did not match")
 	assert.Len(bsm.trustedPool.sessMap, 0)
 
 	// The session list is empty. TODO Should return an error indicating such
 	// (This test should fail and be corrected once this is actually implemented)
+	transcodeCalls = 0
 	_, err = processSegment(context.Background(), cxn, seg)
 	assert.Nil(err)
-	assert.Equal(2, transcodeCalls, "Segment submission calls did not match")
+	assert.Equal(0, transcodeCalls, "Segment submission calls did not match")
 	assert.Len(bsm.trustedPool.sessMap, 0)
 }
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -482,7 +482,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 						monitor.StreamStarted(nonce)
 					}
 				}
-				go processSegment(cxn, seg)
+				go processSegment(context.Background(), cxn, seg)
 			})
 
 			segOptions := segmenter.SegmenterOptions{
@@ -951,7 +951,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	// Do the transcoding!
-	urls, err := processSegment(cxn, seg)
+	urls, err := processSegment(r.Context(), cxn, seg)
 	if err != nil {
 		httpErr := fmt.Sprintf("http push error processing segment url=%s manifestID=%s err=%v", r.URL, mid, err)
 		glog.Error(httpErr)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -43,7 +43,7 @@ var pushResetWg sync.WaitGroup // needed to synchronize exits from HTTP push
 // }
 var port = 10000
 
-// waitForTCP trries to establish TCP connectin for a specified time
+// waitForTCP tries to establish TCP connection for a specified time
 func waitForTCP(waitForTarget time.Duration, uri string) error {
 	var u *url.URL
 	var err error


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
B will take any more attempts of sending the segment to O if the client closed/canceled the request connection.

Before, even if the client was not interested in transcoding anymore, B tried transcoding until the `maxAttemps` number is reached.

**Specific updates (required)**
- Use the request context to determine if B should retry the transcoding

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Introduced `println` and sent requests from the script for two options:
- request is suddenly closed => observed no retries
- request is kept open => retries occurred

**Does this pull request close any open issues?**
fix #2113

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
