### PR TITLE
Add timeouts to eth client

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,7 @@
 ### Features ⚒
 
 #### General
+- \#2289 Add timeouts to ETH client (@leszko)
 
 #### Broadcaster
 

--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	ethTxTimeout              = 600 * time.Second
+	ethTxTimeout              = 5 * time.Minute
 	endpoint                  = "http://localhost:8545/"
 	gethMiningAccount         = "87da6a8c6e9eff15d703fc2773e32f6af8dbe301"
 	gethMiningAccountOverride = false
@@ -188,7 +188,8 @@ func ethSetup(ethAcctAddr, keystoreDir string, isBroadcaster bool) {
 		return
 	}
 
-	tm := eth.NewTransactionManager(backend, gpm, am, 5*time.Minute, 0)
+	maxTxReplacements := 0
+	tm := eth.NewTransactionManager(backend, gpm, am, ethTxTimeout, maxTxReplacements)
 	go tm.Start()
 	defer tm.Stop()
 
@@ -199,6 +200,7 @@ func ethSetup(ethAcctAddr, keystoreDir string, isBroadcaster bool) {
 		GasPriceMonitor:    gpm,
 		TransactionManager: tm,
 		Signer:             types.LatestSignerForChainID(chainID),
+		CheckTxTimeout:     time.Duration(int64(ethTxTimeout) * int64(maxTxReplacements+1)),
 	}
 
 	client, err := eth.NewClient(ethCfg)

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -478,6 +478,7 @@ func main() {
 			GasPriceMonitor:    gpm,
 			TransactionManager: tm,
 			Signer:             types.LatestSignerForChainID(chainID),
+			CheckTxTimeout:     time.Duration(int64(*txTimeout) * int64(*maxTxReplacements+1)),
 		}
 
 		client, err := eth.NewClient(ethCfg)

--- a/eth/client.go
+++ b/eth/client.go
@@ -39,7 +39,7 @@ var (
 	ErrReplacingMinedTx   = fmt.Errorf("trying to replace already mined tx")
 	ErrCurrentRoundLocked = fmt.Errorf("current round locked")
 	ErrMissingBackend     = fmt.Errorf("missing Ethereum client backend")
-	ethRpcTimeout         = 5 * time.Minute
+	ethRpcTimeout         = 2 * time.Minute
 )
 
 type LivepeerEthClient interface {

--- a/eth/client.go
+++ b/eth/client.go
@@ -155,7 +155,7 @@ type client struct {
 	gasLimit uint64
 	gasPrice *big.Int
 
-	txTimeout time.Duration
+	checkTxTimeout time.Duration
 }
 
 type LivepeerEthClientConfig struct {
@@ -165,6 +165,7 @@ type LivepeerEthClientConfig struct {
 	TransactionManager *TransactionManager
 	Signer             types.Signer
 	ControllerAddr     ethcommon.Address
+	CheckTxTimeout     time.Duration
 }
 
 func NewClient(cfg LivepeerEthClientConfig) (LivepeerEthClient, error) {
@@ -176,6 +177,7 @@ func NewClient(cfg LivepeerEthClientConfig) (LivepeerEthClient, error) {
 		backend:        backend,
 		tm:             cfg.TransactionManager,
 		controllerAddr: cfg.ControllerAddr,
+		checkTxTimeout: cfg.CheckTxTimeout,
 	}, nil
 }
 
@@ -1099,8 +1101,13 @@ func (c *client) CheckTx(tx *types.Transaction) error {
 	txSub := c.tm.Subscribe(receipts)
 	defer txSub.Unsubscribe()
 
+	timer := time.NewTimer(c.checkTxTimeout)
+	defer timer.Stop()
+
 	for {
 		select {
+		case <-timer.C:
+			return fmt.Errorf("timed out waiting for transaction receipt txHash=%v", tx.Hash().Hex())
 		case err := <-txSub.Err():
 			return err
 		case receipt := <-receipts:

--- a/eth/client_ticketbroker.go
+++ b/eth/client_ticketbroker.go
@@ -16,7 +16,7 @@ func (c *client) FundDepositAndReserve(depositAmount, reserveAmount *big.Int) (*
 	opts := c.transactOpts()
 	opts.Value = new(big.Int).Add(depositAmount, reserveAmount)
 
-	return c.ticketBrokerSess.Contract.FundDepositAndReserve(opts, depositAmount, reserveAmount)
+	return c.ticketBroker.FundDepositAndReserve(opts, depositAmount, reserveAmount)
 }
 
 // FundDeposit funds a sender's deposit
@@ -26,7 +26,7 @@ func (c *client) FundDeposit(amount *big.Int) (*types.Transaction, error) {
 	opts := c.transactOpts()
 	opts.Value = amount
 
-	return c.ticketBrokerSess.Contract.FundDeposit(opts)
+	return c.ticketBroker.FundDeposit(opts)
 }
 
 // FundReserve funds a sender's reserve
@@ -36,7 +36,7 @@ func (c *client) FundReserve(amount *big.Int) (*types.Transaction, error) {
 	opts := c.transactOpts()
 	opts.Value = amount
 
-	return c.ticketBrokerSess.Contract.FundReserve(opts)
+	return c.ticketBroker.FundReserve(opts)
 }
 
 // RedeemWinningTicket submits a ticket to be validated by the broker and if a valid winning ticket
@@ -45,7 +45,7 @@ func (c *client) RedeemWinningTicket(ticket *pm.Ticket, sig []byte, recipientRan
 	var recipientRandHash [32]byte
 	copy(recipientRandHash[:], ticket.RecipientRandHash.Bytes()[:32])
 
-	return c.ticketBrokerSess.Contract.RedeemWinningTicket(
+	return c.ticketBroker.RedeemWinningTicket(
 		c.transactOpts(),
 		contracts.MTicketBrokerCoreTicket{
 			Recipient:         ticket.Recipient,
@@ -63,7 +63,7 @@ func (c *client) RedeemWinningTicket(ticket *pm.Ticket, sig []byte, recipientRan
 
 // GetSenderInfo returns the info for a sender
 func (c *client) GetSenderInfo(addr ethcommon.Address) (*pm.SenderInfo, error) {
-	info, err := c.ticketBrokerSess.GetSenderInfo(addr)
+	info, err := c.ticketBroker.GetSenderInfo(c.callOpts(), addr)
 	if err != nil {
 		return nil, err
 	}
@@ -85,5 +85,5 @@ func (c *client) IsUsedTicket(ticket *pm.Ticket) (bool, error) {
 	var ticketHash [32]byte
 	copy(ticketHash[:], ticket.Hash().Bytes()[:32])
 
-	return c.ticketBrokerSess.UsedTickets(ticketHash)
+	return c.ticketBroker.UsedTickets(c.callOpts(), ticketHash)
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Add timeouts for `CheckTx()` function and all ETH RPC calls.

Note that the timeout values are quite conservative, by default:
- 5 min for `CheckTx()`
- 10 min for every ETH RPC call

I don't think we need smaller numbers, because in the correct flow of action, these timeouts should never actually be reached.

**Specific updates (required)**
- Add timeout for the `CheckTx()` execution
- Add timeout for all ETH RPC (contracts) calls
- Refactor client to not include contract sessions anymore

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Checked that using eth client and sending transactions still work fine
- Change `CheckTxTimeout` to 1 ns and check that it always times out
- Change `ethRpcTimeout` to 1 ns and check that all ETH RPC requests fail

**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2207

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
