### PR TITLE
livepeer_cli: Fix the "ERROR: logging before flag.Parse" warning when any option is selected

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,6 +23,7 @@
 
 #### CLI
 - \#2438 Add new menu option to gracefully exit livepeer_cli (@emranemran)
+- \#2186 Fix the "ERROR: logging before flag.Parse" warning when any option is selected (@emranemran)
 
 #### General
 

--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -58,7 +59,7 @@ func main() {
 		return nil
 	}
 	app.Version = core.LivepeerVersion
-	// flag.Parse()
+	flag.Parse()
 	app.Run(os.Args)
 }
 


### PR DESCRIPTION
As part of commit 78789b192 (Issue #928), the call to flag.Parse() was commented out perhaps unintentionally. This call is required prior to using glog calls as noted here:
https://github.com/golang/glog/blob/master/glog.go#L40

**What does this pull request do? Explain your changes. (required)**
- (see above commit desc)

**Specific updates (required)**
- (see above commit desc)

**How did you test each of these updates (required)**
- Tested locally by invoking livepeer_cli and verifying the erroneous warning is suppressed. 

**Does this pull request close any open issues?**
Fix #2186


**Checklist:**
- [X] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [X] README and other documentation updated
- [X] [Pending changelog](./CHANGELOG_PENDING.md) updated
