### PR TITLE
Fix nil pointer in the block header logs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,7 @@
 #### Transcoder
 
 ### Bug Fixes 🐞
+- \#2267 Fix nil pointer in the block header logs (@leszko)
 
 #### General
 

--- a/eth/blockwatch/block_watcher.go
+++ b/eth/blockwatch/block_watcher.go
@@ -637,7 +637,12 @@ func (w *Watcher) enrichWithL1BlockNumber(header *MiniHeader) (*MiniHeader, erro
 	if header == nil || header.L1BlockNumber != nil {
 		return header, nil
 	}
-	return w.client.HeaderByHash(header.Hash)
+	fetchedBlock, err := w.client.HeaderByHash(header.Hash)
+	if err != nil {
+		return header, err
+	}
+	header.L1BlockNumber = fetchedBlock.L1BlockNumber
+	return header, nil
 }
 
 func isUnknownBlockErr(err error) bool {

--- a/eth/blockwatch/block_watcher_test.go
+++ b/eth/blockwatch/block_watcher_test.go
@@ -527,6 +527,7 @@ func TestEnrichWithL1_One(t *testing.T) {
 	header := &MiniHeader{
 		Number: big.NewInt(FakeBlockNumber),
 		Hash:   common.HexToHash(FakeHash),
+		Logs:   []types.Log{logStub},
 	}
 	events := []*Event{{BlockHeader: header}}
 
@@ -536,6 +537,7 @@ func TestEnrichWithL1_One(t *testing.T) {
 	assert.Equal(common.HexToHash(FakeHash), res[0].BlockHeader.Hash)
 	assert.Equal(big.NewInt(FakeBlockNumber), res[0].BlockHeader.Number)
 	assert.Equal(big.NewInt(FakeL1BlockNumber), res[0].BlockHeader.L1BlockNumber)
+	assert.Contains(res[0].BlockHeader.Logs, logStub)
 }
 
 func TestEnrichWithL1_Multiple(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes a bug introduced in https://github.com/livepeer/go-livepeer/pull/2222, block header logs were not preserved while enriching block with L1 Number.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit test + checked in the debug that events returned from L2 API may not contain logs.


**Does this pull request close any open issues?**
<!-- Fixes # -->

fix #2265


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
