### PR TITLE
eth: Round up bumped gas price for the replacement transactions

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,6 +10,7 @@
 
 - \#2114 Add option to repeat the benchmarking process (@jailuthra)
 - \#2111 Ensure `maxFeePerGas` in all transactions never exceed `-masGasPrice` defined by the user (@leszko)
+- \#2126 Round up bumped gas price for the replacement transactions (@leszko)
 
 #### Broadcaster
 
@@ -22,7 +23,6 @@
 - \#2110 Transparently support HTTP/2 for segment requests while allowing HTTP/1 via GODEBUG runtime flags (@yondonfu)
 - \#2124 Do not retry transcoding if HTTP client closed/canceled the connection (@leszko)
 - \#2122 Add the upload segment timeout to improve failing fast (@leszko)
-- \#2126 Round up bumped gas price for the replacement transactions (@leszko)
 
 #### Orchestrator
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,7 @@
 - \#2110 Transparently support HTTP/2 for segment requests while allowing HTTP/1 via GODEBUG runtime flags (@yondonfu)
 - \#2124 Do not retry transcoding if HTTP client closed/canceled the connection (@leszko)
 - \#2122 Add the upload segment timeout to improve failing fast (@leszko)
+- \#2126 Round up bumped gas price for the replacement transactions (@leszko)
 
 #### Orchestrator
 

--- a/eth/transactionManager.go
+++ b/eth/transactionManager.go
@@ -252,7 +252,8 @@ func (tm *TransactionManager) newAdjustedTx(tx *types.Transaction) *types.Transa
 func applyPriceBump(val *big.Int, priceBump uint64) *big.Int {
 	a := big.NewInt(100 + int64(priceBump))
 	b := new(big.Int).Mul(a, val)
-	return b.Div(b, big.NewInt(100))
+	// div round up
+	return b.Div(new(big.Int).Add(b, big.NewInt(99)), big.NewInt(100))
 }
 
 func newReplacementTx(tx *types.Transaction) *types.Transaction {

--- a/eth/transactionManager_test.go
+++ b/eth/transactionManager_test.go
@@ -380,10 +380,16 @@ func TestApplyPriceBump(t *testing.T) {
 	res = applyPriceBump(big.NewInt(500), 101)
 	assert.Equal(big.NewInt(1005), res)
 
-	// Test round down when result is not a whole number
-	// 50 * 1.11 = 55.5 -> 55
+	// Tests round up when result is not a whole number
+	// 50 * 1.11 = 55.5 -> 56
 	res = applyPriceBump(big.NewInt(50), 11)
-	assert.Equal(big.NewInt(55), res)
+	assert.Equal(big.NewInt(56), res)
+	// 501 * 1.11 = 556.11 -> 557
+	res = applyPriceBump(big.NewInt(501), 11)
+	assert.Equal(big.NewInt(557), res)
+	// 9 * 1.11 = 9.99 -> 10
+	res = applyPriceBump(big.NewInt(9), 11)
+	assert.Equal(big.NewInt(10), res)
 }
 
 func TestNewReplacementTx(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Replacement transactions increase the max gas fee by 11%. Before this change, the value was rounded down, which might have resulted in rejecting the replacement transaction (because the requirement is to have at least 10% price bump).

**Specific updates (required)**
- Fix `applyPriceBump()` function to round up instead of round down

**How did you test each of these updates (required)**
unit test


**Does this pull request close any open issues?**
N/A


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
