### PR TITLE
server: Change verification randomness variable meaning

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -39,6 +39,7 @@
 - \#2291 Calling video comparison to improve the security strength (@oscar-davids)
 - \#2326 Split Auth/Webhook functionality into its own file (@thomshutt)
 - \#2357 Begin accepting auth header (from Mist) and have it override callback URL values
+- \#2385 Change verification randomness variable meaning
 
 #### Orchestrator
 - \#2284 Fix issue with not redeeming tickets by Redeemer (@leszko)

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -1654,7 +1655,7 @@ func TestPush_MultipartReturnMultiSession(t *testing.T) {
 	sess3.OrchestratorScore = common.Score_Untrusted
 
 	bsm := bsmWithSessListExt([]*BroadcastSession{sess1}, []*BroadcastSession{sess3, sess2}, false)
-	bsm.VerificationFreq = 1
+	bsm.VerificationFreq = math.MaxInt
 	assert.Equal(0, bsm.untrustedPool.sus.count)
 	// hack: stop pool from refreshing
 	bsm.untrustedPool.refreshing = true


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Change the meaning of the "Verification Frequency" parameter from meaning the odds of it running on a given request are `1 - 1 / VerificationFreq` to `1 / VerificationFreq`

**How did you test each of these updates (required)**
Wrote unit tests for method that calulates the odds


**Does this pull request close any open issues?**
No


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
