### PR TITLE
discovery: Increase orchestrator discovery timeout from 500ms to 1s

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,6 +19,7 @@
 #### General
 
 #### Broadcaster
+- \#2296 Increase orchestrator discovery timeout from `500ms` to `1` (@leszko)
 
 #### Orchestrator
 - \#2284 Fix issue with not redeeming tickets by Redeemer (@leszko)

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -19,7 +19,7 @@ import (
 )
 
 var getOrchestratorsTimeoutLoop = 3 * time.Second
-var getOrchestratorsCutoffTimeout = 500 * time.Millisecond
+var getOrchestratorsCutoffTimeout = 1 * time.Second
 
 var serverGetOrchInfo = server.GetOrchestratorInfo
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Increase orchestrator discovery timeout from 500ms to 1s

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Run teststream in SIN, check [GH comment](https://github.com/livepeer/go-livepeer/issues/2286#issuecomment-1057115579).


**Does this pull request close any open issues?**
<!-- Fixes # -->

fix #2286


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~~README and other documentation updated~~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
