### PR TITLE
core: Fix standalone orchestrator not crashing under UnrecoverableError

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -34,5 +34,6 @@
 
 #### Orchestrator
 - \#2284 Fix issue with not redeeming tickets by Redeemer (@leszko)
+- \#2352 Fix standalone orchestrator not crashing under UnrecoverableError (@leszko)
 
 #### Transcoder

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -552,6 +552,9 @@ func (n *LivepeerNode) transcodeSeg(ctx context.Context, config transcodeConfig,
 	start := time.Now()
 	tData, err := transcoder.Transcode(ctx, md)
 	if err != nil {
+		if _, ok := err.(UnrecoverableError); ok {
+			panic(err)
+		}
 		clog.Errorf(ctx, "Error transcoding segName=%s err=%q", seg.Name, err)
 		return terr(err)
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Fix the issue that O does not fail after the unrecoverable error from lpms (ffmpeg).

The issue is described in this [Discord thread](https://discord.com/channels/423160867534929930/960520369465327647/960520767710306304). In short, when GPU crashes, NVIDIA recommends restarting the whole process, since it's not possible to recover. It worked that way until the [Gracefully notify orchestrator in case of a panic in transcoder PR](https://github.com/livepeer/go-livepeer/pull/2094). In the mentioned PR, the following logic was implemented:
1. Recover from LPMS (ffmpeg) panic
2. Send a message T->O
3. Panic

The logic is fine for the split O/T topology, however for the combined OT, there is a separate code which also needs to implement Point 3. Panic.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Artificially introduce `panic()` and check that a standalone O crashes.


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~~README and other documentation updated~~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
