### PR TITLE
cmd: Make CLI flag casing consistent for dataDir flag

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,7 @@
 
 #### General
 - \#2429 Binaries are uploaded to gcp cloud storage following the new directory structure (@hjpotter92)
+- \#2437 Make CLI flag casing consistent for dataDir flag (@thomshutt)
 
 #### Broadcaster
 - \#2327 Parallelize handling events in Orchestrator Watcher (@red-0ne)

--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -149,7 +149,7 @@ func createTranscoderRunScript(ethAcctAddr, dataDir, serviceHost string) {
 	args := []string{
 		"./livepeer",
 		"-v 99",
-		fmt.Sprintf("-datadir ./%s", dataDir),
+		fmt.Sprintf("-dataDir ./%s", dataDir),
 		"-orchSecret secre",
 		fmt.Sprintf("-orchAddr %s:%d", serviceHost, mediaPort),
 		fmt.Sprintf("-cliAddr %s:%d", serviceHost, cliPort),
@@ -164,7 +164,7 @@ func createRunScript(ethController string, dataDir, serviceHost string, cfg devt
 		"./livepeer",
 		"-v 99",
 		"-ethController " + ethController,
-		"-datadir ./" + dataDir,
+		"-dataDir ./" + dataDir,
 		"-ethAcctAddr " + cfg.Account,
 		"-ethUrl " + cfg.Endpoint,
 		"-ethPassword \"\"",

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -7,13 +7,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/livepeer/go-livepeer/cmd/livepeer/starter"
-	"github.com/livepeer/go-livepeer/common"
 	"os"
 	"os/signal"
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/livepeer/go-livepeer/cmd/livepeer/starter"
+	"github.com/livepeer/go-livepeer/common"
 
 	"github.com/livepeer/livepeer-data/pkg/mistconnector"
 	"github.com/peterbourgon/ff/v3"
@@ -163,7 +164,8 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.MetadataPublishTimeout = flag.Duration("metadataPublishTimeout", *cfg.MetadataPublishTimeout, "Max time to wait in background for publishing operation metadata events")
 
 	// Storage:
-	cfg.Datadir = flag.String("datadir", *cfg.Datadir, "Directory that data is stored in")
+	flag.StringVar(cfg.Datadir, "datadir", *cfg.Datadir, "[Deprecated] Directory that data is stored in")
+	flag.StringVar(cfg.Datadir, "dataDir", *cfg.Datadir, "Directory that data is stored in")
 	cfg.Objectstore = flag.String("objectStore", *cfg.Objectstore, "url of primary object store")
 	cfg.Recordstore = flag.String("recordStore", *cfg.Recordstore, "url of object store for recordings")
 

--- a/cmd/livepeer/livepeer_test.go
+++ b/cmd/livepeer/livepeer_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/peterbourgon/ff/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// This test exists because we wanted to make our CLI argument casing consistent without
+// breaking backwards compatibility
+func TestParseAcceptsEitherDatadirCasing(t *testing.T) {
+	// Reset between tests
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	// No Casing
+	lpc := parseLivepeerConfig()
+
+	err := ff.Parse(flag.CommandLine, []string{
+		"-datadir", "/some/data/dir",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, lpc.Datadir)
+	require.Equal(t, "/some/data/dir", *lpc.Datadir)
+
+	// Reset between tests
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	// Camel Casing
+	lpc = parseLivepeerConfig()
+
+	err = ff.Parse(flag.CommandLine, []string{
+		"-dataDir", "/some/data/dir",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, lpc.Datadir)
+	require.Equal(t, "/some/data/dir", *lpc.Datadir)
+}

--- a/test_args.sh
+++ b/test_args.sh
@@ -124,7 +124,7 @@ else
     kill $pid
 
     # check custom datadir with a network
-    run_lp -broadcaster -datadir "$CUSTOM_DATADIR" -network rinkeby $ETH_ARGS
+    run_lp -broadcaster -dataDir "$CUSTOM_DATADIR" -network rinkeby $ETH_ARGS
     [ ! -d  "$CUSTOM_DATADIR"/rinkeby ] # sanity check that network isn't included
     kill $pid
 

--- a/test_args.sh
+++ b/test_args.sh
@@ -45,7 +45,7 @@ kill $pid
 [ ! -d "$CUSTOM_DATADIR" ]
 
 # check custom datadir without a network (offchain)
-run_lp -broadcaster -datadir "$CUSTOM_DATADIR"
+run_lp -broadcaster -dataDir "$CUSTOM_DATADIR"
 [ -d "$CUSTOM_DATADIR" ]
 [ ! -d  "$CUSTOM_DATADIR"/offchain ] # sanity check that network isn't included
 kill $pid


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds `dataDir` as a CLI option and marks `datadir` as deprecated, making all our CLI options now consistently camel-cased.

**How did you test each of these updates (required)**
- Added unit test
- Ran binary with `--help` and checked it printed both options
- Ran binary using both options and checked data dir specific was created


**Does this pull request close any open issues?**
* https://github.com/livepeer/go-livepeer/issues/1362


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
