### PR TITLE
.github: Fix tagging of images with branch name

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -51,7 +51,7 @@ jobs:
           # livepeer/go-livepeer:BRANCH_NAME and livepeer/go-livepeer:VERSION_STRING. Both are useful
           # to pull from in different contexts.
           # Our Docker tag name should be our branch name with just alphanums
-          BRANCH_TAG="$(echo ${GITHUB_HEAD_REF:-$GITHUB_REF} | sed 's/refs\\/heads\\///' | sed 's/\\//-/g' | tr -cd '[:alnum:]_-')"
+          BRANCH_TAG="$(echo $GHA_REF | sed 's/refs\/heads\///' | sed 's/\//-/g' | tr -cd '[:alnum:]_-')"
           VERSION_TAG=$(./print_version.sh)
           docker build -t current-build -f docker/Dockerfile.release-linux .
           for TAG in $BRANCH_TAG $VERSION_TAG; do

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -50,7 +50,7 @@ jobs:
           # livepeer/go-livepeer:BRANCH_NAME and livepeer/go-livepeer:VERSION_STRING. Both are useful
           # to pull from in different contexts.
           # Our Docker tag name should be our branch name with just alphanums
-          BRANCH_TAG="$(echo $GHA_REF | sed 's/refs\\/heads\\///' | sed 's/\\//-/g' | tr -cd '[:alnum:]_-')"
+          BRANCH_TAG="$(echo ${GITHUB_HEAD_REF:-$GITHUB_REF} | sed 's/refs\\/heads\\///' | sed 's/\\//-/g' | tr -cd '[:alnum:]_-')"
           VERSION_TAG=$(./print_version.sh)
           docker build -t current-build -f docker/Dockerfile.release-linux .
           for TAG in $BRANCH_TAG $VERSION_TAG; do

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Build minimal livepeer distributable
         run: |
+          set -euo pipefail
           # We publish two tags for each build:
           # livepeer/go-livepeer:BRANCH_NAME and livepeer/go-livepeer:VERSION_STRING. Both are useful
           # to pull from in different contexts.


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Apparently it broke since #2399 due to over-escaping of sed arguments.

Staging is running the image right before that PR was merged, because the
`master` tag stopped being updated.

**Specific updates (required)**
- Make the build script fail when there are execution failures
- Revert over-escaping of sed args

**How did you test each of these updates (required)**
Just check the build on the PR and ensure it tags the image properly.

**Does this pull request close any open issues?**
Fixes docker image tags.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
