### PR TITLE
cmd: Add config file support

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,6 +14,7 @@
 - \#2051 Removes HTTP and HTTPS protocols from FFmpeg build (@darkdarkdragon)
 - \#2127 Add warnings to ETH/LPT accounts in Livepeer CLI (@leszko)
 - \#2121 Add contextual logging (@darkdarkdragon)
+- \#2137 Support config file (@leszko)
 
 #### Broadcaster
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/go-livepeer/server"
 	"github.com/livepeer/livepeer-data/pkg/event"
+	"github.com/peterbourgon/ff/v3"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -159,7 +160,13 @@ func main() {
 	orchWebhookURL := flag.String("orchWebhookUrl", "", "Orchestrator discovery callback URL")
 	detectionWebhookURL := flag.String("detectionWebhookUrl", "", "(Experimental) Detection results callback URL")
 
-	flag.Parse()
+	// Config file (used instead of flags)
+	_ = flag.String("config", "", "Config file in the format 'key value', flags take precedence over the config file")
+	ff.Parse(flag.CommandLine, os.Args[1:],
+		ff.WithConfigFileFlag("config"),
+		ff.WithConfigFileParser(ff.PlainParser),
+	)
+
 	vFlag.Value.Set(*verbosity)
 
 	isFlagSet := make(map[string]bool)

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -164,6 +164,7 @@ func main() {
 	_ = flag.String("config", "", "Config file in the format 'key value', flags take precedence over the config file")
 	ff.Parse(flag.CommandLine, os.Args[1:],
 		ff.WithConfigFileFlag("config"),
+		ff.WithEnvVarPrefix("LP"),
 		ff.WithConfigFileParser(ff.PlainParser),
 	)
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -160,7 +160,7 @@ func main() {
 	orchWebhookURL := flag.String("orchWebhookUrl", "", "Orchestrator discovery callback URL")
 	detectionWebhookURL := flag.String("detectionWebhookUrl", "", "(Experimental) Detection results callback URL")
 
-	// Config file (used instead of flags)
+	// Config file
 	_ = flag.String("config", "", "Config file in the format 'key value', flags take precedence over the config file")
 	ff.Parse(flag.CommandLine, os.Args[1:],
 		ff.WithConfigFileFlag("config"),

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -161,7 +161,7 @@ func main() {
 	detectionWebhookURL := flag.String("detectionWebhookUrl", "", "(Experimental) Detection results callback URL")
 
 	// Config file
-	_ = flag.String("config", "", "Config file in the format 'key value', flags take precedence over the config file")
+	_ = flag.String("config", "", "Config file in the format 'key value', flags and env vars take precedence over the config file")
 	ff.Parse(flag.CommandLine, os.Args[1:],
 		ff.WithConfigFileFlag("config"),
 		ff.WithEnvVarPrefix("LP"),

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/peterbourgon/ff/v3 v3.1.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/tsdb v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -363,12 +363,6 @@ github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cO
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.2.0 h1:8ELEri/sWd6fAHT3anAgoKe9Z+XgbW0oLg5qODdhvm8=
 github.com/livepeer/livepeer-data v0.2.0/go.mod h1:vkW1PJ24gOJgx1hHUo07cXkR1b409n+dGpyWJsHKI3s=
-github.com/livepeer/lpms v0.0.0-20211118135113-46f7030c62d9 h1:lIb6ktT7+GSR1RyjT1tovTJCETa/lf/G+SmHe3Hlk5I=
-github.com/livepeer/lpms v0.0.0-20211118135113-46f7030c62d9/go.mod h1:iIvqFRRSIcouTWFheH2/TeDAq7xTVOJNR0eAS84o754=
-github.com/livepeer/lpms v0.0.0-20211130214948-1d4f0f20d7c2 h1:6gjoS8yIs0K+iY6FHy+2QyRH0VLRPytUs5Ij0GO/c+A=
-github.com/livepeer/lpms v0.0.0-20211130214948-1d4f0f20d7c2/go.mod h1:iIvqFRRSIcouTWFheH2/TeDAq7xTVOJNR0eAS84o754=
-github.com/livepeer/lpms v0.0.0-20211130215529-4035626057aa h1:rkGIy4EOdgqDm6WhyONtfWhrYsTLnJXY8irpexhwWTE=
-github.com/livepeer/lpms v0.0.0-20211130215529-4035626057aa/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/lpms v0.0.0-20211208221036-644122186d24 h1:nna6NFrFuDz0xFYsOrZnDaaRUxHuA1tmwnl0oJb6BL4=
 github.com/livepeer/lpms v0.0.0-20211208221036-644122186d24/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
@@ -447,7 +441,10 @@ github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTK
 github.com/paulbellamy/ratecounter v0.2.0/go.mod h1:Hfx1hDpSGoqxkVVpBi/IlYD7kChlfo5C6hzIHwPqfFE=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
+github.com/peterbourgon/ff v1.7.0 h1:hknvTgsh90jNBIjPq7xeq32Y9AmSbpXvjrFW4sJwW+A=
 github.com/peterbourgon/ff v1.7.0/go.mod h1:/KKxnU5cBj4w21jEMj4Rway/kslRP6XAOHh7CH8AyAM=
+github.com/peterbourgon/ff/v3 v3.1.2 h1:0GNhbRhO9yHA4CC27ymskOsuRpmX0YQxwxM9UPiP6JM=
+github.com/peterbourgon/ff/v3 v3.1.2/go.mod h1:XNJLY8EIl6MjMVjBS4F0+G0LYoAqs0DTa4rmHHukKDE=
 github.com/peterh/liner v1.0.1-0.20180619022028-8c1271fcf47f/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 h1:oYW+YCJ1pachXTQmzR3rNLYGGz4g/UgFcjb28p/viDM=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Add a possibility to configure Livepeer using a config file instead of flags.

Sample usage:
```
$ livepeer -config livepeer.conf
```

Sample `livepeer.conf`

```
broadcaster
cliAddr :7937
httpAddr :8938
orchAddr 127.0.0.1:8935,127.0.0.1:8936
v 6
```

**Specific updates (required)**
Used the library https://github.com/peterbourgon/ff, which allows using config file for the flags.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

1. Created a sample config file and checked if it works
2. Checked if both config files and flags are defined if flags take precedence over config file

**Does this pull request close any open issues?**
fix #101

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
