### PR TITLE
eth: Fix nil pointer in client.Vote()

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,6 +13,7 @@
 
 - \#2216 Fix Accept Multiline message on Windows (@leszko)
 - \#2218 Display http status codes in livepeer_cli (@noisersup)
+- \#2227 Fix nil pointer in client.Vote() (@leszko)
 
 #### Broadcaster
 

--- a/eth/client.go
+++ b/eth/client.go
@@ -133,6 +133,8 @@ type client struct {
 	verifierAddr        ethcommon.Address
 	faucetAddr          ethcommon.Address
 
+	transactOpts *bind.TransactOpts
+
 	// Embedded contract sessions
 	*contracts.ControllerSession
 	*contracts.LivepeerTokenSession
@@ -174,6 +176,8 @@ func NewClient(cfg LivepeerEthClientConfig) (LivepeerEthClient, error) {
 }
 
 func (c *client) setContracts(opts *bind.TransactOpts) error {
+	c.transactOpts = opts
+
 	controller, err := contracts.NewController(c.controllerAddr, c.backend)
 	if err != nil {
 		glog.Errorf("Error creating Controller binding: %v", err)
@@ -768,7 +772,7 @@ func (c *client) Vote(pollAddr ethcommon.Address, choiceID *big.Int) (*types.Tra
 		return nil, err
 	}
 
-	return poll.Vote(nil, choiceID)
+	return poll.Vote(c.transactOpts, choiceID)
 }
 
 func (c *client) Reward() (*types.Transaction, error) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Fix nil pointer when calling `client.Vote()`

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Run vote before the chance (it crashed with nil pointer)
- Run after - no crash observed

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
