### PR TITLE
Smarter capabilities check: encoding session limit, verbose errors

### DIFF
--- a/core/capabilities.go
+++ b/core/capabilities.go
@@ -48,6 +48,32 @@ const (
 	Capability_VP9_Encode
 )
 
+var CapabilityNameLookup = map[Capability]string {
+	Capability_Invalid: "Invalid",
+	Capability_Unused: "Unused",
+	Capability_H264: "H.264",
+	Capability_MPEGTS: "MPEGTS",
+	Capability_MP4: "MP4",
+	Capability_FractionalFramerates: "Fractional framerates",
+	Capability_StorageDirect: "Storage direct",
+	Capability_StorageS3: "Storage S3",
+	Capability_StorageGCS: "Storage GCS",
+	Capability_ProfileH264Baseline: "H264 Baseline profile",
+	Capability_ProfileH264Main: "H264 Main profile",
+	Capability_ProfileH264High: "H264 High profile",
+	Capability_ProfileH264ConstrainedHigh: "H264 Constained High profile",
+	Capability_GOP: "GOP",
+	Capability_AuthToken: "Auth token",
+	Capability_SceneClassification: "Scene slassification",
+	Capability_MPEG7VideoSignature: "MPEG7 signature",
+	Capability_HEVC_Decode: "HEVC decode",
+	Capability_HEVC_Encode: "HEVC encode",
+	Capability_VP8_Decode: "VP8 decode",
+	Capability_VP9_Decode: "VP9 decode",
+	Capability_VP8_Encode: "VP8 encode",
+	Capability_VP9_Encode: "VP9 encode",
+}
+
 
 var CapabilityTestLookup = map[Capability]CapabilityTest{
 	// 145x145 is the lowest resolution supported by NVENC on Windows
@@ -77,6 +103,7 @@ var capFormatConv = errors.New("capability: unknown format")
 var capStorageConv = errors.New("capability: unknown storage")
 var capProfileConv = errors.New("capability: unknown profile")
 var capCodecConv = errors.New("capability: unknown codec")
+var capUnknown = errors.New("capability: unknown")
 
 func DefaultCapabilities() []Capability {
 	// Add to this list as new features are added.
@@ -277,6 +304,23 @@ func NewCapabilities(caps []Capability, m []Capability) *Capabilities {
 		c.mandatories = NewCapabilityString(m)
 	}
 	return c
+}
+
+func CapabilityToName(capability Capability) (string, error) {
+	capName, found := CapabilityNameLookup[capability]
+	if !found {
+		return "", capUnknown
+	}
+	return capName, nil
+}
+
+func InArray(capability Capability, caps []Capability) bool {
+	for _, c := range caps {
+		if capability == c {
+			return true
+		}
+	}
+	return false
 }
 
 func inputCodecToCapability(codec ffmpeg.VideoCodec) (Capability, error) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
* Check for Nvidia encoding session limit when testing hardware capabilities
* Immediately fail if some default capability is not supported on hardware
* Display verbose error messages

**Specific updates (required)**
* Extend and refactor TestTranscoderCapabilities function, which is called on node startup

**How did you test each of these updates (required)**
Manually.


**Does this pull request close any open issues?**
<!-- Fixes # -->
https://github.com/livepeer/go-livepeer/issues/2230

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [n/a] README and other documentation updated
- [n/a] [Pending changelog](./CHANGELOG_PENDING.md) updated
