### PR TITLE
Fix dynamic discovery timeout to not retry sending requests, but wait for the same request to complete

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,11 +8,11 @@
 
 #### General
 - \#2289 Add timeouts to ETH client (@leszko)
-
 - \#2282 Add checksums and gpg signature support with binary releases. (@hjpotter92)
 
 #### Broadcaster
 - \#2309 Add dynamic timeout for the orchestrator discovery (@leszko)
+- \#2337 Fix dynamic discovery timeout to not retry sending requests, but wait for the same request to complete (@leszko)
 
 #### Orchestrator
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The last change with the dynamic timeout caused an issue in teststreams described in [Discord](https://discord.com/channels/423160867534929930/932724294230900776/956293748340428821).

The [dynamic timeout PR](https://github.com/livepeer/go-livepeer/pull/2309) changed the discovery between B<>O to work as follows:
1. B tries to discover O in 500 ms
2. If no Os found, then increase the timeout to 1s and send the requests again
3. In no Os found, then increase the timeout to 2s and send the requests again

The problem is that if O responds in, let's say, `1.5s`. Then, now the discovery will now take: 0.5s + 1s + 1.5s = 3s
So even though the response is in 1.5s, the overall time from the black-box perspective is 3s. That pollutes the orch teststream data.

This PR changes the dynamic timeout to not send new request, but to wait for the initial requests to complete (as [proposed initially](https://github.com/livepeer/go-livepeer/pull/2309#pullrequestreview-909438232) by @yondonfu)

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested with local geth. Introduced artificial delay in O and checked the logs in B.


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~README and other documentation updated~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
