### PR TITLE
server: Fix "Too many connections" bug

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -863,13 +863,15 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 						}
 					}
 				}
-				select {
-				case <-ticker.C:
-					if runCheck() {
+				for {
+					select {
+					case <-ticker.C:
+						if runCheck() {
+							return
+						}
+					case <-s.context.Done():
 						return
 					}
-				case <-s.context.Done():
-					return
 				}
 			}(s, cxn.mid, mid)
 		}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

There is a problem with the session cleanup if there is any orchestrator that is transcoding for more than `1 min`.

This is what I believe happens.

1. Session cleanup happens in the `runCheck()` function [1] 
2. We call this session cleanup after `ticker.C`, so `1 min`  after the session started [2]
3. We never call `runCheck()` again (but we should! And we did before the "Add pixel-format in capability logic" PR)

This actually explains the flakiness, because I believe test streams mostly finish the session within 1 min. And I think that the only reason we don't see this issue in the prod broadcasters is that we didn't deploy `master` to prod for a long time.

[1] https://github.com/livepeer/go-livepeer/blob/master/server/mediaserver.go#L840
[2] https://github.com/livepeer/go-livepeer/blob/master/server/mediaserver.go#L867

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~~README and other documentation updated~~
- [ ] ~~[Pending changelog](./CHANGELOG_PENDING.md) updated~~
