### PR TITLE
mediaserver: add useful debug info to http response headers

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,8 @@
 ### Features ⚒
 
 #### General
+- \#2449 Add useful debug info to http response headers (@emranemran)
+- \#1333 Display git-sha in startup logging (@emranemran)
 
 #### Broadcaster
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,10 @@ core/test_segment.go:
 	core/test_segment.sh core/test_segment.go
 
 version=$(shell cat VERSION)
+PRODUCT_RELEASE=$(shell ./print_version.sh)
 
-ldflags := -X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(shell ./print_version.sh)
+ldflags := -X github.com/livepeer/go-livepeer/core.LivepeerVersion=$(PRODUCT_RELEASE)
+
 cgo_cflags :=
 cgo_ldflags :=
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -71,6 +71,7 @@ func main() {
 		fmt.Printf("Golang runtime version: %s %s\n", runtime.Compiler, runtime.Version())
 		fmt.Printf("Architecture: %s\n", runtime.GOARCH)
 		fmt.Printf("Operating system: %s\n", runtime.GOOS)
+		fmt.Printf("Release version: %s\n", core.LivepeerVersion)
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/jaypipes/ghw v0.9.0
 	github.com/livepeer/livepeer-data v0.4.11
-	github.com/livepeer/lpms v0.0.0-20220523122311-fc32eb80248c
+	github.com/livepeer/lpms v0.0.0-20220531215829-edfec467b648
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -142,6 +142,10 @@ func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bo
 		RtmpDisabled: true,
 		WorkDir:      lpNode.WorkDir,
 		HttpMux:      http.NewServeMux(),
+		HttpDebug:    vidplayer.VidPlayerDebug {
+			DebugEnabled:    true,
+			LivepeerVersion: core.LivepeerVersion,
+		},
 	}
 	switch lpNode.NodeType {
 	case core.BroadcasterNode:


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
When viewing HLS manifests/segments, it is often useful to view information on how those segments were generated. This commit adds fields such as git-sha to the HTTP response headers.

**Specific updates (required)**
- Update `LPMSOpts` struct to include a new `VidPlayerDebug` struct (defined in lpms repo) which holds additional parameters. These opts are used to pass useful debugging fields when instantiating a `VidPlayer` (to playback HLS segments). 
- Relevant LPMS repo changes: https://github.com/livepeer/lpms/pull/332

**How did you test each of these updates (required)**
- localhost testing using e2e setup in both off-chain and on-chain (using devtool)
- Chrome devtool inspect tab to verify headers were tagged appropriately in both off-chain and on-chain modes

**Does this pull request close any open issues?**
- Fix \#2415
- Fix \#1333

**Checklist:**
- [X] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
~~[ ] All tests in `./test.sh` pass~~
- [X] README and other documentation updated
- [X] [Pending changelog](./CHANGELOG_PENDING.md) updated
