### PR TITLE
Infer capabilities from input codec

### DIFF
--- a/build/chain_dev.go
+++ b/build/chain_dev.go
@@ -1,3 +1,4 @@
+//go:build !mainnet && !rinkeby
 // +build !mainnet,!rinkeby
 
 package build

--- a/build/chain_mainnet.go
+++ b/build/chain_mainnet.go
@@ -1,3 +1,4 @@
+//go:build mainnet
 // +build mainnet
 
 package build

--- a/build/chain_rinkeby.go
+++ b/build/chain_rinkeby.go
@@ -1,3 +1,4 @@
+//go:build rinkeby
 // +build rinkeby
 
 package build

--- a/core/capabilities_experimental_off.go
+++ b/core/capabilities_experimental_off.go
@@ -1,3 +1,4 @@
+//go:build !experimental
 // +build !experimental
 
 package core

--- a/core/capabilities_experimental_on.go
+++ b/core/capabilities_experimental_on.go
@@ -1,3 +1,4 @@
+//go:build experimental
 // +build experimental
 
 package core

--- a/core/streamdata.go
+++ b/core/streamdata.go
@@ -42,6 +42,7 @@ type StreamParameters struct {
 	Detection        DetectionConfig
 	VerificationFreq uint
 	Nonce            uint64
+	Codec            ffmpeg.VideoCodec
 }
 
 func (s *StreamParameters) StreamID() string {

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -706,12 +706,7 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 	ros := cpl.GetRecordOSSession()
 	segDurMs := getSegDurMsString(seg)
 
-	now := time.Now()
-	hasZeroVideoFrame, err := ffmpeg.HasZeroVideoFrameBytes(seg.Data)
-	if err != nil {
-		clog.Warningf(ctx, "Error checking for zero video frame name=%s bytes=%d took=%s err=%q",
-			seg.Name, len(seg.Data), time.Since(now), err)
-	}
+	hasZeroVideoFrame := seg.IsZeroFrame
 	if ros != nil && !hasZeroVideoFrame {
 		go func() {
 			now := time.Now()

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -51,7 +51,9 @@ func TestPush_ShouldReturn422ForNonRetryable(t *testing.T) {
 	s, cancel := setupServerWithCancel()
 	defer serverCleanup(s)
 	defer cancel()
-	reader := strings.NewReader("InsteadOf.TS")
+
+	d, _ := ioutil.ReadFile("./test.flv")
+	reader := bytes.NewReader(d)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/live/mani/18.ts", reader)
 
@@ -117,6 +119,7 @@ func TestPush_ShouldReturn422ForNonRetryable(t *testing.T) {
 	buf, err = proto.Marshal(tr)
 	require.Nil(t, err)
 	w = httptest.NewRecorder()
+	reader = bytes.NewReader(d)
 	req = httptest.NewRequest("POST", "/live/mani/18.ts", reader)
 	req.Header.Set("Accept", "multipart/mixed")
 	s.HandlePush(w, req)
@@ -135,6 +138,7 @@ func TestPush_ShouldReturn422ForNonRetryable(t *testing.T) {
 	buf, err = proto.Marshal(tr)
 	require.Nil(t, err)
 	w = httptest.NewRecorder()
+	reader = bytes.NewReader(d)
 	req = httptest.NewRequest("POST", "/live/mani/18.ts", reader)
 	req.Header.Set("Accept", "multipart/mixed")
 	s.HandlePush(w, req)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is part of #2123 implementation and a follow up to #2150. Will rebase once #2150 is merged.

**Specific updates (required)**
* Add LPMS function `GetCodecInfo`
* Call it early in `MediaServer.HandlePush` to both determine video\audio codec and check if segment doesn't have video frames
* pass codec info to `registerConnection` to infer additional job capabilities from it

**How did you test each of these updates (required)**
Tests


**Does this pull request close any open issues?**
#2123


**Checklist:**

- [X] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [n/a] README and other documentation updated
- [X] [Pending changelog](./CHANGELOG_PENDING.md) updated
