### PR TITLE
monitor: Move monitor.Enabled check to inside monitoring code

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -176,7 +176,7 @@ func (orch *orchestrator) ProcessPayment(ctx context.Context, payment net.Paymen
 		)
 		if err != nil {
 			clog.Errorf(ctx, "Error receiving ticket sessionID=%v recipientRandHash=%x senderNonce=%v: %v", manifestID, ticket.RecipientRandHash, ticket.SenderNonce, err)
-			monitor.PaymentRecvError(ctx, sender.Hex(), err.Error())			}
+			monitor.PaymentRecvError(ctx, sender.Hex(), err.Error())
 			if _, ok := err.(*pm.FatalReceiveErr); ok {
 				return err
 			}
@@ -255,7 +255,6 @@ func (orch *orchestrator) PriceInfo(sender ethcommon.Address) (*net.PriceInfo, e
 	}
 
 	monitor.TranscodingPrice(sender.String(), price)
-
 
 	return &net.PriceInfo{
 		PricePerUnit:  price.Num().Int64(),

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -62,7 +62,7 @@ func (lt *LocalTranscoder) Transcode(ctx context.Context, md *SegTranscodingMeta
 		return nil, err
 	}
 
-	if monitor.Enabled && parseErr == nil {
+	if parseErr == nil {
 		// This will run only when fname is actual URL and contains seqNo in it.
 		// When orchestrator works as transcoder, `fname` will be relative path to file in local
 		// filesystem and will not contain seqNo in it. For that case `SegmentTranscoded` will
@@ -105,7 +105,7 @@ func (nv *NvidiaTranscoder) Transcode(ctx context.Context, md *SegTranscodingMet
 		return nil, err
 	}
 
-	if monitor.Enabled && parseErr == nil {
+	if parseErr == nil {
 		// This will run only when fname is actual URL and contains seqNo in it.
 		// When orchestrator works as transcoder, `fname` will be relative path to file in local
 		// filesystem and will not contain seqNo in it. For that case `SegmentTranscoded` will

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -113,9 +113,7 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 		}
 		if err != nil && !errors.Is(err, context.Canceled) {
 			clog.Errorf(ctx, "err=%q", err)
-			if monitor.Enabled {
-				monitor.LogDiscoveryError(ctx, uri.String(), err.Error())
-			}
+			monitor.LogDiscoveryError(ctx, uri.String(), err.Error())
 		}
 		errCh <- err
 	}

--- a/eth/gaspricemonitor.go
+++ b/eth/gaspricemonitor.go
@@ -48,11 +48,9 @@ func NewGasPriceMonitor(gpo GasPriceOracle, pollingInterval time.Duration, minGa
 	if minGasPrice != nil {
 		minGasP = minGasPrice
 	}
-	if monitor.Enabled {
-		monitor.MinGasPrice(minGasP)
-		if maxGasPrice != nil {
-			monitor.MaxGasPrice(maxGasPrice)
-		}
+	monitor.MinGasPrice(minGasP)
+	if maxGasPrice != nil {
+		monitor.MaxGasPrice(maxGasPrice)
 	}
 
 	return &GasPriceMonitor{
@@ -80,10 +78,7 @@ func (gpm *GasPriceMonitor) SetMinGasPrice(minGasPrice *big.Int) {
 	gpm.gasPriceMu.Lock()
 	defer gpm.gasPriceMu.Unlock()
 	gpm.minGasPrice = minGasPrice
-
-	if monitor.Enabled {
-		monitor.MinGasPrice(minGasPrice)
-	}
+	monitor.MinGasPrice(minGasPrice)
 }
 
 func (gpm *GasPriceMonitor) MinGasPrice() *big.Int {
@@ -159,10 +154,7 @@ func (gpm *GasPriceMonitor) SetMaxGasPrice(gp *big.Int) {
 	gpm.gasPriceMu.Lock()
 	defer gpm.gasPriceMu.Unlock()
 	gpm.maxGasPrice = gp
-
-	if monitor.Enabled {
-		monitor.MaxGasPrice(gp)
-	}
+	monitor.MaxGasPrice(gp)
 }
 
 func (gpm *GasPriceMonitor) MaxGasPrice() *big.Int {
@@ -179,10 +171,7 @@ func (gpm *GasPriceMonitor) fetchAndUpdateGasPrice(ctx context.Context) error {
 
 	if gasPrice.Cmp(gpm.minGasPrice) >= 0 {
 		gpm.updateGasPrice(gasPrice)
-
-		if monitor.Enabled {
-			monitor.SuggestedGasPrice(gasPrice)
-		}
+		monitor.SuggestedGasPrice(gasPrice)
 	}
 
 	return nil

--- a/eth/watchers/senderwatcher.go
+++ b/eth/watchers/senderwatcher.go
@@ -72,7 +72,7 @@ func (sw *SenderWatcher) setSenderInfo(addr ethcommon.Address, info *pm.SenderIn
 	defer sw.mu.Unlock()
 	sw.senders[addr] = info
 
-	if addr == sw.lpEth.Account().Address && monitor.Enabled {
+	if addr == sw.lpEth.Account().Address {
 		monitor.Deposit(addr.Hex(), info.Deposit)
 		monitor.Reserve(addr.Hex(), info.Reserve.FundsRemaining)
 	}
@@ -269,7 +269,7 @@ func (sw *SenderWatcher) handleLog(log types.Log) error {
 		}
 	}
 
-	if sender == sw.lpEth.Account().Address && monitor.Enabled {
+	if sender == sw.lpEth.Account().Address {
 		monitor.Deposit(sender.Hex(), sw.senders[sender].Deposit)
 		monitor.Reserve(sender.Hex(), sw.senders[sender].Reserve.FundsRemaining)
 	}

--- a/pm/sendermonitor.go
+++ b/pm/sendermonitor.go
@@ -361,15 +361,11 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 	// Fail early if ticket is used
 	used, err := sm.broker.IsUsedTicket(ticket.Ticket)
 	if err != nil {
-		if monitor.Enabled {
-			monitor.TicketRedemptionError(ticket.Sender.Hex())
-		}
+		monitor.TicketRedemptionError(ticket.Sender.Hex())
 		return nil, err
 	}
 	if used {
-		if monitor.Enabled {
-			monitor.TicketRedemptionError(ticket.Sender.Hex())
-		}
+		monitor.TicketRedemptionError(ticket.Sender.Hex())
 		return nil, errIsUsedTicket
 	}
 
@@ -415,26 +411,20 @@ func (sm *LocalSenderMonitor) redeemWinningTicket(ticket *SignedTicket) (*types.
 	// is an error in transaction submission
 	tx, err := sm.broker.RedeemWinningTicket(ticket.Ticket, ticket.Sig, ticket.RecipientRand)
 	if err != nil {
-		if monitor.Enabled {
-			monitor.TicketRedemptionError(ticket.Sender.Hex())
-		}
+		monitor.TicketRedemptionError(ticket.Sender.Hex())
 		return nil, err
 	}
 
 	// Wait for transaction to confirm
 	if err := sm.broker.CheckTx(tx); err != nil {
-		if monitor.Enabled {
-			monitor.TicketRedemptionError(ticket.Sender.Hex())
-		}
+		monitor.TicketRedemptionError(ticket.Sender.Hex())
 		// Return tx so caller can utilize the tx if it fails
 		return tx, err
 	}
 
-	if monitor.Enabled {
-		// TODO(yondonfu): Handle case where < ticket.FaceValue is actually
-		// redeemed i.e. if sender reserve cannot cover the full ticket.FaceValue
-		monitor.ValueRedeemed(ticket.Sender.Hex(), ticket.Ticket.FaceValue)
-	}
+	// TODO(yondonfu): Handle case where < ticket.FaceValue is actually
+	// redeemed i.e. if sender reserve cannot cover the full ticket.FaceValue
+	monitor.ValueRedeemed(ticket.Sender.Hex(), ticket.Ticket.FaceValue)
 
 	return tx, nil
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -51,9 +51,7 @@ func authenticateStream(authURL *url.URL, incomingRequestURL string) (*authWebho
 
 	took := time.Since(started)
 	glog.Infof("Stream authentication for authURL=%s url=%s dur=%s", authURL, incomingRequestURL, took)
-	if monitor.Enabled {
-		monitor.AuthWebhookFinished(took)
-	}
+	monitor.AuthWebhookFinished(took)
 
 	return &authResp, nil
 }

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -286,7 +286,7 @@ func (sp *SessionPool) selectSessions(ctx context.Context, sessionsNum int) []*B
 			if !includesSession(selectedSessions, ls) {
 				clog.V(common.DEBUG).Infof(ctx, "Swapping from orch=%v to orch=%+v for manifestID=%s", ls.Transcoder(),
 					getOrchs(selectedSessions), sp.mid)
-					monitor.OrchestratorSwapped(ctx)
+				monitor.OrchestratorSwapped(ctx)
 			}
 		}
 		sp.lastSess = append([]*BroadcastSession{}, selectedSessions...)
@@ -733,7 +733,7 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 					name, len(seg.Data), took)
 				cpl.FlushRecord()
 			}
-			monitor.RecordingSegmentSaved(took, err)			}
+			monitor.RecordingSegmentSaved(took, err)
 		}()
 	}
 	uri, err := cpl.GetOSSession().SaveData(ctx, name, seg.Data, nil, 0)
@@ -746,10 +746,10 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 		seg.Name = uri // hijack seg.Name to convey the uploaded URI
 	}
 	err = cpl.InsertHLSSegment(vProfile, seg.SeqNo, uri, seg.Duration)
-	monitor.SourceSegmentAppeared(ctx, nonce, seg.SeqNo, string(mid), vProfile.Name, ros != nil)	}
+	monitor.SourceSegmentAppeared(ctx, nonce, seg.SeqNo, string(mid), vProfile.Name, ros != nil)
 	if err != nil {
 		clog.Errorf(ctx, "Error inserting segment err=%q", err)
-		monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorDuplicateSegment, err, false, "")		}
+		monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorDuplicateSegment, err, false, "")
 	}
 
 	if hasZeroVideoFrame {

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -198,8 +198,6 @@ func removeSessionFromList(sessions []*BroadcastSession, sess *BroadcastSession)
 
 func selectSession(sessions []*BroadcastSession, exclude []*BroadcastSession, durMult int) *BroadcastSession {
 	for _, session := range sessions {
-		clog.Errorf(nil, "TIME SINCE: %v. BOOL PART 1: %v. BOOL PART 2: %v. BOOL PART 3: !%v", time.Since(session.SegsInFlight[0].startTime).String(), len(session.SegsInFlight) > 0, time.Since(session.SegsInFlight[0].startTime) < time.Duration(durMult)*session.SegsInFlight[0].segDur, includesSession(exclude, session))
-
 		if len(session.SegsInFlight) > 0 &&
 			time.Since(session.SegsInFlight[0].startTime) < time.Duration(durMult)*session.SegsInFlight[0].segDur &&
 			!includesSession(exclude, session) {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -411,9 +411,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 				}
 				if !streamStarted {
 					streamStarted = true
-					if monitor.Enabled {
-						monitor.StreamStarted(nonce)
-					}
+					monitor.StreamStarted(nonce)
 				}
 				go processSegment(context.Background(), cxn, seg)
 			})
@@ -431,9 +429,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 
 		}(rtmpStrm)
 
-		if monitor.Enabled {
-			monitor.StreamCreated(string(mid), nonce)
-		}
+		monitor.StreamCreated(string(mid), nonce)
 
 		glog.Infof("\n\nVideo Created With ManifestID: %v\n\n", mid)
 
@@ -543,10 +539,8 @@ func (s *LivepeerServer) registerConnection(ctx context.Context, rtmpStrm stream
 	fastVerificationEnabled, fastVerificationUsing := countStreamsWithFastVerificationEnabled(s.rtmpConnections)
 	s.connectionLock.Unlock()
 
-	if monitor.Enabled {
-		monitor.CurrentSessions(sessionsNumber)
-		monitor.FastVerificationEnabledAndUsingCurrentSessions(fastVerificationEnabled, fastVerificationUsing)
-	}
+	monitor.CurrentSessions(sessionsNumber)
+	monitor.FastVerificationEnabledAndUsingCurrentSessions(fastVerificationEnabled, fastVerificationUsing)
 
 	return cxn, nil
 }
@@ -585,11 +579,9 @@ func removeRTMPStream(ctx context.Context, s *LivepeerServer, extmid core.Manife
 	delete(s.rtmpConnections, intmid)
 	delete(s.internalManifests, extmid)
 
-	if monitor.Enabled {
-		monitor.StreamEnded(ctx, cxn.nonce)
-		monitor.CurrentSessions(len(s.rtmpConnections))
-		monitor.FastVerificationEnabledAndUsingCurrentSessions(countStreamsWithFastVerificationEnabled(s.rtmpConnections))
-	}
+	monitor.StreamEnded(ctx, cxn.nonce)
+	monitor.CurrentSessions(len(s.rtmpConnections))
+	monitor.FastVerificationEnabledAndUsingCurrentSessions(countStreamsWithFastVerificationEnabled(s.rtmpConnections))
 
 	return nil
 }
@@ -754,10 +746,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 		mid = intmid
 	}
 	cxn, exists := s.rtmpConnections[mid]
