### PR TITLE
Redeem tickets only when recipient is active

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,6 +13,7 @@
 - \#2171 Make transactions compatible with Arbitrum and fix setting max gas price (@leszko)
 - \#2252 Use different hardcoded redeemGas when connected to an Arbitrum network (@leszko)
 - \#2251 Add fail fast for Arbitrum One Mainnet when LIP-73 has not been activated yet (@leszko)
+- \#2253 Redeem tickets only when recipient is active (@leszko)
 
 #### Broadcaster
 

--- a/common/db.go
+++ b/common/db.go
@@ -567,6 +567,19 @@ func (db *DB) OrchCount(filter *DBOrchFilter) (int, error) {
 	return int(count64), nil
 }
 
+func (db *DB) IsOrchActive(addr ethcommon.Address, round *big.Int) (bool, error) {
+	orchs, err := db.SelectOrchs(
+		&DBOrchFilter{
+			CurrentRound: round,
+			Addresses:    []ethcommon.Address{addr},
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+	return len(orchs) > 0, nil
+}
+
 func (db *DB) InsertUnbondingLock(id *big.Int, delegator ethcommon.Address, amount, withdrawRound *big.Int) error {
 	glog.V(DEBUG).Infof("db: Inserting unbonding lock %v for delegator %v", id, delegator.Hex())
 	_, err := db.insertUnbondingLock.Exec(id.Int64(), delegator.Hex(), amount.String(), withdrawRound.Int64())

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -564,6 +564,34 @@ func TestDBFilterOrchs(t *testing.T) {
 	assert.Len(orchsFiltered, 0)
 }
 
+func TestIsOrchActive(t *testing.T) {
+	assert := assert.New(t)
+
+	dbh, dbraw, _ := TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+
+	addr := pm.RandAddress().String()
+	activationRound := 5
+	orch := NewDBOrch(addr, "https://127.0.0.1:8936", 1, int64(activationRound), int64(activationRound+2), 0)
+	dbh.UpdateOrch(orch)
+
+	// inactive in round 4
+	isActive, err := dbh.IsOrchActive(ethcommon.HexToAddress(addr), big.NewInt(4))
+	assert.NoError(err)
+	assert.False(isActive)
+
+	// active in round 5
+	isActive, err = dbh.IsOrchActive(ethcommon.HexToAddress(addr), big.NewInt(5))
+	assert.NoError(err)
+	assert.True(isActive)
+
+	// active in round 6
+	isActive, err = dbh.IsOrchActive(ethcommon.HexToAddress(addr), big.NewInt(6))
+	assert.NoError(err)
+	assert.True(isActive)
+}
+
 func TestDBUnbondingLocks(t *testing.T) {
 	dbh, dbraw, err := TempDB(t)
 	defer dbh.Close()

--- a/pm/queue_test.go
+++ b/pm/queue_test.go
@@ -329,3 +329,29 @@ func TestTicketQueue_Length(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(qlen, 3)
 }
+
+func TestIsRecipientActive(t *testing.T) {
+	assert := assert.New(t)
+
+	ts := newStubTicketStore()
+	tm := &stubTimeManager{round: big.NewInt(100)}
+	sm := &LocalSenderMonitor{
+		ticketStore: ts,
+		tm:          tm,
+	}
+	sender := RandAddress()
+	q := newTicketQueue(sender, sm)
+	addr := RandAddress()
+
+	// active
+	ts.isActive = true
+	assert.True(q.isRecipientActive(addr))
+
+	// inactive
+	ts.isActive = false
+	assert.False(q.isRecipientActive(addr))
+
+	// db error
+	ts.err = errors.New("some error")
+	assert.True(q.isRecipientActive(addr))
+}

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -16,6 +16,7 @@ import (
 type stubBlockStore struct {
 	lastBlock *big.Int
 	err       error
+	isActive  bool
 }
 
 type stubTicketStore struct {
@@ -32,6 +33,9 @@ func newStubTicketStore() *stubTicketStore {
 	return &stubTicketStore{
 		tickets:   make(map[ethcommon.Address][]*SignedTicket),
 		submitted: make(map[string]bool),
+		stubBlockStore: stubBlockStore{
+			isActive: true,
+		},
 	}
 }
 
@@ -108,6 +112,10 @@ func (ts *stubTicketStore) WinningTicketCount(sender ethcommon.Address, minCreat
 		}
 	}
 	return count, nil
+}
+
+func (ts *stubTicketStore) IsOrchActive(addr ethcommon.Address, round *big.Int) (bool, error) {
+	return ts.isActive, ts.err
 }
 
 func (ts *stubBlockStore) LastSeenBlock() (*big.Int, error) {

--- a/pm/ticketstore.go
+++ b/pm/ticketstore.go
@@ -2,6 +2,7 @@ package pm
 
 import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"math/big"
 )
 
 // TicketStore is an interface which describes an object capable
@@ -23,4 +24,7 @@ type TicketStore interface {
 
 	// WinningTicketCount returns the amount of non-redeemed winning tickets for a sender in the TicketStore
 	WinningTicketCount(sender ethcommon.Address, minCreationRound int64) (int, error)
+
+	// IsOrchActive returns true if the given orchestrator addr is active in the given round
+	IsOrchActive(addr ethcommon.Address, round *big.Int) (bool, error)
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Check if the recipient is active before redeeming the ticket.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

The same testing as described [here](https://github.com/livepeer/internal-project-tracking/issues/322#issuecomment-1033592122).

This time, when the orchestrator was inactive, this was the message (only with debug logs enabled):
```
I0210 15:34:23.237192   26302 queue.go:134] Ticket recipient is not active in this round, cannot redeem ticket recipientRandHash=59c006119dccedb68bff820c2754ad7662f6ceb7f23310cad52c272b74872bcb senderNonce=1
```

When the orchestrator became active, it redeemed the ticket.
```
******************************Eth Transaction******************************

Invoking transaction: "redeemWinningTicket". Inputs: "_ticket: { Recipient: 0x7E71B5087bc14abd6aF3Bbe2d87Ea0ADC14Ce56F  Sender: 0x7E71B5087bc14abd6aF3Bbe2d87Ea0ADC14Ce56F  FaceValue: 34782608695652173  WinProb: 33290225655728407058145081652868458784123513979168705244586300000000000000000  SenderNonce: 1  RecipientRandHash: 0x59c006119dccedb68bff820c2754ad7662f6ceb7f23310cad52c272b74872bcb  AuxData: 0x0000000000000000000000000000000000000000000000000000000000008414ecc7d83d923df7611fcda8bd67cc2aca904939e4b8417a1bc5f91e0d8487119d }  _sig: 0x27f8f5a6a08a5e3caac9bae27851d79ae69a67c9d7b63c080a138d846100f4d56970305363598c24994e7d84a1293437af869bc896948e19b89c2a5eb9a6199c1b  _recipientRand: 33683099207914901971858567325965190760487315520271124299464254139206992337416"  Hash: "0xf161f1db583a99d40efdaff72400f8f8e35590103ccd8dba36564eb425f4dcff". 

***************************************************************************
```

**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2250

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
