### PR TITLE
e2e-tests: changed protocol docker image from streamflow to confluence

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -28,7 +28,7 @@ type gethContainer struct {
 func setupGeth(t *testing.T) *gethContainer {
 	ctx := context.TODO()
 	req := testcontainers.ContainerRequest{
-		Image:        "livepeer/geth-with-livepeer-protocol:streamflow",
+		Image:        "livepeer/geth-with-livepeer-protocol:confluence",
 		ExposedPorts: []string{"8546/tcp", "8545/tcp"},
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Updates the e2e tests geth setup to use the confluence version of the livepeer protocol

**Specific updates (required)**
Updates the docker dependency in `e2e.go`

**How did you test each of these updates (required)**
Successfully run `test_e2e.sh`


**Does this pull request close any open issues?**
No


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