-	if monitor.Enabled {
-		fastVerificationEnabled, fastVerificationUsing := countStreamsWithFastVerificationEnabled(s.rtmpConnections)
-		monitor.FastVerificationEnabledAndUsingCurrentSessions(fastVerificationEnabled, fastVerificationUsing)
-	}
+	monitor.FastVerificationEnabledAndUsingCurrentSessions(countStreamsWithFastVerificationEnabled(s.rtmpConnections))
 	s.connectionLock.RUnlock()
 	ctx = clog.AddManifestID(ctx, string(mid))
 	if exists && cxn != nil {
@@ -946,9 +935,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	select {
 	case <-r.Context().Done():
 		// HTTP request already timed out
-		if monitor.Enabled {
-			monitor.HTTPClientTimedOut1(ctx)
-		}
+		monitor.HTTPClientTimedOut1(ctx)
 		return
 	default:
 	}
@@ -1033,9 +1020,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		clog.Errorf(ctx, "Error sending transcoded response url=%s err=%q", r.URL.String(), err)
-		if monitor.Enabled {
-			monitor.HTTPClientTimedOut2(ctx)
-		}
+		monitor.HTTPClientTimedOut2(ctx)
 		return
 	}
 	if f, ok := w.(http.Flusher); ok {
@@ -1045,15 +1030,11 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	select {
 	case <-r.Context().Done():
 		// HTTP request already timed out
-		if monitor.Enabled {
-			monitor.HTTPClientTimedOut2(ctx)
-		}
+		monitor.HTTPClientTimedOut2(ctx)
 		return
 	default:
 	}
-	if monitor.Enabled {
-		monitor.SegmentFullyProcessed(ctx, seg.Duration, roundtripTime.Seconds())
-	}
+	monitor.SegmentFullyProcessed(ctx, seg.Duration, roundtripTime.Seconds())
 }
 
 // getPlaylistsFromStore finds all the json playlist files belonging to the provided manifests

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -282,9 +282,7 @@ func sendTranscodeResult(ctx context.Context, n *core.LivepeerNode, orchAddr str
 	uploadDur := time.Since(uploadStart)
 	clog.V(common.VERBOSE).InfofErr(ctx, "Transcoding done results sent for taskId=%d url=%s uploadDur=%v", notify.TaskId, notify.Url, uploadDur, err)
 
-	if monitor.Enabled {
-		monitor.SegmentUploaded(ctx, 0, uint64(notify.TaskId), uploadDur, "")
-	}
+	monitor.SegmentUploaded(ctx, 0, uint64(notify.TaskId), uploadDur, "")
 }
 
 // Orchestrator gRPC
