### PR TITLE
Per-stream metrics

### DIFF
--- a/clog/clog.go
+++ b/clog/clog.go
@@ -19,6 +19,8 @@ type clogContextKeyT struct{}
 var clogContextKey = clogContextKeyT{}
 
 const (
+	ClientIP = "clientIP"
+
 	// standard keys
 	manifestID    = "manifestID"
 	sessionID     = "sessionID"
@@ -96,6 +98,22 @@ func AddVal(ctx context.Context, key, val string) context.Context {
 	cmap.vals[key] = val
 	cmap.mu.Unlock()
 	return ctx
+}
+
+func GetManifestID(ctx context.Context) string {
+	return GetVal(ctx, manifestID)
+}
+
+func GetVal(ctx context.Context, key string) string {
+	var val string
+	cmap, _ := ctx.Value(clogContextKey).(*values)
+	if cmap == nil {
+		return val
+	}
+	cmap.mu.Lock()
+	val = cmap.vals[key]
+	cmap.mu.Unlock()
+	return val
 }
 
 func Warningf(ctx context.Context, format string, args ...interface{}) {

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -147,6 +147,8 @@ func main() {
 	reward := flag.Bool("reward", false, "Set to true to run a reward service")
 	// Metrics & logging:
 	monitor := flag.Bool("monitor", false, "Set to true to send performance metrics")
+	metricsPerStream := flag.Bool("metricsPerStream", false, "Set to true to group performance metrics per stream")
+	metricsExposeClientIP := flag.Bool("metricsClientIP", false, "Set to true to expose client's IP in metrics")
 	version := flag.Bool("version", false, "Print out the version")
 	verbosity := flag.String("v", "", "Log verbosity.  {4|5|6}")
 	metadataQueueUri := flag.String("metadataQueueUri", "", "URI for message broker to send operation metadata")
@@ -354,7 +356,12 @@ func main() {
 	lpmon.NodeID += hn
 
 	if *monitor {
+		if *metricsExposeClientIP {
+			*metricsPerStream = true
+		}
 		lpmon.Enabled = true
+		lpmon.PerStreamMetrics = *metricsPerStream
+		lpmon.ExposeClientIP = *metricsExposeClientIP
 		nodeType := lpmon.Default
 		switch n.NodeType {
 		case core.BroadcasterNode:

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -743,7 +743,7 @@ func TestProcessPayment_GivenRecipientError_ReturnsNil(t *testing.T) {
 	recipient.On("TxCostMultiplier", mock.Anything).Return(big.NewRat(1, 1), nil)
 
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", false, nil)
-	err := orch.ProcessPayment(defaultPayment(t), ManifestID("some manifest"))
+	err := orch.ProcessPayment(context.Background(), defaultPayment(t), ManifestID("some manifest"))
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -759,7 +759,7 @@ func TestProcessPayment_GivenNoSender_ReturnsError(t *testing.T) {
 
 	protoPayment.Sender = nil
 
-	err := orch.ProcessPayment(protoPayment, ManifestID("some manifest"))
+	err := orch.ProcessPayment(context.Background(), protoPayment, ManifestID("some manifest"))
 
 	assert := assert.New(t)
 	assert.Error(err)
@@ -776,7 +776,7 @@ func TestProcessPayment_GivenNoTicketParams_ReturnsNil(t *testing.T) {
 
 	protoPayment.TicketParams = nil
 
-	err := orch.ProcessPayment(protoPayment, ManifestID("some manifest"))
+	err := orch.ProcessPayment(context.Background(), protoPayment, ManifestID("some manifest"))
 
 	assert := assert.New(t)
 	assert.Nil(err)
@@ -785,7 +785,7 @@ func TestProcessPayment_GivenNoTicketParams_ReturnsNil(t *testing.T) {
 func TestProcessPayment_GivenNilNode_ReturnsNil(t *testing.T) {
 	orch := &orchestrator{}
 
-	err := orch.ProcessPayment(defaultPayment(t), ManifestID("some manifest"))
+	err := orch.ProcessPayment(context.Background(), defaultPayment(t), ManifestID("some manifest"))
 
 	assert.Nil(t, err)
 }
@@ -795,7 +795,7 @@ func TestProcessPayment_GivenNilRecipient_ReturnsNil(t *testing.T) {
 	orch := NewOrchestrator(n, nil)
 	n.Recipient = nil
 
-	err := orch.ProcessPayment(defaultPayment(t), ManifestID("some manifest"))
+	err := orch.ProcessPayment(context.Background(), defaultPayment(t), ManifestID("some manifest"))
 
 	assert.Nil(t, err)
 }
@@ -823,7 +823,7 @@ func TestProcessPayment_ActiveOrchestrator(t *testing.T) {
 	orch.node.SetBasePrice(big.NewRat(0, 1))
 
 	// orchestrator inactive -> error
-	err := orch.ProcessPayment(defaultPayment(t), ManifestID("some manifest"))
+	err := orch.ProcessPayment(context.Background(), defaultPayment(t), ManifestID("some manifest"))
 	expErr := fmt.Sprintf("orchestrator %v is not eligible for payments in round %v, cannot process payments", addr.Hex(), 10)
 	assert.EqualError(err, expErr)
 
@@ -836,7 +836,7 @@ func TestProcessPayment_ActiveOrchestrator(t *testing.T) {
 
 	recipient.On("TxCostMultiplier", mock.Anything).Return(big.NewRat(1, 1), nil)
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("some sessionID", false, nil)
-	err = orch.ProcessPayment(defaultPayment(t), ManifestID("some manifest"))
+	err = orch.ProcessPayment(context.Background(), defaultPayment(t), ManifestID("some manifest"))
 	assert.NoError(err)
 }
 
@@ -861,13 +861,13 @@ func TestProcessPayment_InvalidExpectedPrice(t *testing.T) {
 
 	// test ExpectedPrice.PixelsPerUnit = 0
 	pay.ExpectedPrice = &net.PriceInfo{PricePerUnit: 500, PixelsPerUnit: 0}
-	err := orch.ProcessPayment(pay, ManifestID("some manifest"))
+	err := orch.ProcessPayment(context.Background(), pay, ManifestID("some manifest"))
 	assert.Error(err)
 	assert.EqualError(err, fmt.Sprintf("invalid expected price sent with payment err=%q", "pixels per unit is 0"))
 
 	// test ExpectedPrice = nil
 	pay.ExpectedPrice = nil
-	err = orch.ProcessPayment(pay, ManifestID("some manifest"))
+	err = orch.ProcessPayment(context.Background(), pay, ManifestID("some manifest"))
 	assert.Error(err)
 	assert.EqualError(err, fmt.Sprintf("invalid expected price sent with payment err=%q", "expected price is nil"))
 }
@@ -896,7 +896,7 @@ func TestProcessPayment_GivenLosingTicket_DoesNotRedeem(t *testing.T) {
 	recipient.On("TxCostMultiplier", mock.Anything).Return(big.NewRat(1, 1), nil)
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("some sessionID", false, nil)
 
-	err := orch.ProcessPayment(defaultPayment(t), ManifestID("some manifest"))
+	err := orch.ProcessPayment(context.Background(), defaultPayment(t), ManifestID("some manifest"))
 
 	time.Sleep(time.Millisecond * 20)
 	assert := assert.New(t)
@@ -934,7 +934,7 @@ func TestProcessPayment_GivenWinningTicket_RedeemError(t *testing.T) {
 
 	errorLogsBefore := glog.Stats.Error.Lines()
 
-	err := orch.ProcessPayment(defaultPayment(t), manifestID)
+	err := orch.ProcessPayment(context.Background(), defaultPayment(t), manifestID)
 
 	time.Sleep(time.Millisecond * 20)
 	errorLogsAfter := glog.Stats.Error.Lines()
@@ -974,7 +974,7 @@ func TestProcessPayment_GivenWinningTicket_Redeems(t *testing.T) {
 
 	errorLogsBefore := glog.Stats.Error.Lines()
 
-	err := orch.ProcessPayment(defaultPayment(t), manifestID)
+	err := orch.ProcessPayment(context.Background(), defaultPayment(t), manifestID)
 
 	time.Sleep(time.Millisecond * 20)
 	errorLogsAfter := glog.Stats.Error.Lines()
@@ -1037,7 +1037,7 @@ func TestProcessPayment_GivenMultipleWinningTickets_RedeemsAll(t *testing.T) {
 		CreationRoundBlockHash: ethcommon.BytesToHash(payment.ExpirationParams.CreationRoundBlockHash),
 	}
 
-	err := orch.ProcessPayment(payment, manifestID)
+	err := orch.ProcessPayment(context.Background(), payment, manifestID)
 
 	time.Sleep(time.Millisecond * 20)
 	assert := assert.New(t)
@@ -1101,7 +1101,7 @@ func TestProcessPayment_GivenConcurrentWinningTickets_RedeemsAll(t *testing.T) {
 				)
 			}
 
-			err := orch.ProcessPayment(*defaultPaymentWithTickets(t, senderParams), ManifestID(manifestID))
+			err := orch.ProcessPayment(context.Background(), *defaultPaymentWithTickets(t, senderParams), ManifestID(manifestID))
 			assert.Nil(err)
 
 			wg.Done()
@@ -1154,7 +1154,7 @@ func TestProcessPayment_GivenReceiveTicketError_ReturnsError(t *testing.T) {
 		)
 	}
 
-	err := orch.ProcessPayment(*defaultPaymentWithTickets(t, senderParams), manifestID)
+	err := orch.ProcessPayment(context.Background(), *defaultPaymentWithTickets(t, senderParams), manifestID)
 
 	time.Sleep(time.Millisecond * 20)
 	assert := assert.New(t)
@@ -1163,7 +1163,7 @@ func TestProcessPayment_GivenReceiveTicketError_ReturnsError(t *testing.T) {
 
 	// Does not loop through tickets if won==false and error is a fatal receive error
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", false, pm.NewFatalReceiveErr(errors.New("ReceiveTicket error"))).Once()
-	err = orch.ProcessPayment(*defaultPaymentWithTickets(t, senderParams), manifestID)
+	err = orch.ProcessPayment(context.Background(), *defaultPaymentWithTickets(t, senderParams), manifestID)
 	time.Sleep(time.Millisecond * 20)
 	_, ok := err.(*pm.FatalReceiveErr)
 	assert.True(ok)
@@ -1173,7 +1173,7 @@ func TestProcessPayment_GivenReceiveTicketError_ReturnsError(t *testing.T) {
 	// Redeem winning tickets if won==true and not a signature error (but err != nil)
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", true, errors.New("ReceiveTicket error")).Once()
 	recipient.On("ReceiveTicket", mock.Anything, mock.Anything, mock.Anything).Return("", true, nil).Once()
-	err = orch.ProcessPayment(*defaultPaymentWithTickets(t, senderParams), manifestID)
+	err = orch.ProcessPayment(context.Background(), *defaultPaymentWithTickets(t, senderParams), manifestID)
 	time.Sleep(time.Millisecond * 20)
 	assert.EqualError(err, "ReceiveTicket error")
 	// 3 RedeemWinningTicket calls (1 + 2)
@@ -1210,7 +1210,7 @@ func TestProcessPayment_PaymentError_DoesNotIncreaseCreditBalance(t *testing.T) 
 	assert := assert.New(t)
 
 	payment := defaultPayment(t)
-	err := orch.ProcessPayment(payment, manifestID)
+	err := orch.ProcessPayment(context.Background(), payment, manifestID)
 	assert.Error(err)
 	assert.Nil(orch.node.Balances.Balance(ethcommon.BytesToAddress(payment.Sender), manifestID))
 }
@@ -1288,7 +1288,7 @@ func TestSufficientBalance_IsSufficient_ReturnsTrue(t *testing.T) {
 	payment.TicketParams.FaceValue = big.NewInt(100).Bytes()
 	payment.TicketParams.WinProb = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)).Bytes()
 
-	err := orch.ProcessPayment(payment, manifestID)
+	err := orch.ProcessPayment(context.Background(), payment, manifestID)
 	assert.Nil(err)
 	recipient.On("EV").Return(big.NewRat(100, 100))
 	assert.True(orch.SufficientBalance(ethcommon.BytesToAddress(payment.Sender), manifestID))
@@ -1329,7 +1329,7 @@ func TestSufficientBalance_IsNotSufficient_ReturnsFalse(t *testing.T) {
 	payment.TicketParams.FaceValue = big.NewInt(100).Bytes()
 	payment.TicketParams.WinProb = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 256), big.NewInt(1)).Bytes()
 
-	err := orch.ProcessPayment(payment, manifestID)
+	err := orch.ProcessPayment(context.Background(), payment, manifestID)
 	assert.Nil(err)
 	recipient.On("EV").Return(big.NewRat(10000, 1))
 	assert.False(orch.SufficientBalance(ethcommon.BytesToAddress(payment.Sender), manifestID))

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -108,7 +108,7 @@ func (orch *orchestrator) TranscoderResults(tcID int64, res *RemoteTranscoderRes
 	orch.node.TranscoderManager.transcoderResults(tcID, res)
 }
 
-func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID ManifestID) error {
+func (orch *orchestrator) ProcessPayment(ctx context.Context, payment net.Payment, manifestID ManifestID) error {
 	if orch.node == nil || orch.node.Recipient == nil {
 		return nil
 	}
@@ -175,7 +175,7 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 			tsp.SenderNonce,
 		)
 
-		glog.V(common.DEBUG).Infof("Receiving ticket sessionID=%v faceValue=%v winProb=%v ev=%v", manifestID, eth.FormatUnits(ticket.FaceValue, "ETH"), ticket.WinProbRat().FloatString(10), ticket.EV().FloatString(2))
+		clog.V(common.DEBUG).Infof(ctx, "Receiving ticket sessionID=%v faceValue=%v winProb=%v ev=%v", manifestID, eth.FormatUnits(ticket.FaceValue, "ETH"), ticket.WinProbRat().FloatString(10), ticket.EV().FloatString(2))
 
 		_, won, err := orch.node.Recipient.ReceiveTicket(
 			ticket,
@@ -183,10 +183,10 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 			seed,
 		)
 		if err != nil {
-			glog.Errorf("Error receiving ticket sessionID=%v recipientRandHash=%x senderNonce=%v: %v", manifestID, ticket.RecipientRandHash, ticket.SenderNonce, err)
+			clog.Errorf(ctx, "Error receiving ticket sessionID=%v recipientRandHash=%x senderNonce=%v: %v", manifestID, ticket.RecipientRandHash, ticket.SenderNonce, err)
 
 			if monitor.Enabled {
-				monitor.PaymentRecvError(err.Error())
+				monitor.PaymentRecvError(ctx, sender.Hex(), err.Error())
 			}
 			if _, ok := err.(*pm.FatalReceiveErr); ok {
 				return err
@@ -203,22 +203,22 @@ func (orch *orchestrator) ProcessPayment(payment net.Payment, manifestID Manifes
 		}
 
 		if won {
-			glog.V(common.DEBUG).Infof("Received winning ticket sessionID=%v recipientRandHash=%x senderNonce=%v", manifestID, ticket.RecipientRandHash, ticket.SenderNonce)
+			clog.V(common.DEBUG).Infof(ctx, "Received winning ticket sessionID=%v recipientRandHash=%x senderNonce=%v", manifestID, ticket.RecipientRandHash, ticket.SenderNonce)
 
 			totalWinningTickets++
 
 			go func(ticket *pm.Ticket, sig []byte, seed *big.Int) {
 				if err := orch.node.Recipient.RedeemWinningTicket(ticket, sig, seed); err != nil {
-					glog.Errorf("error redeeming ticket sessionID=%v recipientRandHash=%x senderNonce=%v err=%q", manifestID, ticket.RecipientRandHash, ticket.SenderNonce, err)
+					clog.Errorf(ctx, "error redeeming ticket sessionID=%v recipientRandHash=%x senderNonce=%v err=%q", manifestID, ticket.RecipientRandHash, ticket.SenderNonce, err)
 				}
 			}(ticket, tsp.Sig, seed)
 		}
 	}
 
 	if monitor.Enabled {
-		monitor.TicketValueRecv(totalEV)
-		monitor.TicketsRecv(totalTickets)
-		monitor.WinningTicketsRecv(totalWinningTickets)
+		monitor.TicketValueRecv(ctx, sender.Hex(), totalEV)
+		monitor.TicketsRecv(ctx, sender.Hex(), totalTickets)
+		monitor.WinningTicketsRecv(ctx, sender.Hex(), totalWinningTickets)
 	}
 
 	if receiveErr != nil {

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -117,7 +117,7 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 		if err != nil && !errors.Is(err, context.Canceled) {
 			clog.Errorf(ctx, "err=%q", err)
 			if monitor.Enabled {
-				monitor.LogDiscoveryError(err.Error())
+				monitor.LogDiscoveryError(ctx, uri.String(), err.Error())
 			}
 		}
 		errCh <- err
@@ -162,7 +162,7 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 		}
 	}
 
-	glog.Infof("Done fetching orch info numOrch=%d responses=%d/%d timeout=%t",
+	clog.Infof(ctx, "Done fetching orch info numOrch=%d responses=%d/%d timeout=%t",
 		len(infos), nbResp, len(uris), timeout)
 	return infos, nil
 }

--- a/monitor/census_test.go
+++ b/monitor/census_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAveragerCanBeRemoved(t *testing.T) {
-	a1 := newAverager()
+	a1 := newAverager("test")
 	if !a1.canBeRemoved() {
 		t.Fatal("Should be able to remove empty buffer")
 	}
@@ -33,7 +33,7 @@ func TestAveragerCanBeRemoved(t *testing.T) {
 	if !a1.canBeRemoved() {
 		t.Fatal("Should be able to remove buffer with all transcoded segments")
 	}
-	a2 := newAverager()
+	a2 := newAverager("test")
 	a2.addEmerged(1)
 	old := timeToWaitForError
 	timeToWaitForError = time.Millisecond
@@ -61,7 +61,7 @@ func TestLastSegmentTimeout(t *testing.T) {
 	if sr := census.successRate(); sr != 1 {
 		t.Fatalf("Success rate should be 1, not %f", sr)
 	}
-	SegmentFullyTranscoded(1, 1, "ps", "")
+	SegmentFullyTranscoded(context.Background(), 1, 1, "ps", "")
 	if sr := census.successRate(); sr != 1 {
 		t.Fatalf("Success rate should be 1, not %f", sr)
 	}
@@ -73,7 +73,7 @@ func TestLastSegmentTimeout(t *testing.T) {
 	SegmentEmerged(context.TODO(), 1, 3, 3, 1)
 	SegmentTranscodeFailed(context.TODO(), SegmentTranscodeErrorSessionEnded, 1, 3, fmt.Errorf("some"), true)
 	SegmentEmerged(context.TODO(), 1, 4, 3, 1)
-	SegmentFullyTranscoded(1, 4, "ps", "")
+	SegmentFullyTranscoded(context.Background(), 1, 4, "ps", "")
 	if sr := census.successRate(); sr != 0.75 {
 		t.Fatalf("Success rate should be 0.75, not %f", sr)
 	}
@@ -84,7 +84,7 @@ func TestLastSegmentTimeout(t *testing.T) {
 
 	StreamCreated("h1", 2)
 	SegmentEmerged(context.TODO(), 2, 1, 3, 1)
-	SegmentFullyTranscoded(2, 1, "ps", "")
+	SegmentFullyTranscoded(context.Background(), 2, 1, "ps", "")
 	SegmentEmerged(context.TODO(), 2, 2, 3, 1)
 	StreamEnded(context.TODO(), 2)
 	if len(census.success) != 1 {
@@ -110,7 +110,7 @@ func TestLastSegmentTimeout(t *testing.T) {
 
 	StreamCreated("h3", 3)
 	SegmentEmerged(context.TODO(), 3, 1, 3, 1)
-	SegmentFullyTranscoded(3, 1, "ps", "")
+	SegmentFullyTranscoded(context.Background(), 3, 1, "ps", "")
 	SegmentEmerged(context.TODO(), 3, 2, 3, 1)
 	StreamEnded(context.TODO(), 3)
 	if len(census.success) != 1 {

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -362,13 +362,13 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 	used, err := sm.broker.IsUsedTicket(ticket.Ticket)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.TicketRedemptionError()
+			monitor.TicketRedemptionError(ticket.Sender.Hex())
 		}
 		return nil, err
 	}
 	if used {
 		if monitor.Enabled {
-			monitor.TicketRedemptionError()
+			monitor.TicketRedemptionError(ticket.Sender.Hex())
 		}
 		return nil, errIsUsedTicket
 	}
@@ -416,7 +416,7 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 	tx, err := sm.broker.RedeemWinningTicket(ticket.Ticket, ticket.Sig, ticket.RecipientRand)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.TicketRedemptionError()
+			monitor.TicketRedemptionError(ticket.Sender.Hex())
 		}
 		return nil, err
 	}
@@ -424,7 +424,7 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 	// Wait for transaction to confirm
 	if err := sm.broker.CheckTx(tx); err != nil {
 		if monitor.Enabled {
-			monitor.TicketRedemptionError()
+			monitor.TicketRedemptionError(ticket.Sender.Hex())
 		}
 		// Return tx so caller can utilize the tx if it fails
 		return tx, err
@@ -433,7 +433,7 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 	if monitor.Enabled {
 		// TODO(yondonfu): Handle case where < ticket.FaceValue is actually
 		// redeemed i.e. if sender reserve cannot cover the full ticket.FaceValue
-		monitor.ValueRedeemed(ticket.Ticket.FaceValue)
+		monitor.ValueRedeemed(ticket.Sender.Hex(), ticket.Ticket.FaceValue)
 	}
 
 	return tx, nil

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -283,7 +283,7 @@ func sendTranscodeResult(ctx context.Context, n *core.LivepeerNode, orchAddr str
 	clog.V(common.VERBOSE).InfofErr(ctx, "Transcoding done results sent for taskId=%d url=%s uploadDur=%v", notify.TaskId, notify.Url, uploadDur, err)
 
 	if monitor.Enabled {
-		monitor.SegmentUploaded(ctx, 0, uint64(notify.TaskId), uploadDur)
+		monitor.SegmentUploaded(ctx, 0, uint64(notify.TaskId), uploadDur, "")
 	}
 }
 

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -53,7 +53,7 @@ type Orchestrator interface {
 	TranscodeSeg(context.Context, *core.SegTranscodingMetadata, *stream.HLSSegment) (*core.TranscodeResult, error)
 	ServeTranscoder(stream net.Transcoder_RegisterTranscoderServer, capacity int, capabilities *net.Capabilities)
 	TranscoderResults(job int64, res *core.RemoteTranscoderResult)
-	ProcessPayment(payment net.Payment, manifestID core.ManifestID) error
+	ProcessPayment(ctx context.Context, payment net.Payment, manifestID core.ManifestID) error
 	TicketParams(sender ethcommon.Address, priceInfo *net.PriceInfo) (*net.TicketParams, error)
 	PriceInfo(sender ethcommon.Address) (*net.PriceInfo, error)
 	SufficientBalance(addr ethcommon.Address, manifestID core.ManifestID) bool

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -133,7 +133,7 @@ func (r *stubOrchestrator) StreamIDs(jobID string) ([]core.StreamID, error) {
 	return []core.StreamID{}, nil
 }
 
-func (r *stubOrchestrator) ProcessPayment(payment net.Payment, manifestID core.ManifestID) error {
+func (r *stubOrchestrator) ProcessPayment(ctx context.Context, payment net.Payment, manifestID core.ManifestID) error {
 	return nil
 }
 
@@ -1302,7 +1302,7 @@ func (o *mockOrchestrator) ServeTranscoder(stream net.Transcoder_RegisterTransco
 func (o *mockOrchestrator) TranscoderResults(job int64, res *core.RemoteTranscoderResult) {
 	o.Called(job, res)
 }
-func (o *mockOrchestrator) ProcessPayment(payment net.Payment, manifestID core.ManifestID) error {
+func (o *mockOrchestrator) ProcessPayment(ctx context.Context, payment net.Payment, manifestID core.ManifestID) error {
 	args := o.Called(payment, manifestID)
 	return args.Error(0)
 }

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -72,19 +72,23 @@ var httpClient = &http.Client{
 func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 	orch := h.orchestrator
 
+	remoteAddr := getRemoteAddr(r)
+	ctx := clog.AddVal(r.Context(), clog.ClientIP, remoteAddr)
+
 	payment, err := getPayment(r.Header.Get(paymentHeader))
 	if err != nil {
-		glog.Error("Could not parse payment")
+		clog.Errorf(ctx, "Could not parse payment")
 		http.Error(w, err.Error(), http.StatusPaymentRequired)
 		return
 	}
 
 	sender := getPaymentSender(payment)
+	ctx = clog.AddVal(ctx, "sender", sender.Hex())
 
 	// check the segment sig from the broadcaster
 	seg := r.Header.Get(segmentHeader)
 
-	segData, ctx, err := verifySegCreds(r.Context(), orch, seg, sender)
+	segData, ctx, err := verifySegCreds(ctx, orch, seg, sender)
 	if err != nil {
 		clog.Errorf(ctx, "Could not verify segment creds err=%q", err)
 		http.Error(w, err.Error(), http.StatusForbidden)
@@ -98,7 +102,7 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 		monitor.SegmentEmerged(ctx, 0, uint64(segData.Seq), len(segData.Profiles), segData.Duration.Seconds())
 	}
 
-	if err := orch.ProcessPayment(payment, core.ManifestID(segData.AuthToken.SessionId)); err != nil {
+	if err := orch.ProcessPayment(ctx, payment, core.ManifestID(segData.AuthToken.SessionId)); err != nil {
 		clog.Errorf(ctx, "error processing payment: %v", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -219,6 +223,9 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 
 	// Debit the fee for the total pixel count
 	orch.DebitFees(sender, core.ManifestID(segData.AuthToken.SessionId), payment.GetExpectedPrice(), pixels)
+	if monitor.Enabled {
+		monitor.MilPixelsProcessed(ctx, float64(pixels)/1000000.0)
+	}
 
 	// construct the response
 	var result net.TranscodeResult
@@ -395,14 +402,17 @@ func verifySegCreds(ctx context.Context, orch Orchestrator, segCreds string, bro
 
 func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSSegment, nonce uint64, calcPerceptualHash, verified bool) (*ReceivedTranscodeResult, error) {
 	uploaded := seg.Name != "" // hijack seg.Name to convey the uploaded URI
-	if sess.OrchestratorInfo != nil && sess.OrchestratorInfo.AuthToken != nil {
-		ctx = clog.AddOrchSessionID(ctx, sess.OrchestratorInfo.AuthToken.SessionId)
+	if sess.OrchestratorInfo != nil {
+		if sess.OrchestratorInfo.AuthToken != nil {
+			ctx = clog.AddOrchSessionID(ctx, sess.OrchestratorInfo.AuthToken.SessionId)
+		}
+		ctx = clog.AddVal(ctx, "orchestrator", sess.OrchestratorInfo.Transcoder)
 	}
 
 	segCreds, err := genSegCreds(sess, seg, calcPerceptualHash)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorGenCreds, err, false)
+			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorGenCreds, err, false, sess.OrchestratorInfo.Transcoder)
 		}
 		return nil, err
 	}
@@ -438,7 +448,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 		clog.Errorf(ctx, "Could not create payment bytes=%v err=%q", len(data), err)
 
 		if monitor.Enabled {
-			monitor.PaymentCreateError()
+			monitor.PaymentCreateError(ctx)
 		}
 
 		return nil, err
@@ -466,7 +476,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	if err != nil {
 		clog.Errorf(ctx, "Could not generate transcode request to orch=%s", ti.Transcoder)
 		if monitor.Enabled {
-			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorGenCreds, err, false)
+			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorGenCreds, err, false, sess.OrchestratorInfo.Transcoder)
 		}
 		return nil, err
 	}
@@ -489,7 +499,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	if err != nil {
 		clog.Errorf(ctx, "Unable to submit segment orch=%v orch=%s uploadDur=%s err=%q", ti.Transcoder, ti.Transcoder, uploadDur, err)
 		if monitor.Enabled {
-			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorUnknown, err, false)
+			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorUnknown, err, false, sess.OrchestratorInfo.Transcoder)
 		}
 		return nil, fmt.Errorf("header timeout: %w", err)
 	}
@@ -499,8 +509,8 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	// submitted as well so we consider the update's credit as spent
 	balUpdate.Status = CreditSpent
 	if monitor.Enabled {
-		monitor.TicketValueSent(balUpdate.NewCredit)
-		monitor.TicketsSent(balUpdate.NumTickets)
+		monitor.TicketValueSent(ctx, balUpdate.NewCredit)
+		monitor.TicketsSent(ctx, balUpdate.NumTickets)
 	}
 
 	if resp.StatusCode != 200 {
@@ -509,17 +519,17 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 		clog.Errorf(ctx, "Error submitting segment code=%d orch=%s err=%q", resp.StatusCode, ti.Transcoder, string(data))
 		if monitor.Enabled {
 			if resp.StatusCode == 403 && strings.Contains(errorString, "OrchestratorCapped") {
-				monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorOrchestratorCapped, errors.New(errorString), false)
+				monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorOrchestratorCapped, errors.New(errorString), false, sess.OrchestratorInfo.Transcoder)
 			} else {
 				monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadError(resp.Status),
-					fmt.Errorf("Code: %d Error: %s", resp.StatusCode, errorString), false)
+					fmt.Errorf("Code: %d Error: %s", resp.StatusCode, errorString), false, sess.OrchestratorInfo.Transcoder)
 			}
 		}
 		return nil, fmt.Errorf(errorString)
 	}
 	clog.Infof(ctx, "Uploaded segment orch=%s dur=%s", ti.Transcoder, uploadDur)
 	if monitor.Enabled {
-		monitor.SegmentUploaded(ctx, nonce, seg.SeqNo, uploadDur)
+		monitor.SegmentUploaded(ctx, nonce, seg.SeqNo, uploadDur, ti.Transcoder)
 	}
 
 	data, err = ioutil.ReadAll(resp.Body)
@@ -589,7 +599,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 		balUpdate.Debit.Mul(new(big.Rat).SetInt64(pixelCount), priceInfo)
 
 		if monitor.Enabled {
-			monitor.MilPixelsProcessed(float64(pixelCount) / 1000000.0)
+			monitor.MilPixelsProcessed(ctx, float64(pixelCount)/1000000.0)
 		}
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds per-stream metrics. Also adds Broadcaster's IP to Orchestrator's metric.

**Specific updates (required)**
- Added `manifest_id` label to some metrics
- Expose `mil_pixels_processed` metric on Orchestrator
- For `mil_pixels_processed` metric added `client_ip` label which represent Broadcaster's IP address
- Expose Eth address in payments metrics

All those are opt-it: there is two new command-line switches that off by default.



**How did you test each of these updates (required)**
Manually

**Does this pull request close any open issues?**
Fixes #2172 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
