### PR TITLE
common: move functions to ffmpeg module

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -165,10 +165,6 @@ func BytesToVideoProfile(txData []byte) ([]ffmpeg.VideoProfile, error) {
 	return profiles, nil
 }
 
-func DefaultProfileName(width int, height int, bitrate int) string {
-	return fmt.Sprintf("%dx%d_%d", width, height, bitrate)
-}
-
 func FFmpegProfiletoNetProfile(ffmpegProfiles []ffmpeg.VideoProfile) ([]*net.VideoProfile, error) {
 	profiles := make([]*net.VideoProfile, 0, len(ffmpegProfiles))
 	for _, profile := range ffmpegProfiles {
@@ -183,7 +179,7 @@ func FFmpegProfiletoNetProfile(ffmpegProfiles []ffmpeg.VideoProfile) ([]*net.Vid
 		}
 		name := profile.Name
 		if name == "" {
-			name = "ffmpeg_" + DefaultProfileName(width, height, bitrate)
+			name = "ffmpeg_" + ffmpeg.DefaultProfileName(width, height, bitrate)
 		}
 		format := net.VideoProfile_MPEGTS
 		switch profile.Format {
@@ -249,22 +245,6 @@ func ProfilesNames(profiles []ffmpeg.VideoProfile) string {
 	}
 	names.Sort()
 	return strings.Join(names, ",")
-}
-
-func EncoderProfileNameToValue(profile string) (ffmpeg.Profile, error) {
-	var EncoderProfileLookup = map[string]ffmpeg.Profile{
-		"":                    ffmpeg.ProfileNone,
-		"none":                ffmpeg.ProfileNone,
-		"h264baseline":        ffmpeg.ProfileH264Baseline,
-		"h264main":            ffmpeg.ProfileH264Main,
-		"h264high":            ffmpeg.ProfileH264High,
-		"h264constrainedhigh": ffmpeg.ProfileH264ConstrainedHigh,
-	}
-	p, ok := EncoderProfileLookup[strings.ToLower(profile)]
-	if !ok {
-		return -1, ErrProfName
-	}
-	return p, nil
 }
 
 func ProfileExtensionFormat(ext string) ffmpeg.Format {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -209,13 +209,13 @@ func TestVideoProfile_ProfileNameToValue(t *testing.T) {
 	outp := []ffmpeg.Profile{ffmpeg.ProfileNone, ffmpeg.ProfileH264Baseline, ffmpeg.ProfileH264Main, ffmpeg.ProfileH264High, ffmpeg.ProfileH264ConstrainedHigh}
 	assert.Len(inp, len(outp))
 	for i, profile := range inp {
-		p, err := EncoderProfileNameToValue(profile)
+		p, err := ffmpeg.EncoderProfileNameToValue(profile)
 		assert.Nil(err)
 		assert.Equal(outp[i], p)
 	}
-	p, _ := EncoderProfileNameToValue("none")
+	p, _ := ffmpeg.EncoderProfileNameToValue("none")
 	assert.Equal(ffmpeg.ProfileNone, p)
-	_, err := EncoderProfileNameToValue("invalid")
+	_, err := ffmpeg.EncoderProfileNameToValue("invalid")
 	assert.Equal(ErrProfName, err, "Could not get profile value")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/jaypipes/ghw v0.7.0
 	github.com/livepeer/livepeer-data v0.4.8
-	github.com/livepeer/lpms v0.0.0-20220111151401-0eb91f2facdb
+	github.com/livepeer/lpms v0.0.0-20220202164815-ec799c43e5fc
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,8 @@ github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cO
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.4.8 h1:dbv+rYLUIgWnNjEuUY3itUlL36sWk73euRwT5GhGwt0=
 github.com/livepeer/livepeer-data v0.4.8/go.mod h1:VIbJRdyH2Tas8EgLVkP79IPMepFDOv0dgHYLEZsCaf4=
-github.com/livepeer/lpms v0.0.0-20220111151401-0eb91f2facdb h1:2EM2tlBmcnK6QiT5JjWyRVya5N2UXDT/1evaMVmTzTQ=
-github.com/livepeer/lpms v0.0.0-20220111151401-0eb91f2facdb/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
+github.com/livepeer/lpms v0.0.0-20220202164815-ec799c43e5fc h1:BFGTqR948H8U6Hw9uiorjMoM8qAdp3V1hPZAiJ6lO+o=
+github.com/livepeer/lpms v0.0.0-20220202164815-ec799c43e5fc/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -391,7 +391,7 @@ func jsonProfileToVideoProfile(resp *authWebhookResponse) ([]ffmpeg.VideoProfile
 	for _, profile := range resp.Profiles {
 		name := profile.Name
 		if name == "" {
-			name = "webhook_" + common.DefaultProfileName(
+			name = "webhook_" + ffmpeg.DefaultProfileName(
 				profile.Width,
 				profile.Height,
 				profile.Bitrate)
@@ -411,7 +411,7 @@ func jsonProfileToVideoProfile(resp *authWebhookResponse) ([]ffmpeg.VideoProfile
 				gop = time.Duration(gopFloat * float64(time.Second))
 			}
 		}
-		encodingProfile, err := common.EncoderProfileNameToValue(profile.Profile)
+		encodingProfile, err := ffmpeg.EncoderProfileNameToValue(profile.Profile)
 		if err != nil {
 			return nil, err
 		}

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -273,7 +273,7 @@ func makeFfmpegVideoProfiles(protoProfiles []*net.VideoProfile) ([]ffmpeg.VideoP
 	for _, profile := range protoProfiles {
 		name := profile.Name
 		if name == "" {
-			name = "net_" + common.DefaultProfileName(int(profile.Width), int(profile.Height), int(profile.Bitrate))
+			name = "net_" + ffmpeg.DefaultProfileName(int(profile.Width), int(profile.Height), int(profile.Bitrate))
 		}
 		format := ffmpeg.FormatMPEGTS
 		switch profile.Format {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Avoiding code duplication. Moving common functions to lpms/ffmpeg module.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- `common.DefaultProfileName()` >> `ffmpeg.DefaultProfileName()`
- `common.EncoderProfileNameToValue()` >> `fmpeg.EncoderProfileNameToValue()`
- `ffmpeg.ParseProfiles()` returns `[]ffmpeg.VideoProfile`, `error`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes livepeer/lpms#283

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
