### PR TITLE
eth,server: Use global total supply instead of L2 supply to calculate participation rate on Arbitrum networks

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,7 @@
 
 ### Bug Fixes 🐞
 - \#2267 Fix nil pointer in the block header logs (@leszko)
+- \#2276 Use global total supply instead of L2 supply to calculate participation rate on Arbitrum networks (@leszko)
 
 #### General
 

--- a/eth/client.go
+++ b/eth/client.go
@@ -107,6 +107,7 @@ type LivepeerEthClient interface {
 	Inflation() (*big.Int, error)
 	InflationChange() (*big.Int, error)
 	TargetBondingRate() (*big.Int, error)
+	GetGlobalTotalSupply() (*big.Int, error)
 	Paused() (bool, error)
 
 	// Governance
@@ -469,6 +470,10 @@ func (c *client) InflationChange() (*big.Int, error) {
 
 func (c *client) TargetBondingRate() (*big.Int, error) {
 	return c.minterSess.TargetBondingRate()
+}
+
+func (c *client) GetGlobalTotalSupply() (*big.Int, error) {
+	return c.minterSess.GetGlobalTotalSupply()
 }
 
 func (c *client) CurrentMintableTokens() (*big.Int, error) {

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -384,6 +384,7 @@ func (c *StubClient) UnbondingPeriod() (uint64, error)            { return 0, ni
 func (c *StubClient) Inflation() (*big.Int, error)                { return big.NewInt(0), nil }
 func (c *StubClient) InflationChange() (*big.Int, error)          { return big.NewInt(0), nil }
 func (c *StubClient) TargetBondingRate() (*big.Int, error)        { return big.NewInt(0), nil }
+func (c *StubClient) GetGlobalTotalSupply() (*big.Int, error)     { return big.NewInt(0), nil }
 
 // Helpers
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -374,12 +374,12 @@ func withdrawFeesHandler(client eth.LivepeerEthClient, getChainId func() (int64,
 	return mustHaveClient(client, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// for L1 contracts backwards-compatibility
 		var tx *ethtypes.Transaction
-		chainId, err := getChainId()
+		isL1Network, err := isL1Network(getChainId)
 		if err != nil {
 			respondWith500(w, err.Error())
 			return
 		}
-		if chainId == MainnetChainId || chainId == RinkebyChainId {
+		if isL1Network {
 			// L1 contracts
 			tx, err = client.L1WithdrawFees()
 			if err != nil {
@@ -436,4 +436,13 @@ func setMinGasPriceHandler(client eth.LivepeerEthClient) http.Handler {
 		respondOk(w, []byte("setMinGasPrice success"))
 	}),
 	)
+}
+
+func isL1Network(getChainId func() (int64, error)) (bool, error) {
+	chainId, err := getChainId()
+	if err != nil {
+		return false, err
+	}
+	isL1Network := chainId == MainnetChainId || chainId == RinkebyChainId
+	return isL1Network, err
 }

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -895,7 +895,17 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 				return
 			}
 
-			totalSupply, err := lp.TotalSupply()
+			isL1Network, err := isL1Network(getChainId)
+			if err != nil {
+				glog.Error(err)
+				return
+			}
+			var totalSupply *big.Int
+			if isL1Network {
+				totalSupply, err = lp.TotalSupply()
+			} else {
+				totalSupply, err = lp.GetGlobalTotalSupply()
+			}
 			if err != nil {
 				glog.Error(err)
 				return


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Implemented as described here: https://github.com/livepeer/go-livepeer/issues/2275

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

### Arbitrum Testnet Rinkeby - before the change

```
*--------------------------------*--------------------------------*
|                   Total Supply | 6845088.180812007147050307 LPT |
*--------------------------------*--------------------------------*
| Current Participation Rate (%) |                  0.03127051517 |
*--------------------------------*--------------------------------*
```

### Arbitrum Testnet Rinkeby - after the change

```
*--------------------------------*--------------------------------*
|                   Total Supply |    13688041.821979775736803028 |
|                                |                            LPT |
*--------------------------------*--------------------------------*
| Current Participation Rate (%) |                  0.01563769578 |
*--------------------------------*--------------------------------*
```



# Rinkeby - before the change

```
*--------------------------------*--------------------------------*
|                   Total Supply | 6843718.370257810730818088 LPT |
*--------------------------------*--------------------------------*
| Current Participation Rate (%) |                 0.007506151076 |
*--------------------------------*--------------------------------*
```

# Rinkeby - after the change

```
*--------------------------------*--------------------------------*
|                   Total Supply | 6843718.370257810730818088 LPT |
*--------------------------------*--------------------------------*
| Current Participation Rate (%) |                 0.007506151076 |
*--------------------------------*--------------------------------*
```


**Does this pull request close any open issues?**
<!-- Fixes # -->

fix #2275

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
