### PR TITLE
Use L1 block number for Ticket Parameters and Round Initialization

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,8 +7,8 @@
 ### Features ⚒
 
 #### General
-
 - \#2208 Improve Feed PubSub: execute subscribers' blocking operations in separate goroutines (@leszko)
+- \#2222 Use L1 block number for Ticket Parameters and Round Initialization (@leszko)
 
 #### Broadcaster
 

--- a/eth/blockwatch/fake_client.go
+++ b/eth/blockwatch/fake_client.go
@@ -12,6 +12,12 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
+const (
+	FakeHash          = "0x6bbf9b6e836207ab25379c20e517a89090cbbaf8877746f6ed7fb6820770816b"
+	FakeBlockNumber   = 30
+	FakeL1BlockNumber = 50
+)
+
 // fixtureTimestep holds the JSON-RPC data available at every timestep of the simulation.
 type fixtureTimestep struct {
 	GetLatestBlock   MiniHeader                 `json:"getLatestBlock"  gencodec:"required"`
@@ -65,6 +71,15 @@ func (fc *fakeClient) HeaderByNumber(number *big.Int) (*MiniHeader, error) {
 // HeaderByHash fetches a block header by its block hash. If no block exists with this number it will return
 // a `ethereum.NotFound` error.
 func (fc *fakeClient) HeaderByHash(hash common.Hash) (*MiniHeader, error) {
+	// predefined block
+	if hash.String() == FakeHash {
+		return &MiniHeader{
+			Hash:          common.HexToHash(FakeHash),
+			Number:        big.NewInt(FakeBlockNumber),
+			L1BlockNumber: big.NewInt(FakeL1BlockNumber),
+		}, nil
+	}
+
 	fc.fixtureMut.Lock()
 	defer fc.fixtureMut.Unlock()
 	timestep := fc.fixtureData[fc.currentTimestep]
@@ -87,10 +102,10 @@ func (fc *fakeClient) FilterLogs(q ethereum.FilterQuery) ([]types.Log, error) {
 				common.HexToHash("0x0000000000000000000000004bdd0d16cfa18e33860470fc4d65c6f5cee60959"),
 			},
 			Data:        common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000337ad34c0"),
-			BlockNumber: uint64(30),
+			BlockNumber: uint64(FakeBlockNumber),
 			TxHash:      common.HexToHash("0xd9bb5f9e888ee6f74bedcda811c2461230f247c205849d6f83cb6c3925e54586"),
 			TxIndex:     uint(0),
-			BlockHash:   common.HexToHash("0x6bbf9b6e836207ab25379c20e517a89090cbbaf8877746f6ed7fb6820770816b"),
+			BlockHash:   common.HexToHash(FakeHash),
 			Index:       uint(0),
 			Removed:     false,
 		},

--- a/eth/blockwatch/stack.go
+++ b/eth/blockwatch/stack.go
@@ -10,10 +10,11 @@ import (
 
 // MiniHeader is a succinct representation of an Ethereum block header
 type MiniHeader struct {
-	Hash   ethcommon.Hash
-	Parent ethcommon.Hash
-	Number *big.Int
-	Logs   []types.Log
+	Hash          ethcommon.Hash
+	Parent        ethcommon.Hash
+	Number        *big.Int
+	L1BlockNumber *big.Int
+	Logs          []types.Log
 }
 
 // MiniHeaderStore is an interface for a store that manages the state of a MiniHeader collection

--- a/eth/blockwatch/testdata/fake_client_block_poller_fixtures.json
+++ b/eth/blockwatch/testdata/fake_client_block_poller_fixtures.json
@@ -801,6 +801,48 @@
           "parent": "0x7ac62ad1dc23753eb35ccbe193fdf1ad33828a68ed1c497a17ae66f7baa98144",
           "number": 11
         }
+      },
+      "getBlockByHash": {
+        "0x22a63eebe1b8f4034c3552502c0ba4ffbd613b6ee3cd5b530f75202ddc6d6220": {
+          "hash": "0x22a63eebe1b8f4034c3552502c0ba4ffbd613b6ee3cd5b530f75202ddc6d6220",
+          "parent": "0x2804206056bff166dbeef754799a248c48dd9521b21ee5898b7632837069200c",
+          "number": 5
+        },
+        "0x85fe65e36f4cc457a774cfe500ba7f3efaa6535dd6cb80373b3e91978ecaa01a": {
+          "hash": "0x85fe65e36f4cc457a774cfe500ba7f3efaa6535dd6cb80373b3e91978ecaa01a",
+          "parent": "0x22a63eebe1b8f4034c3552502c0ba4ffbd613b6ee3cd5b530f75202ddc6d6220",
+          "number": 6
+        },
+        "0xc308739706b1cf523663cbd1d8ce01208f7811cc6ff2005d23a13898f2f5adff": {
+          "hash": "0xc308739706b1cf523663cbd1d8ce01208f7811cc6ff2005d23a13898f2f5adff",
+          "parent": "0x85fe65e36f4cc457a774cfe500ba7f3efaa6535dd6cb80373b3e91978ecaa01a",
+          "number": 7
+        },
+        "0x7718297b91827d7a2f9238f4501a5c47cd6a5da83811e53d1cf1231346bd2001": {
+          "hash": "0x7718297b91827d7a2f9238f4501a5c47cd6a5da83811e53d1cf1231346bd2001",
+          "parent": "0xc308739706b1cf523663cbd1d8ce01208f7811cc6ff2005d23a13898f2f5adff",
+          "number": 8
+        },
+        "0x95483b1c35b7a6cdf6e56dc2ac22bda14b26b395823712ac9f881f3639718402": {
+          "hash": "0x95483b1c35b7a6cdf6e56dc2ac22bda14b26b395823712ac9f881f3639718402",
+          "parent": "0x7718297b91827d7a2f9238f4501a5c47cd6a5da83811e53d1cf1231346bd2001",
+          "number": 9
+        },
+        "0x7ac62ad1dc23753eb35ccbe193fdf1ad33828a68ed1c497a17ae66f7baa98144": {
+          "hash": "0x7ac62ad1dc23753eb35ccbe193fdf1ad33828a68ed1c497a17ae66f7baa98144",
+          "parent": "0x95483b1c35b7a6cdf6e56dc2ac22bda14b26b395823712ac9f881f3639718402",
+          "number": 10
+        },
+        "0x42a1a146cee23d156a8525a6ff9e3b41de7f40fb06e58323deb1443da7ba5dc2": {
+          "hash": "0x42a1a146cee23d156a8525a6ff9e3b41de7f40fb06e58323deb1443da7ba5dc2",
+          "parent": "0x7ac62ad1dc23753eb35ccbe193fdf1ad33828a68ed1c497a17ae66f7baa98144",
+          "number": 11
+        },
+        "0xf908916f8ea921df3a6256fc20874577139c9544fd04c7644ff14075bf102b22": {
+          "hash": "0xf908916f8ea921df3a6256fc20874577139c9544fd04c7644ff14075bf102b22",
+          "parent": "0x42a1a146cee23d156a8525a6ff9e3b41de7f40fb06e58323deb1443da7ba5dc2",
+          "number": 12
+        }
       }
     ],
     "scenarioLabel": "REORG_OUT_ALL_RETAINED_BLOCKS"

