### PR TITLE
Update ffmpeg for thread.h

### DIFF
--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -150,7 +150,7 @@ fi
 if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]]; then
   git clone https://github.com/livepeer/FFmpeg.git "$ROOT/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$ROOT/ffmpeg"
-  git checkout 653f5f479d411e1adf8268be34d74030dfc719f7
+  git checkout dd7e5c34e75fcb8ed79e0798d190d523e11ce60b
   ./configure ${TARGET_OS:-} $DISABLE_FFMPEG_COMPONENTS --fatal-warnings \
     --enable-libx264 --enable-gpl \
     --enable-protocol=rtmp,file,pipe \


### PR DESCRIPTION
I had to modify ffmpeg Makefile install section in order to copy
to include directory both libavutil/thread.h and config.h

This change makes install script take updated ffmpeg by default

**What does this pull request do? Explain your changes. (required)**

install_ffmpeg.sh clones our FFmpeg fork, then checks out particular commit. This pull request changes aforementioned commit to the one with FFmpeg changes I did. FFmpeg changes, in turn, are about installing libavutil/thread.h and config.h in ~/compiled/include/ directory.

**Specific updates (required)**

Change commit id in install_ffmpeg.sh:153

**How did you test each of these updates (required)**

I removed the ~/ffmpeg manually, and then reinstalled it by the means of modified install_ffmpeg.sh. Then verified that libavutil/thread.h and config.h are indeed installed. Then compiled new version of LPMS, one that requires thread.h (and config.h in turn). Everything went fine.

**Does this pull request close any open issues?**
None that I know of.


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] Read the [contribution guide](./doc/contributing.md)
- [ x] `make` runs successfully
- [ x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
I haven't done last two things, because I am not sure to write there in case of such a trivial/irrelevant (I mean for go-livepeer) change.