### PR TITLE
livepeer_cli: Improve user feedback when specifying numeric values for some wizard options

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,7 +21,7 @@
 ### Bug Fixes 🐞
 
 #### CLI
-- \#1602 Improve user feedback when specifying numeric values for some wizard options (@kparkins)
+- \#2345 Improve user feedback when specifying numeric values for some wizard options (@kparkins)
 
 #### General
 - \#2299 Split devtool Orchestrator run scripts into versions with/without external transcoder and prevent Transcoder/Broadcaster run scripts from using same CLI port (@thomshutt)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,9 @@
 
 ### Bug Fixes 🐞
 
+#### CLI
+- \#1602 Improve user feedback when specifying numeric values for some wizard options (@kparkins)
+
 #### General
 - \#2299 Split devtool Orchestrator run scripts into versions with/without external transcoder and prevent Transcoder/Broadcaster run scripts from using same CLI port (@thomshutt)
 

--- a/cmd/livepeer_cli/wizard.go
+++ b/cmd/livepeer_cli/wizard.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/livepeer/go-livepeer/build"
 	"io/ioutil"
 	"math/big"
 	"net/http"
@@ -13,6 +12,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/livepeer/go-livepeer/build"
 
 	"github.com/ethereum/go-ethereum/log"
 	lpcommon "github.com/livepeer/go-livepeer/common"
@@ -161,15 +162,15 @@ func (w *wizard) readDefaultInt(def int) int {
 	return def
 }
 
