### PR TITLE
livepeer_cli: add menu option to exit gracefully

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,6 +19,7 @@
 ### Bug Fixes 🐞
 
 #### CLI
+- \#2438 Add new menu option to gracefully exit livepeer_cli (@emranemran)
 
 #### General
 

--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -110,6 +110,10 @@ func (w *wizard) initializeOptions() []wizardOpt {
 		{desc: "Sign a message", invoke: w.signMessage},
 		{desc: "Sign typed data", invoke: w.signTypedData},
 		{desc: "Vote in a poll", invoke: w.vote, orchestrator: true},
+		{desc: "Exit", invoke: func() {
+			fmt.Println("Goodbye, my friend")
+			os.Exit(0)
+		}},
 	}
 	return options
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adding new menu option to exit livepeer_cli gracefully without having to use Ctrl+C. 

**Specific updates (required)**
- New menu option 

**How did you test each of these updates (required)**
Tested locally and error code was verified. Attempted using other menu options prior to using the new exit option and everything worked as expected. 

**Does this pull request close any open issues?**
fix #2287

**Checklist:**
- [X] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
- ~~[ ] All tests in `./test.sh` pass~~ --> MacM1 fails locally on unrelated error but GH actions will pass 
- [X] README and other documentation updated
- [X] [Pending changelog](./CHANGELOG_PENDING.md) updated
