### PR TITLE
cmd,common,server: Add LP_EXTEND_TIMEOUTS environment variable

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,6 +10,7 @@
 - \#2383 Add E2E Tests for checking Livepeer on-chain interactions (@leszko)
 
 #### Broadcaster
+- \#2392 Add LP_EXTEND_TIMEOUTS env variable to extend timeouts for Stream Tester (@leszko)
 
 #### Orchestrator
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -8,9 +8,11 @@ import (
 	"flag"
 	"fmt"
 	"github.com/livepeer/go-livepeer/cmd/livepeer/starter"
+	"github.com/livepeer/go-livepeer/common"
 	"os"
 	"os/signal"
 	"runtime"
+	"strconv"
 	"time"
 
 	"github.com/livepeer/livepeer-data/pkg/mistconnector"
@@ -48,6 +50,7 @@ func main() {
 	}
 
 	vFlag.Value.Set(*verbosity)
+	extendTimeouts()
 
 	cfg = updateNilsForUnsetFlags(cfg)
 
@@ -197,4 +200,16 @@ func updateNilsForUnsetFlags(cfg starter.LivepeerConfig) starter.LivepeerConfig 
 	}
 
 	return res
+}
+
+// extendTimeouts extends transcoding timeouts for the testing purpose.
+// This functionality is intended for Stream Tester to avoid timing out while measuring orchestrator performance.
+func extendTimeouts() {
+	if boolVal, _ := strconv.ParseBool(os.Getenv("LP_EXTEND_TIMEOUTS")); boolVal {
+		// Make all timeouts 8s for the common segment durations
+		common.SegUploadTimeoutMultiplier = 4.0
+		common.SegmentUploadTimeout = 8 * time.Second
+		common.HTTPDialTimeout = 8 * time.Second
+		common.SegHttpPushTimeoutMultiplier = 4.0
+	}
 }

--- a/common/util.go
+++ b/common/util.go
@@ -26,10 +26,19 @@ import (
 	"google.golang.org/grpc/peer"
 )
 
+// HTTPDialTimeout timeout used to establish an HTTP connection between nodes
+var HTTPDialTimeout = 2 * time.Second
+
 // HTTPTimeout timeout used in HTTP connections between nodes
 var HTTPTimeout = 8 * time.Second
 
-// SegmentUploadTimeout timeout used in HTTP connections for uploading the segment
+// SegHttpPushTimeoutMultiplier used in the HTTP connection for pushing the segment
+var SegHttpPushTimeoutMultiplier = 4.0
+
+// SegUploadTimeoutMultiplier used in HTTP connection for uploading the segment
+var SegUploadTimeoutMultiplier = 0.5
+
+// SegmentUploadTimeout timeout used in HTTP connections for uploading the segment duration is not defined
 var SegmentUploadTimeout = 2 * time.Second
 
 // Max Segment Duration


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Add env variable `LP_EXTEND_TIMEOUTS` which extends all broadcaster's timeouts to `8s`.

This is a hack to fix Test Streams, so the parameter is not exposed as a flag (or in config file). It's planned to be temporary until the poper solution for Test Streams is implemented: https://github.com/livepeer/stream-tester/issues/145

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Added printlns with timeouts and tested on local devnet

**Does this pull request close any open issues?**
<!-- Fixes # -->
fix https://github.com/livepeer/stream-tester/issues/144

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~README and other documentation updated~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
