### PR TITLE
eth: Backfill blocks in batches

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,7 @@
 #### General
 - \#1333 Display git-sha in startup logging (@emranemran)
 - \#2443 Add e2e tests for O configuration and resignation (@red-0ne)
+- \#2489 Backfill blocks in batches (@leszko)
 
 #### Broadcaster
 - \#2462 cmd: Delete temporary env variable LP_IS_ORCH_TESTER (@leszko)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -879,10 +879,12 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 		// Backfill events that the node has missed since its last seen block. This method will block
 		// and the node will not continue setup until it finishes
-		if err := blockWatcher.BackfillEventsIfNeeded(blockWatchCtx); err != nil {
+		glog.Infof("Backfilling block events (this can take a while)...\n")
+		if err := blockWatcher.BackfillEvents(blockWatchCtx); err != nil {
 			glog.Errorf("Failed to backfill events: %v", err)
 			return
 		}
+		glog.Info("Done backfilling block events")
 
 		blockWatcherErr := make(chan error, 1)
 		go func() {

--- a/eth/blockwatch/block_watcher_test.go
+++ b/eth/blockwatch/block_watcher_test.go
@@ -41,6 +41,7 @@ func TestWatcher(t *testing.T) {
 	for i := 0; i < fakeClient.NumberOfTimesteps(); i++ {
 		scenarioLabel := fakeClient.GetScenarioLabel()
 
+		err := watcher.pollNextBlock()
 		require.NoError(t, err)
 
 		retainedBlocks, err := watcher.InspectRetainedBlocks()
@@ -188,12 +189,13 @@ func TestGetMissedEventsToBackfillSomeMissed(t *testing.T) {
 
 	store := &stubMiniHeaderStore{}
 	// Add block number 5 as the last block seen by BlockWatcher
-	lastBlockSeen := &MiniHeader{
+	preLastBlockSeen := &MiniHeader{
 		Number: big.NewInt(5),
 		Hash:   common.HexToHash("0x293b9ea024055a3e9eddbf9b9383dc7731744111894af6aa038594dc1b61f87f"),
 		Parent: common.HexToHash("0x26b13ac89500f7fcdd141b7d1b30f3a82178431eca325d1cf10998f9d68ff5ba"),
 	}
-	err = store.InsertMiniHeader(lastBlockSeen)
+	err = store.InsertMiniHeader(preLastBlockSeen)
+
 	require.NoError(t, err)
 
 	config.Store = store
@@ -210,7 +212,7 @@ func TestGetMissedEventsToBackfillSomeMissed(t *testing.T) {
 	headers, err := store.FindAllMiniHeadersSortedByNumber()
 	require.NoError(t, err)
 	require.Len(t, headers, 1)
-	assert.Equal(t, big.NewInt(30), headers[0].Number)
+	assert.Equal(t, big.NewInt(29), headers[0].Number)
 }
 
 func TestGetMissedEventsToBackfillNoneMissed(t *testing.T) {

--- a/eth/blockwatch/block_watcher_test.go
+++ b/eth/blockwatch/block_watcher_test.go
@@ -41,7 +41,6 @@ func TestWatcher(t *testing.T) {
 	for i := 0; i < fakeClient.NumberOfTimesteps(); i++ {
 		scenarioLabel := fakeClient.GetScenarioLabel()
 
-		err := watcher.pollNextBlock()
 		require.NoError(t, err)
 
 		retainedBlocks, err := watcher.InspectRetainedBlocks()

--- a/eth/blockwatch/testdata/fake_client_fast_sync_fixture.json
+++ b/eth/blockwatch/testdata/fake_client_fast_sync_fixture.json
@@ -15,6 +15,11 @@
             "hash": "0x382b25dd926322722bba2575b5092be661a99f26472e2b7c2bb3d51e6bd2b09c",
             "parent": "0xb57233b65a0da953da19d685d10a65e3124207fd1cf4694e3fc0f7279373bf5f",
             "number": 30
+          },
+          "29": {
+            "hash": "0xb57233b65a0da953da19d685d10a65e3124207fd1cf4694e3fc0f7279373bf5f",
+            "parent": "0x0f52679a1ff257072b0588234c9cf9727cc4fe3a973e5fa528474d2be638253b",
+            "number": 29
           }
         },
         "getBlockByHash": {
@@ -27,6 +32,11 @@
             "hash": "0x382b25dd926322722bba2575b5092be661a99f26472e2b7c2bb3d51e6bd2b09c",
             "parent": "0xb57233b65a0da953da19d685d10a65e3124207fd1cf4694e3fc0f7279373bf5f",
             "number": 30
+          },
+          "0xb57233b65a0da953da19d685d10a65e3124207fd1cf4694e3fc0f7279373bf5f": {
+            "hash": "0xb57233b65a0da953da19d685d10a65e3124207fd1cf4694e3fc0f7279373bf5f",
+            "parent": "0x0f52679a1ff257072b0588234c9cf9727cc4fe3a973e5fa528474d2be638253b",
+            "number": 29
           }
         },
         "getCorrectChain": [],


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Optimize the number of ETH RPC request by first backfilling blocks in batches during the block sync. In result, only the latest block is polled separately instead of polling all missing blocks one-by-one.

This also fixes the Livepeer downtime issue in the case when Livepeer cannot catch up with the blocks and therefore can't transcode.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- In `syncToLatestBlock()`, execute first block backfilling and then poll block only for the latest one
- Update unit tests

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Deployed an orchestrator and checked that it can transcode the video
- Check that block backfilling catches all interesting information (e.g. DepositFund, etc.)

**Does this pull request close any open issues?**
<!-- Fixes # -->
fix #2480


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~README and other documentation updated~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
