### PR TITLE
discovery: Add dynamic timeout for the orchestrator discovery

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,6 +10,7 @@
 - \#2289 Add timeouts to ETH client (@leszko)
 
 #### Broadcaster
+- \#2309 Add dynamic timeout for the orchestrator discovery (@leszko)
 
 #### Orchestrator
 

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -918,9 +918,10 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 
 func TestCachedPool_GetOrchestrators_TicketParamsValidation(t *testing.T) {
 	// Test setup
-
 	gmp := runtime.GOMAXPROCS(50)
 	defer runtime.GOMAXPROCS(gmp)
+	// Disable retrying discovery with extended timeout
+	maxGetOrchestratorCutoffTimeout = getOrchestratorsCutoffTimeout
 
 	server.BroadcastCfg.SetMaxPrice(nil)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Add dynamic timeout for the orchestrator discovery process.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Tested with local geth. Introduced artificial delay in O and checked the logs in B.


**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2306


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~~README and other documentation updated~~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
