### PR TITLE
Log error during T startup

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1068,7 +1068,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	//Set up the media server
 	s, err := server.NewLivepeerServer(*cfg.RtmpAddr, n, httpIngest, *cfg.TranscodingOptions)
 	if err != nil {
-		glog.Fatal("Error creating Livepeer server err=", err)
+		glog.Fatalf("Error creating Livepeer server: err=%q", err)
 	}
 
 	ec := make(chan error)
@@ -1101,7 +1101,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		orch := core.NewOrchestrator(s.LivepeerNode, timeWatcher)
 
 		go func() {
-			server.StartTranscodeServer(orch, *cfg.HttpAddr, s.HTTPMux, n.WorkDir, n.TranscoderManager != nil)
+			err = server.StartTranscodeServer(orch, *cfg.HttpAddr, s.HTTPMux, n.WorkDir, n.TranscoderManager != nil)
+			if err != nil {
+				glog.Fatalf("Error starting Transcoder node: err=%q", err)
+			}
 			tc <- struct{}{}
 		}()
 

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -175,7 +175,7 @@ func (h *lphttp) Ping(context context.Context, req *net.PingPong) (*net.PingPong
 }
 
 // XXX do something about the implicit start of the http mux? this smells
-func StartTranscodeServer(orch Orchestrator, bind string, mux *http.ServeMux, workDir string, acceptRemoteTranscoders bool) {
+func StartTranscodeServer(orch Orchestrator, bind string, mux *http.ServeMux, workDir string, acceptRemoteTranscoders bool) error {
 	s := grpc.NewServer()
 	lp := lphttp{
 		orchestrator: orch,
@@ -191,7 +191,7 @@ func StartTranscodeServer(orch Orchestrator, bind string, mux *http.ServeMux, wo
 
 	cert, key, err := getCert(orch.ServiceURI(), workDir)
 	if err != nil {
-		return // XXX return error
+		return err
 	}
 
 	glog.Info("Listening for RPC on ", bind)
@@ -202,7 +202,7 @@ func StartTranscodeServer(orch Orchestrator, bind string, mux *http.ServeMux, wo
 		//ReadTimeout:  HTTPTimeout,
 		//WriteTimeout: HTTPTimeout,
 	}
-	srv.ListenAndServeTLS(cert, key)
+	return srv.ListenAndServeTLS(cert, key)
 }
 
 // CheckOrchestratorAvailability - the broadcaster calls CheckOrchestratorAvailability which invokes Ping on the orchestrator


### PR DESCRIPTION
Fix for no log message, if error occurs in `server.StartTranscodeServer` during node startup.