### PR TITLE
Backfill always from the back last seen in DB

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,7 @@
 #### General
 - \#2208 Improve Feed PubSub: execute subscribers' blocking operations in separate goroutines (@leszko)
 - \#2222 Use L1 block number for Ticket Parameters and Round Initialization (@leszko)
+- \#2240 Backfill always from the back last seen in DB (instead of the last round block) (@leszko)
 
 #### Broadcaster
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -482,28 +482,10 @@ func main() {
 		}
 		topics := watchers.FilterTopics()
 
-		// Determine backfilling start block
-		originalLastSeenBlock, err := dbh.LastSeenBlock()
-		if err != nil {
-			glog.Errorf("db: failed to retrieve latest retained block: %v", err)
-			return
-		}
-		currentRoundStartBlock, err := client.CurrentRoundStartBlock()
-		if err != nil {
-			glog.Errorf("eth: failed to retrieve current round start block: %v", err)
-			return
-		}
-
-		var blockWatcherBackfillStartBlock *big.Int
-		if originalLastSeenBlock == nil || originalLastSeenBlock.Cmp(currentRoundStartBlock) < 0 {
-			blockWatcherBackfillStartBlock = currentRoundStartBlock
-		}
-
 		blockWatcherCfg := blockwatch.Config{
 			Store:               n.Database,
 			PollingInterval:     blockPollingTime,
 			StartBlockDepth:     rpc.LatestBlockNumber,
-			BackfillStartBlock:  blockWatcherBackfillStartBlock,
 			BlockRetentionLimit: blockWatcherRetentionLimit,
 			WithLogs:            true,
 			Topics:              topics,

--- a/eth/blockwatch/block_watcher.go
+++ b/eth/blockwatch/block_watcher.go
@@ -45,7 +45,6 @@ type Config struct {
 	Store               MiniHeaderStore
 	PollingInterval     time.Duration
 	StartBlockDepth     rpc.BlockNumber
-	BackfillStartBlock  *big.Int
 	BlockRetentionLimit int
 	WithLogs            bool
 	Topics              []common.Hash
@@ -58,7 +57,6 @@ type Config struct {
 type Watcher struct {
 	blockRetentionLimit int
 	startBlockDepth     rpc.BlockNumber
-	backfillStartBlock  *big.Int
 	stack               *Stack
 	client              Client
 	blockFeed           event.Feed
@@ -79,7 +77,6 @@ func New(config Config) *Watcher {
 		pollingInterval:     config.PollingInterval,
 		blockRetentionLimit: config.BlockRetentionLimit,
 		startBlockDepth:     config.StartBlockDepth,
-		backfillStartBlock:  config.BackfillStartBlock,
 		stack:               stack,
 		client:              config.Client,
 		withLogs:            config.WithLogs,
@@ -330,9 +327,7 @@ func (w *Watcher) getMissedEventsToBackfill(ctx context.Context) ([]*Event, erro
 	}
 	latestBlockNum := int(latestBlock.Number.Int64())
 
-	if w.backfillStartBlock != nil {
-		startBlockNum = int(w.backfillStartBlock.Int64())
-	} else if latestRetainedBlock != nil {
+	if latestRetainedBlock != nil {
 		latestRetainedBlockNum = int(latestRetainedBlock.Number.Int64())
 		// Events for latestRetainedBlock already processed, start at latestRetainedBlock + 1
 		startBlockNum = latestRetainedBlockNum + 1

--- a/eth/blockwatch/block_watcher_test.go
+++ b/eth/blockwatch/block_watcher_test.go
@@ -214,48 +214,6 @@ func TestGetMissedEventsToBackfillSomeMissed(t *testing.T) {
 	assert.Equal(t, big.NewInt(30), headers[0].Number)
 }
 
-func TestGetMissedEventsToBackfill_BackfillStartBlock(t *testing.T) {
-	// Fixture will return block 30 as the tip of the chain
-	fakeClient, err := newFakeClient("testdata/fake_client_fast_sync_fixture.json")
-	require.NoError(t, err)
-
-	store := &stubMiniHeaderStore{}
-
-	config.Store = store
-	config.Client = fakeClient
-	config.BackfillStartBlock = big.NewInt(0)
-	watcher := New(config)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	events, err := watcher.getMissedEventsToBackfill(ctx)
-	require.NoError(t, err)
-	assert.Len(t, events, 1)
-
-	// Check that block 30 is now in the DB as it is the last processed block
-	headers, err := store.FindAllMiniHeadersSortedByNumber()
-	require.NoError(t, err)
-	require.Len(t, headers, 1)
-	assert.Equal(t, big.NewInt(30), headers[0].Number)
-
-	store = &stubMiniHeaderStore{}
-	config.Store = store
-	config.BackfillStartBlock = big.NewInt(5)
-	watcher = New(config)
-	events, err = watcher.getMissedEventsToBackfill(ctx)
-	require.NoError(t, err)
-	assert.Len(t, events, 1)
-
-	// Check that block 30 is now in the DB as it is the last processed block
-	headers, err = store.FindAllMiniHeadersSortedByNumber()
-	require.NoError(t, err)
-	require.Len(t, headers, 1)
-	assert.Equal(t, big.NewInt(30), headers[0].Number)
-
-	config.BackfillStartBlock = nil
-}
-
 func TestGetMissedEventsToBackfillNoneMissed(t *testing.T) {
 	// Fixture will return block 5 as the tip of the chain
 	fakeClient, err := newFakeClient("testdata/fake_client_basic_fixture.json")


### PR DESCRIPTION
Remove code related to backfilling from the last round. From now on, we always backfill from the last block seen in DB.

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested backfilling in Aribitrum. On testnet it took ~10s / 1 day on my machine.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
