### PR TITLE
eth, pm: Use previous round L1 block for ticket expiration if the current block hash is zero

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,7 @@
 - \#2337 Fix dynamic discovery timeout to not retry sending requests, but wait for the same request to complete (@leszko)
 
 #### Orchestrator
+- \#2362 Backdate tickets by one round if the block hash for the current round is 0 (@leszko)
 
 #### Transcoder
 

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -241,6 +241,7 @@ type StubClient struct {
 	TranscoderAddress            common.Address
 	BlockNum                     *big.Int
 	BlockHashToReturn            common.Hash
+	BlockHashForRoundMap         map[int64]common.Hash
 	ProcessHistoricalUnbondError error
 	Orchestrators                []*lpTypes.Transcoder
 	Round                        *big.Int
@@ -276,6 +277,11 @@ func (e *StubClient) LastInitializedRound() (*big.Int, error) {
 	return e.Round, e.Errors["LastInitializedRound"]
 }
 func (e *StubClient) BlockHashForRound(round *big.Int) ([32]byte, error) {
+	if e.BlockHashForRoundMap != nil {
+		if hash, ok := e.BlockHashForRoundMap[round.Int64()]; ok {
+			return hash, nil
+		}
+	}
 	return e.BlockHashToReturn, e.Errors["BlockHashForRound"]
 }
 func (e *StubClient) CurrentRoundInitialized() (bool, error) { return false, nil }

--- a/eth/watchers/timewatcher.go
+++ b/eth/watchers/timewatcher.go
@@ -26,12 +26,13 @@ import (
 //	* Last Seen Block Number
 type TimeWatcher struct {
 	// state
-	mu                         sync.RWMutex
-	lastInitializedRound       *big.Int
-	lastInitializedL1BlockHash [32]byte
-	currentRoundStartL1Block   *big.Int
-	transcoderPoolSize         *big.Int
-	lastSeenL1Block            *big.Int
+	mu                            sync.RWMutex
+	lastInitializedRound          *big.Int
+	lastInitializedL1BlockHash    [32]byte
+	preLastInitializedL1BlockHash [32]byte
+	currentRoundStartL1Block      *big.Int
+	transcoderPoolSize            *big.Int
+	lastSeenL1Block               *big.Int
 
 	// last initialized round number subscription feeds
 	roundSubFeed  event.Feed
@@ -70,11 +71,15 @@ func NewTimeWatcher(roundsManagerAddr ethcommon.Address, watcher BlockWatcher, l
 	if err != nil {
 		return nil, fmt.Errorf("error fetching initial lastInitializedL1BlockHash value err=%q", err)
 	}
+	pbh, err := tw.lpEth.BlockHashForRound(prevRound(lr))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching initial prelastInitializedL1BlockHash value err=%q", err)
+	}
 	num, err := tw.lpEth.CurrentRoundStartBlock()
 	if err != nil {
 		return nil, fmt.Errorf("error fetching current round start block err=%q", err)
 	}
-	tw.setLastInitializedRound(lr, bh, num)
+	tw.setLastInitializedRound(lr, bh, pbh, num)
 
 	lastSeenBlock, err := tw.watcher.GetLatestBlock()
 	if err != nil {
@@ -102,11 +107,18 @@ func (tw *TimeWatcher) LastInitializedRound() *big.Int {
 	return tw.lastInitializedRound
 }
 
-// LastInitializedBlockHash returns the blockhash of the block the last round was initiated in
+// LastInitializedL1BlockHash returns the blockhash of the L1 block the last round was initiated in
 func (tw *TimeWatcher) LastInitializedL1BlockHash() [32]byte {
 	tw.mu.RLock()
 	defer tw.mu.RUnlock()
 	return tw.lastInitializedL1BlockHash
+}
+
+// PreLastInitializedL1BlockHash returns the blockhash of the L1 block the previous to the last round was initiated in
+func (tw *TimeWatcher) PreLastInitializedL1BlockHash() [32]byte {
+	tw.mu.RLock()
+	defer tw.mu.RUnlock()
+	return tw.preLastInitializedL1BlockHash
 }
 
 func (tw *TimeWatcher) CurrentRoundStartL1Block() *big.Int {
@@ -115,11 +127,12 @@ func (tw *TimeWatcher) CurrentRoundStartL1Block() *big.Int {
 	return tw.currentRoundStartL1Block
 }
 
-func (tw *TimeWatcher) setLastInitializedRound(round *big.Int, hash [32]byte, startBlk *big.Int) {
+func (tw *TimeWatcher) setLastInitializedRound(round *big.Int, hash [32]byte, preHash [32]byte, startBlk *big.Int) {
 	tw.mu.Lock()
 	defer tw.mu.Unlock()
 	tw.lastInitializedRound = round
 	tw.lastInitializedL1BlockHash = hash
+	tw.preLastInitializedL1BlockHash = preHash
 	tw.currentRoundStartL1Block = startBlk
 }
 
@@ -248,9 +261,22 @@ func (tw *TimeWatcher) handleLog(log types.Log) error {
 		if err != nil {
 			return err
 		}
-		tw.setLastInitializedRound(lr, bh, roundStartL1Block)
+		pbh, err := tw.lpEth.BlockHashForRound(prevRound(lr))
+		if err != nil {
+			return err
+		}
+		tw.setLastInitializedRound(lr, bh, pbh, roundStartL1Block)
 	} else {
-		tw.setLastInitializedRound(nr.Round, nr.BlockHash, roundStartL1Block)
+		var pbh [32]byte
+		if nr.Round.Cmp(big.NewInt(0).Add(tw.lastInitializedRound, big.NewInt(1))) == 0 {
+			pbh = tw.lastInitializedL1BlockHash
+		} else {
+			pbh, err = tw.lpEth.BlockHashForRound(prevRound(nr.Round))
+			if err != nil {
+				return err
+			}
+		}
+		tw.setLastInitializedRound(nr.Round, nr.BlockHash, pbh, roundStartL1Block)
 	}
 
 	// Get the active transcoder pool size when we receive a NewRound event
@@ -263,4 +289,8 @@ func (tw *TimeWatcher) handleLog(log types.Log) error {
 	tw.roundSubFeed.Send(log)
 
 	return nil
+}
+
+func prevRound(lr *big.Int) *big.Int {
+	return big.NewInt(0).Sub(lr, big.NewInt(1))
 }

--- a/eth/watchers/timewatcher.go
+++ b/eth/watchers/timewatcher.go
@@ -73,7 +73,7 @@ func NewTimeWatcher(roundsManagerAddr ethcommon.Address, watcher BlockWatcher, l
 	}
 	pbh, err := tw.lpEth.BlockHashForRound(prevRound(lr))
 	if err != nil {
-		return nil, fmt.Errorf("error fetching initial prelastInitializedL1BlockHash value err=%q", err)
+		return nil, fmt.Errorf("error fetching initial preLastInitializedL1BlockHash value err=%q", err)
 	}
 	num, err := tw.lpEth.CurrentRoundStartBlock()
 	if err != nil {

--- a/eth/watchers/timewatcher.go
+++ b/eth/watchers/timewatcher.go
@@ -114,7 +114,7 @@ func (tw *TimeWatcher) LastInitializedL1BlockHash() [32]byte {
 	return tw.lastInitializedL1BlockHash
 }
 
-// PreLastInitializedL1BlockHash returns the blockhash of the L1 block the previous to the last round was initiated in
+// PreLastInitializedL1BlockHash returns the blockhash of the L1 block for the round proceeding the last initialized round
 func (tw *TimeWatcher) PreLastInitializedL1BlockHash() [32]byte {
 	tw.mu.RLock()
 	defer tw.mu.RUnlock()

--- a/eth/watchers/timewatcher.go
+++ b/eth/watchers/timewatcher.go
@@ -248,6 +248,10 @@ func (tw *TimeWatcher) handleLog(log types.Log) error {
 		return fmt.Errorf("unable to decode event: %v", err)
 	}
 
+	return tw.handleDecodedLog(log, nr)
+}
+
+func (tw *TimeWatcher) handleDecodedLog(log types.Log, nr contracts.RoundsManagerNewRound) error {
 	roundStartL1Block, err := tw.lpEth.CurrentRoundStartBlock()
 	if err != nil {
 		return err

--- a/pm/broker.go
+++ b/pm/broker.go
@@ -70,8 +70,10 @@ type Broker interface {
 type TimeManager interface {
 	// LastInitializedRound returns the last initialized round of the Livepeer protocol
 	LastInitializedRound() *big.Int
-	// LastInitializedBlockHash returns the blockhash of the block the last round was initiated in
+	// LastInitializedL1BlockHash returns the blockhash of the L1 block the last round was initiated in
 	LastInitializedL1BlockHash() [32]byte
+	// PreLastInitializedL1BlockHash returns the blockhash of the L1 block the previous to the last round was initiated in
+	PreLastInitializedL1BlockHash() [32]byte
 	// GetTranscoderPoolSize returns the size of the active transcoder set for a round
 	GetTranscoderPoolSize() *big.Int
 	// LastSeenBlock returns the last seen block number

--- a/pm/broker.go
+++ b/pm/broker.go
@@ -72,7 +72,7 @@ type TimeManager interface {
 	LastInitializedRound() *big.Int
 	// LastInitializedL1BlockHash returns the blockhash of the L1 block the last round was initiated in
 	LastInitializedL1BlockHash() [32]byte
-	// PreLastInitializedL1BlockHash returns the blockhash of the L1 block the previous to the last round was initiated in
+	// PreLastInitializedL1BlockHash returns the blockhash of the L1 block for the round proceeding the last initialized round
 	PreLastInitializedL1BlockHash() [32]byte
 	// GetTranscoderPoolSize returns the size of the active transcoder set for a round
 	GetTranscoderPoolSize() *big.Int

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -225,7 +225,7 @@ func (r *recipient) ticketExpirationsParams() *TicketExpirationParams {
 	// Because of a bug in Arbitrum, some L1 blocks have zero block hashes
 	// In that case, try to use the previous round block instead
 	if roundBlockHash == [32]byte{} {
-		round -= 1
+		round--
 		roundBlockHash = r.tm.PreLastInitializedL1BlockHash()
 	}
 

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -201,10 +201,7 @@ func (r *recipient) TicketParams(sender ethcommon.Address, price *big.Rat) (*Tic
 
 	winProb := r.winProb(faceValue)
 
-	ticketExpirationParams := &TicketExpirationParams{
-		CreationRound:          r.tm.LastInitializedRound().Int64(),
-		CreationRoundBlockHash: r.tm.LastInitializedL1BlockHash(),
-	}
+	ticketExpirationParams := r.ticketExpirationsParams()
 
 	recipientRand := r.rand(seed, sender, faceValue, winProb, expirationL1Block, price, ticketExpirationParams)
 	recipientRandHash := crypto.Keccak256Hash(ethcommon.LeftPadBytes(recipientRand.Bytes(), uint256Size))
@@ -219,6 +216,23 @@ func (r *recipient) TicketParams(sender ethcommon.Address, price *big.Rat) (*Tic
 		PricePerPixel:     price,
 		ExpirationParams:  ticketExpirationParams,
 	}, nil
+}
+
+func (r *recipient) ticketExpirationsParams() *TicketExpirationParams {
+	round := r.tm.LastInitializedRound().Int64()
+	roundBlockHash := r.tm.LastInitializedL1BlockHash()
+
+	// Because of a bug in Arbitrum, some L1 blocks have zero block hashes
+	// In that case, try to use the previous round block instead
+	if roundBlockHash == [32]byte{} {
+		round -= 1
+		roundBlockHash = r.tm.PreLastInitializedL1BlockHash()
+	}
+
+	return &TicketExpirationParams{
+		CreationRound:          round,
+		CreationRoundBlockHash: roundBlockHash,
+	}
 }
 
 func (r *recipient) txCost() *big.Int {

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -273,6 +273,7 @@ func (s *stubSigner) Account() accounts.Account {
 type stubTimeManager struct {
 	round              *big.Int
 	blkHash            [32]byte
+	preBlkHash         [32]byte
 	transcoderPoolSize *big.Int
 	lastSeenBlock      *big.Int
 
@@ -289,6 +290,10 @@ func (m *stubTimeManager) LastInitializedRound() *big.Int {
 
 func (m *stubTimeManager) LastInitializedL1BlockHash() [32]byte {
 	return m.blkHash
+}
+
+func (m *stubTimeManager) PreLastInitializedL1BlockHash() [32]byte {
+	return m.preBlkHash
 }
 
 func (m *stubTimeManager) GetTranscoderPoolSize() *big.Int {

--- a/server/redeemer_test.go
+++ b/server/redeemer_test.go
@@ -847,6 +847,7 @@ func (s *stubSenderManager) Clear(addr ethcommon.Address) {
 type stubTimeManager struct {
 	round              *big.Int
 	blkHash            [32]byte
+	preBlkHash         [32]byte
 	transcoderPoolSize *big.Int
 	lastSeenBlock      *big.Int
 
@@ -860,6 +861,10 @@ func (m *stubTimeManager) LastInitializedRound() *big.Int {
 
 func (m *stubTimeManager) LastInitializedL1BlockHash() [32]byte {
 	return m.blkHash
+}
+
+func (m *stubTimeManager) PreLastInitializedL1BlockHash() [32]byte {
+	return m.preBlkHash
 }
 
 func (m *stubTimeManager) GetTranscoderPoolSize() *big.Int {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Arbitrum sometimes returns `0x00` as the L1 Block Hash. To prevent a situation when all Os cannot receive tickets for the whole round, we can use the previous round as the ticket expiration parameter.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- unit tests
- local geth with `streamflow` contracts


**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2360


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~~README and other documentation updated~~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
