### PR TITLE
add darwin arm64 build, bump to Go 1.17.6

### DIFF
--- a/.github/workflows/linux-tensorflow.yml
+++ b/.github/workflows/linux-tensorflow.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15.5' 
+        go-version: '1.17.6'
     - name: Cache go modules
       id: cache-go-mod
       uses: actions/cache@v2.1.5

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15.5' 
+        go-version: '1.17.6'
     - name: Cache go modules
       id: cache-go-mod
       uses: actions/cache@v2.1.5
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.15.5'
+          go-version: '1.17.6'
       - name: Cache go modules
         id: cache-go-mod
         uses: actions/cache@v2.1.5

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -6,8 +6,15 @@ on:
       - master
 jobs:
   build:
-    runs-on: macOS-latest
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+    runs-on: macos-latest
     steps:
+    - name: Set build environment
+      run: echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
     - name: Checkout
       uses: actions/checkout@v2
       with:
@@ -23,17 +30,17 @@ jobs:
       uses: actions/cache@v2.1.5
       with:
         path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-${{ matrix.arch }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-${{ matrix.arch }}-go-
     - name: Cache ffmpeg
       id: cache-ffmpeg
       uses: actions/cache@v2.1.5
       with:
         path: ~/compiled
-        key: ${{ runner.os }}-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
+        key: ${{ runner.os }}-${{ matrix.arch }}-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
         restore-keys: |
-          ${{ runner.os }}-ffmpeg
+          ${{ runner.os }}-${{ matrix.arch }}-ffmpeg
     - name: Install dependencies
       run: brew install coreutils
     - name: Install go modules

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.15.5'
+        go-version: '1.17.6'
     - name: Cache go modules
       id: cache-go-mod
       uses: actions/cache@v2.1.5

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ uname_s := $(shell uname -s)
 ifeq ($(uname_s),Darwin)
 		cgo_ldflags += -framework CoreFoundation -framework Security
 	ifeq ($(GOARCH),arm64)
-		cgo_ldflags += --target=arm64-apple-macos11
 		cgo_cflags += --target=arm64-apple-macos11
 		cgo_ldflags += --target=arm64-apple-macos11
 	endif

--- a/Makefile
+++ b/Makefile
@@ -17,28 +17,34 @@ core/test_segment.go:
 version=$(shell cat VERSION)
 
 ldflags := -X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(shell ./print_version.sh)
+cgo_cflags :=
 cgo_ldflags :=
 
 uname_s := $(shell uname -s)
 ifeq ($(uname_s),Darwin)
 		cgo_ldflags += -framework CoreFoundation -framework Security
+	ifeq ($(GOARCH),arm64)
+		cgo_ldflags += --target=arm64-apple-macos11
+		cgo_cflags += --target=arm64-apple-macos11
+		cgo_ldflags += --target=arm64-apple-macos11
+	endif
 endif
 
 .PHONY: livepeer
 livepeer:
-	GO111MODULE=on CGO_LDFLAGS="$(cgo_ldflags)" go build -tags $(BUILD_TAGS) -ldflags="$(ldflags)" cmd/livepeer/*.go
+	GO111MODULE=on CGO_ENABLED=1 CGO_CFLAGS="$(cgo_cflags)" CGO_LDFLAGS="$(cgo_ldflags)" go build -tags $(BUILD_TAGS) -ldflags="$(ldflags)" cmd/livepeer/*.go
 
 .PHONY: livepeer_cli
 livepeer_cli:
-	GO111MODULE=on CGO_LDFLAGS="$(cgo_ldflags)" go build -tags $(BUILD_TAGS) -ldflags="$(ldflags)" cmd/livepeer_cli/*.go
+	GO111MODULE=on CGO_ENABLED=1 CGO_CFLAGS="$(cgo_cflags)" CGO_LDFLAGS="$(cgo_ldflags)" go build -tags $(BUILD_TAGS) -ldflags="$(ldflags)" cmd/livepeer_cli/*.go
 
 .PHONY: livepeer_bench
 livepeer_bench:
-	GO111MODULE=on CGO_LDFLAGS="$(cgo_ldflags)" go build -ldflags="$(ldflags)" cmd/livepeer_bench/*.go
+	GO111MODULE=on CGO_ENABLED=1 CGO_CFLAGS="$(cgo_cflags)" CGO_LDFLAGS="$(cgo_ldflags)" go build -ldflags="$(ldflags)" cmd/livepeer_bench/*.go
 
 .PHONY: livepeer_router
 livepeer_router:
-	GO111MODULE=on CGO_LDFLAGS="$(cgo_ldflags)" go build -ldflags="$(ldflags)" cmd/livepeer_router/*.go
+	GO111MODULE=on CGO_ENABLED=1 CGO_CFLAGS="$(cgo_cflags)" CGO_LDFLAGS="$(cgo_ldflags)" go build -ldflags="$(ldflags)" cmd/livepeer_router/*.go
 
 .PHONY: localdocker
 localdocker:

--- a/docker/Dockerfile.build-linux
+++ b/docker/Dockerfile.build-linux
@@ -7,7 +7,7 @@ ENV LIBRARY_PATH /usr/local/cuda/lib64
 
 RUN apt-get update \
   && apt-get install -y software-properties-common curl apt-transport-https \
-  && curl https://dl.google.com/go/go1.15.5.linux-amd64.tar.gz | tar -C /usr/local -xz \
+  && curl https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz | tar -C /usr/local -xz \
   && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
   && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs)  stable" \
   && apt-key adv --keyserver keyserver.ubuntu.com --recv 15CF4D18AF4F7421 \

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -5,9 +5,20 @@ set -ex
 ROOT="${1:-$HOME}"
 ARCH="$(uname -m)"
 NPROC=${NPROC:-$(nproc)}
+EXTRA_CFLAGS=""
+EXTRA_LDFLAGS=""
+EXTRA_FFMPEG_FLAGS=""
 
 if [[ $ARCH == "arm64" ]] && [[ $(uname) == "Darwin" ]]; then
   # Detect Apple Silicon
+  IS_M1=1
+fi
+if [[ $ARCH == "x86_64" ]] && [[ $(uname) == "Darwin" ]] && [[ "${GOARCH:-}" == "arm64" ]]; then
+  echo "cross-compiling darwin-arm64"
+  EXTRA_CFLAGS="$EXTRA_CFLAGS --target=arm64-apple-macos11"
+  EXTRA_LDFLAGS="$EXTRA_LDFLAGS --target=arm64-apple-macos11"
+  HOST_OS="--host=aarch64-darwin"
+  EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --arch=aarch64 --enable-cross-compile"
   IS_M1=1
 fi
 echo "Arch $ARCH ${IS_M1:+(Apple Silicon)}"
@@ -71,7 +82,7 @@ if [ ! -e "$ROOT/x264" ]; then
     # older git master, does not compile on Apple Silicon
     git checkout 545de2ffec6ae9a80738de1b2c8cf820249a2530
   fi
-  ./configure --prefix="$ROOT/compiled" --enable-pic --enable-static ${HOST_OS:-} --disable-cli
+  ./configure --prefix="$ROOT/compiled" --enable-pic --enable-static ${HOST_OS:-} --disable-cli --extra-cflags="$EXTRA_CFLAGS" --extra-asflags="$EXTRA_CFLAGS"
   make -j$NPROC
   make -j$NPROC install-lib-static
 fi
@@ -98,19 +109,18 @@ if [[ $(uname) == "Linux" && $BUILD_TAGS == *"debug-video"* ]]; then
   fi
 fi
 
-EXTRA_FFMPEG_FLAGS=""
 DISABLE_FFMPEG_COMPONENTS=""
-EXTRA_LDFLAGS=""
+EXTRA_FFMPEG_LDFLAGS="$EXTRA_LDFLAGS"
 # all flags which should be present for production build, but should be replaced/removed for debug build
 DEV_FFMPEG_FLAGS="--disable-programs"
 
 if [ $(uname) == "Darwin" ]; then
-  EXTRA_LDFLAGS="-framework CoreFoundation -framework Security"
+  EXTRA_FFMPEG_LDFLAGS="$EXTRA_FFMPEG_LDFLAGS -framework CoreFoundation -framework Security"
 else
   # If we have clang, we can compile with CUDA support!
   if which clang > /dev/null; then
     echo "clang detected, building with GPU support"
-    EXTRA_FFMPEG_FLAGS="--enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_cuda,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
+    EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_cuda,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
     if [[ $BUILD_TAGS == *"experimental"* ]]; then
         if [ ! -e "/usr/local/lib/libtensorflow_framework.so" ]; then
           LIBTENSORFLOW_VERSION=2.3.0 \
@@ -149,8 +159,8 @@ if [ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]; then
     --enable-filter=aresample,asetnsamples,fps,scale,hwdownload,select,livepeer_dnn,signature \
     --enable-encoder=aac,opus,libx264 \
     --enable-decoder=aac,opus,h264 \
-    --extra-cflags="-I${ROOT}/compiled/include" \
-    --extra-ldflags="-L${ROOT}/compiled/lib ${EXTRA_LDFLAGS}" \
+    --extra-cflags="-I${ROOT}/compiled/include ${EXTRA_CFLAGS}" \
+    --extra-ldflags="-L${ROOT}/compiled/lib ${EXTRA_FFMPEG_LDFLAGS}" \
     --prefix="$ROOT/compiled" \
     $EXTRA_FFMPEG_FLAGS \
     $DEV_FFMPEG_FLAGS


### PR DESCRIPTION
This PR adds Darwin cross-compilation support for supporting both legacy amd64 and M1 arm64 macs.

All of the pieces here — install_ffmpeg.sh, Makefile, and upload_build.sh, are controlled through the $GOARCH environment variable. Should make it easy. If we ever support full cross-compilation, controlling it through $GOOS makes sense to me too.

**This also includes a version bump to Go 1.17.6**. There was a specific [compilation bug in 1.15.5](https://github.com/golang/go/issues/42565) and Go didn't support darwin-arm64 targets until Go 1.16. But if we're upgrading anyway I figure it makes sense to go to the latest and greatest.