### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,7 @@
 #### General
 - \#2289 Add timeouts to ETH client (@leszko)
 - \#2282 Add checksums and gpg signature support with binary releases. (@hjpotter92)
+- \#2344 Use T.TempDir to create temporary test directory (@Juneezee)
 
 #### Broadcaster
 - \#2309 Add dynamic timeout for the orchestrator discovery (@leszko)

--- a/core/capabilities_test.go
+++ b/core/capabilities_test.go
@@ -2,8 +2,6 @@ package core
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -130,18 +128,17 @@ func TestCapability_CompatibleBitstring(t *testing.T) {
 }
 
 // We need this in order to call `NvidiaTranscoder::Transcode()` properly
-func setupWorkDir() (string, func()) {
-	tmp, _ := ioutil.TempDir("", "")
+func setupWorkDir(t *testing.T) (string, func()) {
+	tmp := t.TempDir()
 	WorkDir = tmp
 	cleanup := func() {
 		WorkDir = ""
-		defer os.RemoveAll(tmp)
 	}
 	return tmp, cleanup
 }
 
 func TestCapability_TranscoderCapabilities(t *testing.T) {
-	tmpdir, cleanup := setupWorkDir()
+	tmpdir, cleanup := setupWorkDir(t)
 	defer cleanup()
 
 	// nvidia test

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -48,8 +47,7 @@ func TestTranscode(t *testing.T) {
 	//Set up the node
 	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	seth := &eth.StubClient{}
-	tmp, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	n, _ := NewLivepeerNode(seth, tmp, nil)
 	ffmpeg.InitFFmpeg()
 
@@ -90,8 +88,7 @@ func TestTranscode(t *testing.T) {
 }
 
 func TestTranscodeSeg(t *testing.T) {
-	tmp, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	profiles := []ffmpeg.VideoProfile{ffmpeg.P720p60fps16x9, ffmpeg.P144p30fps16x9}
 	n, _ := NewLivepeerNode(nil, tmp, nil)
@@ -133,8 +130,7 @@ func TestTranscodeLoop_GivenNoSegmentsPastTimeout_CleansSegmentChan(t *testing.T
 	//Set up the node
 	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 	seth := &eth.StubClient{}
-	tmp, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	n, _ := NewLivepeerNode(seth, tmp, nil)
 	ffmpeg.InitFFmpeg()
 	ss := StubSegment()

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -3,10 +3,8 @@ package core
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net/url"
-	"os"
 	"testing"
 
 	"github.com/golang/glog"
@@ -68,12 +66,10 @@ func TestTranscodeAndBroadcast(t *testing.T) {
 	storage := drivers.NewMemoryDriver(nil).NewSession("")
 	config := transcodeConfig{LocalOS: storage, OS: storage}
 
-	tmpdir, _ := ioutil.TempDir("", "")
-	n, err := NewLivepeerNode(nil, tmpdir, nil)
+	n, err := NewLivepeerNode(nil, t.TempDir(), nil)
 	if err != nil {
 		t.Errorf("Error: %v", err)
 	}
-	defer os.RemoveAll(tmpdir)
 	n.Transcoder = tr
 
 	md := &SegTranscodingMetadata{Profiles: p, AuthToken: stubAuthToken()}

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -6,13 +6,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/golang/glog"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/golang/glog"
 
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/common"

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -19,8 +19,7 @@ func stubMetadata(sess string, profile ...ffmpeg.VideoProfile) *SegTranscodingMe
 }
 
 func TestLocalTranscoder(t *testing.T) {
-	tmp, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	tc := NewLocalTranscoder(tmp)
 	ffmpeg.InitFFmpeg()
 
@@ -47,9 +46,7 @@ func TestNvidia_Transcoder(t *testing.T) {
 		return
 	}
 
-	tmp, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(tmp)
-	WorkDir = tmp
+	WorkDir = t.TempDir()
 	defer func() { WorkDir = "" }()
 	// test.ts sample isn't in a supported pixel format, so use this instead
 	fname := "test2.ts"
@@ -102,9 +99,7 @@ func TestResToTranscodeData(t *testing.T) {
 
 	// Test error after a successful read
 	res = &ffmpeg.TranscodeResults{Encoded: make([]ffmpeg.MediaInfo, 3)}
-	tempDir, err := ioutil.TempDir("", "TestResToTranscodeData")
-	require.Nil(err)
-	defer os.Remove(tempDir)
+	tempDir := t.TempDir()
 
 	file1, err := ioutil.TempFile(tempDir, "foo")
 	require.Nil(err)
@@ -228,8 +223,7 @@ func TestProfilesToTranscodeOptions(t *testing.T) {
 
 func TestAudioCopy(t *testing.T) {
 	assert := assert.New(t)
-	dir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	tc := NewLocalTranscoder(dir)
 	ffmpeg.InitFFmpeg()
 
@@ -255,8 +249,7 @@ func TestAudioCopy(t *testing.T) {
 func TestTranscoder_Formats(t *testing.T) {
 	// Helps ensure the necessary ffmpeg configure options are enabled
 	assert := assert.New(t)
-	dir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	in := &ffmpeg.TranscodeOptionsIn{Fname: "test.ts"}
 	for k, v := range ffmpeg.ExtensionFormats {

--- a/eth/accountmanager_test.go
+++ b/eth/accountmanager_test.go
@@ -2,9 +2,7 @@ package eth
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -83,7 +81,6 @@ var jsonTypedData = `
 
 func TestAccountManager(t *testing.T) {
 	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
 
 	a, err := ks.NewAccount("foo")
 	if err != nil {
@@ -114,7 +111,6 @@ func TestAccountManager(t *testing.T) {
 
 func TestEmptyPassphrase(t *testing.T) {
 	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
 
 	a, err := ks.NewAccount("")
 	if err != nil {
@@ -145,7 +141,6 @@ func TestSign(t *testing.T) {
 	assert := assert.New(t)
 
 	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
 
 	a, err := ks.NewAccount("")
 	require.Nil(err)
@@ -170,7 +165,6 @@ func TestSignTypedData(t *testing.T) {
 	assert := assert.New(t)
 
 	dir, ks := tmpKeyStore(t, true)
-	defer os.RemoveAll(dir)
 
 	a, err := ks.NewAccount("")
 	require.Nil(err)
@@ -192,10 +186,7 @@ func TestSignTypedData(t *testing.T) {
 }
 
 func tmpKeyStore(t *testing.T, encrypted bool) (string, *keystore.KeyStore) {
-	d, err := ioutil.TempDir("", "eth-keystore-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	d := t.TempDir()
 
 	new := keystore.NewPlaintextKeyStore
 	if encrypted {

--- a/server/cert_test.go
+++ b/server/cert_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"testing"
@@ -41,12 +40,7 @@ func sha1sums(t *testing.T, cert, key string) ([]byte, []byte, error) {
 
 func TestRPCCert(t *testing.T) {
 	url, _ := url.Parse("https://livepeer.org")
-	wd, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Error("Could not get tempdir ", err)
-		return
-	}
-	defer os.RemoveAll(wd)
+	wd := t.TempDir()
 	cf, kf, err := getCert(url, wd)
 	if err != nil {
 		t.Error("Could not get cert/key ", err)

--- a/server/redeemer_test.go
+++ b/server/redeemer_test.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -61,9 +59,7 @@ func TestRedeemerServer_Start(t *testing.T) {
 	url, err := url.ParseRequestURI("https://127.0.0.1:8935")
 	require.Nil(err)
 
-	tmpdir, err := ioutil.TempDir("", "")
-	require.Nil(err)
-	defer os.Remove(tmpdir)
+	tmpdir := t.TempDir()
 
 	errCh := make(chan error)
 	go func() {

--- a/verification/epic_test.go
+++ b/verification/epic_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -104,14 +103,12 @@ func TestEpic_EpicResultsToVerificationResults(t *testing.T) {
 func TestEpic_WriteSegments(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", t.Name())
-	assert.Nil(err)
-	defer os.RemoveAll(dir) // clean up
+	dir := t.TempDir()
 	baseDir := filepath.Base(dir)
 	bucketPath := "https://livepeer.s3.amazonaws.com"
 
 	// empty case
-	_, _, err = writeSegments(&Params{}, dir)
+	_, _, err := writeSegments(&Params{}, dir)
 	assert.Equal(ErrMissingSource, err)
 
 	// successful cases


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

A testing cleanup. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Replaces `ioutil.TempDir` with `t.TempDir` 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Testing environment: Linux 5.16.16, amd64, Go 1.18

- Run the changed test cases on Goland
- `./test.sh`

**Does this pull request close any open issues?**
<!-- Fixes # -->
N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