@@ -413,9 +411,7 @@ func (h *lphttp) TranscodeResults(w http.ResponseWriter, r *http.Request) {
 		dlDur := time.Since(start)
 		glog.V(common.VERBOSE).Infof("Downloaded results from remote transcoder=%s taskId=%d dur=%s", r.RemoteAddr, tid, dlDur)
 
-		if monitor.Enabled {
-			monitor.SegmentDownloaded(r.Context(), 0, uint64(tid), dlDur)
-		}
+		monitor.SegmentDownloaded(r.Context(), 0, uint64(tid), dlDur)
 
 		orch.TranscoderResults(tid, &res)
 	}

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -420,7 +420,9 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 
 	segCreds, err := genSegCreds(sess, seg, calcPerceptualHash)
 	if err != nil {
-		monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorGenCreds, err, false, sess.OrchestratorInfo.Transcoder)
+		if monitor.Enabled {
+			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorGenCreds, err, false, sess.OrchestratorInfo.Transcoder)
+		}
 		return nil, err
 	}
 	data := seg.Data

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -99,9 +99,7 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 
 	clog.V(common.VERBOSE).Infof(ctx, "Received segment dur=%v", segData.Duration)
 
-	if monitor.Enabled {
-		monitor.SegmentEmerged(ctx, 0, uint64(segData.Seq), len(segData.Profiles), segData.Duration.Seconds())
-	}
+	monitor.SegmentEmerged(ctx, 0, uint64(segData.Seq), len(segData.Profiles), segData.Duration.Seconds())
 
 	if err := orch.ProcessPayment(ctx, payment, core.ManifestID(segData.AuthToken.SessionId)); err != nil {
 		clog.Errorf(ctx, "error processing payment: %v", err)
@@ -139,9 +137,7 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 	dlDur := time.Since(dlStart)
 	clog.V(common.VERBOSE).Infof(ctx, "Downloaded segment dur=%v", dlDur)
 
-	if monitor.Enabled {
-		monitor.SegmentDownloaded(ctx, 0, uint64(segData.Seq), dlDur)
-	}
+	monitor.SegmentDownloaded(ctx, 0, uint64(segData.Seq), dlDur)
 
 	uri := ""
 	if r.Header.Get("Content-Type") == "application/vnd+livepeer.uri" {
@@ -224,9 +220,7 @@ func (h *lphttp) ServeSegment(w http.ResponseWriter, r *http.Request) {
 
 	// Debit the fee for the total pixel count
 	orch.DebitFees(sender, core.ManifestID(segData.AuthToken.SessionId), payment.GetExpectedPrice(), pixels)
-	if monitor.Enabled {
-		monitor.MilPixelsProcessed(ctx, float64(pixels)/1000000.0)
-	}
+	monitor.MilPixelsProcessed(ctx, float64(pixels)/1000000.0)
 
 	// construct the response
 	var result net.TranscodeResult
@@ -426,9 +420,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 
 	segCreds, err := genSegCreds(sess, seg, calcPerceptualHash)
 	if err != nil {
-		if monitor.Enabled {
-			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorGenCreds, err, false, sess.OrchestratorInfo.Transcoder)
-		}
+		monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorGenCreds, err, false, sess.OrchestratorInfo.Transcoder)
 		return nil, err
 	}
 	data := seg.Data
@@ -461,11 +453,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	payment, err := genPayment(ctx, sess, balUpdate.NumTickets)
 	if err != nil {
 		clog.Errorf(ctx, "Could not create payment bytes=%v err=%q", len(data), err)
-
-		if monitor.Enabled {
-			monitor.PaymentCreateError(ctx)
-		}
-
+		monitor.PaymentCreateError(ctx)
 		return nil, err
 	}
 
@@ -490,9 +478,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	req, err := http.NewRequestWithContext(ctx, "POST", ti.Transcoder+"/segment", bytes.NewBuffer(data))
 	if err != nil {
 		clog.Errorf(ctx, "Could not generate transcode request to orch=%s", ti.Transcoder)
-		if monitor.Enabled {
-			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorGenCreds, err, false, sess.OrchestratorInfo.Transcoder)
-		}
+		monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorGenCreds, err, false, sess.OrchestratorInfo.Transcoder)
 		return nil, err
 	}
 
