### PR TITLE
livepeer/starter: remove testTranscoder flag

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,7 @@
 
 - \#2466 bugfix: rendition resolution fix for portrait input videos; Min resolution applied for Nvidia hardware (@AlexKordic)
 - \#338 lpms: Add exception handling code for importing a binary signature (@oscar_davids)
+- \#2472 livepeer/starter: deprecate testTranscoder flag to prevent starting an O with no capabilities (@emahbub)
 
 #### CLI
 - \#2456 cli: Show O rather than B options when -redeemer flag set (@thomshutt)

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -116,7 +116,6 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.CurrentManifest = flag.Bool("currentManifest", *cfg.CurrentManifest, "Expose the currently active ManifestID as \"/stream/current.m3u8\"")
 	cfg.Nvidia = flag.String("nvidia", *cfg.Nvidia, "Comma-separated list of Nvidia GPU device IDs (or \"all\" for all available devices)")
 	cfg.Netint = flag.String("netint", *cfg.Netint, "Comma-separated list of NetInt device GUIDs (or \"all\" for all available devices)")
-	cfg.TestTranscoder = flag.Bool("testTranscoder", *cfg.TestTranscoder, "Test Nvidia GPU transcoding at startup")
 	cfg.SceneClassificationModelPath = flag.String("sceneClassificationModelPath", *cfg.SceneClassificationModelPath, "Path to scene classification model")
 	cfg.DetectContent = flag.Bool("detectContent", *cfg.DetectContent, "Set to true to enable content type detection")
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -83,7 +83,6 @@ type LivepeerConfig struct {
 	CurrentManifest              *bool
 	Nvidia                       *string
 	Netint                       *string
-	TestTranscoder               *bool
 	SceneClassificationModelPath *string
 	DetectContent                *bool
 	EthAcctAddr                  *string
@@ -147,7 +146,6 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultCurrentManifest := false
 	defaultNvidia := ""
 	defaultNetint := ""
-	defaultTestTranscoder := true
 	defaultDetectContent := false
 	defaultSceneClassificationModelPath := "tasmodel.pb"
 
@@ -213,7 +211,6 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		CurrentManifest:              &defaultCurrentManifest,
 		Nvidia:                       &defaultNvidia,
 		Netint:                       &defaultNetint,
-		TestTranscoder:               &defaultTestTranscoder,
 		SceneClassificationModelPath: &defaultSceneClassificationModelPath,
 		DetectContent:                &defaultDetectContent,
 
@@ -387,15 +384,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 			glog.Infof("Transcoding on these %v devices: %v", accelName, devices)
 			// Test transcoding with specified device
-			if *cfg.TestTranscoder {
-				transcoderCaps, err = core.TestTranscoderCapabilities(devices, tf)
-				if err != nil {
-					glog.Fatal(err)
-					return
-				}
-			} else {
-				// no capability test was run, assume default capabilities
-				transcoderCaps = append(transcoderCaps, core.DefaultCapabilities()...)
+			transcoderCaps, err = core.TestTranscoderCapabilities(devices, tf)
+			if err != nil {
+				glog.Fatal(err)
+				return
 			}
 			// initialize Tensorflow runtime on each device to reduce delay when creating new transcoding session
 			if accel == ffmpeg.Nvidia && *cfg.DetectContent {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The -testTranscoder flag defaults to true which requires all hardware
transcoders to call core.TestTranscoderCapabilities() to discover
transcoding caps. Setting this flag to false is not a valid use case
anymore so this change deprecates that option.

**Specific updates (required)**
- Remove the use of  testTranscoder flag and allow code path to always call TestTranscoderCapabilities() which it already does as the option defaults to false. 

**How did you test each of these updates (required)**
- WIP: to be tested on GCP w/ nvidia hardware...

**Does this pull request close any open issues?**
Fix \#2450

**Checklist:**
- [X] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
~~[ ] All tests in `./test.sh` pass~~
- [X] README and other documentation updated
- [X] [Pending changelog](./CHANGELOG_PENDING.md) updated
