### PR TITLE
eth/accountmanager: allow generation with a provided password

### DIFF
--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -177,7 +177,7 @@ func ethSetup(ethAcctAddr, keystoreDir string, isBroadcaster bool) {
 		return
 	}
 
-	am, err := eth.NewAccountManager(ethcommon.HexToAddress(ethAcctAddr), keystoreDir, chainID)
+	am, err := eth.NewAccountManager(ethcommon.HexToAddress(ethAcctAddr), keystoreDir, chainID, passphrase)
 	if err != nil {
 		glog.Errorf("Error creating Ethereum account manager: %v", err)
 		return

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -686,7 +686,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		}
 		defer gpm.Stop()
 
-		am, err := eth.NewAccountManager(ethcommon.HexToAddress(*cfg.ethAcctAddr), keystoreDir, chainID)
+		am, err := eth.NewAccountManager(ethcommon.HexToAddress(*cfg.ethAcctAddr), keystoreDir, chainID, *cfg.ethPassword)
 		if err != nil {
 			glog.Errorf("Error creating Ethereum account manager: %v", err)
 			return

--- a/eth/accountmanager.go
+++ b/eth/accountmanager.go
@@ -39,7 +39,7 @@ type accountManager struct {
 	keyStore *keystore.KeyStore
 }
 
-func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string, chainID *big.Int) (AccountManager, error) {
+func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string, chainID *big.Int, passphrase string) (AccountManager, error) {
 	keyStore := keystore.NewKeyStore(keystoreDir, keystore.StandardScryptN, keystore.StandardScryptP)
 
 	acctExists := keyStore.HasAddress(accountAddr)
@@ -50,14 +50,22 @@ func NewAccountManager(accountAddr ethcommon.Address, keystoreDir string, chainI
 	if numAccounts == 0 || ((accountAddr != ethcommon.Address{}) && !acctExists) {
 		glog.Infof("No Ethereum account found. Creating a new account")
 		glog.Infof("This process will create a new Ethereum account for this Livepeer node")
-		glog.Infof("Please enter a passphrase to encrypt the Private Keystore file for the Ethereum account.")
-		glog.Infof("This process will ask for this passphrase every time it is launched")
-		glog.Infof("(no characters will appear in Terminal when the passphrase is entered)")
 
-		// Account does not exist yet, set it up
-		acct, err = createAccount(keyStore)
-		if err != nil {
-			return nil, err
+		if passphrase == "" {
+			glog.Infof("Please enter a passphrase to encrypt the Private Keystore file for the Ethereum account.")
+			glog.Infof("This process will ask for this passphrase every time it is launched")
+			glog.Infof("(no characters will appear in Terminal when the passphrase is entered)")
+
+			// Account does not exist yet, set it up
+			acct, err = createAccount(keyStore)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			acct, err = keyStore.NewAccount(passphrase)
+			if err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		glog.V(common.SHORT).Infof("Found existing ETH account")

--- a/eth/accountmanager_test.go
+++ b/eth/accountmanager_test.go
@@ -87,7 +87,7 @@ func TestAccountManager(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	am, err := NewAccountManager(a.Address, dir, big.NewInt(777))
+	am, err := NewAccountManager(a.Address, dir, big.NewInt(777), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestEmptyPassphrase(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	am, err := NewAccountManager(a.Address, dir, big.NewInt(777))
+	am, err := NewAccountManager(a.Address, dir, big.NewInt(777), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,7 +145,7 @@ func TestSign(t *testing.T) {
 	a, err := ks.NewAccount("")
 	require.Nil(err)
 
-	am, err := NewAccountManager(a.Address, dir, big.NewInt(777))
+	am, err := NewAccountManager(a.Address, dir, big.NewInt(777), "")
 	require.Nil(err)
 
 	_, err = am.Sign([]byte("foo"))
@@ -169,7 +169,7 @@ func TestSignTypedData(t *testing.T) {
 	a, err := ks.NewAccount("")
 	require.Nil(err)
 
-	am, err := NewAccountManager(a.Address, dir, big.NewInt(777))
+	am, err := NewAccountManager(a.Address, dir, big.NewInt(777), "")
 	require.Nil(err)
 
 	am.Unlock("")


### PR DESCRIPTION
Facilitates a wallet to be created and repeatedly accessed using external tools, e.g. catalyst. Open to other designs if folks think this is a a bad idea.