### PR TITLE
[wip] cmd: allow `livepeer` to be embedded elsewhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 
 .PHONY: livepeer
 livepeer:
-	GO111MODULE=on CGO_LDFLAGS="$(cgo_ldflags)" go build -tags $(BUILD_TAGS) -ldflags="$(ldflags)" cmd/livepeer/*.go
+	GO111MODULE=on CGO_LDFLAGS="$(cgo_ldflags)" go build -tags $(BUILD_TAGS) -ldflags="$(ldflags)" cmd/livepeer/main/*.go
 
 .PHONY: livepeer_cli
 livepeer_cli:

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -1,7 +1,7 @@
 /*
 Livepeer is a peer-to-peer global video live streaming network.  The Golp project is a go implementation of the Livepeer protocol.  For more information, visit the project wiki.
 */
-package main
+package livepeer
 
 import (
 	"context"
@@ -70,7 +70,7 @@ const RtmpPort = "1935"
 const RpcPort = "8935"
 const CliPort = "7935"
 
-func main() {
+func Run() {
 	// Override the default flag set since there are dependencies that
 	// incorrectly add their own flags (specifically, due to the 'testing'
 	// package being linked)

--- a/cmd/livepeer/livepeer_test.go
+++ b/cmd/livepeer/livepeer_test.go
@@ -1,4 +1,4 @@
-package main
+package livepeer
 
 import (
 	"context"

--- a/cmd/livepeer/main/livepeer.go
+++ b/cmd/livepeer/main/livepeer.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/livepeer/go-livepeer/cmd/livepeer"
+)
+
+func main() {
+	livepeer.Run()
+}


### PR DESCRIPTION
Just food-for-thought for now. Potentially looking at doing something like https://github.com/livepeer/livepeer-data/pull/31 in all of our projects to create one mega-binary for Livepeer in a Box 2.0.

If we move forward with this we'd probably do the same thing in all the other binaries.