### PR TITLE
docker.yaml: Push docker tag for latest builds on master branch.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,7 +54,9 @@ jobs:
           BRANCH_TAG="$(echo $GHA_REF | sed -e 's:refs/heads/::; s:/:-:g' | tr -cd '[:alnum:]_-')"
           VERSION_TAG=$(./print_version.sh)
           docker build -t current-build -f docker/Dockerfile.release-linux .
-          for TAG in $BRANCH_TAG $VERSION_TAG; do
+          LATEST_TAG=""
+          if [[ "$GITHUB_REF_NAME" == "master" ]]; then LATEST_TAG="latest"; fi
+          for TAG in $BRANCH_TAG $VERSION_TAG $LATEST_TAG; do
             docker tag current-build livepeer/go-livepeer:${TAG}-linux
             docker push livepeer/go-livepeer:${TAG}-linux
             # Manifest step is optional in case the Windows build hasn't finished yet

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,7 @@
 
 #### General
 - \#2429 Binaries are uploaded to gcp cloud storage following the new directory structure (@hjpotter92)
+- \#2440 Create and push `go-livepeer:latest` tagged images to dockerhub (@hjpotter92)
 
 #### Broadcaster
 - \#2327 Parallelize handling events in Orchestrator Watcher (@red-0ne)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Creates and pushes `go-livepeer:latest` tag for docker images.

**Specific updates (required)**
- In case the github action is working on `master` branch, a docker tag for `:latest` is generated
- The tag is pushed to dockerhub
- This helps users who want to just run `docker pull livepeer/go-livepeer` without referencing a specific commit/version.

**How did you test each of these updates (required)**
This PR!

**Does this pull request close any open issues?**
Fixes #1352 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated