### PR TITLE
Fix Webhook discovery, refresh pool before getting pool size

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,6 +11,7 @@
 
 #### Broadcaster
 - \#2392 Add LP_EXTEND_TIMEOUTS env variable to extend timeouts for Stream Tester (@leszko)
+- \#2413 Fix Webhook discovery, refresh pool before getting pool size (@leszko)
 
 #### Orchestrator
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	vFlag.Value.Set(*verbosity)
-	extendTimeouts()
+	streamTesterMode()
 
 	cfg = updateNilsForUnsetFlags(cfg)
 
@@ -202,14 +202,17 @@ func updateNilsForUnsetFlags(cfg starter.LivepeerConfig) starter.LivepeerConfig 
 	return res
 }
 
-// extendTimeouts extends transcoding timeouts for the testing purpose.
+// streamTesterMode extends transcoding timeouts and disable caching for the testing purpose.
 // This functionality is intended for Stream Tester to avoid timing out while measuring orchestrator performance.
-func extendTimeouts() {
-	if boolVal, _ := strconv.ParseBool(os.Getenv("LP_EXTEND_TIMEOUTS")); boolVal {
+func streamTesterMode() {
+	if boolVal, _ := strconv.ParseBool(os.Getenv("LP_IS_ORCH_TESTER")); boolVal {
 		// Make all timeouts 8s for the common segment durations
 		common.SegUploadTimeoutMultiplier = 4.0
 		common.SegmentUploadTimeout = 8 * time.Second
 		common.HTTPDialTimeout = 8 * time.Second
 		common.SegHttpPushTimeoutMultiplier = 4.0
+
+		// Disable caching for Orchestrator Discovery Webhook
+		common.WebhookDiscoveryRefreshInterval = 0
 	}
 }

--- a/common/util.go
+++ b/common/util.go
@@ -41,6 +41,9 @@ var SegUploadTimeoutMultiplier = 0.5
 // SegmentUploadTimeout timeout used in HTTP connections for uploading the segment duration is not defined
 var SegmentUploadTimeout = 2 * time.Second
 
+// WebhookDiscoveryRefreshInterval defines for long the Webhook Discovery values should be cached
+var WebhookDiscoveryRefreshInterval = 1 * time.Minute
+
 // Max Segment Duration
 var MaxDuration = (5 * time.Minute)
 

--- a/discovery/wh_discovery.go
+++ b/discovery/wh_discovery.go
@@ -98,6 +98,9 @@ func (w *webhookPool) Size() int {
 }
 
 func (w *webhookPool) SizeWith(scorePred common.ScorePred) int {
+	// Refresh pool
+	w.GetInfos()
+
 	var size int
 	w.mu.RLock()
 	if w.pool != nil {

--- a/discovery/wh_discovery.go
+++ b/discovery/wh_discovery.go
@@ -17,8 +17,6 @@ import (
 	"github.com/golang/glog"
 )
 
-var whRefreshInterval = 1 * time.Minute
-
 type webhookResponse struct {
 	Address string  `json:"address,omitempty"`
 	Score   float32 `json:"score,omitempty"`
@@ -50,7 +48,7 @@ func (w *webhookPool) getInfos() ([]common.OrchestratorLocalInfo, error) {
 	w.mu.RUnlock()
 
 	// retrive addrs from cache if time since lastRequest is less than the refresh interval
-	if time.Since(lastReq) < whRefreshInterval {
+	if time.Since(lastReq) < common.WebhookDiscoveryRefreshInterval {
 		return pool.GetInfos(), nil
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Fix webhook-based discovery and remove webhook caching for Stream Tester.

Webhook-based discovery did not refresh pool while calling `size()` function which resulted in the following scenario:
1. For `On` the pool is `[]` (size `0`)
2. Webhook is updated to `On+1`
3. Selection process checks the pool size and returns `0`

This affected Stream Tester which returned score `0` for both `On+1` and `On` (even though `On` is down and `On+1` is up).

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Refresh webhook-based pool while getting its size
- Rename env var `LP_EXTEND_TIMEOUTS` to `LP_IS_ORCH_TESTER`
- Remove webhook caching for Stream Tester

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Running Stream Tester in staging and checking the results.


**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2270
fix #2370
fix #2412


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~README and other documentation updated~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
