### PR TITLE
Add fail fast for Arbitrum One Mainnet when LIP-73 has not been activated yet

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,7 @@
 - \#2240 Backfill always from the back last seen in DB (instead of the last round block) (@leszko)
 - \#2171 Make transactions compatible with Arbitrum and fix setting max gas price (@leszko)
 - \#2252 Use different hardcoded redeemGas when connected to an Arbitrum network (@leszko)
+- \#2251 Add fail fast for Arbitrum One Mainnet when LIP-73 has not been activated yet (@leszko)
 
 #### Broadcaster
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -428,6 +428,26 @@ func main() {
 			return
 		}
 
+		// TODO: Remove after LIP-73 block (Arbitrum L2 contracts are unpaused)
+		arbitrumOneChainId := big.NewInt(42161)
+		lip73Block := big.NewInt(14207040)
+		if arbitrumOneChainId.Cmp(chainID) == 0 {
+			ethClient, err := blockwatch.NewRPCClient(*ethUrl, ethRPCTimeout)
+			if err != nil {
+				glog.Errorf("Failed to connect to Ethereum client: %v", err)
+				return
+			}
+			head, err := ethClient.HeaderByNumber(nil)
+			if err != nil {
+				glog.Errorf("Failed to get the latest block: %v", err)
+				return
+			}
+			if head.L1BlockNumber.Cmp(lip73Block) <= 0 {
+				glog.Errorf("LIP-73 has not been activated yet")
+				return
+			}
+		}
+
 		if !build.ChainSupported(chainID.Int64()) {
 			glog.Errorf("node does not support chainID = %v right now", chainID)
 			return


### PR DESCRIPTION
Temporarily add fail fast for Arbitrum One Mainnet when LIP-73 has not been activated yet.

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

1. Tried to run on Arbitrum One Mainnet.

```
$ ./livepeer -network some-network -ethUrl https://arb1.arbitrum.io/rpc -orchestrator -transcoder
I0210 11:27:16.716149   90877 livepeer.go:260] ***Livepeer is running on the some-network network***
E0210 11:27:17.675315   90877 livepeer.go:436] LIP-73 has not been activated yet
```

Changed `lip37Block` to the current Mainnet block number `14177801`
```
$ ./livepeer -network some-network-2 -ethUrl https://arb1.arbitrum.io/rpc -orchestrator -transcoder
I0210 11:29:51.028816   91068 livepeer.go:260] ***Livepeer is running on the some-network-2 network***
I0210 11:29:52.149630   91068 accountmanager.go:72] Using Ethereum account: 0x416BE189c67c58257E8867cdB41d55986127E76f
I0210 11:29:52.647704   91068 accountmanager.go:95] Please enter the passphrase to unlock Ethereum account 0x416BE189c67c58257E8867cdB41d55986127E76f
Passphrase: 
I0210 11:29:55.646791   91068 accountmanager.go:106] Unlocked ETH account: 0x416BE189c67c58257E8867cdB41d55986127E76f
E0210 11:29:55.825268   91068 client.go:198] Error getting LivepeerToken address: execution reverted
E0210 11:29:55.825300   91068 livepeer.go:496] Failed to set gas info on Livepeer Ethereum Client: execution reverted
```

**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2247

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
