### PR TITLE
net: fix no sessions error if O hostname doesn't match

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -105,7 +105,6 @@ func (o *orchestratorPool) GetInfo(uri string) common.OrchestratorLocalInfo {
 			}
 		}
 	}
-	// TODO: indicate error
 	return res
 }
 

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -70,7 +70,6 @@ func ResolveURL(urlToResolve *url.URL) []*url.URL {
 	} else {
 		host, port = urlToResolve.Host, ""
 	}
-	isV6 := strings.Count(host, ":") > 0
 	if net2.ParseIP(host) == nil {
 		// handle localhost - won't work for custom hosts entry!
 		var addrs []string
@@ -89,7 +88,7 @@ func ResolveURL(urlToResolve *url.URL) []*url.URL {
 			newUrl, _ := url.Parse(urlToResolve.String())
 			if port != "" {
 				// enclose ipv6 into brackets
-				if isV6 {
+				if strings.Count(addr, ":") > 0 {
 					newUrl.Host = fmt.Sprintf("[%s]:%s", addr, port)
 				} else {
 					newUrl.Host = fmt.Sprintf("%s:%s", addr, port)

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -61,14 +61,15 @@ func TestResolveURL(t *testing.T) {
 		}
 		return []string{"1.1.1.1", "aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa"}, nil
 	}
+
 	srcUrl, _ := url.Parse("https://example.com:5555")
 	urls := ResolveURL(srcUrl)
 	// check results length
 	assert.Equal(t, len(urls), 2)
-	// check first ip
+	// check ipv4 with port
 	assert.Equal(t, "https://1.1.1.1:5555", urls[0].String())
-	// second ip
-	assert.Equal(t, "https://aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:5555", urls[1].String())
+	// check ipv6 with port
+	assert.Equal(t, "https://[aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa:aaaa]:5555", urls[1].String())
 
 	// test no port
 	srcUrl, _ = url.Parse("https://example.com")
@@ -97,7 +98,7 @@ func TestResolveURL(t *testing.T) {
 	assert.Equal(t, 1, len(urls))
 	assert.Equal(t, "https://error:5555:1233", urls[0].String())
 
-	// test ipv6 port handling
+	// test ipv6 port handling - no resolve
 	srcUrl, _ = url.Parse("https://[1000:2000:3000:4000:5000:6000:7000:8001]:5555")
 	urls = ResolveURL(srcUrl)
 	assert.Equal(t, 1, len(urls))

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -722,6 +722,10 @@ func selectOrchestrator(ctx context.Context, n *core.LivepeerNode, params *core.
 			bcastOS = bcastOS.OS().NewSession(pfx)
 		}
 
+		oinfo := n.OrchestratorPool.GetInfo(tinfo.Transcoder)
+		if oinfo.URL == nil {
+			return nil, errors.New("cannot get orchestrator info")
+		}
 		session := &BroadcastSession{
 			Broadcaster:       core.NewBroadcaster(n),
 			Params:            params,
@@ -733,7 +737,7 @@ func selectOrchestrator(ctx context.Context, n *core.LivepeerNode, params *core.
 			Balances:          n.Balances,
 			Balance:           balance,
 			lock:              &sync.RWMutex{},
-			OrchestratorScore: n.OrchestratorPool.GetInfo(tinfo.Transcoder).Score, // todo: use score from OrchestratorLocalInfo
+			OrchestratorScore: oinfo.Score,
 		}
 
 		sessions = append(sessions, session)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -175,7 +175,8 @@ func (d *stubDiscovery) GetInfos() []common.OrchestratorLocalInfo {
 }
 
 func (d *stubDiscovery) GetInfo(uri string) common.OrchestratorLocalInfo {
-	var res common.OrchestratorLocalInfo
+	url, _ := url.Parse(uri)
+	res := common.OrchestratorLocalInfo{URL: url}
 	return res
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Issue #2485 
Particularly nasty bug with observable issue occurring in unrelated session management logic, but straightforward resolution. The root cause is OrchestratorPool returning empty OrchestratorLocalInfo, if O's `-serviceAddr` doesn't match B's `-orchAddr` precisely (e.g. **localhost** won't match **127.0.0.1**). It might have caused silent O selection issues in any case when `-orchAddr` or `-serviceAddr` were specified.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add host name resolution function, with support for `localhost`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->
Issue #2485 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
