### PR TITLE
server: Begin accepting auth header and have it override callback URL values

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -14,6 +14,8 @@ import (
 	"github.com/livepeer/go-livepeer/monitor"
 )
 
+const LIVERPEER_TRANSCODE_CONFIG_HEADER = "Livepeer-Transcode-Configuration"
+
 // Call a webhook URL, passing the request URL we received
 // Based on the response, we can authenticate and confirm whether to accept an incoming stream
 func authenticateStream(authURL *url.URL, incomingRequestURL string) (*authWebhookResponse, error) {
@@ -59,7 +61,7 @@ func authenticateStream(authURL *url.URL, incomingRequestURL string) (*authWebho
 }
 
 func getTranscodeConfiguration(r *http.Request) (*authWebhookResponse, error) {
-	transcodeConfigurationHeader := r.Header.Get("Livepeer-Transcode-Configuration")
+	transcodeConfigurationHeader := r.Header.Get(LIVERPEER_TRANSCODE_CONFIG_HEADER)
 	if transcodeConfigurationHeader == "" {
 		return nil, nil
 	}
@@ -68,4 +70,28 @@ func getTranscodeConfiguration(r *http.Request) (*authWebhookResponse, error) {
 	err := json.Unmarshal([]byte(transcodeConfigurationHeader), &transcodeConfiguration)
 
 	return &transcodeConfiguration, err
+}
+
+// Compare two sets of profiles. Since there's no deep equality method in Go,
+// we marshal to JSON and compare the resulting strings
+func (a authWebhookResponse) areProfilesEqual(b authWebhookResponse) bool {
+	// Return quickly in simple cases without trying to marshal JSON
+	if len(a.Profiles) != len(b.Profiles) {
+		return false
+	}
+	if len(a.Profiles) == 0 {
+		return true
+	}
+
+	profilesA, err := json.Marshal(a.Profiles)
+	if err != nil {
+		return false
+	}
+
+	profilesB, err := json.Marshal(b.Profiles)
+	if err != nil {
+		return false
+	}
+
+	return string(profilesA) == string(profilesB)
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -57,3 +57,15 @@ func authenticateStream(authURL *url.URL, incomingRequestURL string) (*authWebho
 
 	return &authResp, nil
 }
+
+func getTranscodeConfiguration(r *http.Request) (*authWebhookResponse, error) {
+	transcodeConfigurationHeader := r.Header.Get("Livepeer-Transcode-Configuration")
+	if transcodeConfigurationHeader == "" {
+		return nil, nil
+	}
+
+	var transcodeConfiguration authWebhookResponse
+	err := json.Unmarshal([]byte(transcodeConfigurationHeader), &transcodeConfiguration)
+
+	return &transcodeConfiguration, err
+}

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -101,6 +101,151 @@ func TestTranscodeAuthHeaderParsing(t *testing.T) {
 	require.Equal(t, "id-456", config.SessionID)
 }
 
+func TestProfileEqualityWithNoProfiles(t *testing.T) {
+	a := authWebhookResponse{}
+	b := authWebhookResponse{}
+
+	require.True(t, a.areProfilesEqual(b))
+}
+
+func TestProfileEqualityFailsWhenProfilesDiffer(t *testing.T) {
+	a := authWebhookResponse{
+		Profiles: []authWebhookResponseProfiles{
+			{
+				Name:    "Name 1",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+		},
+	}
+	b := authWebhookResponse{
+		Profiles: []authWebhookResponseProfiles{
+			{
+				Name:    "Name DIFFERENT",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+		},
+	}
+
+	require.False(t, a.areProfilesEqual(b))
+}
+
+func TestProfileEqualityFailsWhenNumProfilesDiffer(t *testing.T) {
+	a := authWebhookResponse{
+		Profiles: []authWebhookResponseProfiles{
+			{
+				Name:    "Name 1",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+			{
+				Name:    "Name 2",
+				Profile: "Profile 2",
+				GOP:     "",
+				Bitrate: 20000,
+				Width:   1,
+				Height:  1,
+				FPS:     1000,
+				Encoder: "encoder-2",
+				FPSDen:  900,
+			},
+		},
+	}
+	b := authWebhookResponse{
+		Profiles: []authWebhookResponseProfiles{
+			{
+				Name:    "Name 1",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+		},
+	}
+
+	require.False(t, a.areProfilesEqual(b))
+}
+
+func TestProfileEqualityWithMultipleProfiles(t *testing.T) {
+	a := authWebhookResponse{
+		Profiles: []authWebhookResponseProfiles{
+			{
+				Name:    "Name 1",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+			{
+				Name:    "Name 2",
+				Profile: "Profile 2",
+				GOP:     "",
+				Bitrate: 20000,
+				Width:   1,
+				Height:  1,
+				FPS:     1000,
+				Encoder: "encoder-2",
+				FPSDen:  900,
+			},
+		},
+	}
+	b := authWebhookResponse{
+		Profiles: []authWebhookResponseProfiles{
+			{
+				Name:    "Name 1",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+			{
+				Name:    "Name 2",
+				Profile: "Profile 2",
+				GOP:     "",
+				Bitrate: 20000,
+				Width:   1,
+				Height:  1,
+				FPS:     1000,
+				Encoder: "encoder-2",
+				FPSDen:  900,
+			},
+		},
+	}
+
+	require.True(t, a.areProfilesEqual(b))
+}
+
 func stubAuthServer(t *testing.T, respCode int, respBody string) (*httptest.Server, *url.URL) {
 	server := httptest.NewServer(
 		http.HandlerFunc(

--- a/test_args.sh
+++ b/test_args.sh
@@ -285,7 +285,7 @@ $TMPDIR/livepeer -broadcaster -transcodingOptions $TMPDIR/invalid.json 2>&1 |   
 
 # Check that it fails out on an invalid schema - width / height as strings
 echo '[{"width":"1","height":"2"}]' > $TMPDIR/schema.json
-$TMPDIR/livepeer -broadcaster -transcodingOptions $TMPDIR/schema.json 2>&1 | grep "cannot unmarshal string into Go struct field .width of type int"
+$TMPDIR/livepeer -broadcaster -transcodingOptions $TMPDIR/schema.json 2>&1 | grep "cannot unmarshal string into Go struct field authWebhookResponseProfiles.width of type int"
 
 # Check that local verification is disabled by default in off-chain mode
 $TMPDIR/livepeer -broadcaster -transcodingOptions invalid 2>&1 | grep -v "Local verification enabled"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
- Begin accepting a new `Livepeer-Transcode-Configuration` header in the HTTP Push segment endpoint. 
- If present, this header should have the same format as the response from the "HTTP Auth Callback URL".
- If present and the Manifest ID from the path is **not** referring to an existing Manifest ID, then a call is still made to the callback URL as before (and fails if this call returns an error) but the fields it returns are overridden by the ones in the header
- If present and the Manifest ID in the URL already exists, this field is ignored

**Specific updates (required)**
- Create a new method for parsing the header and associated unit tests
- Add logic to override response from callback URL in the case outlined above. Unit test for this override behavior.

**How did you test each of these updates (required)**
✅ Wrote new unit tests
❌ TODO: Manual testing


**Does this pull request close any open issues?**
- https://github.com/livepeer/go-livepeer/issues/2332

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
