### PR TITLE
cli: Show O rather than B options when -redeemer flag set

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,7 @@
 ### Bug Fixes 🐞
 
 #### CLI
+- \#2456 cli: Show O rather than B options when -redeemer flag set (@thomshutt)
 
 #### General
 

--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -120,12 +120,14 @@ func (w *wizard) initializeOptions() []wizardOpt {
 }
 
 func (w *wizard) filterOptions(options []wizardOpt) []wizardOpt {
+	isOrchestratorOrRedeemer := w.orchestrator || w.isRedeemer()
+	println("isOrchestratorOrRedeemer", isOrchestratorOrRedeemer)
 	filtered := make([]wizardOpt, 0, len(options))
 	for _, opt := range options {
 		if opt.testnet && !w.testnet {
 			continue
 		}
-		if !opt.orchestrator && !opt.notOrchestrator || w.orchestrator && opt.orchestrator || !w.orchestrator && opt.notOrchestrator {
+		if !opt.orchestrator && !opt.notOrchestrator || isOrchestratorOrRedeemer && opt.orchestrator || !isOrchestratorOrRedeemer && opt.notOrchestrator {
 			filtered = append(filtered, opt)
 		}
 	}

--- a/cmd/livepeer_cli/livepeer_cli.go
+++ b/cmd/livepeer_cli/livepeer_cli.go
@@ -52,6 +52,7 @@ func main() {
 			in:       bufio.NewReader(os.Stdin),
 		}
 		w.orchestrator = w.isOrchestrator()
+		w.redeemer = w.isRedeemer()
 		w.checkNet()
 		w.run()
 
@@ -67,6 +68,7 @@ type wizard struct {
 	httpPort     string
 	host         string
 	orchestrator bool
+	redeemer     bool
 	testnet      bool
 	offchain     bool
 	in           *bufio.Reader // Wrapper around stdin to allow reading user input
@@ -120,8 +122,7 @@ func (w *wizard) initializeOptions() []wizardOpt {
 }
 
 func (w *wizard) filterOptions(options []wizardOpt) []wizardOpt {
-	isOrchestratorOrRedeemer := w.orchestrator || w.isRedeemer()
-	println("isOrchestratorOrRedeemer", isOrchestratorOrRedeemer)
+	isOrchestratorOrRedeemer := w.orchestrator || w.redeemer
 	filtered := make([]wizardOpt, 0, len(options))
 	for _, opt := range options {
 		if opt.testnet && !w.testnet {

--- a/cmd/livepeer_cli/wizard_transcoder.go
+++ b/cmd/livepeer_cli/wizard_transcoder.go
@@ -28,6 +28,11 @@ func (w *wizard) isOrchestrator() bool {
 	return isT == "true"
 }
 
+func (w *wizard) isRedeemer() bool {
+	isT := httpGet(fmt.Sprintf("http://%v:%v/IsRedeemer", w.host, w.httpPort))
+	return isT == "true"
+}
+
 func myHostPort() string {
 	// TODO Fall back to try other services if this one fails. Ask a peer?
 	// 	http://myexternalip.com

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -3,6 +3,14 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/cenkalti/backoff"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -15,13 +23,6 @@ import (
 	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/pkg/errors"
-	"math/big"
-	"net/http"
-	"net/url"
-	"regexp"
-	"strconv"
-	"strings"
-	"time"
 )
 
 const MainnetChainId = 1
@@ -110,6 +111,12 @@ func (s *LivepeerServer) orchestratorInfoHandler(client eth.LivepeerEthClient) h
 func (s *LivepeerServer) isOrchestratorHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		respondOk(w, []byte(fmt.Sprintf("%v", s.LivepeerNode.NodeType == core.OrchestratorNode)))
+	})
+}
+
+func (s *LivepeerServer) isRedeemerHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		respondOk(w, []byte(fmt.Sprintf("%v", s.LivepeerNode.NodeType == core.RedeemerNode)))
 	})
 }
 

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -3,6 +3,7 @@ package server
 import (
 	"flag"
 	"net/http"
+
 	// pprof adds handlers to default mux via `init()`
 	_ "net/http/pprof"
 
@@ -47,6 +48,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 	mux.Handle("/currentBlock", currentBlockHandler(db))
 	mux.Handle("/orchestratorInfo", s.orchestratorInfoHandler(client))
 	mux.Handle("/IsOrchestrator", s.isOrchestratorHandler())
+	mux.Handle("/IsRedeemer", s.isRedeemerHandler())
 
 	// Broadcast / Transcoding config
 	mux.Handle("/setBroadcastConfig", mustHaveFormParams(setBroadcastConfigHandler()))


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The CLI now shows Orchestrator rather than Broadcaster options when go-livepeer is running with the `-redeemer` flag set.

**Specific updates (required)**
- Add a new /IsRedeemer HTTP endpoint to avoid overloading /IsOrchestrator
- Make CLI option generation check this endpoint as well as /IsOrchestrator

**How did you test each of these updates (required)**
Ran the app with the `-redeemer` flag and the CLI before and after my change


**Does this pull request close any open issues?**
fix #2257


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
