### PR TITLE
server/mediaserver: fix for recordings with no -authWebhookUrl

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -1350,7 +1350,7 @@ func (s *LivepeerServer) HandleRecordings(w http.ResponseWriter, r *http.Request
 		return
 	}
 	var manifests []string
-	if len(resp.PreviousSessions) > 0 {
+	if resp != nil && len(resp.PreviousSessions) > 0 {
 		manifests = append(resp.PreviousSessions, manifestID)
 	} else {
 		manifests = []string{manifestID}
@@ -1481,7 +1481,11 @@ func (s *LivepeerServer) HandleRecordings(w http.ResponseWriter, r *http.Request
 	} else if !returnMasterPlaylist {
 		mpl := mediaLists[track]
 		if mpl != nil {
-			mainJspl.AddSegmentsToMPL(manifests, track, mpl, resp.RecordObjectStoreURL)
+			osUrl := ""
+			if resp != nil {
+				osUrl = resp.RecordObjectStoreURL
+			}
+			mainJspl.AddSegmentsToMPL(manifests, track, mpl, osUrl)
 			// check (debug code)
 			startSeq := mpl.Segments[0].SeqId
 			for _, seg := range mpl.Segments[1:] {


### PR DESCRIPTION
Two null pointer exceptions here if go-livepeer is configured to use a `-recordObjectStore` directly with no `-authWebhookUrl` configured. Would love to get an automated test for this, but I guess we're deprecating these features soon anyway...

This makes the following function properly:
```
livepeer -broadcaster -recordStore s3+https://GOOGAMT7AUXJ2SXGAGRI4NQI:[redacted]@storage.googleapis.com/go-livepeer-vod-test
```
And is needed to verify the breakage in https://github.com/livepeer/go-livepeer/issues/2476