### PR TITLE
docker: Trigger docker builds when tags are pushed.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,54 +1,64 @@
 name: Docker Build
+
 on:
   pull_request:
   push:
     branches:
       - master
+    tags:
+      - "v*"
+
 jobs:
   build:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        # Needed for commands that depend on git tags
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-    - name: Set global environment variables
-      run: |
-        echo "PKG_CONFIG_PATH=/root/compiled/lib/pkgconfig" >> $GITHUB_ENV
-        echo "GOPATH=/go" >> $GITHUB_ENV
-    - name: DockerHub login
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASS }}
-    - name: Build Linux specific builder container
-      run: |
-        docker pull livepeerci/build-platform:latest || echo 'no pre-existing cache found'
-        docker build -t livepeerci/build-platform:latest --cache-from=livepeerci/build-platform:latest -f docker/Dockerfile.build-linux .
-        docker push livepeerci/build-platform:latest
-    - name: Build livepeer in a container shared between Linux and Windows
-      run: |
-        docker pull livepeerci/build:latest || echo 'no pre-existing cache found'
-        ./ci_env.sh docker build --build-arg BUILD_TAGS -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
-        docker push livepeerci/build:latest
-    - name: Build minimal livepeer distributable 
-      run: |
-        # We publish two tags for each build:
-        # livepeer/go-livepeer:BRANCH_NAME and livepeer/go-livepeer:VERSION_STRING. Both are useful
-        # to pull from in different contexts.
-        # Our Docker tag name should be our branch name with just alphanums
-        BRANCH_TAG=$(echo $GHA_REF | sed 's/refs\/heads\///' | sed 's/\//-/g' | tr -cd '[:alnum:]_-')
-        VERSION_TAG=$(./print_version.sh)
-        docker build -t current-build -f docker/Dockerfile.release-linux .
-        for TAG in $BRANCH_TAG $VERSION_TAG; do
-          docker tag current-build livepeer/go-livepeer:${TAG}-linux
-          docker push livepeer/go-livepeer:${TAG}-linux
-          # Manifest step is optional in case the Windows build hasn't finished yet
-          docker manifest create livepeer/go-livepeer:${TAG} livepeer/go-livepeer:${TAG}-linux livepeer/go-livepeer:${TAG}-windows || true
-          docker manifest push livepeer/go-livepeer:${TAG} || true
-        done
-      env:
-        GHA_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          # Check https://github.com/livepeer/go-livepeer/pull/1891
+          # for ref value discussion
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set global environment variables
+        run: |
+          echo "PKG_CONFIG_PATH=/root/compiled/lib/pkgconfig" >> $GITHUB_ENV
+          echo "GOPATH=/go" >> $GITHUB_ENV
+
+      - name: DockerHub login
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASS }}
+
+      - name: Build Linux specific builder container
+        run: |
+          docker pull livepeerci/build-platform:latest || echo 'no pre-existing cache found'
+          docker build -t livepeerci/build-platform:latest --cache-from=livepeerci/build-platform:latest -f docker/Dockerfile.build-linux .
+          docker push livepeerci/build-platform:latest
+
+      - name: Build livepeer in a container shared between Linux and Windows
+        run: |
+          docker pull livepeerci/build:latest || echo 'no pre-existing cache found'
+          ./ci_env.sh docker build --build-arg BUILD_TAGS -t livepeerci/build:latest --cache-from=livepeerci/build:latest -f docker/Dockerfile.build .
+          docker push livepeerci/build:latest
+
+      - name: Build minimal livepeer distributable
+        run: |
+          # We publish two tags for each build:
+          # livepeer/go-livepeer:BRANCH_NAME and livepeer/go-livepeer:VERSION_STRING. Both are useful
+          # to pull from in different contexts.
+          # Our Docker tag name should be our branch name with just alphanums
+          BRANCH_TAG="$(echo $GHA_REF | sed 's/refs\\/heads\\///' | sed 's/\\//-/g' | tr -cd '[:alnum:]_-')"
+          VERSION_TAG=$(./print_version.sh)
+          docker build -t current-build -f docker/Dockerfile.release-linux .
+          for TAG in $BRANCH_TAG $VERSION_TAG; do
+            docker tag current-build livepeer/go-livepeer:${TAG}-linux
+            docker push livepeer/go-livepeer:${TAG}-linux
+            # Manifest step is optional in case the Windows build hasn't finished yet
+            docker manifest create livepeer/go-livepeer:${TAG} livepeer/go-livepeer:${TAG}-linux livepeer/go-livepeer:${TAG}-windows || true
+            docker manifest push livepeer/go-livepeer:${TAG} || true
+          done
+        env:
+          GHA_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}


### PR DESCRIPTION
<!-- A clear and concise description of what this pull request does. -->
When `v0.5.30` was released, the docker workflow was not able to pick up tag information as tag got pushed at a later stage than when this build got triggered. This led to missing image tag from dockerhub repository.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
Create hook to trigger builds on tag pushes.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
NA

**Does this pull request close any open issues?**
<!-- Fixes # -->
nope, just discord discussions. Too minor a change to warrant a pending changelog update.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated