### PR TITLE
cmd: Add fail-fast approach in case of incorrect config file

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,7 @@
 ### Features ⚒
 
 #### General
+- \#2198 Add fail-fast approach in case of incorrect config file (@leszko)
 
 #### Broadcaster
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -168,7 +168,7 @@ func main() {
 		ff.WithConfigFileParser(ff.PlainParser),
 	)
 	if err != nil {
-		glog.Fatal("Error using config file: ", err)
+		glog.Fatal("Error parsing config: ", err)
 	}
 
 	vFlag.Value.Set(*verbosity)

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -162,11 +162,14 @@ func main() {
 
 	// Config file
 	_ = flag.String("config", "", "Config file in the format 'key value', flags and env vars take precedence over the config file")
-	ff.Parse(flag.CommandLine, os.Args[1:],
+	err = ff.Parse(flag.CommandLine, os.Args[1:],
 		ff.WithConfigFileFlag("config"),
 		ff.WithEnvVarPrefix("LP"),
 		ff.WithConfigFileParser(ff.PlainParser),
 	)
+	if err != nil {
+		glog.Fatal("Error using config file: ", err)
+	}
 
 	vFlag.Value.Set(*verbosity)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fail fast when there is an error in the Livepeer config file.

**Specific updates (required)**
N/A

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
1. Non-existing config file
```
$ ./livepeer -config nonExistingFile.conf
F0120 11:58:24.943412   42834 livepeer.go:171] Error using config file: open nonExistingFile.conf: no such file or directory
```
2. Config file with a flag that was not defined
```
$ cat livepeer.conf 
reward false malformed
$ ./livepeer -config livepeer.conf 
F0120 11:59:23.205466   42904 livepeer.go:171] Error using config file: error setting flag "reward" from config file: parse error
```
3. Malformed config file
```
$ cat livepeer.conf 
nonExistingFlag 123
reward false
$ ./livepeer -config livepeer.conf 
F0120 11:59:52.497457   42961 livepeer.go:171] Error using config file: config file flag "nonExistingFlag" not defined in flag set
```

**Does this pull request close any open issues?**
fix #2193

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
