### PR TITLE
discovery: Include Pending Os in discovery

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,6 +10,8 @@
 
 #### Broadcaster
 
+- \#2188 Include pending Os in the discovery mechanism (@leszko)
+
 #### Orchestrator
 
 #### Transcoder

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -70,7 +70,7 @@ func (dbo *DBOrchestratorPoolCache) getURLs() ([]*url.URL, error) {
 	orchs, err := dbo.store.SelectOrchs(
 		&common.DBOrchFilter{
 			MaxPrice:       server.BroadcastCfg.MaxPrice(),
-			CurrentRound:   dbo.rm.LastInitializedRound(),
+			CurrentRound:   dbo.nextRound(),
 			UpdatedLastDay: true,
 		},
 	)
@@ -168,7 +168,7 @@ func (dbo *DBOrchestratorPoolCache) Size() int {
 	count, _ := dbo.store.OrchCount(
 		&common.DBOrchFilter{
 			MaxPrice:       server.BroadcastCfg.MaxPrice(),
-			CurrentRound:   dbo.rm.LastInitializedRound(),
+			CurrentRound:   dbo.nextRound(),
 			UpdatedLastDay: true,
 		},
 	)
@@ -200,7 +200,7 @@ func (dbo *DBOrchestratorPoolCache) cacheTranscoderPool() error {
 func (dbo *DBOrchestratorPoolCache) cacheOrchestratorStake() error {
 	orchs, err := dbo.store.SelectOrchs(
 		&common.DBOrchFilter{
-			CurrentRound: dbo.rm.LastInitializedRound(),
+			CurrentRound: dbo.nextRound(),
 		},
 	)
 	if err != nil {
@@ -276,7 +276,7 @@ func (dbo *DBOrchestratorPoolCache) pollOrchestratorInfo(ctx context.Context) er
 func (dbo *DBOrchestratorPoolCache) cacheDBOrchs() error {
 	orchs, err := dbo.store.SelectOrchs(
 		&common.DBOrchFilter{
-			CurrentRound: dbo.rm.LastInitializedRound(),
+			CurrentRound: dbo.nextRound(),
 		},
 	)
 	if err != nil {
@@ -351,6 +351,13 @@ func (dbo *DBOrchestratorPoolCache) cacheDBOrchs() error {
 	}
 
 	return nil
+}
+
+func (dbo *DBOrchestratorPoolCache) nextRound() *big.Int {
+	if dbo.rm.LastInitializedRound() == nil {
+		return nil
+	}
+	return new(big.Int).Add(dbo.rm.LastInitializedRound(), big.NewInt(1))
 }
 
 func parseURI(addr string) (*url.URL, error) {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1070,12 +1070,13 @@ func TestCachedPool_GetOrchestrators_OnlyActiveOrchestrators(t *testing.T) {
 	}
 
 	// check size
-	assert.Equal(25, pool.Size())
+	// 25 active Os + 1 pending O
+	assert.Equal(26, pool.Size())
 
 	infos := pool.GetInfos()
-	assert.Len(infos, 25)
+	assert.Len(infos, 26)
 	for _, info := range infos {
-		assert.Contains(addresses[:25], info.URL.String())
+		assert.Contains(addresses[:26], info.URL.String())
 	}
 	oinfos, err := pool.GetOrchestrators(context.TODO(), 50, newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 	for _, info := range oinfos {
@@ -1084,7 +1085,7 @@ func TestCachedPool_GetOrchestrators_OnlyActiveOrchestrators(t *testing.T) {
 	}
 
 	assert.Nil(err, "Should not be error")
-	assert.Len(infos, 25)
+	assert.Len(infos, 26)
 }
 
 func TestNewWHOrchestratorPoolCache(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Make B discover Os that will be activated in the next round. It's related to the L2 migration so that the moved Os could be all of the sudden discovered.

**Specific updates (required)**
Update the round in the DB filter in `db_discovery.go`.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Tested locally with geth.
1. Before the change, B could not discover Os that were just registered.
2. After the change, B could discover Os that were just registered.

**Does this pull request close any open issues?**
<!-- Fixes # -->

fix #2148 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