@@ -513,9 +499,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	uploadDur := time.Since(start)
 	if err != nil {
 		clog.Errorf(ctx, "Unable to submit segment orch=%v orch=%s uploadDur=%s err=%q", ti.Transcoder, ti.Transcoder, uploadDur, err)
-		if monitor.Enabled {
-			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorUnknown, err, false, sess.OrchestratorInfo.Transcoder)
-		}
+		monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorUnknown, err, false, sess.OrchestratorInfo.Transcoder)
 		return nil, fmt.Errorf("header timeout: %w", err)
 	}
 	defer resp.Body.Close()
@@ -523,38 +507,30 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	// If the segment was submitted then we assume that any payment included was
 	// submitted as well so we consider the update's credit as spent
 	balUpdate.Status = CreditSpent
-	if monitor.Enabled {
-		monitor.TicketValueSent(ctx, balUpdate.NewCredit)
-		monitor.TicketsSent(ctx, balUpdate.NumTickets)
-	}
+	monitor.TicketValueSent(ctx, balUpdate.NewCredit)
+	monitor.TicketsSent(ctx, balUpdate.NumTickets)
 
 	if resp.StatusCode != 200 {
 		data, _ := ioutil.ReadAll(resp.Body)
 		errorString := strings.TrimSpace(string(data))
 		clog.Errorf(ctx, "Error submitting segment code=%d orch=%s err=%q", resp.StatusCode, ti.Transcoder, string(data))
-		if monitor.Enabled {
-			if resp.StatusCode == 403 && strings.Contains(errorString, "OrchestratorCapped") {
-				monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorOrchestratorCapped, errors.New(errorString), false, sess.OrchestratorInfo.Transcoder)
-			} else {
-				monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadError(resp.Status),
-					fmt.Errorf("Code: %d Error: %s", resp.StatusCode, errorString), false, sess.OrchestratorInfo.Transcoder)
-			}
+		if resp.StatusCode == 403 && strings.Contains(errorString, "OrchestratorCapped") {
+			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadErrorOrchestratorCapped, errors.New(errorString), false, sess.OrchestratorInfo.Transcoder)
+		} else {
+			monitor.SegmentUploadFailed(ctx, nonce, seg.SeqNo, monitor.SegmentUploadError(resp.Status),
+				fmt.Errorf("Code: %d Error: %s", resp.StatusCode, errorString), false, sess.OrchestratorInfo.Transcoder)
 		}
 		return nil, fmt.Errorf(errorString)
 	}
 	clog.Infof(ctx, "Uploaded segment orch=%s dur=%s", ti.Transcoder, uploadDur)
