### PR TITLE
drivers: Refactor package as a more generic and performant library

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,7 @@
 
 #### General
 - \#2383 Add E2E Tests for checking Livepeer on-chain interactions (@leszko)
+- \#2223 Refactor `drivers` package as a reusable and more performant lib (@victorges)
 
 #### Broadcaster
 - \#2392 Add LP_EXTEND_TIMEOUTS env variable to extend timeouts for Stream Tester (@leszko)

--- a/core/capabilities_test.go
+++ b/core/capabilities_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"io"
 	"sort"
 	"testing"
 	"time"
@@ -394,7 +395,7 @@ func (os *stubOS) GetInfo() *net.OSInfo {
 	return &net.OSInfo{StorageType: net.OSInfo_StorageType(os.storageType)}
 }
 func (os *stubOS) EndSession() {}
-func (os *stubOS) SaveData(context.Context, string, []byte, map[string]string, time.Duration) (string, error) {
+func (os *stubOS) SaveData(context.Context, string, io.Reader, map[string]string, time.Duration) (string, error) {
 	return "", nil
 }
 func (os *stubOS) IsExternal() bool      { return false }

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/big"
@@ -132,7 +133,7 @@ func TestServiceURIChange(t *testing.T) {
 
 	drivers.NodeStorage = drivers.NewMemoryDriver(n.GetServiceURI())
 	sesh := drivers.NodeStorage.NewSession("testpath")
-	savedUrl, err := sesh.SaveData(context.TODO(), "testdata1", []byte{0, 0, 0}, nil, 0)
+	savedUrl, err := sesh.SaveData(context.TODO(), "testdata1", bytes.NewReader([]byte{0, 0, 0}), nil, 0)
 	require.Nil(err)
 	assert.Equal("test://testurl.com/stream/testpath/testdata1", savedUrl)
 
@@ -140,7 +141,7 @@ func TestServiceURIChange(t *testing.T) {
 	newUrl, err := url.Parse("test://newurl.com")
 	n.SetServiceURI(newUrl)
 	require.Nil(err)
-	furl, err := sesh.SaveData(context.TODO(), "testdata2", []byte{0, 0, 0}, nil, 0)
+	furl, err := sesh.SaveData(context.TODO(), "testdata2", bytes.NewReader([]byte{0, 0, 0}), nil, 0)
 	require.Nil(err)
 	assert.Equal("test://newurl.com/stream/testpath/testdata2", furl)
 
@@ -148,7 +149,7 @@ func TestServiceURIChange(t *testing.T) {
 	secondUrl, err := url.Parse("test://secondurl.com")
 	n.SetServiceURI(secondUrl)
 	require.Nil(err)
-	surl, err := sesh.SaveData(context.TODO(), "testdata3", []byte{0, 0, 0}, nil, 0)
+	surl, err := sesh.SaveData(context.TODO(), "testdata3", bytes.NewReader([]byte{0, 0, 0}), nil, 0)
 	require.Nil(err)
 	assert.Equal("test://secondurl.com/stream/testpath/testdata3", surl)
 }

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -540,7 +541,7 @@ func (n *LivepeerNode) transcodeSeg(ctx context.Context, config transcodeConfig,
 		// Need to store segment in our local OS
 		var err error
 		name := fmt.Sprintf("%d.tempfile", seg.SeqNo)
-		url, err = config.LocalOS.SaveData(ctx, name, seg.Data, nil, 0)
+		url, err = config.LocalOS.SaveData(ctx, name, bytes.NewReader(seg.Data), nil, 0)
 		if err != nil {
 			return terr(err)
 		}

--- a/core/playlistmanager_test.go
+++ b/core/playlistmanager_test.go
@@ -289,7 +289,7 @@ func TestCleanup(t *testing.T) {
 	testData := []byte{1, 2, 3, 4}
 
 	c := NewBasicPlaylistManager(mid, osSession, nil)
-	uri, err := c.GetOSSession().SaveData(context.TODO(), "testName", testData, nil, 0)
+	uri, err := c.GetOSSession().SaveData(context.TODO(), "testName", bytes.NewReader(testData), nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -2,6 +2,7 @@
 package drivers
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -62,7 +63,7 @@ type PageInfo interface {
 type OSSession interface {
 	OS() OSDriver
 
-	SaveData(ctx context.Context, name string, data []byte, meta map[string]string, timeout time.Duration) (string, error)
+	SaveData(ctx context.Context, name string, data io.Reader, meta map[string]string, timeout time.Duration) (string, error)
 	EndSession()
 
 	// Info in order to have this session used via RPC
@@ -192,7 +193,7 @@ func SaveRetried(ctx context.Context, sess OSSession, name string, data []byte, 
 	var uri string
 	var err error
 	for i := 0; i < retryCount; i++ {
-		uri, err = sess.SaveData(ctx, name, data, meta, 0)
+		uri, err = sess.SaveData(ctx, name, bytes.NewReader(data), meta, 0)
 		if err == nil {
 			return uri, err
 		}

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -43,7 +43,7 @@ type FileInfo struct {
 	Name         string
 	ETag         string
 	LastModified time.Time
-	Size         int64
+	Size         *int64
 }
 
 type FileInfoReader struct {

--- a/drivers/drivers.go
+++ b/drivers/drivers.go
@@ -138,7 +138,7 @@ func ParseOSURL(input string, useFullAPI bool) (OSDriver, error) {
 			return nil, fmt.Errorf("password is required with s3:// OS")
 		}
 		base := path.Base(u.Path)
-		return NewS3Driver(u.Host, base, u.User.Username(), pw, useFullAPI), nil
+		return NewS3Driver(u.Host, base, u.User.Username(), pw, useFullAPI)
 	}
 	// custom s3-compatible store
 	if u.Scheme == "s3+http" || u.Scheme == "s3+https" {
@@ -163,7 +163,7 @@ func ParseOSURL(input string, useFullAPI bool) (OSDriver, error) {
 		if !ok {
 			return nil, fmt.Errorf("password is required with s3:// OS")
 		}
-		return NewCustomS3Driver(hosturl.String(), bucket, region, u.User.Username(), pw, useFullAPI), nil
+		return NewCustomS3Driver(hosturl.String(), bucket, region, u.User.Username(), pw, useFullAPI)
 	}
 	if u.Scheme == "gs" {
 		file := u.User.Username()

--- a/drivers/gs.go
+++ b/drivers/gs.go
@@ -240,7 +240,7 @@ func (gspi *gsPageInfo) listFiles() error {
 				Name:         attrs.Name,
 				ETag:         attrs.Etag,
 				LastModified: attrs.Updated,
-				Size:         attrs.Size,
+				Size:         &attrs.Size,
 			}
 			gspi.files = append(gspi.files, fi)
 		}
@@ -303,7 +303,7 @@ func (os *gsSession) ReadData(ctx context.Context, name string) (*FileInfoReader
 	}
 	res := &FileInfoReader{}
 	res.Name = name
-	res.Size = attrs.Size
+	res.Size = &attrs.Size
 	res.ETag = attrs.Etag
 	res.LastModified = attrs.Updated
 	if len(attrs.Metadata) > 0 {

--- a/drivers/gs.go
+++ b/drivers/gs.go
@@ -163,7 +163,7 @@ func (os *gsSession) SaveData(ctx context.Context, name string, data io.Reader, 
 		objh := os.client.Bucket(os.bucket).Object(keyname)
 		clog.V(common.VERBOSE).Infof(ctx, "Saving to GS %s/%s", os.bucket, keyname)
 		if timeout == 0 {
-			timeout = saveTimeout
+			timeout = defaultSaveTimeout
 		}
 		ctx, cancel := context.WithTimeout(clog.Clone(context.Background(), ctx), timeout)
 		defer cancel()

--- a/drivers/local.go
+++ b/drivers/local.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"path"
@@ -197,7 +198,7 @@ func (ostore *MemorySession) GetInfo() *net.OSInfo {
 	return nil
 }
 
-func (ostore *MemorySession) SaveData(ctx context.Context, name string, data []byte, meta map[string]string, timeout time.Duration) (string, error) {
+func (ostore *MemorySession) SaveData(ctx context.Context, name string, data io.Reader, meta map[string]string, timeout time.Duration) (string, error) {
 	path, file := path.Split(ostore.getAbsolutePath(name))
 
 	ostore.dLock.Lock()
@@ -207,8 +208,12 @@ func (ostore *MemorySession) SaveData(ctx context.Context, name string, data []b
 		return "", fmt.Errorf("Session ended")
 	}
 
+	bytes, err := ioutil.ReadAll(data)
+	if err != nil {
+		return "", err
+	}
 	dc := ostore.getCacheForStream(path)
-	dc.Insert(file, data)
+	dc.Insert(file, bytes)
 
 	return ostore.getAbsoluteURI(name), nil
 }

--- a/drivers/local.go
+++ b/drivers/local.go
@@ -123,7 +123,8 @@ func (ostore *MemorySession) ListFiles(ctx context.Context, prefix, delim string
 						}
 					} else {
 						if pprefix == "" || strings.HasPrefix(it.name, pprefix) {
-							fi := FileInfo{Name: path.Join(cachePath, it.name), Size: int64(len(it.data))}
+							size := int64(len(it.data))
+							fi := FileInfo{Name: path.Join(cachePath, it.name), Size: &size}
 							pi.files = append(pi.files, fi)
 						}
 					}
@@ -139,10 +140,11 @@ func (ostore *MemorySession) ReadData(ctx context.Context, name string) (*FileIn
 	if data == nil {
 		return nil, errors.New("Not found")
 	}
+	size := int64(len(data))
 	res := &FileInfoReader{
 		FileInfo: FileInfo{
 			Name: name,
-			Size: int64(len(data)),
+			Size: &size,
 		},
 		Body: ioutil.NopCloser(bytes.NewReader(data)),
 	}

--- a/drivers/local_test.go
+++ b/drivers/local_test.go
@@ -4,18 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/golang/glog"
 	"github.com/stretchr/testify/assert"
 )
-
-func copyBytes(src string) []byte {
-	srcb := []byte(src)
-	dst := make([]byte, len(srcb))
-	copy(dst, srcb)
-	return dst
-}
 
 func TestLocalOS(t *testing.T) {
 	tempData1 := "dataitselftempdata1"
@@ -31,17 +25,17 @@ func TestLocalOS(t *testing.T) {
 	assert.NoError((err))
 	os := NewMemoryDriver(u)
 	sess := os.NewSession(("sesspath")).(*MemorySession)
-	path, err := sess.SaveData(context.TODO(), "name1/1.ts", copyBytes(tempData1), nil, 0)
+	path, err := sess.SaveData(context.TODO(), "name1/1.ts", strings.NewReader(tempData1), nil, 0)
 	glog.Info(path)
 	fmt.Println(path)
 	assert.Equal("fake.com/url/stream/sesspath/name1/1.ts", path)
 	data := sess.GetData("sesspath/name1/1.ts")
 	fmt.Printf("got Data: '%s'\n", data)
 	assert.Equal(tempData1, string(data))
-	path, err = sess.SaveData(context.TODO(), "name1/1.ts", copyBytes(tempData2), nil, 0)
+	path, err = sess.SaveData(context.TODO(), "name1/1.ts", strings.NewReader(tempData2), nil, 0)
 	data = sess.GetData("sesspath/name1/1.ts")
 	assert.Equal(tempData2, string(data))
-	path, err = sess.SaveData(context.TODO(), "name1/2.ts", copyBytes(tempData3), nil, 0)
+	path, err = sess.SaveData(context.TODO(), "name1/2.ts", strings.NewReader(tempData3), nil, 0)
 	data = sess.GetData("sesspath/name1/2.ts")
 	assert.Equal(tempData3, string(data))
 	// Test trim prefix when baseURI != nil
@@ -56,7 +50,7 @@ func TestLocalOS(t *testing.T) {
 	// Test trim prefix when baseURI = nil
 	os = NewMemoryDriver(nil)
 	sess = os.NewSession("sesspath").(*MemorySession)
-	path, err = sess.SaveData(context.TODO(), "name1/1.ts", copyBytes(tempData1), nil, 0)
+	path, err = sess.SaveData(context.TODO(), "name1/1.ts", strings.NewReader(tempData1), nil, 0)
 	assert.Nil(err)
 	assert.Equal("/stream/sesspath/name1/1.ts", path)
 

--- a/drivers/overwrite_queue.go
+++ b/drivers/overwrite_queue.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"bytes"
 	"context"
 	"time"
 
@@ -69,7 +70,7 @@ func (oq *OverwriteQueue) workerLoop() {
 				data = oq.getLastMessage(data)
 				glog.V(common.VERBOSE).Infof("Start saving %s name=%s bytes=%d try=%d", oq.desc, oq.name, len(data), try)
 				now := time.Now()
-				_, err = oq.session.SaveData(context.Background(), oq.name, data, nil, timeout)
+				_, err = oq.session.SaveData(context.Background(), oq.name, bytes.NewReader(data), nil, timeout)
 				took := time.Since(now)
 				if err == nil {
 					glog.V(common.VERBOSE).Infof("Saving %s name=%s bytes=%d took=%s try=%d", oq.desc, oq.name,

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -208,7 +208,7 @@ func (s3pi *s3pageInfo) listFiles() error {
 			Name:         *cont.Key,
 			ETag:         *cont.ETag,
 			LastModified: *cont.LastModified,
-			Size:         *cont.Size,
+			Size:         cont.Size,
 		}
 		s3pi.files = append(s3pi.files, fi)
 	}
@@ -264,7 +264,7 @@ func (os *s3Session) ReadData(ctx context.Context, name string) (*FileInfoReader
 	res.LastModified = *resp.LastModified
 	res.ETag = *resp.ETag
 	res.Name = name
-	res.Size = *resp.ContentLength
+	res.Size = resp.ContentLength
 	if len(resp.Metadata) > 0 {
 		res.Metadata = make(map[string]string, len(resp.Metadata))
 		for k, v := range resp.Metadata {

--- a/drivers/s3.go
+++ b/drivers/s3.go
@@ -300,7 +300,8 @@ func (os *s3Session) saveDataPut(ctx context.Context, name string, data io.Reade
 	}
 
 	uploader := s3manager.NewUploader(os.s3sess, func(u *s3manager.Uploader) {
-		u.Concurrency = 2
+		u.Concurrency = 8
+		u.PartSize = 63 * 1024 * 1024
 		u.RequestOptions = append(u.RequestOptions, request.WithLogLevel(aws.LogDebug))
 	})
 	params := &s3manager.UploadInput{

--- a/drivers/session_mock.go
+++ b/drivers/session_mock.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/livepeer/go-livepeer/net"
@@ -22,7 +23,7 @@ func NewMockOSSession() *MockOSSession {
 	}
 }
 
-func (s *MockOSSession) SaveData(ctx context.Context, name string, data []byte, meta map[string]string, timeout time.Duration) (string, error) {
+func (s *MockOSSession) SaveData(ctx context.Context, name string, data io.Reader, meta map[string]string, timeout time.Duration) (string, error) {
 	args := s.Called(name, data, meta, timeout)
 	if s.waitForCh {
 		s.back <- struct{}{}

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -763,7 +763,7 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 			}
 		}()
 	}
-	uri, err := cpl.GetOSSession().SaveData(ctx, name, seg.Data, nil, 0)
+	uri, err := cpl.GetOSSession().SaveData(ctx, name, bytes.NewReader(seg.Data), nil, 0)
 	if err != nil {
 		clog.Errorf(ctx, "Error saving segment err=%q", err)
 		if monitor.Enabled {
@@ -795,7 +795,7 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 				return nil, err
 			}
 			name := fmt.Sprintf("%s/%d%s", profile.Name, seg.SeqNo, ext)
-			uri, err := cpl.GetOSSession().SaveData(ctx, name, seg.Data, nil, 0)
+			uri, err := cpl.GetOSSession().SaveData(ctx, name, bytes.NewReader(seg.Data), nil, 0)
 			if err != nil {
 				clog.Errorf(ctx, "Error saving segment err=%q", err)
 				if monitor.Enabled {
@@ -1049,7 +1049,7 @@ func prepareForTranscoding(ctx context.Context, cxn *rtmpConnection, sess *Broad
 	sess.lock.RUnlock()
 	if ios != nil {
 		// XXX handle case when orch expects direct upload
-		uri, err := ios.SaveData(ctx, name, seg.Data, nil, 0)
+		uri, err := ios.SaveData(ctx, name, bytes.NewReader(seg.Data), nil, 0)
 		if err != nil {
 			clog.Errorf(ctx, "Error saving segment to OS manifestID=%v nonce=%d seqNo=%d err=%q", cxn.mid, cxn.nonce, seg.SeqNo, err)
 			if monitor.Enabled {
@@ -1168,7 +1168,7 @@ func downloadResults(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSe
 				return
 			}
 			name := fmt.Sprintf("%s/%d%s", profile.Name, seg.SeqNo, ext)
-			newURL, err := bos.SaveData(ctx, name, data, nil, 0)
+			newURL, err := bos.SaveData(ctx, name, bytes.NewReader(data), nil, 0)
 			if err != nil {
 				switch err.Error() {
 				case "Session ended":
@@ -1311,7 +1311,7 @@ func verify(verifier *verification.SegmentVerifier, cxn *rtmpConnection,
 				// Hence, trim the /stream/<manifestID> prefix if it exists.
 				pfx := fmt.Sprintf("/stream/%s/", sess.Params.ManifestID)
 				uri := strings.TrimPrefix(accepted.URIs[i], pfx)
-				_, err := sess.BroadcasterOS.SaveData(context.TODO(), uri, data, nil, 0)
+				_, err := sess.BroadcasterOS.SaveData(context.TODO(), uri, bytes.NewReader(data), nil, 0)
 				if err != nil {
 					return err
 				}

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -180,7 +181,7 @@ type stubOSSession struct {
 	err      error
 }
 
-func (s *stubOSSession) SaveData(ctx context.Context, name string, data []byte, meta map[string]string, timeout time.Duration) (string, error) {
+func (s *stubOSSession) SaveData(ctx context.Context, name string, data io.Reader, meta map[string]string, timeout time.Duration) (string, error) {
 	s.saved = append(s.saved, name)
 	return "saved_" + name, s.err
 }
@@ -1298,7 +1299,7 @@ func TestVerifier_Verify(t *testing.T) {
 	}
 	mem, ok := drivers.NewMemoryDriver(nil).NewSession("streamName").(*drivers.MemorySession)
 	assert.True(ok)
-	name, err := mem.SaveData(context.TODO(), "/rendition/seg/1", []byte("attempt1"), nil, 0)
+	name, err := mem.SaveData(context.TODO(), "/rendition/seg/1", strings.NewReader("attempt1"), nil, 0)
 	assert.Nil(err)
 	assert.Equal([]byte("attempt1"), mem.GetData(name))
 	sess.BroadcasterOS = mem
@@ -1310,7 +1311,7 @@ func TestVerifier_Verify(t *testing.T) {
 
 	// Now "insert" 2nd attempt into OS
 	// and ensure 1st attempt is what remains after verification
-	_, err = mem.SaveData(context.TODO(), "/rendition/seg/1", []byte("attempt2"), nil, 0)
+	_, err = mem.SaveData(context.TODO(), "/rendition/seg/1", strings.NewReader("attempt2"), nil, 0)
 	assert.Nil(err)
 	assert.Equal([]byte("attempt2"), mem.GetData(name))
 	renditionData = [][]byte{[]byte("attempt2")}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -1438,7 +1438,7 @@ func (s *LivepeerServer) HandleRecordings(w http.ResponseWriter, r *http.Request
 			mainJspl.AddSegmentsToMPL(manifests, trackName, mpl, resp.RecordObjectStoreURL)
 			fileName := trackName + ".m3u8"
 			nows := time.Now()
-			_, err = sess.SaveData(ctx, fileName, mpl.Encode().Bytes(), nil, 0)
+			_, err = sess.SaveData(ctx, fileName, mpl.Encode(), nil, 0)
 			clog.V(common.VERBOSE).Infof(ctx, "Saving playlist fileName=%s took=%s", fileName, time.Since(nows))
 			if err != nil {
 				clog.Errorf(ctx, "Error saving finalized json playlist to store err=%q", err)
@@ -1447,7 +1447,7 @@ func (s *LivepeerServer) HandleRecordings(w http.ResponseWriter, r *http.Request
 			}
 		}
 		nows := time.Now()
-		_, err = sess.SaveData(ctx, "index.m3u8", masterPList.Encode().Bytes(), nil, 0)
+		_, err = sess.SaveData(ctx, "index.m3u8", masterPList.Encode(), nil, 0)
 		clog.V(common.VERBOSE).Infof(ctx, "Saving playlist fileName=%s took=%s", "index.m3u8", time.Since(nows))
 		if err != nil {
 			clog.Errorf(ctx, "Error saving playlist to store err=%q", err)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -1160,7 +1160,9 @@ func TestRegisterConnection(t *testing.T) {
 	assert.Equal(err, errAlreadyExists)
 
 	// Check for params with an existing OS assigned
-	storage := drivers.NewS3Driver("", "", "", "", false).NewSession("")
+	driver, err := drivers.NewS3Driver("", "", "", "", false)
+	assert.Nil(err)
+	storage := driver.NewSession("")
 	strm = stream.NewBasicRTMPVideoStream(&core.StreamParameters{ManifestID: core.RandomManifestID(), OS: storage})
 	cxn, err = s.registerConnection(context.TODO(), strm, nil, PixelFormatNone())
 	assert.Nil(err)

--- a/server/recordings_test.go
+++ b/server/recordings_test.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/golang/glog"
@@ -62,15 +64,15 @@ func TestRecordingHandler(t *testing.T) {
 	profile := ffmpeg.P144p25fps16x9
 	jpl.InsertHLSSegment(&profile, 1, "sess1/testNode/P144p25fps16x9/1.ts", 2100)
 	bjpl, _ := json.Marshal(jpl)
-	msess1.SaveData(context.TODO(), "testNode/playlist_1.json", bjpl, nil, 0)
+	msess1.SaveData(context.TODO(), "testNode/playlist_1.json", bytes.NewReader(bjpl), nil, 0)
 	jpl = core.NewJSONPlaylist()
 	jpl.InsertHLSSegment(&profile, 2, "sess2/testNode/P144p25fps16x9/2.ts", 2100)
 	bjpl, _ = json.Marshal(jpl)
-	msess2.SaveData(context.TODO(), "testNode/playlist_2.json", bjpl, nil, 0)
+	msess2.SaveData(context.TODO(), "testNode/playlist_2.json", bytes.NewReader(bjpl), nil, 0)
 	jpl = core.NewJSONPlaylist()
 	jpl.InsertHLSSegment(&profile, 1, "sess3/testNode/P144p25fps16x9/3.ts", 2100)
 	bjpl, _ = json.Marshal(jpl)
-	msess3.SaveData(context.TODO(), "testNode/playlist_3.json", bjpl, nil, 0)
+	msess3.SaveData(context.TODO(), "testNode/playlist_3.json", bytes.NewReader(bjpl), nil, 0)
 
 	resp = makeReq("GET", "/recordings/sess3/P144p25fps16x9.m3u8")
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -123,7 +125,7 @@ func TestRecording(t *testing.T) {
 
 	mos := drivers.TestMemoryStorages["recstore4"]
 	msess := mos.NewSession("sess1")
-	msess.SaveData(context.TODO(), "testNode/source/1.ts", []byte("segmentdata"), nil, 0)
+	msess.SaveData(context.TODO(), "testNode/source/1.ts", strings.NewReader("segmentdata"), nil, 0)
 
 	resp = makeReq("GET", "/live/sess1/testNode/source/1.ts")
 	body, _ := ioutil.ReadAll(resp.Body)
@@ -136,12 +138,12 @@ func TestRecording(t *testing.T) {
 	jpl.InsertHLSSegment(&profile, 1, "testNode/P144p25fps16x9/1.ts", 2100)
 	bjpl, err := json.Marshal(jpl)
 	assert.Nil(err)
-	msess.SaveData(context.TODO(), "testNode/playlist_1.json", bjpl, nil, 0)
+	msess.SaveData(context.TODO(), "testNode/playlist_1.json", bytes.NewReader(bjpl), nil, 0)
 	jpl = core.NewJSONPlaylist()
 	jpl.InsertHLSSegment(&profile, 2, "testNode/P144p25fps16x9/2.ts", 2100)
 	bjpl, err = json.Marshal(jpl)
 	assert.Nil(err)
-	msess.SaveData(context.TODO(), "testNode/playlist_2.json", bjpl, nil, 0)
+	msess.SaveData(context.TODO(), "testNode/playlist_2.json", bytes.NewReader(bjpl), nil, 0)
 
 	resp = makeReq("GET", "/live/sess1/index.m3u8")
 	body, _ = ioutil.ReadAll(resp.Body)
@@ -172,12 +174,12 @@ func TestRecording(t *testing.T) {
 	jpl.InsertHLSSegment(&profile, 3, "testNode/P144p25fps16x9/3.ts", 2100)
 	bjpl, err = json.Marshal(jpl)
 	assert.Nil(err)
-	msess.SaveData(context.TODO(), "testNode/playlist_1.json", bjpl, nil, 0)
+	msess.SaveData(context.TODO(), "testNode/playlist_1.json", bytes.NewReader(bjpl), nil, 0)
 	jpl = core.NewJSONPlaylist()
 	jpl.InsertHLSSegment(&profile, 4, "testNode/P144p25fps16x9/4.ts", 2450)
 	bjpl, err = json.Marshal(jpl)
 	assert.Nil(err)
-	msess.SaveData(context.TODO(), "testNode/playlist_2.json", bjpl, nil, 0)
+	msess.SaveData(context.TODO(), "testNode/playlist_2.json", bytes.NewReader(bjpl), nil, 0)
 	resp = makeReq("GET", "/live/sess2/P144p25fps16x9.m3u8?finalize=false")
 	body, _ = ioutil.ReadAll(resp.Body)
 	resp.Body.Close()

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -194,7 +194,8 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 		}
 		name := fmt.Sprintf("%s/%d%s", segData.Profiles[i].Name, segData.Seq, ext)
 		// The use of := here is probably a bug?!?
-		uri, err := res.OS.SaveData(ctx, name, res.TranscodeData.Segments[i].Data, nil, 0)
+		segData := bytes.NewReader(res.TranscodeData.Segments[i].Data)
+		uri, err := res.OS.SaveData(ctx, name, segData, nil, 0)
 		if err != nil {
 			clog.Errorf(ctx, "Could not upload segment")
 			break
@@ -207,7 +208,8 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 		// Save perceptual hash if generated
 		if res.TranscodeData.Segments[i].PHash != nil {
 			pHashFile := name + ".phash"
-			pHashUri, err := res.OS.SaveData(ctx, pHashFile, res.TranscodeData.Segments[i].PHash, nil, 0)
+			pHashData := bytes.NewReader(res.TranscodeData.Segments[i].PHash)
+			pHashUri, err := res.OS.SaveData(ctx, pHashFile, pHashData, nil, 0)
 			if err != nil {
 				clog.Errorf(ctx, "Could not upload segment perceptual hash")
 				break

--- a/verification/verify_test.go
+++ b/verification/verify_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -340,9 +341,10 @@ func TestVerifyPixels(t *testing.T) {
 
 	// Create memory session and save a test file
 	bos := drivers.NewMemoryDriver(nil).NewSession("foo")
-	data, err := ioutil.ReadFile("../server/test.flv")
+	file, err := os.Open("../server/test.flv")
 	require.Nil(err)
-	fname, err := bos.SaveData(context.TODO(), "test.ts", data, nil, 0)
+	defer file.Close()
+	fname, err := bos.SaveData(context.TODO(), "test.ts", file, nil, 0)
 	require.Nil(err)
 	memOS, ok := bos.(*drivers.MemorySession)
 	require.True(ok)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to make some improvements to the `drivers` package so that it can also be used
as a library from other projects, specifically the `task-runner` for VOD tasks. It is currently
using the drivers library for a platform-agnostic way of accessing Object Stores for reading
and writing VOD assets.

The greatest advantage of that is that we can just use the same Object Store API from
`livepeer-com` to declare where assets should be stored as well as stream recordings,
keeping the whole interface leaner.

**Specific updates (required)**
- Make the `Size` property optional in our `File` representation. It is optional in the AWS SDK and is not returned in all implementations of it, like previous versions of Filebase, so it was required at some point (not anymore) but I still think it makes sense to keep it.
- Make the drivers receive an `io.Reader` instead of the whole buffered file. The reader is compatible with clients that have the whole bytes in memory, but requiring all clients to buffer the entire contents in memory is not ideal. This would have made the VOD tasks much more inefficient, needing to read the entire files in memory before sending to the OS.
- Use an S3 Uploader for uploading files to S3. This avoids the need of buffering the files before uploading, since the simpler upload SDK requires the file to be an `io.ReadSeeker` due to hashing purposes. The uploader is the suggested solution in [the open issue in their SDK repo](https://github.com/aws/aws-sdk-go/issues/915).

**How did you test each of these updates (required)**
 - Fixed and then ran/passed all tests in `go-livepeer`
 - Used the `drivers` lib in the `task-runner` for VOD and already deployed it in production, it's working great
 - Did a bunch of performance tests with Storj folks to come up with the optimal configurations for the S3 uploader (which end up being good both for Storj and for GCP)

**Does this pull request close any open issues?**
Part of https://github.com/livepeer/task-runner/issues/14

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [-] README and other documentation updated (not necessary IMO)
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated 

(does it need a changelog update?)
