### PR TITLE
Fix issue with not redeeming tickets by Redeemer

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,5 +21,6 @@
 #### Broadcaster
 
 #### Orchestrator
+- \#2284 Fix issue with not redeeming tickets by Redeemer (@leszko)
 
 #### Transcoder

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -635,10 +635,7 @@ func main() {
 				return
 			}
 
-			orchSetupCtx, cancel := context.WithCancel(ctx)
-			defer cancel()
-
-			if err := setupOrchestrator(orchSetupCtx, n, recipientAddr); err != nil {
+			if err := setupOrchestrator(n, recipientAddr); err != nil {
 				glog.Errorf("Error setting up orchestrator: %v", err)
 				return
 			}
@@ -721,6 +718,11 @@ func main() {
 		}
 
 		if n.NodeType == core.RedeemerNode {
+			if err := setupOrchestrator(n, recipientAddr); err != nil {
+				glog.Errorf("Error setting up orchestrator: %v", err)
+				return
+			}
+
 			r, err := server.NewRedeemer(
 				recipientAddr,
 				n.Eth,
@@ -1173,7 +1175,7 @@ func getServiceURI(n *core.LivepeerNode, serviceAddr string) (*url.URL, error) {
 	return ethUri, nil
 }
 
-func setupOrchestrator(ctx context.Context, n *core.LivepeerNode, ethOrchAddr ethcommon.Address) error {
+func setupOrchestrator(n *core.LivepeerNode, ethOrchAddr ethcommon.Address) error {
 	// add orchestrator to DB
 	orch, err := n.Eth.GetTranscoder(ethOrchAddr)
 	if err != nil {

--- a/cmd/livepeer/livepeer_test.go
+++ b/cmd/livepeer/livepeer_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"math/big"
 	"testing"
@@ -40,7 +39,7 @@ func TestSetupOrchestrator(t *testing.T) {
 	n, err := core.NewLivepeerNode(stubEthClient, "", dbh)
 	require.Nil(err)
 
-	err = setupOrchestrator(context.Background(), n, orch)
+	err = setupOrchestrator(n, orch)
 	assert.Nil(err)
 
 	orchs, err := dbh.SelectOrchs(&common.DBOrchFilter{
@@ -53,7 +52,7 @@ func TestSetupOrchestrator(t *testing.T) {
 
 	// test eth.GetTranscoder error
 	stubEthClient.Err = errors.New("GetTranscoder error")
-	err = setupOrchestrator(context.Background(), n, orch)
+	err = setupOrchestrator(n, orch)
 	assert.EqualError(err, "GetTranscoder error")
 }
 

--- a/common/db.go
+++ b/common/db.go
@@ -570,14 +570,17 @@ func (db *DB) OrchCount(filter *DBOrchFilter) (int, error) {
 func (db *DB) IsOrchActive(addr ethcommon.Address, round *big.Int) (bool, error) {
 	orchs, err := db.SelectOrchs(
 		&DBOrchFilter{
-			CurrentRound: round,
-			Addresses:    []ethcommon.Address{addr},
+			Addresses: []ethcommon.Address{addr},
 		},
 	)
 	if err != nil {
 		return false, err
 	}
-	return len(orchs) > 0, nil
+	if len(orchs) == 0 {
+		return false, errors.New("Orchestrator not found")
+	}
+	isActive := orchs[0].ActivationRound <= round.Int64() && round.Int64() < orchs[0].DeactivationRound
+	return isActive, nil
 }
 
 func (db *DB) InsertUnbondingLock(id *big.Int, delegator ethcommon.Address, amount, withdrawRound *big.Int) error {

--- a/common/db_test.go
+++ b/common/db_test.go
@@ -572,12 +572,17 @@ func TestIsOrchActive(t *testing.T) {
 	defer dbraw.Close()
 
 	addr := pm.RandAddress().String()
+
+	// not found
+	isActive, err := dbh.IsOrchActive(ethcommon.HexToAddress(addr), big.NewInt(4))
+	assert.EqualError(err, "Orchestrator not found")
+
 	activationRound := 5
 	orch := NewDBOrch(addr, "https://127.0.0.1:8936", 1, int64(activationRound), int64(activationRound+2), 0)
 	dbh.UpdateOrch(orch)
 
 	// inactive in round 4
-	isActive, err := dbh.IsOrchActive(ethcommon.HexToAddress(addr), big.NewInt(4))
+	isActive, err = dbh.IsOrchActive(ethcommon.HexToAddress(addr), big.NewInt(4))
 	assert.NoError(err)
 	assert.False(isActive)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fix issue when Redeemer can't redeem a ticket.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add `ethOrchAddr` to DB `orchestrator` while starting Livepeer Node in the Redeemer mode (before it was added only when started in the Orchestrator mode)
- Ease the condition for redeeming the ticket Before it was that the orchestrator exists in SQLite DB and had the activation round before the current round. Now, we also redeem a ticket when no orchestrator is found.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
unit tests


**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2283

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