-	if monitor.Enabled {
-		monitor.SegmentUploaded(ctx, nonce, seg.SeqNo, uploadDur, ti.Transcoder)
-	}
+	monitor.SegmentUploaded(ctx, nonce, seg.SeqNo, uploadDur, ti.Transcoder)
 
 	data, err = ioutil.ReadAll(resp.Body)
 	tookAllDur := time.Since(start)
 
 	if err != nil {
 		clog.Errorf(ctx, "Unable to read response body for segment orch=%s err=%q", ti.Transcoder, err)
-		if monitor.Enabled {
-			monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorReadBody, nonce, seg.SeqNo, err, false)
-		}
+		monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorReadBody, nonce, seg.SeqNo, err, false)
 		return nil, fmt.Errorf("body timeout: %w", err)
 	}
 	transcodeDur := tookAllDur - uploadDur
@@ -563,9 +539,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	err = proto.Unmarshal(data, &tr)
 	if err != nil {
 		clog.Errorf(ctx, "Unable to parse response for segment orch=%s err=%q", ti.Transcoder, err)
-		if monitor.Enabled {
-			monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorParseResponse, nonce, seg.SeqNo, err, false)
-		}
+		monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorParseResponse, nonce, seg.SeqNo, err, false)
 		return nil, err
 	}
 