-func (w *wizard) readBigInt() *big.Int {
+func (w *wizard) readBigInt(prompt string) *big.Int {
+	if prompt == "" {
+		prompt = ">"
+	}
 	for {
-		fmt.Printf("> ")
+		fmt.Printf(prompt)
 		text, err := w.in.ReadString('\n')
 		if err != nil {
 			log.Crit("Failed to read user input", "err", err)
-		}
-		if text = strings.TrimSpace(text); text == "" {
-			continue
 		}
 		val, err := lpcommon.ParseBigInt(strings.TrimSpace(text))
 		if err != nil {

--- a/cmd/livepeer_cli/wizard.go
+++ b/cmd/livepeer_cli/wizard.go
@@ -164,7 +164,7 @@ func (w *wizard) readDefaultInt(def int) int {
 
 func (w *wizard) readBigInt(prompt string) *big.Int {
 	for {
-		fmt.Printf(prompt)
+		fmt.Printf(fmt.Sprintf("%s - > ", prompt))
 		text, err := w.in.ReadString('\n')
 		if err != nil {
 			log.Crit("Failed to read user input", "err", err)

--- a/cmd/livepeer_cli/wizard.go
+++ b/cmd/livepeer_cli/wizard.go
@@ -163,9 +163,6 @@ func (w *wizard) readDefaultInt(def int) int {
 }
 
 func (w *wizard) readBigInt(prompt string) *big.Int {
-	if prompt == "" {
-		prompt = ">"
-	}
 	for {
 		fmt.Printf(prompt)
 		text, err := w.in.ReadString('\n')

--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -165,7 +165,7 @@ func (w *wizard) bond() {
 
 	amount := big.NewInt(0)
 	for amount.Cmp(big.NewInt(0)) == 0 || balBigInt.Cmp(amount) < 0 {
-		amount = w.readBigInt("Enter bond amount - > ")
+		amount = w.readBigInt("Enter bond amount")
 		if amount.Cmp(big.NewInt(0)) == 0 {
 			break
 		}
@@ -276,7 +276,7 @@ func (w *wizard) unbond() {
 	}
 
 	for amount.Cmp(big.NewInt(0)) == 0 || dInfo.BondedAmount.Cmp(amount) < 0 {
-		amount = w.readBigInt("Enter unbond amount - > ")
+		amount = w.readBigInt("Enter unbond amount")
 		if dInfo.BondedAmount.Cmp(amount) < 0 {
 			fmt.Printf("Must enter an amount less than or equal to the current bonded amount.")
 		}

--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -165,8 +165,7 @@ func (w *wizard) bond() {
 
 	amount := big.NewInt(0)
 	for amount.Cmp(big.NewInt(0)) == 0 || balBigInt.Cmp(amount) < 0 {
-		fmt.Printf("Enter bond amount - ")
-		amount = w.readBigInt()
+		amount = w.readBigInt("Enter bond amount - > ")
 		if amount.Cmp(big.NewInt(0)) == 0 {
 			break
 		}
@@ -277,8 +276,7 @@ func (w *wizard) unbond() {
 	}
 
 	for amount.Cmp(big.NewInt(0)) == 0 || dInfo.BondedAmount.Cmp(amount) < 0 {
-		fmt.Printf("Enter unbond amount - ")
-		amount = w.readBigInt()
+		amount = w.readBigInt("Enter unbond amount - > ")
 		if dInfo.BondedAmount.Cmp(amount) < 0 {
 			fmt.Printf("Must enter an amount less than or equal to the current bonded amount.")
 		}

--- a/cmd/livepeer_cli/wizard_eth.go
+++ b/cmd/livepeer_cli/wizard_eth.go
@@ -7,8 +7,7 @@ import (
 
 func (w *wizard) setMaxGasPrice() {
 	fmt.Printf("Current maximum gas price: %v\n", w.maxGasPrice())
-	fmt.Printf("Enter new maximum gas price in Wei (enter \"0\" for no maximum gas price)")
-	amount := w.readBigInt()
+	amount := w.readBigInt("Enter new maximum gas price in Wei (enter \"0\" for no maximum gas price) > ")
 
 	val := url.Values{
 		"amount": {fmt.Sprintf("%v", amount.String())},
@@ -19,8 +18,7 @@ func (w *wizard) setMaxGasPrice() {
 
 func (w *wizard) setMinGasPrice() {
 	fmt.Printf("Current minimum gas price: %v\n", w.minGasPrice())
-	fmt.Printf("Enter new minimum gas price in Wei")
-	minGasPrice := w.readBigInt()
+	minGasPrice := w.readBigInt("Enter new minimum gas price in Wei > ")
 
 	val := url.Values{
 		"minGasPrice": {fmt.Sprintf("%v", minGasPrice.String())},

--- a/cmd/livepeer_cli/wizard_eth.go
+++ b/cmd/livepeer_cli/wizard_eth.go
@@ -7,7 +7,7 @@ import (
 
 func (w *wizard) setMaxGasPrice() {
 	fmt.Printf("Current maximum gas price: %v\n", w.maxGasPrice())
-	amount := w.readBigInt("Enter new maximum gas price in Wei (enter \"0\" for no maximum gas price) > ")
+	amount := w.readBigInt("Enter new maximum gas price in Wei (enter \"0\" for no maximum gas price)")
 
 	val := url.Values{
 		"amount": {fmt.Sprintf("%v", amount.String())},
@@ -18,7 +18,7 @@ func (w *wizard) setMaxGasPrice() {
 
 func (w *wizard) setMinGasPrice() {
 	fmt.Printf("Current minimum gas price: %v\n", w.minGasPrice())
-	minGasPrice := w.readBigInt("Enter new minimum gas price in Wei > ")
+	minGasPrice := w.readBigInt("Enter new minimum gas price in Wei")
 
 	val := url.Values{
 		"minGasPrice": {fmt.Sprintf("%v", minGasPrice.String())},

--- a/cmd/livepeer_cli/wizard_token.go
+++ b/cmd/livepeer_cli/wizard_token.go
@@ -12,8 +12,7 @@ func (w *wizard) transferTokens() {
 	fmt.Printf("Enter receipient address (in hex i.e. 0xfoo) - ")
 	to := w.readString()
 
-	fmt.Printf("Enter amount - ")
-	amount := w.readBigInt()
+	amount := w.readBigInt("Enter amount - > ")
 
 	val := url.Values{
 		"to":     {fmt.Sprintf("%v", to)},

--- a/cmd/livepeer_cli/wizard_token.go
+++ b/cmd/livepeer_cli/wizard_token.go
@@ -12,7 +12,7 @@ func (w *wizard) transferTokens() {
 	fmt.Printf("Enter receipient address (in hex i.e. 0xfoo) - ")
 	to := w.readString()
 
-	amount := w.readBigInt("Enter amount - > ")
+	amount := w.readBigInt("Enter amount")
 
 	val := url.Values{
 		"to":     {fmt.Sprintf("%v", to)},

--- a/cmd/livepeer_cli/wizard_transcoder.go
+++ b/cmd/livepeer_cli/wizard_transcoder.go
@@ -143,7 +143,7 @@ func (w *wizard) activateOrchestrator() {
 
 			amount := big.NewInt(0)
 			for amount.Cmp(big.NewInt(0)) == 0 || balBigInt.Cmp(amount) < 0 {
-				amount = w.readBigInt("Enter bond amount - > ")
+				amount = w.readBigInt("Enter bond amount")
 				if balBigInt.Cmp(amount) < 0 {
 					fmt.Printf("Must enter an amount smaller than the current balance. ")
 				}

--- a/cmd/livepeer_cli/wizard_transcoder.go
+++ b/cmd/livepeer_cli/wizard_transcoder.go
@@ -143,8 +143,7 @@ func (w *wizard) activateOrchestrator() {
 
 			amount := big.NewInt(0)
 			for amount.Cmp(big.NewInt(0)) == 0 || balBigInt.Cmp(amount) < 0 {
-				fmt.Printf("Enter bond amount - ")
-				amount = w.readBigInt()
+				amount = w.readBigInt("Enter bond amount - > ")
 				if balBigInt.Cmp(amount) < 0 {
 					fmt.Printf("Must enter an amount smaller than the current balance. ")
 				}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR addresses issues outlined in Issue #1602 relating to poor user experience in the livepeer_cli when specifying numeric values for some wizard options (gas price, bonding, unbonding, and transfer amount). In particular, it attempts to provide better feedback to the user when invalid values are supplied.

**Specific updates (required)**
- Add prompt parameter to _readBigInt_ in wizard.go and change to log an error when parsing an int fails.
- Update calls to _readBigInt_ to pass a relevant prompt. 

**How did you test each of these updates (required)**
- Ran all unit tests (PASSED)
- Tested the CLI manually for each of the affected options.

**Does this pull request close any open issues?**
- Fixes #1602 
- Closing 1602 may mean a new issue should be created to follow-up on other wizard options that were not addressed.

**Checklist:**
- [X] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [X] [Pending changelog](./CHANGELOG_PENDING.md) updated
