### PR TITLE
server: Don't fail to get Transcode Results if Detections header missing

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,6 +11,7 @@
 #### Broadcaster
 
 #### Orchestrator
+- \#2465 server: Don't fail to get Transcode Results if Detections header missing
 
 #### Transcoder
 

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -265,14 +265,16 @@ func sendTranscodeResult(ctx context.Context, n *core.LivepeerNode, orchAddr str
 
 	pixels := int64(0)
 	// add detections
-	if tData != nil && len(tData.Detections) > 0 {
-		detectData, err := json.Marshal(tData.Detections)
-		if err != nil {
-			clog.Errorf(ctx, "Error posting results, couldn't serialize detection data orch=%s staskId=%d url=%s err=%q", orchAddr,
-				notify.TaskId, notify.Url, err)
-			return
+	if tData != nil {
+		if len(tData.Detections) > 0 {
+			detectData, err := json.Marshal(tData.Detections)
+			if err != nil {
+				clog.Errorf(ctx, "Error posting results, couldn't serialize detection data orch=%s staskId=%d url=%s err=%q", orchAddr,
+					notify.TaskId, notify.Url, err)
+				return
+			}
+			req.Header.Set("Detections", string(detectData))
 		}
-		req.Header.Set("Detections", string(detectData))
 		pixels = tData.Pixels
 	}
 	req.Header.Set("Pixels", strconv.FormatInt(pixels, 10))

--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -265,7 +265,7 @@ func sendTranscodeResult(ctx context.Context, n *core.LivepeerNode, orchAddr str
 
 	pixels := int64(0)
 	// add detections
-	if tData != nil {
+	if tData != nil && len(tData.Detections) > 0 {
 		detectData, err := json.Marshal(tData.Detections)
 		if err != nil {
 			clog.Errorf(ctx, "Error posting results, couldn't serialize detection data orch=%s staskId=%d url=%s err=%q", orchAddr,

--- a/server/ot_rpc_test.go
+++ b/server/ot_rpc_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/lpms/ffmpeg"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type stubTranscoder struct {
@@ -136,6 +137,108 @@ func TestRemoteTranscoder_Profiles(t *testing.T) {
 
 		i++
 	}
+}
+
+func TestTranscodeResults_ErrorsWhenAuthHeaderMissing(t *testing.T) {
+	var l lphttp
+	var w = httptest.NewRecorder()
+
+	r, err := http.NewRequest(http.MethodGet, "/TranscodeResults", nil)
+	require.NoError(t, err)
+
+	l.TranscodeResults(w, r)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Contains(t, w.Body.String(), "Unauthorized")
+}
+
+func TestTranscodeResults_ErrorsWhenCredentialsInvalid(t *testing.T) {
+	var l lphttp
+	l.orchestrator = newStubOrchestrator()
+	l.orchestrator.TranscoderSecret()
+	var w = httptest.NewRecorder()
+
+	r, err := http.NewRequest(http.MethodGet, "/TranscodeResults", nil)
+	require.NoError(t, err)
+
+	r.Header.Set("Authorization", protoVerLPT)
+	r.Header.Set("Credentials", "BAD CREDENTIALS")
+
+	l.TranscodeResults(w, r)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Contains(t, w.Body.String(), "Unauthorized")
+}
+
+func TestTranscodeResults_ErrorsWhenContentTypeMissing(t *testing.T) {
+	var l lphttp
+	l.orchestrator = newStubOrchestrator()
+	l.orchestrator.TranscoderSecret()
+	var w = httptest.NewRecorder()
+
+	r, err := http.NewRequest(http.MethodGet, "/TranscodeResults", nil)
+	require.NoError(t, err)
+
+	r.Header.Set("Authorization", protoVerLPT)
+	r.Header.Set("Credentials", "")
+
+	l.TranscodeResults(w, r)
+	require.Equal(t, http.StatusUnsupportedMediaType, w.Code)
+	require.Contains(t, w.Body.String(), "mime: no media type")
+}
+
+func TestTranscodeResults_ErrorsWhenTaskIDMissing(t *testing.T) {
+	var l lphttp
+	l.orchestrator = newStubOrchestrator()
+	l.orchestrator.TranscoderSecret()
+	var w = httptest.NewRecorder()
+
+	r, err := http.NewRequest(http.MethodGet, "/TranscodeResults", nil)
+	require.NoError(t, err)
+
+	r.Header.Set("Authorization", protoVerLPT)
+	r.Header.Set("Credentials", "")
+	r.Header.Set("Content-Type", "video/mp4")
+
+	l.TranscodeResults(w, r)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "Invalid Task ID")
+}
+
+func TestTranscodeResults_DoesNotErrorWhenSceneDetectionHeaderMissing(t *testing.T) {
+	var l lphttp
+	l.orchestrator = newStubOrchestrator()
+	l.orchestrator.TranscoderSecret()
+	var w = httptest.NewRecorder()
+
+	r, err := http.NewRequest(http.MethodGet, "/TranscodeResults", nil)
+	require.NoError(t, err)
+
+	r.Header.Set("Authorization", protoVerLPT)
+	r.Header.Set("Credentials", "")
+	r.Header.Set("Content-Type", "video/mp4")
+	r.Header.Set("TaskId", "123")
+	r.Header.Set("Pixels", "1")
+
+	l.TranscodeResults(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestTranscodeResults_ErrorsWhenPixelsHeaderMissing(t *testing.T) {
+	var l lphttp
+	l.orchestrator = newStubOrchestrator()
+	l.orchestrator.TranscoderSecret()
+	var w = httptest.NewRecorder()
+
+	r, err := http.NewRequest(http.MethodGet, "/TranscodeResults", nil)
+	require.NoError(t, err)
+
+	r.Header.Set("Authorization", protoVerLPT)
+	r.Header.Set("Credentials", "")
+	r.Header.Set("Content-Type", "video/mp4")
+	r.Header.Set("TaskId", "123")
+
+	l.TranscodeResults(w, r)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "Invalid Pixels")
 }
 
 func TestRemoteTranscoder_FullProfiles(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The "Scene Detection" feature should currently be a no-op unless explicitly enabled with a flag, but the current implementation fails to return Transcode results for a standalone T if detection isn't enabled.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Only try to parse the Detections header if it's present
- Only send the Detections header if detections have been performed

**How did you test each of these updates (required)**
- Added unit tests
- Ran O / T locally


**Does this pull request close any open issues?**
fix #2459 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