@@ -578,15 +552,13 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 		if err.Error() == "MediaStats Failure" {
 			clog.Infof(ctx, "Ensure the keyframe interval is 4 seconds or less")
 		}
-		if monitor.Enabled {
-			switch res.Error {
-			case "OrchestratorBusy":
-				monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorOrchestratorBusy, nonce, seg.SeqNo, err, false)
-			case "OrchestratorCapped":
-				monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorOrchestratorCapped, nonce, seg.SeqNo, err, false)
-			default:
-				monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorTranscode, nonce, seg.SeqNo, err, false)
-			}
+		switch res.Error {
+		case "OrchestratorBusy":
+			monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorOrchestratorBusy, nonce, seg.SeqNo, err, false)
+		case "OrchestratorCapped":
+			monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorOrchestratorCapped, nonce, seg.SeqNo, err, false)
+		default:
+			monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorTranscode, nonce, seg.SeqNo, err, false)
 		}
 		return nil, err
 	case *net.TranscodeResult_Data:
@@ -595,9 +567,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	default:
 		clog.Errorf(ctx, "Unexpected or unset transcode response field for orch=%s", ti.Transcoder)
 		err = fmt.Errorf("UnknownResponse")
-		if monitor.Enabled {
-			monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorUnknownResponse, nonce, seg.SeqNo, err, false)
-		}
+		monitor.SegmentTranscodeFailed(ctx, monitor.SegmentTranscodeErrorUnknownResponse, nonce, seg.SeqNo, err, false)
 		return nil, err
 	}
 
