### PR TITLE
cmd: Delete temporary env variable LP_IS_ORCH_TESTER

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,7 @@
 #### General
 
 #### Broadcaster
+- \#2462 cmd: Delete temporary env variable LP_IS_ORCH_TESTER (@leszko)
 
 #### Orchestrator
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -10,12 +10,9 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
-	"strconv"
 	"time"
 
 	"github.com/livepeer/go-livepeer/cmd/livepeer/starter"
-	"github.com/livepeer/go-livepeer/common"
-
 	"github.com/livepeer/livepeer-data/pkg/mistconnector"
 	"github.com/peterbourgon/ff/v3"
 
@@ -51,7 +48,6 @@ func main() {
 	}
 
 	vFlag.Value.Set(*verbosity)
-	streamTesterMode()
 
 	cfg = updateNilsForUnsetFlags(cfg)
 
@@ -204,19 +200,4 @@ func updateNilsForUnsetFlags(cfg starter.LivepeerConfig) starter.LivepeerConfig 
 	}
 
 	return res
-}
-
-// streamTesterMode extends transcoding timeouts and disable caching for the testing purpose.
-// This functionality is intended for Stream Tester to avoid timing out while measuring orchestrator performance.
-func streamTesterMode() {
-	if boolVal, _ := strconv.ParseBool(os.Getenv("LP_IS_ORCH_TESTER")); boolVal {
-		// Make all timeouts 8s for the common segment durations
-		common.SegUploadTimeoutMultiplier = 4.0
-		common.SegmentUploadTimeout = 8 * time.Second
-		common.HTTPDialTimeout = 8 * time.Second
-		common.SegHttpPushTimeoutMultiplier = 4.0
-
-		// Disable caching for Orchestrator Discovery Webhook
-		common.WebhookDiscoveryRefreshInterval = 0
-	}
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Orchtester does not use a separate Broadcaster anymore, so the `LP_IS_ORCH_TESTER` variable is not needed.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Cleanup
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
N/A


**Does this pull request close any open issues?**
fix https://github.com/livepeer/stream-tester/issues/160


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~README and other documentation updated~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
