### PR TITLE
reduce number metrics

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -1153,10 +1153,6 @@ func downloadResults(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSe
 		segURLs[i] = url
 		segData[i] = data
 		segLock.Unlock()
-
-		if monitor.Enabled {
-			monitor.TranscodedSegmentAppeared(ctx, nonce, seg.SeqNo, profile.Name, bros != nil)
-		}
 	}
 
 	dlStart := time.Now()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Reduces number of metrics datapoints

**Specific updates (required)**
- removed `segment_transcoded_appeared_total` and `transcode_latency_seconds` metrics (they was per transcoding profile and so not useful, we do have corresponding overall metrics)
- record `upload_time_seconds` and `discovery_errors_total` metrics per orchestrator and not per stream

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