--- a/eth/roundinitializer_test.go
+++ b/eth/roundinitializer_test.go
@@ -102,7 +102,7 @@ func TestRoundInitializer_TryInitialize(t *testing.T) {
 		lastInitializedBlockHash: [32]byte{123},
 	}
 	initializer := NewRoundInitializer(client, tw)
-	initializer.nextRoundStartBlock = big.NewInt(5)
+	initializer.nextRoundStartL1Block = big.NewInt(5)
 	assert := assert.New(t)
 
 	// Test error checking should initialize
@@ -186,7 +186,7 @@ func TestRoundInitializer_Start_Stop(t *testing.T) {
 	err = <-errC
 	assert.Nil(err)
 	// should have set next round start block
-	assert.Equal(initializer.nextRoundStartBlock, big.NewInt(105)) // 100 + 5
+	assert.Equal(initializer.nextRoundStartL1Block, big.NewInt(105)) // 100 + 5
 }
 
 func TestRoundInitializer_RoundSubscription(t *testing.T) {
@@ -214,7 +214,7 @@ func TestRoundInitializer_RoundSubscription(t *testing.T) {
 
 	// Test set next round start block on initializer
 	time.Sleep(1 * time.Second)
-	assert.Equal(initializer.nextRoundStartBlock, big.NewInt(10)) // 5 +5
+	assert.Equal(initializer.nextRoundStartL1Block, big.NewInt(10)) // 5 +5
 	tw.currentRoundStartBlock = big.NewInt(100)
 	tw.roundSink <- types.Log{}
 	time.Sleep(1 * time.Second)
@@ -222,7 +222,7 @@ func TestRoundInitializer_RoundSubscription(t *testing.T) {
 	initializer.Stop()
 	err := <-errC
 	assert.Nil(err)
-	assert.Equal(initializer.nextRoundStartBlock, new(big.Int).Add(roundLength, tw.currentRoundStartBlock))
+	assert.Equal(initializer.nextRoundStartL1Block, new(big.Int).Add(roundLength, tw.currentRoundStartBlock))
 }
 
 func TestRoundInitializer_BlockSubscription(t *testing.T) {
@@ -255,7 +255,7 @@ func TestRoundInitializer_BlockSubscription(t *testing.T) {
 	// block < next round start block do nothing
 	tw.blockSink <- big.NewInt(5)
 	time.Sleep(1 * time.Second)
-	assert.Equal(initializer.nextRoundStartBlock, big.NewInt(10))
+	assert.Equal(initializer.nextRoundStartL1Block, big.NewInt(10))
 
 	// block >= next round start block , try initialize
 	caller := ethcommon.HexToAddress("foo")
@@ -302,7 +302,7 @@ type stubTimeWatcher struct {
 	blockSub  event.Subscription
 }
 
-func (m *stubTimeWatcher) LastSeenBlock() *big.Int {
+func (m *stubTimeWatcher) LastSeenL1Block() *big.Int {
 	return m.lastBlock
 }
 
@@ -310,7 +310,7 @@ func (m *stubTimeWatcher) LastInitializedRound() *big.Int {
 	return m.lastInitializedRound
 }
 
-func (m *stubTimeWatcher) LastInitializedBlockHash() [32]byte {
+func (m *stubTimeWatcher) LastInitializedL1BlockHash() [32]byte {
 	return m.lastInitializedBlockHash
 }
 
@@ -318,7 +318,7 @@ func (m *stubTimeWatcher) GetTranscoderPoolSize() *big.Int {
 	return nil
 }
 
-func (m *stubTimeWatcher) CurrentRoundStartBlock() *big.Int {
+func (m *stubTimeWatcher) CurrentRoundStartL1Block() *big.Int {
 	return m.currentRoundStartBlock
 }
 
@@ -328,7 +328,7 @@ func (m *stubTimeWatcher) SubscribeRounds(sink chan<- types.Log) event.Subscript
 	return m.roundSub
 }
 
-func (m *stubTimeWatcher) SubscribeBlocks(sink chan<- *big.Int) event.Subscription {
+func (m *stubTimeWatcher) SubscribeL1Blocks(sink chan<- *big.Int) event.Subscription {
 	m.blockSink = sink
 	m.blockSub = &stubSubscription{errCh: make(<-chan error)}
 	return m.blockSub

--- a/eth/watchers/stub.go
+++ b/eth/watchers/stub.go
@@ -342,9 +342,10 @@ func (s *stubUnbondingLockStore) Get(id int64) *stubUnbondingLock {
 
 func defaultMiniHeader() *blockwatch.MiniHeader {
 	block := &blockwatch.MiniHeader{
-		Number: big.NewInt(450),
-		Parent: pm.RandHash(),
-		Hash:   pm.RandHash(),
+		Number:        big.NewInt(450),
+		L1BlockNumber: big.NewInt(650),
+		Parent:        pm.RandHash(),
+		Hash:          pm.RandHash(),
 	}
 	log := types.Log{
 		Topics:    []ethcommon.Hash{pm.RandHash(), pm.RandHash()},

--- a/pm/broker.go
+++ b/pm/broker.go
@@ -71,15 +71,15 @@ type TimeManager interface {
 	// LastInitializedRound returns the last initialized round of the Livepeer protocol
 	LastInitializedRound() *big.Int
 	// LastInitializedBlockHash returns the blockhash of the block the last round was initiated in
-	LastInitializedBlockHash() [32]byte
+	LastInitializedL1BlockHash() [32]byte
 	// GetTranscoderPoolSize returns the size of the active transcoder set for a round
 	GetTranscoderPoolSize() *big.Int
 	// LastSeenBlock returns the last seen block number
-	LastSeenBlock() *big.Int
+	LastSeenL1Block() *big.Int
 	// SubscribeRounds allows one to subscribe to new round events
 	SubscribeRounds(sink chan<- types.Log) event.Subscription
 	// SubscribeBlocks allows one to subscribe to newly seen block numbers
-	SubscribeBlocks(sink chan<- *big.Int) event.Subscription
+	SubscribeL1Blocks(sink chan<- *big.Int) event.Subscription
 }
 
 // SenderManager defines the methods for fetching sender information

--- a/pm/sender.go
+++ b/pm/sender.go
@@ -154,9 +154,9 @@ func (s *sender) validateTicketParams(ticketParams *TicketParams, numTickets int
 		return nil
 	}
 
-	latestBlock := s.timeManager.LastSeenBlock()
+	latestL1Block := s.timeManager.LastSeenL1Block()
 
-	currentBuffer := new(big.Int).Sub(ticketParams.ExpirationBlock, latestBlock).Int64()
+	currentBuffer := new(big.Int).Sub(ticketParams.ExpirationBlock, latestL1Block).Int64()
 	if currentBuffer <= paramsExpiryBuffer {
 		return ErrTicketParamsExpired
 	}
@@ -194,7 +194,7 @@ func (s *sender) validateTicketParams(ticketParams *TicketParams, numTickets int
 
 func (s *sender) expirationParams() *TicketExpirationParams {
 	round := s.timeManager.LastInitializedRound()
-	blkHash := s.timeManager.LastInitializedBlockHash()
+	blkHash := s.timeManager.LastInitializedL1BlockHash()
 
 	return &TicketExpirationParams{
 		CreationRound:          round.Int64(),

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -279,7 +279,7 @@ func (m *stubTimeManager) LastInitializedRound() *big.Int {
 	return m.round
 }
 
-func (m *stubTimeManager) LastInitializedBlockHash() [32]byte {
+func (m *stubTimeManager) LastInitializedL1BlockHash() [32]byte {
 	return m.blkHash
 }
 
@@ -287,7 +287,7 @@ func (m *stubTimeManager) GetTranscoderPoolSize() *big.Int {
 	return m.transcoderPoolSize
 }
 
-func (m *stubTimeManager) LastSeenBlock() *big.Int {
+func (m *stubTimeManager) LastSeenL1Block() *big.Int {
 	return m.lastSeenBlock
 }
 
@@ -297,7 +297,7 @@ func (m *stubTimeManager) SubscribeRounds(sink chan<- types.Log) event.Subscript
 	return m.roundSub
 }
 
-func (m *stubTimeManager) SubscribeBlocks(sink chan<- *big.Int) event.Subscription {
+func (m *stubTimeManager) SubscribeL1Blocks(sink chan<- *big.Int) event.Subscription {
 	m.blockNumSink = sink
 	m.blockNumSub = &stubSubscription{errCh: make(<-chan error)}
 	return m.blockNumSub

--- a/server/redeemer_test.go
+++ b/server/redeemer_test.go
@@ -862,7 +862,7 @@ func (m *stubTimeManager) LastInitializedRound() *big.Int {
 	return m.round
 }
 
-func (m *stubTimeManager) LastInitializedBlockHash() [32]byte {
+func (m *stubTimeManager) LastInitializedL1BlockHash() [32]byte {
 	return m.blkHash
 }
 
@@ -870,7 +870,7 @@ func (m *stubTimeManager) GetTranscoderPoolSize() *big.Int {
 	return m.transcoderPoolSize
 }
 
-func (m *stubTimeManager) LastSeenBlock() *big.Int {
+func (m *stubTimeManager) LastSeenL1Block() *big.Int {
 	return m.lastSeenBlock
 }
 
@@ -878,7 +878,7 @@ func (m *stubTimeManager) SubscribeRounds(sink chan<- types.Log) event.Subscript
 	return &stubSubscription{}
 }
 
-func (m *stubTimeManager) SubscribeBlocks(sink chan<- *big.Int) event.Subscription {
+func (m *stubTimeManager) SubscribeL1Blocks(sink chan<- *big.Int) event.Subscription {
 	m.blockNumSink = sink
 	m.blockNumSub = &stubSubscription{errCh: make(chan error)}
 	return m.blockNumSub


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Use L1 block numbers during Round Initialization and in Ticket Params.

Important comments:
- The L1 block numbers are not stored in DB and therefore need to be enriched with L1 Block Number [using Arbitrum RPC API](https://github.com/leszko/go-livepeer/blob/2dbae16237ff82706324975e96050e28aea884a3/eth/blockwatch/block_watcher.go#L625); an alternative approach would be to store L1 Block Numbers in DB:
  - it would mean fewer calls to Aribtrum RPC API
  - it would be a backward-incompatible change
  - I think enriching blocks on-the-fly is good enough
- `TimeWatcher` now has a function `LastSeenL1Block()`, but I found it does not need to have `LastSeenBlock()` anymore
- Having now both `blocks` and `l1Blocks` in the code can be super-confusing, I tried to rename all the necessary parts of the code, so that `block` always refers to L2 Block, however, there are still a places for which we may need an additional renaming in the future:
   - [TicketParams](https://github.com/leszko/go-livepeer/blob/7125e3c9778622f216441baa7b951cbd009943db/pm/ticket.go#L34)
   - [lp_rpc.proto](https://github.com/leszko/go-livepeer/blob/4fceaff0fce6bed65dae12428006408dc5064e15/net/lp_rpc.proto#L1)
   - Eth contracts or/and contract bindings
- There is one place where we could think about optimizing more, which is to try to fetch L1 Number while fetching logs in [this part](https://github.com/leszko/go-livepeer/blob/079f4ebe0801327fec6664cd5756100cf19e4d82/eth/blockwatch/block_watcher.go#L398)), but it doesn't seem to be an issue at the moment.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add L1 Block Number while fetching blocks by Block Watcher from ETH API
- Use L1 Block Number in Time Watcher (and propagate it to Ticket Sender and Recipient)
- Rename all `block` into `l1Block` when it refers to L1 Blocks
- Refactor Block Watcher Client (reuse ETH API code)

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Tests on Arbitrum:
1. Added debug logs to Round Initializer to check that it uses L1 block numbers
2. Add debug logs to ticket params to check that that sender and receiver use  L1 block numbers for ticket params

**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2220

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
