### PR TITLE
server: Begin accepting auth header and have it override callback URL values

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -36,6 +36,7 @@
 - \#2296 Increase orchestrator discovery timeout from `500ms` to `1` (@leszko)
 - \#2291 Calling video comparison to improve the security strength (@oscar-davids)
 - \#2326 Split Auth/Webhook functionality into its own file (@thomshutt)
+- \#2357 Begin accepting auth header (from Mist) and have it override callback URL values
 
 #### Orchestrator
 - \#2284 Fix issue with not redeeming tickets by Redeemer (@leszko)

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,6 +66,185 @@ func TestAuthSucceeds(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "123", resp.ManifestID)
 	require.Equal(t, "456", resp.StreamID)
+}
+
+func TestNoErrorWhenTranscodeAuthHeaderNotPassed(t *testing.T) {
+	r, err := http.NewRequest(http.MethodPost, "some.com/url", nil)
+	require.NoError(t, err)
+
+	config, err := getTranscodeConfiguration(r)
+
+	require.NoError(t, err)
+	require.Nil(t, config)
+}
+
+func TestErrorWhenTranscodeAuthHeaderIsInvalidJSON(t *testing.T) {
+	r, err := http.NewRequest(http.MethodPost, "some.com/url", nil)
+	require.NoError(t, err)
+	r.Header.Add("Livepeer-Transcode-Configuration", `{"end brace": "is missing"`)
+
+	_, err = getTranscodeConfiguration(r)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected end of JSON input")
+}
+
+func TestTranscodeAuthHeaderParsing(t *testing.T) {
+	r, err := http.NewRequest(http.MethodPost, "some.com/url", nil)
+	require.NoError(t, err)
+	r.Header.Add("Livepeer-Transcode-Configuration", `{"manifestID": "id-123", "sessionID": "id-456"}`)
+
+	config, err := getTranscodeConfiguration(r)
+
+	require.NoError(t, err)
+	require.NotNil(t, config)
+	require.Equal(t, "id-123", config.ManifestID)
+	require.Equal(t, "id-456", config.SessionID)
+}
+
+func TestProfileEqualityWithNoProfiles(t *testing.T) {
+	a := authWebhookResponse{}
+	b := authWebhookResponse{}
+
+	require.True(t, a.areProfilesEqual(b))
+}
+
+func TestProfileEqualityFailsWhenProfilesDiffer(t *testing.T) {
+	a := authWebhookResponse{
+		Profiles: []ffmpeg.JsonProfile{
+			{
+				Name:    "Name 1",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+		},
+	}
+	b := authWebhookResponse{
+		Profiles: []ffmpeg.JsonProfile{
+			{
+				Name:    "Name DIFFERENT",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+		},
+	}
+
+	require.False(t, a.areProfilesEqual(b))
+}
+
+func TestProfileEqualityFailsWhenNumProfilesDiffer(t *testing.T) {
+	a := authWebhookResponse{
+		Profiles: []ffmpeg.JsonProfile{
+			{
+				Name:    "Name 1",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+			{
+				Name:    "Name 2",
+				Profile: "Profile 2",
+				GOP:     "",
+				Bitrate: 20000,
+				Width:   1,
+				Height:  1,
+				FPS:     1000,
+				Encoder: "encoder-2",
+				FPSDen:  900,
+			},
+		},
+	}
+	b := authWebhookResponse{
+		Profiles: []ffmpeg.JsonProfile{
+			{
+				Name:    "Name 1",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+		},
+	}
+
+	require.False(t, a.areProfilesEqual(b))
+}
+
+func TestProfileEqualityWithMultipleProfiles(t *testing.T) {
+	a := authWebhookResponse{
+		Profiles: []ffmpeg.JsonProfile{
+			{
+				Name:    "Name 1",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+			{
+				Name:    "Name 2",
+				Profile: "Profile 2",
+				GOP:     "",
+				Bitrate: 20000,
+				Width:   1,
+				Height:  1,
+				FPS:     1000,
+				Encoder: "encoder-2",
+				FPSDen:  900,
+			},
+		},
+	}
+	b := authWebhookResponse{
+		Profiles: []ffmpeg.JsonProfile{
+			{
+				Name:    "Name 1",
+				Profile: "Profile 1",
+				GOP:     "intra",
+				Bitrate: 10000,
+				Width:   1024,
+				Height:  768,
+				FPS:     1,
+				Encoder: "encoder-1",
+				FPSDen:  1,
+			},
+			{
+				Name:    "Name 2",
+				Profile: "Profile 2",
+				GOP:     "",
+				Bitrate: 20000,
+				Width:   1,
+				Height:  1,
+				FPS:     1000,
+				Encoder: "encoder-2",
+				FPSDen:  900,
+			},
+		},
+	}
+
+	require.True(t, a.areProfilesEqual(b))
 }
 
 func stubAuthServer(t *testing.T, respCode int, respBody string) (*httptest.Server, *url.URL) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
- Begin accepting a new `Livepeer-Transcode-Configuration` header in the HTTP Push segment endpoint. 
- If present, this header should have the same format as the response from the "HTTP Auth Callback URL".
- If present and the Manifest ID from the path is **not** referring to an existing Manifest ID, then a call is still made to the callback URL as before (and fails if this call returns an error) but the fields it returns are overridden by the ones in the header
- If present and the Manifest ID in the URL already exists, this field is ignored

**Specific updates (required)**
- Create a new method for parsing the header and associated unit tests
- Add logic to override response from callback URL in the case outlined above. Unit test for this override behavior.

**How did you test each of these updates (required)**
✅ Wrote new unit tests
✅ TODO: Manual testing


**Does this pull request close any open issues?**
- https://github.com/livepeer/go-livepeer/issues/2332

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