@@ -613,16 +583,12 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 
 		balUpdate.Debit.Mul(new(big.Rat).SetInt64(pixelCount), priceInfo)
 
-		if monitor.Enabled {
-			monitor.MilPixelsProcessed(ctx, float64(pixelCount)/1000000.0)
-		}
+		monitor.MilPixelsProcessed(ctx, float64(pixelCount)/1000000.0)
 	}
 
 	// transcode succeeded; continue processing response
-	if monitor.Enabled {
-		monitor.SegmentTranscoded(ctx, nonce, seg.SeqNo, time.Duration(seg.Duration*float64(time.Second)), transcodeDur,
-			common.ProfilesNames(params.Profiles), sess.IsTrusted(), verified)
-	}
+	monitor.SegmentTranscoded(ctx, nonce, seg.SeqNo, time.Duration(seg.Duration*float64(time.Second)), transcodeDur,
+		common.ProfilesNames(params.Profiles), sess.IsTrusted(), verified)
 
 	clog.Infof(ctx, "Successfully transcoded segment segName=%s seqNo=%d orch=%s dur=%s",
 		seg.Name, seg.SeqNo, ti.Transcoder, transcodeDur)

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -3,6 +3,7 @@ package server
 import (
 	"flag"
 	"net/http"
+
 	// pprof adds handlers to default mux via `init()`
 	_ "net/http/pprof"
 
@@ -109,9 +110,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 	mux.Handle("/debug", s.debugHandler())
 
 	// Metrics
-	if monitor.Enabled {
-		mux.Handle("/metrics", monitor.Exporter)
-	}
+	mux.Handle("/metrics", monitor.Exporter)
 
 	return mux
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Move `monitor.Enabled` check to a single place inside the monitoring code, to clean up calling code / avoid having to remember to do the check on each metric.

**How did you test each of these updates (required)**
- Ran unit tests


**Does this pull request close any open issues?**
No


**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [N/A] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
