### PR TITLE
core: Allows Os receive payments while pending activation

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -30,6 +30,8 @@
 
 #### Orchestrator
 
+- \#2146 Allows Os receive payments while pending activation (@leszko)
+
 #### Transcoder
 - \#2094 Gracefully notify orchestrator in case of a panic in transcoder (@leszko)
 

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1195,19 +1195,32 @@ func TestIsPaymentEligible(t *testing.T) {
 	addr := defaultRecipient
 	dbh, dbraw := tempDBWithOrch(t, &common.DBOrch{
 		EthereumAddr:      addr.Hex(),
-		ActivationRound:   1,
+		ActivationRound:   2,
 		DeactivationRound: 999,
 	})
 	defer dbh.Close()
 	defer dbraw.Close()
 
+	// not active yet
 	n, _ := NewLivepeerNode(nil, "", dbh)
 	rm := &stubRoundsManager{
-		round: big.NewInt(10),
+		round: big.NewInt(0),
 	}
 	orch := NewOrchestrator(n, rm)
 
 	ok, err := orch.isPaymentEligible(addr)
+	assert.False(ok)
+	assert.NoError(err)
+
+	// pending activation
+	rm.round = big.NewInt(1)
+	ok, err = orch.isPaymentEligible(addr)
+	assert.True(ok)
+	assert.NoError(err)
+
+	// active
+	rm.round = big.NewInt(10)
+	ok, err = orch.isPaymentEligible(addr)
 	assert.True(ok)
 	assert.NoError(err)
 

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -799,7 +799,7 @@ func TestProcessPayment_ActiveOrchestrator(t *testing.T) {
 
 	// orchestrator inactive -> error
 	err := orch.ProcessPayment(defaultPayment(t), ManifestID("some manifest"))
-	expErr := fmt.Sprintf("orchestrator %v is inactive in round %v, cannot process payments", addr.Hex(), 10)
+	expErr := fmt.Sprintf("orchestrator %v is not eligible for payments in round %v, cannot process payments", addr.Hex(), 10)
 	assert.EqualError(err, expErr)
 
 	// orchestrator is active -> no error
@@ -1207,13 +1207,13 @@ func TestIsActive(t *testing.T) {
 	}
 	orch := NewOrchestrator(n, rm)
 
-	ok, err := orch.isActive(addr)
+	ok, err := orch.isPaymentEligible(addr)
 	assert.True(ok)
 	assert.NoError(err)
 
 	// inactive
 	rm.round = big.NewInt(1000)
-	ok, err = orch.isActive(addr)
+	ok, err = orch.isPaymentEligible(addr)
 	assert.False(ok)
 	assert.NoError(err)
 }

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1190,7 +1190,7 @@ func TestProcessPayment_PaymentError_DoesNotIncreaseCreditBalance(t *testing.T) 
 	assert.Nil(orch.node.Balances.Balance(ethcommon.BytesToAddress(payment.Sender), manifestID))
 }
 
-func TestIsActive(t *testing.T) {
+func TestIsPaymentEligible(t *testing.T) {
 	assert := assert.New(t)
 	addr := defaultRecipient
 	dbh, dbraw := tempDBWithOrch(t, &common.DBOrch{


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Allow receiving payments by orchestrator which is not yet activated (but will be activated in the next round).

**Specific updates (required)**
N/A

**How did you test each of these updates (required)**
1. Set up local geth
2. Set up Broadcaster and Orchestrator
3. Manually updated SQLite DB for Orchester to modify acivationRound
4. Check that the segments are still transcoded when the current round is `activationRound - 1`, but are not transcoded when the current round is `activationRound - 2`.


**Does this pull request close any open issues?**
fix #2140


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
