### PR TITLE
re-compile .proto files in the CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -76,6 +76,13 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.17.6'
+      - name: Install protobuf
+        run: |
+          go install github.com/golang/protobuf/protoc-gen-go@v1.3.5
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - name: Cache go modules
         id: cache-go-mod
         uses: actions/cache@v2.1.5
@@ -95,6 +102,12 @@ jobs:
       - name: go fmt
         run: |
           go fmt ./...
+          git diff --exit-code
+      - name: Compile proto files
+        run: |
+          protoc --version
+          touch net/lp_rpc.proto net/redeemer.proto
+          make net/lp_rpc.pb.go net/redeemer.pb.go
           git diff --exit-code
       - name: Lint
         run: |

--- a/net/redeemer.pb.go
+++ b/net/redeemer.pb.go
@@ -211,7 +211,9 @@ func init() {
 	proto.RegisterType((*MaxFloatUpdate)(nil), "net.MaxFloatUpdate")
 }
 
-func init() { proto.RegisterFile("net/redeemer.proto", fileDescriptor_41a074e4ea0232f2) }
+func init() {
+	proto.RegisterFile("net/redeemer.proto", fileDescriptor_41a074e4ea0232f2)
+}
 
 var fileDescriptor_41a074e4ea0232f2 = []byte{
 	// 323 bytes of a gzipped FileDescriptorProto
@@ -240,11 +242,11 @@ var fileDescriptor_41a074e4ea0232f2 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // TicketRedeemerClient is the client API for TicketRedeemer service.
 //
@@ -256,10 +258,10 @@ type TicketRedeemerClient interface {
 }
 
 type ticketRedeemerClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewTicketRedeemerClient(cc *grpc.ClientConn) TicketRedeemerClient {
+func NewTicketRedeemerClient(cc grpc.ClientConnInterface) TicketRedeemerClient {
 	return &ticketRedeemerClient{cc}
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
In CI forces compilation of `.proto` files, and if result is different than committed one - fails CI test.
This serves two purposes:
1. Makes sure `.proto` files committed along side with generated `.go` files
2. Serves as documentation for which version of protobuf code generation tool we're using.

**Specific updates (required)**
- Add new step to `linux.yml`


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
