### PR TITLE
Update O capabilities when T connects and disconnects, basic capacity support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,12 +76,6 @@ jobs:
           go fmt ./...
           git diff --exit-code
 
-      - name: Compile proto files
-        run: |
-          protoc --version
-          touch net/lp_rpc.proto net/redeemer.proto
-          make net/lp_rpc.pb.go net/redeemer.pb.go
-
       - name: Lint
         run: |
           export PKG_CONFIG_PATH=~/compiled/lib/pkgconfig

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,7 +81,6 @@ jobs:
           protoc --version
           touch net/lp_rpc.proto net/redeemer.proto
           make net/lp_rpc.pb.go net/redeemer.pb.go
-          git diff --exit-code
 
       - name: Lint
         run: |

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -307,7 +307,7 @@ func main() {
 		n.OrchSecret, _ = common.GetPass(*orchSecret)
 	}
 
-	transcoderCaps := core.DefaultCapabilities()
+	var transcoderCaps []core.Capability
 	if *transcoder {
 		core.WorkDir = *datadir
 		if *nvidia != "" {
@@ -938,12 +938,11 @@ func main() {
 			// Only enable experimental capabilities if scene classification model is actually loaded
 			transcoderCaps = append(transcoderCaps, core.ExperimentalCapabilities()...)
 		}
-		n.Capabilities = core.NewCapabilities(transcoderCaps, core.MandatoryOCapabilities())
-
 		if !*transcoder && n.OrchSecret == "" {
 			glog.Fatal("Running an orchestrator requires an -orchSecret for standalone mode or -transcoder for orchestrator+transcoder mode")
 		}
 	}
+	n.Capabilities = core.NewCapabilities(transcoderCaps, core.MandatoryOCapabilities())
 	*cliAddr = defaultAddr(*cliAddr, "127.0.0.1", CliPort)
 
 	if drivers.NodeStorage == nil {

--- a/core/capabilities.go
+++ b/core/capabilities.go
@@ -2,10 +2,10 @@ package core
 
 import (
 	"errors"
-
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/lpms/ffmpeg"
+	"sync"
 )
 
 type Capability int
@@ -15,6 +15,8 @@ type Capabilities struct {
 	bitstring   CapabilityString
 	mandatories CapabilityString
 	constraints Constraints
+	capacities  map[Capability]int
+	mutex       sync.Mutex
 }
 type CapabilityTest struct {
 	inVideoData []byte
@@ -281,28 +283,95 @@ func (c *Capabilities) ToNetCapabilities() *net.Capabilities {
 	if c == nil {
 		return nil
 	}
-	return &net.Capabilities{Bitstring: c.bitstring, Mandatories: c.mandatories}
+	netCaps := &net.Capabilities{Bitstring: c.bitstring, Mandatories: c.mandatories, Capacities: make(map[uint32]uint32)}
+	for capability, capacity := range c.capacities {
+		netCaps.Capacities[uint32(capability)] = uint32(capacity)
+	}
+	return netCaps
 }
 
 func CapabilitiesFromNetCapabilities(caps *net.Capabilities) *Capabilities {
 	if caps == nil {
 		return nil
 	}
-	return &Capabilities{
+	coreCaps := &Capabilities{
 		bitstring:   caps.Bitstring,
 		mandatories: caps.Mandatories,
+		capacities:  make(map[Capability]int),
 	}
+	if caps.Capacities == nil || len(caps.Capacities) == 0 {
+		// build capacities map if not present (struct received from previous versions)
+		for arrIdx := 0; arrIdx < len(caps.Bitstring); arrIdx++ {
+			for capIdx := 0; capIdx < 64; capIdx++ {
+				capInt := arrIdx*64 + capIdx
+				if caps.Bitstring[arrIdx]&uint64(1<<capIdx) > 0 {
+					coreCaps.capacities[Capability(capInt)] = 1
+				}
+			}
+		}
+	} else {
+		for capabilityInt, capacity := range caps.Capacities {
+			coreCaps.capacities[Capability(capabilityInt)] = int(capacity)
+		}
+	}
+	return coreCaps
 }
 
 func NewCapabilities(caps []Capability, m []Capability) *Capabilities {
-	c := &Capabilities{}
+	c := &Capabilities{capacities: make(map[Capability]int)}
 	if len(caps) > 0 {
 		c.bitstring = NewCapabilityString(caps)
+		// initialize capacities to 1 by default, mandatory capabilities doesn't have capacities
+		for _, capability := range caps {
+			c.capacities[capability] = 1
+		}
 	}
 	if len(m) > 0 {
 		c.mandatories = NewCapabilityString(m)
 	}
 	return c
+}
+
+func (cap *Capabilities) AddCapacity(newCaps *Capabilities) {
+	cap.mutex.Lock()
+	defer cap.mutex.Unlock()
+	for capability, capacity := range newCaps.capacities {
+		curCapacity, e := cap.capacities[capability]
+		if !e {
+			cap.capacities[capability] = 0
+		}
+		cap.capacities[capability] = curCapacity + capacity
+		arrIdx := int(capability) / 64
+		bitIdx := int(capability) % 64
+		if arrIdx >= len(cap.bitstring) {
+			cap.bitstring = append(cap.bitstring, 0)
+		}
+		cap.bitstring[arrIdx] |= uint64(1 << bitIdx)
+	}
+}
+
+func (cap *Capabilities) RemoveCapacity(goneCaps *Capabilities) {
+	cap.mutex.Lock()
+	defer cap.mutex.Unlock()
+	for capability, capacity := range goneCaps.capacities {
+		curCapacity, e := cap.capacities[capability]
+		if !e {
+			continue
+		}
+		newCapacity := curCapacity - capacity
+		if newCapacity <= 0 {
+			delete(cap.capacities, capability)
+			arrIdx := int(capability) / 64
+			bitIdx := int(capability) % 64
+			if arrIdx >= len(cap.bitstring) {
+				// shouldn't reach this point
+				continue
+			}
+			cap.bitstring[arrIdx] &= ^uint64(1 << bitIdx)
+		} else {
+			cap.capacities[capability] = newCapacity
+		}
+	}
 }
 
 func CapabilityToName(capability Capability) (string, error) {

--- a/core/capabilities.go
+++ b/core/capabilities.go
@@ -276,6 +276,8 @@ func (c *Capabilities) ToNetCapabilities() *net.Capabilities {
 	if c == nil {
 		return nil
 	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	netCaps := &net.Capabilities{Bitstring: c.bitstring, Mandatories: c.mandatories, Capacities: make(map[uint32]uint32)}
 	for capability, capacity := range c.capacities {
 		netCaps.Capacities[uint32(capability)] = uint32(capacity)

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -102,6 +102,7 @@ func NewLivepeerNode(e eth.LivepeerEthClient, wd string, dbh *common.DB) (*Livep
 		AutoAdjustPrice: true,
 		SegmentChans:    make(map[ManifestID]SegmentChan),
 		segmentMutex:    &sync.RWMutex{},
+		Capabilities:    &Capabilities{capacities: map[Capability]int{}},
 	}, nil
 }
 

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -663,6 +663,10 @@ func (n *LivepeerNode) transcodeSegmentLoop(logCtx context.Context, md *SegTrans
 
 func (n *LivepeerNode) serveTranscoder(stream net.Transcoder_RegisterTranscoderServer, capacity int, capabilities *net.Capabilities) {
 	from := common.GetConnectionAddr(stream.Context())
+	coreCaps := CapabilitiesFromNetCapabilities(capabilities)
+	n.Capabilities.AddCapacity(coreCaps)
+	defer n.Capabilities.RemoveCapacity(coreCaps)
+	// Manage blocks while transcoder is connected
 	n.TranscoderManager.Manage(stream, capacity, capabilities)
 	glog.V(common.DEBUG).Infof("Closing transcoder=%s channel", from)
 }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/jaypipes/ghw v0.7.0
 	github.com/livepeer/livepeer-data v0.4.11
-	github.com/livepeer/lpms v0.0.0-20220209162529-44fe3cdd2790
+	github.com/livepeer/lpms v0.0.0-20220322090848-7c772da19b33
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/jaypipes/ghw v0.7.0
 	github.com/livepeer/livepeer-data v0.4.11
-	github.com/livepeer/lpms v0.0.0-20220322090848-7c772da19b33
+	github.com/livepeer/lpms v0.0.0-20220225123538-29300e5f7c12
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,3 +44,5 @@ require (
 	google.golang.org/grpc v1.38.0
 	pgregory.net/rapid v0.4.0
 )
+
+replace github.com/livepeer/lpms => ../lpms

--- a/go.mod
+++ b/go.mod
@@ -44,5 +44,3 @@ require (
 	google.golang.org/grpc v1.38.0
 	pgregory.net/rapid v0.4.0
 )
-
-replace github.com/livepeer/lpms => ../lpms

--- a/go.sum
+++ b/go.sum
@@ -421,6 +421,8 @@ github.com/livepeer/livepeer-data v0.4.11 h1:Sv+ss8e4vcscnMWLxcRJ2g3sNIHyQ3RzCtg
 github.com/livepeer/livepeer-data v0.4.11/go.mod h1:VIbJRdyH2Tas8EgLVkP79IPMepFDOv0dgHYLEZsCaf4=
 github.com/livepeer/lpms v0.0.0-20220209162529-44fe3cdd2790 h1:ZArRP3s+eVBPc32Bj+T2+vptpfywqAxwmcC+o3/cVio=
 github.com/livepeer/lpms v0.0.0-20220209162529-44fe3cdd2790/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
+github.com/livepeer/lpms v0.0.0-20220322090848-7c772da19b33 h1:EQdk2TS3EdyIBv7gKuSNbOsWoJc/60Yk1grgZP1iDCE=
+github.com/livepeer/lpms v0.0.0-20220322090848-7c772da19b33/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=

--- a/go.sum
+++ b/go.sum
@@ -421,6 +421,8 @@ github.com/livepeer/livepeer-data v0.4.11 h1:Sv+ss8e4vcscnMWLxcRJ2g3sNIHyQ3RzCtg
 github.com/livepeer/livepeer-data v0.4.11/go.mod h1:VIbJRdyH2Tas8EgLVkP79IPMepFDOv0dgHYLEZsCaf4=
 github.com/livepeer/lpms v0.0.0-20220209162529-44fe3cdd2790 h1:ZArRP3s+eVBPc32Bj+T2+vptpfywqAxwmcC+o3/cVio=
 github.com/livepeer/lpms v0.0.0-20220209162529-44fe3cdd2790/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
+github.com/livepeer/lpms v0.0.0-20220225123538-29300e5f7c12 h1:B+EIxr9kHYGRV/6JuN4YrDIT3QKoiwkBsG1hUd4LQOM=
+github.com/livepeer/lpms v0.0.0-20220225123538-29300e5f7c12/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/lpms v0.0.0-20220322090848-7c772da19b33 h1:EQdk2TS3EdyIBv7gKuSNbOsWoJc/60Yk1grgZP1iDCE=
 github.com/livepeer/lpms v0.0.0-20220322090848-7c772da19b33/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=

--- a/net/lp_rpc.pb.go
+++ b/net/lp_rpc.pb.go
@@ -426,6 +426,8 @@ type Capabilities struct {
 	Bitstring []uint64 `protobuf:"varint,1,rep,packed,name=bitstring,proto3" json:"bitstring,omitempty"`
 	// Bit string of features that are required to be supported
 	Mandatories          []uint64 `protobuf:"varint,2,rep,packed,name=mandatories,proto3" json:"mandatories,omitempty"`
+	// Capacity corresponding to each capability
+	Capacities map[uint32]uint32 `protobuf:"bytes,3,rep,name=capacities,proto3" json:"capacities,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`

--- a/net/lp_rpc.pb.go
+++ b/net/lp_rpc.pb.go
@@ -425,12 +425,12 @@ type Capabilities struct {
 	// Bit string of supported features - one bit per feature
 	Bitstring []uint64 `protobuf:"varint,1,rep,packed,name=bitstring,proto3" json:"bitstring,omitempty"`
 	// Bit string of features that are required to be supported
-	Mandatories          []uint64 `protobuf:"varint,2,rep,packed,name=mandatories,proto3" json:"mandatories,omitempty"`
+	Mandatories []uint64 `protobuf:"varint,2,rep,packed,name=mandatories,proto3" json:"mandatories,omitempty"`
 	// Capacity corresponding to each capability
-	Capacities map[uint32]uint32 `protobuf:"bytes,3,rep,name=capacities,proto3" json:"capacities,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Capacities           map[uint32]uint32 `protobuf:"bytes,3,rep,name=capacities,proto3" json:"capacities,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
+	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
+	XXX_sizecache        int32             `json:"-"`
 }
 
 func (m *Capabilities) Reset()         { *m = Capabilities{} }

--- a/net/lp_rpc.proto
+++ b/net/lp_rpc.proto
@@ -92,6 +92,9 @@ message Capabilities {
     // Bit string of features that are required to be supported
     repeated uint64 mandatories = 2;
 
+    // Capacity corresponding to each capability
+    map<uint32, uint32> capacities = 3;
+
     // Non-binary capability constraints, such as supported ranges.
     message Constraints {
             // Empty for now


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Part of #2123 implementation, specifically #2231
It adds capacity map to the capabilities structure, which is currently used only for standalone T accounting on O. With this change, B will know if O has Ts with capabilities required for job upon next [refreshSessions()](https://github.com/livepeer/go-livepeer/blob/10705d2467decefce6f1bea030d005adcfebfc23/server/broadcast.go#L120) call.

**What it doesn't do**
It doesn't affect B-O discovery in any way. Theoretically, capability discovery should be decoupled with node discovery and, if standalone Ts would be common, should happen more frequently, maybe continuously.


**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- add capacity map to capabilities structure
- do not add any capabilities on start for standalone O
- add and remove capabilities when T connects and disconnects

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
New tests, existing tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->
#2231

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [X] README and other documentation updated
- [X] [Pending changelog](./CHANGELOG_PENDING.md) updated
