### PR TITLE
pm: lower avgGasPrice

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -33,6 +33,7 @@
 #### Broadcaster
 
 #### Orchestrator
+- \#2493 cmd: Fix reward flag (@leszko)
 - \#2481 Lower `avgGasPrice` to prevent dropping streams during the gas price spikes (@leszko)
 
 #### Transcoder

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -33,6 +33,6 @@
 #### Broadcaster
 
 #### Orchestrator
-- \#2493 cmd: Fix reward flag (@leszko)
+- \#2481 Lower `avgGasPrice` to prevent dropping streams during the gas price spikes (@leszko)
 
 #### Transcoder

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -28,7 +28,7 @@ var evMultiplier = big.NewInt(100)
 
 // Hardcode to 200 gwei
 // TODO: Replace this hardcoded value by dynamically determining the average gas price during a period of time
-var avgGasPrice = new(big.Int).Mul(big.NewInt(200), new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil))
+var avgGasPrice = new(big.Int).Mul(big.NewInt(140), new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil))
 
 // Recipient is an interface which describes an object capable
 // of receiving tickets
@@ -300,8 +300,7 @@ func (r *recipient) faceValue(sender ethcommon.Address) (*big.Int, error) {
 	// because there is a good chance that the current gasPrice will come back down by the time a winning ticket is received
 	// and needs to be redeemed.
 	// For now, avgGasPrice is hardcoded. See the comment for avgGasPrice for TODO information.
-	// Use || here for lazy evaluation. If the first clause is true we ignore the second clause.
-	if !(faceValue.Cmp(txCost) >= 0 || faceValue.Cmp(r.txCostWithGasPrice(avgGasPrice)) >= 0) {
+	if faceValue.Cmp(txCost) < 0 && faceValue.Cmp(r.txCostWithGasPrice(avgGasPrice)) < 0 {
 		return nil, errInsufficientSenderReserve
 	}
 

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -26,9 +26,9 @@ var paramsExpiryBuffer = int64(1)
 
 var evMultiplier = big.NewInt(100)
 
-// Hardcode to 200 gwei
+// Hardcode to 3 gwei
 // TODO: Replace this hardcoded value by dynamically determining the average gas price during a period of time
-var avgGasPrice = new(big.Int).Mul(big.NewInt(140), new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil))
+var avgGasPrice = new(big.Int).Mul(big.NewInt(3), new(big.Int).Exp(big.NewInt(10), big.NewInt(9), nil))
 
 // Recipient is an interface which describes an object capable
 // of receiving tickets


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Lower the hardcoded avg gas price to prevent Os from dropping streams in case of the gas price spikes.

The value is changed from `200` => `140`. Here's the rationale why this value was chosen. In our problematic scenario, in the case when `maxFaceValue` is **not** set, then:

1. In order to not drop the stream during gas spike this condition `faceValue.Cmp(r.txCostWithGasPrice(avgGasPrice)) < 0` must be `false`
2. In the worse case scenario, face value [equals to max float](https://github.com/livepeer/go-livepeer/blob/8b3fcd674859f184407323266b6d1aae0ab42534/pm/recipient.go#L279) (which corresponds to the [B's reserve](https://github.com/livepeer/go-livepeer/blob/5d9bcaa325d8caa18151b42f50f4f78bf76834d7/pm/sendermonitor.go#L191), currently `180000000000000000`)
3. `txCostWithGasPrice()` is calculated as `redeemGas * avgGasPrice`, where Arbitrum `redeemGas` is [hardcoded](url) as `1200000`
4. That means that `180000000000000000 < 1200000 * avgGasPrice` must be `false`
5. That means that `180000000000000000 >= 1200000 * avgGasPrice` must be `true`
6. That means that `avgGasPrice <= 180000000000000000 / 1200000` => `avgGasPrice <= 150000000000`

So, with the current B's reserve and the current hardcoded `redeemGas`, the `avgGasPrice` must be smaller than `150 Gwei`. To make a buffer, I changed it to `140`.


**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Change `avgGasPrice`
- Simplify the condition check

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Debugged with Orchestrator.


**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2473


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~README and other documentation updated~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
