### PR TITLE
Handle case when `BUILD_TAGS` contain multiple values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ endif
 
 .PHONY: livepeer
 livepeer:
-	GO111MODULE=on CGO_ENABLED=1 CGO_CFLAGS="$(cgo_cflags)" CGO_LDFLAGS="$(cgo_ldflags)" go build -o $(GO_BUILD_DIR) -tags $(BUILD_TAGS) -ldflags="$(ldflags)" cmd/livepeer/*.go
+	GO111MODULE=on CGO_ENABLED=1 CGO_CFLAGS="$(cgo_cflags)" CGO_LDFLAGS="$(cgo_ldflags)" go build -o $(GO_BUILD_DIR) -tags "$(BUILD_TAGS)" -ldflags="$(ldflags)" cmd/livepeer/*.go
 
 .PHONY: livepeer_cli
 livepeer_cli:
-	GO111MODULE=on CGO_ENABLED=1 CGO_CFLAGS="$(cgo_cflags)" CGO_LDFLAGS="$(cgo_ldflags)" go build -o $(GO_BUILD_DIR) -tags $(BUILD_TAGS) -ldflags="$(ldflags)" cmd/livepeer_cli/*.go
+	GO111MODULE=on CGO_ENABLED=1 CGO_CFLAGS="$(cgo_cflags)" CGO_LDFLAGS="$(cgo_ldflags)" go build -o $(GO_BUILD_DIR) -tags "$(BUILD_TAGS)" -ldflags="$(ldflags)" cmd/livepeer_cli/*.go
 
 .PHONY: livepeer_bench
 livepeer_bench:
@@ -52,5 +52,5 @@ localdocker:
 	# docker build -t livepeerbinary:debian -f Dockerfile.debian .
 	# Manually build our context... this is hacky but docker refuses to support symlinks
 	# or selectable .dockerignore files
-	tar ch --exclude=.git . | docker build --build-arg BUILD_TAGS=$(BUILD_TAGS) -t livepeerbinary:debian -f docker/Dockerfile.debian -
+	tar ch --exclude=.git . | docker build --build-arg BUILD_TAGS="$(BUILD_TAGS)" -t livepeerbinary:debian -f docker/Dockerfile.debian -
 	rm .git.describe


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

When developing we have `BUILD_TAGS=debug-video experimental`. This PR fixes Makefile to expand `BUILD_TAGS` as single value.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
