### PR TITLE
upload_build.sh: Upload to gcp cloud storage follows new directory structure

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -51,7 +51,7 @@ jobs:
           # livepeer/go-livepeer:BRANCH_NAME and livepeer/go-livepeer:VERSION_STRING. Both are useful
           # to pull from in different contexts.
           # Our Docker tag name should be our branch name with just alphanums
-          BRANCH_TAG="$(echo $GHA_REF | sed 's/refs\/heads\///' | sed 's/\//-/g' | tr -cd '[:alnum:]_-')"
+          BRANCH_TAG="$(echo $GHA_REF | sed -e 's:refs/heads/::; s:/:-:g' | tr -cd '[:alnum:]_-')"
           VERSION_TAG=$(./print_version.sh)
           docker build -t current-build -f docker/Dockerfile.release-linux .
           for TAG in $BRANCH_TAG $VERSION_TAG; do

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,7 @@
 ### Features ⚒
 
 #### General
+- \#2429 Binaries are uploaded to gcp cloud storage following the new directory structure (@hjpotter92)
 
 #### Broadcaster
 

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -94,8 +94,10 @@ if [[ "${GCLOUD_KEY:-}" == "" ]]; then
 fi
 
 # https://stackoverflow.com/a/44751929/990590
-bucket=build.livepeer.live
-resource="/${bucket}/${VERSION_AND_NETWORK}/${FILE}"
+BUCKET="build.livepeer.live"
+PROJECT="go-livepeer"
+BUCKET_PATH="${PROJECT}/${VERSION_AND_NETWORK}/${FILE}"
+resource="/${BUCKET}/${BUCKET_PATH}"
 contentType="application/x-compressed-tar"
 dateValue="$(date -R)"
 stringToSign="PUT\n\n${contentType}\n${dateValue}\n${resource}"
@@ -119,6 +121,6 @@ echo "upload done"
 
 curl -X POST --fail -s \
   -H "Content-Type: application/json" \
-  -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $PLATFORM-$ARCH\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/$VERSION_AND_NETWORK/${FILE}\nSHA256:\n${FILE_SHA256}\"}" \
+  -d "{\"content\": \"Build succeeded ✅\nBranch: $BRANCH\nPlatform: $PLATFORM-$ARCH\nLast commit: $(git log -1 --pretty=format:'%s by %an')\nhttps://build.livepeer.live/${BUCKET_PATH}\nSHA256:\n${FILE_SHA256}\"}" \
   $DISCORD_URL
 echo "done"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Uploads built binary archives to new directory structure on gcp cloud storage.

**Specific updates (required)**
Follows the path: `<bucket>/<project>/<version>/<file>` template when uploading file.

**How did you test each of these updates (required)**
Through this PR

**Does this pull request close any open issues?**
no

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
