### PR TITLE
drivers: Make Size an optional property of files

### DIFF
--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -43,7 +43,7 @@ type FileInfo struct {
 	Name         string
 	ETag         string
 	LastModified time.Time
-	Size         int64
+	Size         *int64
 }
 
 type FileInfoReader struct {

--- a/drivers/gs.go
+++ b/drivers/gs.go
@@ -240,7 +240,7 @@ func (gspi *gsPageInfo) listFiles() error {
 				Name:         attrs.Name,
 				ETag:         attrs.Etag,
 				LastModified: attrs.Updated,
-				Size:         attrs.Size,
+				Size:         &attrs.Size,
 			}
 			gspi.files = append(gspi.files, fi)
 		}
@@ -303,7 +303,7 @@ func (os *gsSession) ReadData(ctx context.Context, name string) (*FileInfoReader
 	}
 	res := &FileInfoReader{}
 	res.Name = name
-	res.Size = attrs.Size
+	res.Size = &attrs.Size
 	res.ETag = attrs.Etag
 	res.LastModified = attrs.Updated
 	if len(attrs.Metadata) > 0 {

--- a/drivers/local.go
+++ b/drivers/local.go
@@ -123,7 +123,8 @@ func (ostore *MemorySession) ListFiles(ctx context.Context, prefix, delim string
 						}
 					} else {
 						if pprefix == "" || strings.HasPrefix(it.name, pprefix) {
-							fi := FileInfo{Name: path.Join(cachePath, it.name), Size: int64(len(it.data))}
+							size := int64(len(it.data))
+							fi := FileInfo{Name: path.Join(cachePath, it.name), Size: &size}
 							pi.files = append(pi.files, fi)
 						}
 					}
@@ -139,10 +140,11 @@ func (ostore *MemorySession) ReadData(ctx context.Context, name string) (*FileIn
 	if data == nil {
 		return nil, errors.New("Not found")
 	}
+	size := int64(len(data))
 	res := &FileInfoReader{
 		FileInfo: FileInfo{
 			Name: name,
-			Size: int64(len(data)),
+			Size: &size,
 		},
 		Body: ioutil.NopCloser(bytes.NewReader(data)),
 	}

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -208,7 +208,7 @@ func (s3pi *s3pageInfo) listFiles() error {
 			Name:         *cont.Key,
 			ETag:         *cont.ETag,
 			LastModified: *cont.LastModified,
-			Size:         *cont.Size,
+			Size:         cont.Size,
 		}
 		s3pi.files = append(s3pi.files, fi)
 	}
@@ -264,7 +264,7 @@ func (os *s3Session) ReadData(ctx context.Context, name string) (*FileInfoReader
 	res.LastModified = *resp.LastModified
 	res.ETag = *resp.ETag
 	res.Name = name
-	res.Size = *resp.ContentLength
+	res.Size = resp.ContentLength
 	if len(resp.Metadata) > 0 {
 		res.Metadata = make(map[string]string, len(resp.Metadata))
 		for k, v := range resp.Metadata {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The Filebase S3-compatible API does not return a
file size in the response for files greater than 255 bytes.

That caused a panic on s3.go:267 when reading recordings.

With this change, the problem won't happen anymore cause
we don't even try to dereference the ContentLength, but
hold it as a nilable pointer that should be checked wherever
it is used (right now: nowhere).

**Specific updates (required)**
- Make `FileInfo.Size` a pointer
- Change every place that sets it to set a pointer instead of raw int value

**How did you test each of these updates (required)**
 - `make` 
 - Check all usages of `Size` property (there are none apart from the writes)

**Does this pull request close any open issues?**
Related to https://github.com/livepeer/livepeer-com/issues/879

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
