### PR TITLE
Bump Tensorflow version to fix critical vulnerabilities

### DIFF
--- a/.github/workflows/linux-tensorflow.yml
+++ b/.github/workflows/linux-tensorflow.yml
@@ -51,7 +51,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 30 \
           && sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 30
 
-        LIBTENSORFLOW_VERSION=2.3.0 \
+        LIBTENSORFLOW_VERSION=2.6.3 \
           && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
           && sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
           && sudo ldconfig
@@ -81,7 +81,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Install libtensorflow
         run: |
-          LIBTENSORFLOW_VERSION=2.3.0 \
+          LIBTENSORFLOW_VERSION=2.6.3 \
             && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
             && sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
             && sudo ldconfig

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -113,7 +113,7 @@ else
     EXTRA_FFMPEG_FLAGS="--enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_cuda,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
     if [[ $BUILD_TAGS == *"experimental"* ]]; then
         if [ ! -e "/usr/local/lib/libtensorflow_framework.so" ]; then
-          LIBTENSORFLOW_VERSION=2.3.0 \
+          LIBTENSORFLOW_VERSION=2.6.3 \
           && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
           && sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
           && rm libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz


### PR DESCRIPTION
Fix critical security vulnerabilities:

https://github.com/advisories/GHSA-77gp-3h4r-6428
https://github.com/advisories/GHSA-h6gw-r52c-724r