### PR TITLE
Support lpms tests in install_ffmpeg.sh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/jaypipes/ghw v0.7.0
 	github.com/livepeer/livepeer-data v0.2.0
-	github.com/livepeer/lpms v0.0.0-20211208221036-644122186d24
+	github.com/livepeer/lpms v0.0.0-20220111151401-0eb91f2facdb
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,8 @@ github.com/livepeer/livepeer-data v0.2.0 h1:8ELEri/sWd6fAHT3anAgoKe9Z+XgbW0oLg5q
 github.com/livepeer/livepeer-data v0.2.0/go.mod h1:vkW1PJ24gOJgx1hHUo07cXkR1b409n+dGpyWJsHKI3s=
 github.com/livepeer/lpms v0.0.0-20211208221036-644122186d24 h1:nna6NFrFuDz0xFYsOrZnDaaRUxHuA1tmwnl0oJb6BL4=
 github.com/livepeer/lpms v0.0.0-20211208221036-644122186d24/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
+github.com/livepeer/lpms v0.0.0-20220111151401-0eb91f2facdb h1:2EM2tlBmcnK6QiT5JjWyRVya5N2UXDT/1evaMVmTzTQ=
+github.com/livepeer/lpms v0.0.0-20220111151401-0eb91f2facdb/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -98,6 +98,7 @@ if [[ $(uname) == "Linux" && $BUILD_TAGS == *"debug-video"* ]]; then
 fi
 
 EXTRA_FFMPEG_FLAGS=""
+DISABLE_FFMPEG_COMPONENTS=""
 EXTRA_LDFLAGS=""
 # all flags which should be present for production build, but should be replaced/removed for debug build
 DEV_FFMPEG_FLAGS="--disable-programs"
@@ -131,15 +132,15 @@ if [[ $BUILD_TAGS == *"debug-video"* ]]; then
     FFMPEG_MAKE_EXTRA_ARGS="-j4"
 else
     # disable all unnecessary features for production build
-    EXTRA_FFMPEG_FLAGS+=" --disable-doc --disable-sdl2 --disable-iconv --disable-muxers --disable-demuxers --disable-parsers --disable-protocols "
-    EXTRA_FFMPEG_FLAGS+=" --disable-encoders --disable-decoders --disable-filters --disable-bsfs --disable-postproc --disable-lzma "
+    DISABLE_FFMPEG_COMPONENTS+=" --disable-doc --disable-sdl2 --disable-iconv --disable-muxers --disable-demuxers --disable-parsers --disable-protocols "
+    DISABLE_FFMPEG_COMPONENTS+=" --disable-encoders --disable-decoders --disable-filters --disable-bsfs --disable-postproc --disable-lzma "
 fi
 
 if [ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]; then
   git clone https://github.com/livepeer/FFmpeg.git "$ROOT/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$ROOT/ffmpeg"
   git checkout e0eebeeeddf863f72da0232f9dddc05200340560
-  ./configure ${TARGET_OS:-} --fatal-warnings \
+  ./configure ${TARGET_OS:-} $DISABLE_FFMPEG_COMPONENTS --fatal-warnings \
     --enable-libx264 --enable-gpl \
     --enable-protocol=rtmp,file,pipe \
     --enable-muxer=mpegts,hls,segment,mp4,hevc,matroska,webm,null --enable-demuxer=flv,mpegts,mp4,mov,webm,matroska \

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -99,7 +99,7 @@ fi
 
 EXTRA_FFMPEG_FLAGS=""
 EXTRA_LDFLAGS=""
-# all flags which should present for production build, but should be replaced/removed for debug build
+# all flags which should be present for production build, but should be replaced/removed for debug build
 DEV_FFMPEG_FLAGS="--disable-programs"
 FFMPEG_MAKE_EXTRA_ARGS=""
 
@@ -125,8 +125,14 @@ fi
 
 if [[ $BUILD_TAGS == *"debug-video"* ]]; then
     echo "video debug mode, building ffmpeg with tools, debug info and additional capabilities for running tests"
-    DEV_FFMPEG_FLAGS="--enable-demuxer=hls --enable-filter=ssim --enable-encoder=wrapped_avframe,pcm_s16le --enable-shared --enable-debug=3 --disable-stripping --disable-optimizations --enable-encoder=libx265,libvpx_vp8,libvpx_vp9 --enable-decoder=hevc,libvpx_vp8,libvpx_vp9 --enable-libx265 --enable-libvpx"
+    DEV_FFMPEG_FLAGS="--enable-muxer=md5,flv --enable-demuxer=hls --enable-filter=ssim,tinterlace --enable-encoder=wrapped_avframe,pcm_s16le "
+    DEV_FFMPEG_FLAGS+="--enable-shared --enable-debug=3 --disable-stripping --disable-optimizations --enable-encoder=libx265,libvpx_vp8,libvpx_vp9 "
+    DEV_FFMPEG_FLAGS+="--enable-decoder=hevc,libvpx_vp8,libvpx_vp9 --enable-libx265 --enable-libvpx --enable-bsf=noise "
     FFMPEG_MAKE_EXTRA_ARGS="-j4"
+else
+    # disable all unnecessary features for production build
+    EXTRA_FFMPEG_FLAGS+=" --disable-doc --disable-sdl2 --disable-iconv --disable-muxers --disable-demuxers --disable-parsers --disable-protocols "
+    EXTRA_FFMPEG_FLAGS+=" --disable-encoders --disable-decoders --disable-filters --disable-bsfs --disable-postproc --disable-lzma "
 fi
 
 if [ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]; then
@@ -134,10 +140,6 @@ if [ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]; then
   cd "$ROOT/ffmpeg"
   git checkout e0eebeeeddf863f72da0232f9dddc05200340560
   ./configure ${TARGET_OS:-} --fatal-warnings \
-    --disable-doc --disable-sdl2 --disable-iconv \
-    --disable-muxers --disable-demuxers --disable-parsers --disable-protocols \
-    --disable-encoders --disable-decoders --disable-filters --disable-bsfs \
-    --disable-postproc --disable-lzma \
     --enable-libx264 --enable-gpl \
     --enable-protocol=rtmp,file,pipe \
     --enable-muxer=mpegts,hls,segment,mp4,hevc,matroska,webm,null --enable-demuxer=flv,mpegts,mp4,mov,webm,matroska \


### PR DESCRIPTION
A quick follow-up to #2135 
Motivation is to make all lpms tests work with new `install_ffmpeg.sh` by building for dev/test with default options (without explicit `--disable-...`). Production build will still have only necessary components enabled.