### PR TITLE
Default Issue Labeler

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,18 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Label issues
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        with:
+          add-labels: "status: triage"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          ignore-if-assigned: false


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This pull request adds an Action to automatically label newly-created or reopened issues with `status: triage`.

**Specific updates (required)**
new file `workflow/issue-labeler.yml`


**Test instructions**
add workflow to a private repo, open an issue. in ~1min the label will be added

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
