### PR TITLE
pm: Fix redeeming tickets with zero block hash

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -39,5 +39,6 @@
 #### Orchestrator
 - \#2284 Fix issue with not redeeming tickets by Redeemer (@leszko)
 - \#2352 Fix standalone orchestrator not crashing under UnrecoverableError (@leszko)
+- \#2359 Fix redeeming tickets with zero block hash (@leszko)
 
 #### Transcoder

--- a/pm/queue.go
+++ b/pm/queue.go
@@ -164,8 +164,11 @@ func (q *ticketQueue) handleBlockEvent(latestL1Block *big.Int) {
 }
 
 func isNonRetryableTicketErr(err error) bool {
-	// The latter check depends on logic in eth.client.CheckTx()
-	return err == errIsUsedTicket || strings.Contains(err.Error(), "transaction failed")
+	return err == errIsUsedTicket ||
+		// Depends on logic in eth.client.CheckTx()
+		strings.Contains(err.Error(), "transaction failed") ||
+		// Arbitrum L2 happens to return zero as the L1 block hash which results in this non-retryable error
+		strings.Contains(err.Error(), "ticket creationRound does not have a block hash")
 }
 
 func (q *ticketQueue) isRecipientActive(addr ethcommon.Address) bool {

--- a/pm/queue_test.go
+++ b/pm/queue_test.go
@@ -179,6 +179,16 @@ func TestTicketQueueLoop_IsNonRetryableTicketErr_MarkAsRedeemed(t *testing.T) {
 	consumeQueue(qc)
 	assert.True(ts.submitted[fmt.Sprintf("%x", ticket.Sig)])
 
+	// Test that ticket is marked as redeemed if it has zero as block hash
+	ticket = defaultSignedTicket(sender, 1)
+	addTicket(ticket)
+
+	qc = &queueConsumer{
+		redemptionErr: errors.New("ticket creationRound does not have a block hash"),
+	}
+	consumeQueue(qc)
+	assert.True(ts.submitted[fmt.Sprintf("%x", ticket.Sig)])
+
 	// Test that ticket is not marked as redeemed if there is an error checking the tx, but the tx did not fail
 	ticket = defaultSignedTicket(sender, 2)
 	addTicket(ticket)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Skip redeeming tickets with zero block hash.

For the context, Arbitrum sometimes returns zero as the L1 block hash, which results in the tickets that cannot be redeemed. We need to treat such tickets as non-retryable and therefore skip them.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit test

**Does this pull request close any open issues?**
<!-- Fixes # -->

fix #2358 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~~README and other documentation updated~~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
