### PR TITLE
Improve Feed PubSub: execute subscribers' blocking operations in separate goroutines

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,8 @@
 
 #### General
 
+- \#2208 Improve Feed PubSub: execute subscribers' blocking operations in separate goroutines (@leszko)
+
 #### Broadcaster
 
 #### Orchestrator

--- a/eth/rewardservice.go
+++ b/eth/rewardservice.go
@@ -3,6 +3,7 @@ package eth
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/golang/glog"
@@ -18,6 +19,7 @@ type RewardService struct {
 	working      bool
 	cancelWorker context.CancelFunc
 	tw           timeWatcher
+	mu           sync.Mutex
 }
 
 func NewRewardService(client LivepeerEthClient, tw timeWatcher) *RewardService {
@@ -80,6 +82,9 @@ func (s *RewardService) IsWorking() bool {
 }
 
 func (s *RewardService) tryReward() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	currentRound := s.tw.LastInitializedRound()
 
 	t, err := s.client.GetTranscoder(s.client.Account().Address)

--- a/eth/rewardservice.go
+++ b/eth/rewardservice.go
@@ -51,10 +51,12 @@ func (s *RewardService) Start(ctx context.Context) error {
 				glog.Errorf("Round subscription error err=%q", err)
 			}
 		case <-rounds:
-			err := s.tryReward()
-			if err != nil {
-				glog.Errorf("Error trying to call reward err=%q", err)
-			}
+			go func() {
+				err := s.tryReward()
+				if err != nil {
+					glog.Errorf("Error trying to call reward err=%q", err)
+				}
+			}()
 		case <-cancelCtx.Done():
 			glog.V(5).Infof("Reward service done")
 			return nil

--- a/eth/rewardservice.go
+++ b/eth/rewardservice.go
@@ -35,8 +35,8 @@ func (s *RewardService) Start(ctx context.Context) error {
 	cancelCtx, cancel := context.WithCancel(ctx)
 	s.cancelWorker = cancel
 
-	rounds := make(chan types.Log, 10)
-	sub := s.tw.SubscribeRounds(rounds)
+	roundSink := make(chan types.Log, 10)
+	sub := s.tw.SubscribeRounds(roundSink)
 	defer sub.Unsubscribe()
 
 	s.working = true
@@ -50,7 +50,7 @@ func (s *RewardService) Start(ctx context.Context) error {
 			if err != nil {
 				glog.Errorf("Round subscription error err=%q", err)
 			}
-		case <-rounds:
+		case <-roundSink:
 			go func() {
 				err := s.tryReward()
 				if err != nil {

--- a/eth/roundinitializer.go
+++ b/eth/roundinitializer.go
@@ -34,9 +34,7 @@ type RoundInitializer struct {
 	quit   chan struct{}
 
 	nextRoundStartBlock *big.Int
-
-	// Prevent multiple round initializations at the same time
-	mu sync.Mutex
+	mu                  sync.Mutex
 }
 
 // NewRoundInitializer creates a RoundInitializer instance
@@ -84,9 +82,7 @@ func (r *RoundInitializer) Start() error {
 				glog.Errorf("Round subscription error err=%q", err)
 			}
 		case <-roundSink:
-			go func() {
-				r.nextRoundStartBlock = r.nextRoundStartBlock.Add(r.tw.CurrentRoundStartBlock(), roundLength)
-			}()
+			r.nextRoundStartBlock = r.nextRoundStartBlock.Add(r.tw.CurrentRoundStartBlock(), roundLength)
 		case block := <-blockSink:
 			if block.Cmp(r.nextRoundStartBlock) >= 0 {
 				go func() {

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -57,11 +57,15 @@ func (ow *OrchestratorWatcher) Watch() {
 		case err := <-sub.Err():
 			glog.Error(err)
 		case events := <-events:
-			ow.handleBlockEvents(events)
+			go func() {
+				ow.handleBlockEvents(events)
+			}()
 		case roundEvent := <-roundEvents:
-			if err := ow.handleRoundEvent(roundEvent); err != nil {
-				glog.Errorf("error handling new round event: %v", err)
-			}
+			go func() {
+				if err := ow.handleRoundEvent(roundEvent); err != nil {
+					glog.Errorf("error handling new round event: %v", err)
+				}
+			}()
 		}
 	}
 }

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -60,9 +60,7 @@ func (ow *OrchestratorWatcher) Watch() {
 		case err := <-sub.Err():
 			glog.Error(err)
 		case block := <-blockSink:
-			go func() {
-				ow.handleBlockEvents(block)
-			}()
+			go ow.handleBlockEvents(block)
 		case round := <-roundSink:
 			go func() {
 				if err := ow.handleRoundEvent(round); err != nil {

--- a/eth/watchers/senderwatcher.go
+++ b/eth/watchers/senderwatcher.go
@@ -113,9 +113,7 @@ func (sw *SenderWatcher) Watch() {
 		case err := <-sub.Err():
 			glog.Error(err)
 		case events := <-events:
-			go func() {
-				sw.handleBlockEvents(events)
-			}()
+			go sw.handleBlockEvents(events)
 		case round := <-roundSink:
 			go func() {
 				if err := sw.handleRoundEvent(round); err != nil {

--- a/eth/watchers/senderwatcher.go
+++ b/eth/watchers/senderwatcher.go
@@ -98,8 +98,8 @@ func (sw *SenderWatcher) ClaimedReserve(reserveHolder ethcommon.Address, claiman
 
 // Watch starts the event watching loop
 func (sw *SenderWatcher) Watch() {
-	roundEvents := make(chan types.Log, 10)
-	roundSub := sw.tw.SubscribeRounds(roundEvents)
+	roundSink := make(chan types.Log, 10)
+	roundSub := sw.tw.SubscribeRounds(roundSink)
 	defer roundSub.Unsubscribe()
 
 	events := make(chan []*blockwatch.Event, 10)
@@ -116,9 +116,9 @@ func (sw *SenderWatcher) Watch() {
 			go func() {
 				sw.handleBlockEvents(events)
 			}()
-		case roundEvent := <-roundEvents:
+		case round := <-roundSink:
 			go func() {
-				if err := sw.handleRoundEvent(roundEvent); err != nil {
+				if err := sw.handleRoundEvent(round); err != nil {
 					glog.Errorf("error handling new round event: %v", err)
 				}
 			}()

--- a/eth/watchers/senderwatcher.go
+++ b/eth/watchers/senderwatcher.go
@@ -113,11 +113,15 @@ func (sw *SenderWatcher) Watch() {
 		case err := <-sub.Err():
 			glog.Error(err)
 		case events := <-events:
-			sw.handleBlockEvents(events)
+			go func() {
+				sw.handleBlockEvents(events)
+			}()
 		case roundEvent := <-roundEvents:
-			if err := sw.handleRoundEvent(roundEvent); err != nil {
-				glog.Errorf("error handling new round event: %v", err)
-			}
+			go func() {
+				if err := sw.handleRoundEvent(roundEvent); err != nil {
+					glog.Errorf("error handling new round event: %v", err)
+				}
+			}()
 		}
 	}
 }

--- a/eth/watchers/timewatcher.go
+++ b/eth/watchers/timewatcher.go
@@ -161,7 +161,9 @@ func (tw *TimeWatcher) Watch() error {
 		case err := <-sub.Err():
 			glog.Error(err)
 		case events := <-events:
-			tw.handleBlockEvents(events)
+			go func() {
+				tw.handleBlockEvents(events)
+			}()
 		}
 	}
 }

--- a/eth/watchers/timewatcher.go
+++ b/eth/watchers/timewatcher.go
@@ -162,9 +162,7 @@ func (tw *TimeWatcher) Watch() error {
 		case err := <-sub.Err():
 			glog.Error(err)
 		case block := <-blockSink:
-			go func() {
-				tw.handleBlockEvents(block)
-			}()
+			go tw.handleBlockEvents(block)
 		}
 	}
 }

--- a/eth/watchers/timewatcher.go
+++ b/eth/watchers/timewatcher.go
@@ -151,8 +151,8 @@ func (tw *TimeWatcher) setLastSeenBlock(blockNum *big.Int) {
 
 // Watch the blockwatch subscription for NewRound events
 func (tw *TimeWatcher) Watch() error {
-	events := make(chan []*blockwatch.Event, 10)
-	sub := tw.watcher.Subscribe(events)
+	blockSink := make(chan []*blockwatch.Event, 10)
+	sub := tw.watcher.Subscribe(blockSink)
 	defer sub.Unsubscribe()
 	for {
 		select {
@@ -160,9 +160,9 @@ func (tw *TimeWatcher) Watch() error {
 			return nil
 		case err := <-sub.Err():
 			glog.Error(err)
-		case events := <-events:
+		case block := <-blockSink:
 			go func() {
-				tw.handleBlockEvents(events)
+				tw.handleBlockEvents(block)
 			}()
 		}
 	}

--- a/eth/watchers/unbondingwatcher.go
+++ b/eth/watchers/unbondingwatcher.go
@@ -45,8 +45,8 @@ func NewUnbondingWatcher(addr ethcommon.Address, bondingManagerAddr ethcommon.Ad
 
 // Watch kicks off a loop that handles events from a block subscription
 func (w *UnbondingWatcher) Watch() {
-	blockEvents := make(chan []*blockwatch.Event, 10)
-	sub := w.bw.Subscribe(blockEvents)
+	blockSink := make(chan []*blockwatch.Event, 10)
+	sub := w.bw.Subscribe(blockSink)
 	defer sub.Unsubscribe()
 
 	for {
@@ -55,9 +55,9 @@ func (w *UnbondingWatcher) Watch() {
 			return
 		case err := <-sub.Err():
 			glog.Errorf("error with block subscription: %v", err)
-		case events := <-blockEvents:
+		case block := <-blockSink:
 			go func() {
-				w.handleBlockEvents(events)
+				w.handleBlockEvents(block)
 			}()
 		}
 	}

--- a/eth/watchers/unbondingwatcher.go
+++ b/eth/watchers/unbondingwatcher.go
@@ -3,6 +3,7 @@ package watchers
 import (
 	"fmt"
 	"math/big"
+	"sync"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -25,6 +26,8 @@ type UnbondingWatcher struct {
 	dec   *EventDecoder
 
 	quit chan struct{}
+
+	mu sync.Mutex
 }
 
 // NewUnbondingWatcher creates an UnbondingWatcher instance
@@ -87,6 +90,9 @@ func (w *UnbondingWatcher) handleLog(log types.Log) error {
 		// Noop if we cannot find the event name
 		return nil
 	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
 	switch eventName {
 	case "Unbond":

--- a/eth/watchers/unbondingwatcher.go
+++ b/eth/watchers/unbondingwatcher.go
@@ -59,9 +59,7 @@ func (w *UnbondingWatcher) Watch() {
 		case err := <-sub.Err():
 			glog.Errorf("error with block subscription: %v", err)
 		case block := <-blockSink:
-			go func() {
-				w.handleBlockEvents(block)
-			}()
+			go w.handleBlockEvents(block)
 		}
 	}
 }

--- a/eth/watchers/unbondingwatcher.go
+++ b/eth/watchers/unbondingwatcher.go
@@ -56,7 +56,9 @@ func (w *UnbondingWatcher) Watch() {
 		case err := <-sub.Err():
 			glog.Errorf("error with block subscription: %v", err)
 		case events := <-blockEvents:
-			w.handleBlockEvents(events)
+			go func() {
+				w.handleBlockEvents(events)
+			}()
 		}
 	}
 }

--- a/pm/queue.go
+++ b/pm/queue.go
@@ -3,6 +3,7 @@ package pm
 import (
 	"math/big"
 	"strings"
+	"sync"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang/glog"
@@ -44,6 +45,8 @@ type ticketQueue struct {
 	store  TicketStore
 
 	quit chan struct{}
+
+	mu sync.Mutex
 }
 
 func newTicketQueue(sender ethcommon.Address, sm *LocalSenderMonitor) *ticketQueue {
@@ -112,6 +115,9 @@ func (q *ticketQueue) startQueueLoop() {
 }
 
 func (q *ticketQueue) handleBlockEvent(block *big.Int) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
 	numTickets, err := q.Length()
 	if err != nil {
 		glog.Errorf("Error getting queue length err=%q", err)

--- a/pm/queue.go
+++ b/pm/queue.go
@@ -105,9 +105,7 @@ func (q *ticketQueue) startQueueLoop() {
 				glog.Errorf("Block subscription error err=%q", err)
 			}
 		case block := <-blockSink:
-			go func() {
-				q.handleBlockEvent(block)
-			}()
+			go q.handleBlockEvent(block)
 		case <-q.quit:
 			return
 		}

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -470,9 +470,11 @@ func (sm *LocalSenderMonitor) watchReserveChange() {
 			glog.Error(err)
 			continue
 		case sender := <-sink:
-			sm.mu.Lock()
-			sm.sendMaxFloatChange(sender)
-			sm.mu.Unlock()
+			go func() {
+				sm.mu.Lock()
+				sm.sendMaxFloatChange(sender)
+				sm.mu.Unlock()
+			}()
 		}
 	}
 }

--- a/server/redeemer.go
+++ b/server/redeemer.go
@@ -34,6 +34,7 @@ type Redeemer struct {
 	eth       eth.LivepeerEthClient
 	sm        localSenderMonitor
 	quit      chan struct{}
+	mu        sync.Mutex
 }
 
 // NewRedeemer creates a new ticket redemption service instance


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Avoid blocking Feed mechanism by executing every blocking operation in a separate goroutine. As a result, if any operation blocks, then we have a blocked/leaked goroutine instead of stopping the whole livepeer.

See #2207 for a detailed description.

**Specific updates (required)**
- Serve each feed event in a separate goroutine
- Add locks to avoid multiple goroutines performing the same operations more than once
- Renaming the feed sink variables to keep the same naming convention in all files

**How did you test each of these updates (required)**

Checked the same scenario using the code from `master` and the code from this PR.

1. Insert `time.Sleep(1 * time.Hour)` into `roundinitializer.go#TryInitialize()` to simulate that this operation is blocked
2. Start local Geth, Orchestrator, Broadcaster, and a video stream.
3. From Livepeer CLI, execute a few times `Initialize Round` and `Reward`.
4. After 5 min check the logs from orchestrator

In the case of `master`, orchestrator was blocked and stopped transcoding. Broadcaster failed transcoding with the following logs.

```
I0125 11:23:11.586426    6783 mediaserver.go:925] manifestID=movie nonce=17482076527360272128 seqNo=0 Finished push request at url=http://localhost:8935/live/movie/test197.ts ua=Go-http-client/1.1 addr=127.0.0.1:57864 bytes=995648 dur= resolution= took=26.432ms
I0125 11:23:11.586430    6783 broadcast.go:122] manifestID=movie nonce=17482076527360272128 seqNo=0 Starting session refresh
I0125 11:23:11.586697    6783 rpc.go:265] manifestID=movie nonce=17482076527360272128 Connecting RPC to uri=https://127.0.0.1:8936
I0125 11:23:11.588929    6783 db_discovery.go:129] manifestID=movie nonce=17482076527360272128 invalid ticket params orch=https://127.0.0.1:8936 err="TicketParams expired"
```

In the case of code from this PR, everything worked, even though the roundinitializer was blocked.

**Does this pull request close any open issues?**
fix #2168

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
