### PR TITLE
lpms: bump version to fix recording transmuxing bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jaypipes/ghw v0.9.0
 	github.com/jaypipes/pcidb v1.0.0
 	github.com/livepeer/livepeer-data v0.4.11
-	github.com/livepeer/lpms v0.0.0-20220624092019-622b50738904
+	github.com/livepeer/lpms v0.0.0-20220628192654-ef2dba822181
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -631,6 +631,8 @@ github.com/livepeer/livepeer-data v0.4.11 h1:Sv+ss8e4vcscnMWLxcRJ2g3sNIHyQ3RzCtg
 github.com/livepeer/livepeer-data v0.4.11/go.mod h1:VIbJRdyH2Tas8EgLVkP79IPMepFDOv0dgHYLEZsCaf4=
 github.com/livepeer/lpms v0.0.0-20220624092019-622b50738904 h1:DLVQsRRNi7oRkS0ABVdMPPZW50I9efPUlfIMfBV2tWg=
 github.com/livepeer/lpms v0.0.0-20220624092019-622b50738904/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
+github.com/livepeer/lpms v0.0.0-20220628192654-ef2dba822181 h1:OK2B1A4qSeXUrxwmJo6znARaRiOSH4Bxl535wdtSKNA=
+github.com/livepeer/lpms v0.0.0-20220628192654-ef2dba822181/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes [decoding error on transmuxing](https://github.com/livepeer/go-livepeer/issues/2476), when playing recorded video from cloud storage.

**Specific updates (required)**
Updates are in [LPMS](https://github.com/livepeer/lpms/pull/340). This error occurred, because Ffmpeg's `av_find_input_format` didn't get stream header, as header data was already read from pipe by metadata extracting function. Doesn't happen for files, because they are read from the start in both cases. Normally, we read first portion of the input file twice, which may be inefficient. Relevant for @MikeIndiaAlpha's refactoring work.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
The fix is to disable reading metadata for pipes. This will work 100% for transmuxing, but may not work for corner cases, which require metadata, when input is pipe - if we'll ever have such use cases.

**Does this pull request close any open issues?**
Fixes #2476 


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
