### PR TITLE
cmd: Update hardcoded Rinkeby Eth Controller Address

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,6 +11,7 @@
 #### General
 
 - \#2163 Fix Session crashes right after the O sends a tx, revert #2111 Ensure `maxFeePerGas` in all transactions never exceed `-masGasPrice` (@leszko)
+- \#2177 Update hardcoded Rinkeby Eth Controller Address (@leszko)
 
 #### Broadcaster
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -197,7 +197,7 @@ func main() {
 
 	configOptions := map[string]*NetworkConfig{
 		"rinkeby": {
-			ethController: "0xA268AEa9D048F8d3A592dD7f1821297972D4C8Ea",
+			ethController: "0x9a9827455911a858E55f07911904fACC0D66027E",
 		},
 		"mainnet": {
 			ethController: "0xf96d54e490317c557a967abfa5d6e33006be69b3",


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Update hardcoded Rinkeby Eth Controller.

**Points of attention**:
1. Orchestrators registered via the old controller and not visible via the new controller. With the new controller, I've seen the empty controller list in Rinkeby.
2. LPT balance is not moved from the old controller to the new controller.
3. The same with other fields (deposit, reserve, stake, etc.)

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

N/A

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Started Broadcaster
- Invoked "Get test LPT"
- Invoked "deposit broadcasting funds (ETH)"
- Started Orchestrator
- Register / Activate Orchestrator

**Does this pull request close any open issues?**
<!-- Fixes # -->

fix #2166


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
