### PR TITLE
Split devtool Orchestrator scripts with/without external transcoder. Prevent run scripts from using same CLI port.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ eth/protocol
 /livepeer_router
 /livepeer_bench
 
+# Generated run scripts
+run_*.sh
+
 /.git.describe
 /livepeer-windows-amd64.zip
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,7 +17,7 @@
 ### Bug Fixes 🐞
 
 #### General
-- \#2299 Prevent Transcoder/Broadcaster run scripts from using same CLI port
+- \#2299 Split devtool Orchestrator run scripts into versions with/without external transcoder and prevent Transcoder/Broadcaster run scripts from using same CLI port (@thomshutt)
 
 #### Broadcaster
 - \#2296 Increase orchestrator discovery timeout from `500ms` to `1` (@leszko)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,7 @@
 ### Bug Fixes 🐞
 
 #### General
+- \#2299 Prevent Transcoder/Broadcaster run scripts from using same CLI port
 
 #### Broadcaster
 - \#2296 Increase orchestrator discovery timeout from `500ms` to `1` (@leszko)

--- a/cmd/devtool/README.md
+++ b/cmd/devtool/README.md
@@ -31,5 +31,7 @@ This command will submit the setup transactions for a broadcaster and generate t
 
 `go run cmd/devtool/devtool.go setup transcoder`
 
-This command will submit the setup transactions for an orchestrator/transcoder and generate the Bash scripts 
-`run_orchestrator_<ETH_ACCOUNT>.sh` which can be used to start an orchestrator node and `run_transcoder_<ETH_ACCOUNT>.sh` which can be used to start a transcoder node.
+This command will submit the setup transactions for an orchestrator/transcoder and generate the Bash scripts:
+
+* `run_orchestrator_with_transcoder_<ETH_ACCOUNT>.sh` which can be used to start an orchestrator node that contains a transcoder (combined OT)
+* `run_orchestrator_standalone_<ETH_ACCOUNT>.sh`  and `run_transcoder_<ETH_ACCOUNT>.sh` which can be used to start separate orchestrator and transcoder nodes (split O/T)

--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	clientIdentifier = "geth" // Client identifier to advertise over the network
-	passphrase       = ""
+	passphrase = ""
 )
 
 var (
@@ -133,6 +132,7 @@ func main() {
 	ethSetup(acc, keystoreDir, isBroadcaster)
 	createRunScript(acc, dataDir, serviceHost, isBroadcaster)
 	if !isBroadcaster {
+		cliPort += 1
 		tDataDir := filepath.Join(*baseDataDir, "transcoder_"+acc)
 		err = os.MkdirAll(tDataDir, 0755)
 		if err != nil {
@@ -330,8 +330,8 @@ func ethSetup(ethAcctAddr, keystoreDir string, isBroadcaster bool) {
 func createTranscoderRunScript(ethAcctAddr, dataDir, serviceHost string) {
 	script := "#!/bin/bash\n"
 	// script += fmt.Sprintf(`./livepeer -v 99 -datadir ./%s \
-	script += fmt.Sprintf(`./livepeer -v 99 -datadir ./%s -orchSecret secre -orchAddr %s:%d -transcoder`,
-		dataDir, serviceHost, mediaPort)
+	script += fmt.Sprintf(`./livepeer -v 99 -datadir ./%s -orchSecret secre -orchAddr %s:%d -cliAddr %s:%d -transcoder`,
+		dataDir, serviceHost, mediaPort, serviceHost, cliPort)
 	fName := fmt.Sprintf("run_transcoder_%s.sh", ethAcctAddr)
 	err := ioutil.WriteFile(fName, []byte(script), 0755)
 	if err != nil {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
It's currently not possible to run the `run_broadcaster` and `run_transcoder` scripts generated by devtool simultaneously, because `run_broadcaster` specifies a CLI Port of `7935` and run_transcoder doesn't specify one (and so go-livepeer uses `7935` by default).

**Specific updates (required)**
* Specify <orchestrator port + 1> as the CLI port for the transcoder script
* Split out Orchestrator script into two separate ones (with/without transcoder running)
* Update docs to reflect script changes

**How did you test each of these updates (required)**
* Generated the scripts and streamed with both B/O and B/O/T setup


**Does this pull request close any open issues?**
No


**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
