### PR TITLE
livepeer_cli: use the O's currently registered Service URI as default address

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,6 +21,7 @@
 ### Bug Fixes 🐞
 
 #### CLI
+- \#2416 Use the O's currently registered Service URI as default address (@emranemran)
 
 #### General
 


### PR DESCRIPTION
When changing config options for the Orchestrator via livepeer_cli, the
public host:port of the node is requested for the configuration to be
applied successfully. This host:port address defaults to using the
ip-address of the node instead of using the global domain name that is
registered when setting up an O node. Use the registered Service URI as
the default option such that the entry can be left blank when
configuring options via the livepeer-cli.

**What does this pull request do? Explain your changes. (required)**
(see above commit desc)

**Specific updates (required)**
(see above commit desc)

**How did you test each of these updates (required)**
* testing locally using both off-chain and on-chain OT nodes. 

**Does this pull request close any open issues?**
fix \#2293

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
- ~~[ ] All tests in `./test.sh` pass~~
- ~~[ ] README and other documentation updated~~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
