### PR TITLE
orch watcher parallel fetching

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,7 @@
 #### General
 
 #### Broadcaster
+- \#2327 Parallelize handling events in Orchestrator Watcher (@red-0ne)
 
 #### Orchestrator
 

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -151,7 +151,7 @@ func TestDBOrchestratorPoolCacheSize(t *testing.T) {
 	sender := &pm.MockSender{}
 	node := &core.LivepeerNode{
 		Database: dbh,
-		Eth:      &eth.StubClient{},
+		Eth:      &eth.StubClient{TotalStake: big.NewInt(0)},
 		Sender:   sender,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -210,7 +210,7 @@ func TestNewDBOrchestorPoolCache_NoEthAddress(t *testing.T) {
 
 	node := &core.LivepeerNode{
 		Database: dbh,
-		Eth:      &eth.StubClient{},
+		Eth:      &eth.StubClient{TotalStake: big.NewInt(0)},
 	}
 	// LastInitializedRound() will ensure the stub orch is always returned from the DB
 	rm := &stubRoundsManager{round: big.NewInt(100)}
@@ -264,7 +264,7 @@ func TestNewDBOrchestratorPoolCache_InvalidPrices(t *testing.T) {
 
 	node := &core.LivepeerNode{
 		Database: dbh,
-		Eth:      &eth.StubClient{},
+		Eth:      &eth.StubClient{TotalStake: big.NewInt(0)},
 	}
 	// LastInitializedRound() will ensure the stub orch is always returned from the DB
 	rm := &stubRoundsManager{round: big.NewInt(100)}

--- a/eth/stubclient.go
+++ b/eth/stubclient.go
@@ -353,11 +353,7 @@ func (e *StubClient) GetTranscoderEarningsPoolForRound(addr common.Address, roun
 		return &lpTypes.TokenPools{}, e.TranscoderPoolError
 	}
 
-	totalStake := big.NewInt(0)
-	if e.TotalStake != nil {
-		totalStake = e.TotalStake
-	}
-	return &lpTypes.TokenPools{TotalStake: totalStake}, nil
+	return &lpTypes.TokenPools{TotalStake: e.TotalStake}, nil
 }
 func (e *StubClient) TranscoderPool() ([]*lpTypes.Transcoder, error) {
 	return e.Orchestrators, e.TranscoderPoolError

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -12,7 +12,6 @@ import (
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/eth/blockwatch"
 	"github.com/livepeer/go-livepeer/eth/contracts"
-	lpTypes "github.com/livepeer/go-livepeer/eth/types"
 )
 
 const maxFutureRound = int64(math.MaxInt64)
@@ -191,32 +190,25 @@ func (ow *OrchestratorWatcher) handleRoundEvent(log types.Log) error {
 }
 
 func (ow *OrchestratorWatcher) cacheOrchestratorStake(addr ethcommon.Address, round *big.Int) error {
-	var err error
-
-	defer func() {
-		if err != nil {
-			glog.Errorf("could not cache stake update for orchestrator %v and round %v", addr, round)
-		}
-	}()
-
-	var ep *lpTypes.TokenPools
-	ep, err = ow.lpEth.GetTranscoderEarningsPoolForRound(addr, round)
+	ep, err := ow.lpEth.GetTranscoderEarningsPoolForRound(addr, round)
 	if err != nil {
+		glog.Errorf("could not cache stake update for orchestrator %v and round %v", addr, round)
 		return err
 	}
 
-	var stakeFp int64
-	stakeFp, err = common.BaseTokenAmountToFixed(ep.TotalStake)
+	stakeFp, err := common.BaseTokenAmountToFixed(ep.TotalStake)
 	if err != nil {
+		glog.Errorf("could not cache stake update for orchestrator %v and round %v", addr, round)
 		return err
 	}
 
-	if err = ow.store.UpdateOrch(
+	if err := ow.store.UpdateOrch(
 		&common.DBOrch{
 			EthereumAddr: addr.Hex(),
 			Stake:        stakeFp,
 		},
 	); err != nil {
+		glog.Errorf("could not cache stake update for orchestrator %v and round %v", addr, round)
 		return err
 	}
 

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -53,6 +53,10 @@ func (ow *OrchestratorWatcher) Watch() {
 	sub := ow.watcher.Subscribe(blockSink)
 	defer sub.Unsubscribe()
 
+	if err := ow.handleRoundEvent(); err != nil {
+		glog.Errorf("error handling current round: %v", err)
+	}
+
 	for {
 		select {
 		case <-ow.quit:
@@ -61,9 +65,9 @@ func (ow *OrchestratorWatcher) Watch() {
 			glog.Error(err)
 		case block := <-blockSink:
 			go ow.handleBlockEvents(block)
-		case round := <-roundSink:
+		case _ = <-roundSink:
 			go func() {
-				if err := ow.handleRoundEvent(round); err != nil {
+				if err := ow.handleRoundEvent(); err != nil {
 					glog.Errorf("error handling new round event: %v", err)
 				}
 			}()
@@ -171,7 +175,7 @@ func (ow *OrchestratorWatcher) handleTranscoderDeactivated(log types.Log) error 
 	)
 }
 
-func (ow *OrchestratorWatcher) handleRoundEvent(log types.Log) error {
+func (ow *OrchestratorWatcher) handleRoundEvent() error {
 	round, err := ow.lpEth.CurrentRound()
 	if err != nil {
 		return err

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -17,11 +17,6 @@ import (
 
 const maxFutureRound = int64(math.MaxInt64)
 
-type OrchestratorStakeCachingResult struct {
-	address ethcommon.Address
-	err     error
-}
-
 type OrchestratorWatcher struct {
 	store   common.OrchestratorStore
 	dec     *EventDecoder

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -189,17 +189,17 @@ func (ow *OrchestratorWatcher) handleRoundEvent(log types.Log) error {
 	return nil
 }
 
-func (ow *OrchestratorWatcher) cacheOrchestratorStake(addr ethcommon.Address, round *big.Int) error {
+func (ow *OrchestratorWatcher) cacheOrchestratorStake(addr ethcommon.Address, round *big.Int) {
 	ep, err := ow.lpEth.GetTranscoderEarningsPoolForRound(addr, round)
 	if err != nil {
 		glog.Errorf("could not cache stake update for orchestrator %v and round %v", addr, round)
-		return err
+		return
 	}
 
 	stakeFp, err := common.BaseTokenAmountToFixed(ep.TotalStake)
 	if err != nil {
 		glog.Errorf("could not cache stake update for orchestrator %v and round %v", addr, round)
-		return err
+		return
 	}
 
 	if err := ow.store.UpdateOrch(
@@ -209,8 +209,8 @@ func (ow *OrchestratorWatcher) cacheOrchestratorStake(addr ethcommon.Address, ro
 		},
 	); err != nil {
 		glog.Errorf("could not cache stake update for orchestrator %v and round %v", addr, round)
-		return err
+		return
 	}
 
-	return nil
+	return
 }

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -173,9 +173,6 @@ func (ow *OrchestratorWatcher) handleTranscoderDeactivated(log types.Log) error 
 }
 
 func (ow *OrchestratorWatcher) handleRoundEvent(log types.Log) error {
-	ow.roundMu.Lock()
-	defer ow.roundMu.Unlock()
-
 	round, err := ow.lpEth.CurrentRound()
 	if err != nil {
 		return err
@@ -186,22 +183,16 @@ func (ow *OrchestratorWatcher) handleRoundEvent(log types.Log) error {
 		return err
 	}
 
-	wg := &sync.WaitGroup{}
-
 	for _, o := range orchs {
-		wg.Add(1)
-		go ow.cacheOrchestratorStake(ethcommon.HexToAddress(o.EthereumAddr), round, wg)
+		go ow.cacheOrchestratorStake(ethcommon.HexToAddress(o.EthereumAddr), round)
 	}
-
-	wg.Wait()
 
 	return nil
 }
 
-func (ow *OrchestratorWatcher) cacheOrchestratorStake(addr ethcommon.Address, round *big.Int, wg *sync.WaitGroup) error {
+func (ow *OrchestratorWatcher) cacheOrchestratorStake(addr ethcommon.Address, round *big.Int) error {
 	var err error
 
-	defer wg.Done()
 	defer func() {
 		if err != nil {
 			glog.Errorf("could not cache stake update for orchestrator %v and round %v", addr, round)

--- a/eth/watchers/orchestratorwatcher.go
+++ b/eth/watchers/orchestratorwatcher.go
@@ -53,10 +53,6 @@ func (ow *OrchestratorWatcher) Watch() {
 	sub := ow.watcher.Subscribe(blockSink)
 	defer sub.Unsubscribe()
 
-	if err := ow.handleRoundEvent(); err != nil {
-		glog.Errorf("error handling current round: %v", err)
-	}
-
 	for {
 		select {
 		case <-ow.quit:

--- a/eth/watchers/orchestratorwatcher_test.go
+++ b/eth/watchers/orchestratorwatcher_test.go
@@ -205,4 +205,13 @@ func TestOrchWatcher_HandleRoundEvent_CacheOrchestratorStake(t *testing.T) {
 	errorLogsAfter = glog.Stats.Error.Lines()
 	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
 	stubStore.updateErr = nil
+
+	// Common.BaseTokenAmountToFixed() error
+	errorLogsBefore = glog.Stats.Error.Lines()
+	lpEth.TotalStake = nil
+	tw.sink <- newRoundEvent
+	time.Sleep(20 * time.Millisecond)
+	errorLogsAfter = glog.Stats.Error.Lines()
+	assert.Equal(int64(1), errorLogsAfter-errorLogsBefore)
+	lpEth.TotalStake = expStake
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fetching orchestrator's stake by `OrchestratorWatcher` is now done in parallel instead of fetching them sequencially.

**Specific updates (required)**
- Call  `ow.cacheOrchestratorStake()` in a goroutine 

**How did you test each of these updates (required)**
`go test -run ^TestOrchWatcher`

Also running
```
./livepeer -broadcaster -v 6 -network arbitrum-one-rinkeby -ethUrl https://rinkeby.arbitrum.io/rpc
```
and observe `orchestrators` table with sqlite.

**Does this pull request close any open issues?**
Fixes #2327 


**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~~README and other documentation updated~~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
