### PR TITLE
Y/N Confirmation when sending a transaction via the CLI (#2212)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,7 @@
 ### Features ⚒
 
 #### General
+- \#2212 y/n confirmation when sending a transaction via the CLI (@noisersup)
 
 #### Broadcaster
 

--- a/cmd/livepeer_cli/wizard_token.go
+++ b/cmd/livepeer_cli/wizard_token.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/url"
+	"strings"
 )
 
 func (w *wizard) transferTokens() {
@@ -17,6 +19,27 @@ func (w *wizard) transferTokens() {
 	val := url.Values{
 		"to":     {fmt.Sprintf("%v", to)},
 		"amount": {fmt.Sprintf("%v", amount.String())},
+	}
+
+	var answer string
+	userAccepted := false
+	for !userAccepted {
+		fmt.Printf("Are you sure you want to send %s LPT to \"%s\"? [y/n]: ", val["amount"], val["to"])
+
+		_, err := fmt.Scanln(&answer)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		switch strings.ToLower(answer) {
+		case "y", "yes":
+			userAccepted = true
+		case "n", "no":
+			fmt.Println("Transaction cancelled: Interrupted by user.")
+			return
+		default:
+			fmt.Println("Wrong input!")
+		}
 	}
 
 	httpPostWithParams(fmt.Sprintf("http://%v:%v/transferTokens", w.host, w.httpPort), val)

--- a/cmd/livepeer_cli/wizard_token.go
+++ b/cmd/livepeer_cli/wizard_token.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"net/url"
 	"strings"
 )
@@ -21,24 +20,21 @@ func (w *wizard) transferTokens() {
 		"amount": {fmt.Sprintf("%v", amount.String())},
 	}
 
-	var answer string
+	var input string
 	userAccepted := false
 	for !userAccepted {
-		fmt.Printf("Are you sure you want to send %s LPT to \"%s\"? [y/n]: ", val["amount"], val["to"])
+		fmt.Printf("Are you sure you want to send %s LPT to \"%s\"? (y/n) - ", val["amount"][0], val["to"][0])
 
-		_, err := fmt.Scanln(&answer)
-		if err != nil {
-			log.Fatal(err)
-		}
+		input = w.readString()
 
-		switch strings.ToLower(answer) {
-		case "y", "yes":
+		switch strings.ToLower(input) {
+		case "y":
 			userAccepted = true
-		case "n", "no":
-			fmt.Println("Transaction cancelled: Interrupted by user.")
+		case "n":
+			fmt.Printf("Transaction cancelled: Interrupted by user.\n")
 			return
 		default:
-			fmt.Println("Wrong input!")
+			fmt.Printf("Enter (y)es or (n)o \n")
 		}
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
It adds a confirmation screen to  `transferTokens` function displayed when user
wants to make a transaction.

It displays also amount of tokens and receipient address, because I assumed
that would be helpful (in #2213 there is planned to show user estimated gas fees).

**Specific updates (required)**
- Adds confirmation screen when user makes the transaction
- Shows user basic transaction data ( receipient address, amount of tokens)

**How did you test each of these updates (required)**
Ran tests in `test.sh`


**Does this pull request close any open issues?**
#2212

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
