### PR TITLE
Fix no sessions error if O hostname doesn't match

### DIFF
--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -96,23 +96,8 @@ func (dbo *DBOrchestratorPoolCache) GetInfos() []common.OrchestratorLocalInfo {
 	return infos
 }
 
-func (dbo *DBOrchestratorPoolCache) GetInfo(uri string) common.OrchestratorLocalInfo {
-	uris, _ := dbo.getURLs()
-	res := common.OrchestratorLocalInfo{
-		Score: common.Score_Untrusted,
-	}
-
-	for _, uri_ := range uris {
-		if uri_.String() == uri {
-			res.URL = uri_
-			break
-		}
-	}
-	return res
-}
-
 func (dbo *DBOrchestratorPoolCache) GetOrchestrators(ctx context.Context, numOrchestrators int, suspender common.Suspender, caps common.CapabilityComparator,
-	scorePred common.ScorePred) ([]*net.OrchestratorInfo, error) {
+	scorePred common.ScorePred) (common.OrchestratorDescriptors, error) {
 
 	uris, err := dbo.getURLs()
 	if err != nil || len(uris) <= 0 {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -76,7 +76,7 @@ func TestDeadLock(t *testing.T) {
 	infos, err := pool.GetOrchestrators(context.TODO(), 1, newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 	assert.Nil(err, "Should not be error")
 	assert.Len(infos, 1, "Should return one orchestrator")
-	assert.Equal("transcoderfromtestserver", infos[0].Transcoder)
+	assert.Equal("transcoderfromtestserver", infos[0].RemoteInfo.Transcoder)
 }
 
 func TestDeadLock_NewOrchestratorPoolWithPred(t *testing.T) {
@@ -124,7 +124,7 @@ func TestDeadLock_NewOrchestratorPoolWithPred(t *testing.T) {
 
 	assert.Nil(err, "Should not be error")
 	assert.Len(infos, 1, "Should return one orchestrator")
-	assert.Equal("transcoderfromtestserver", infos[0].Transcoder)
+	assert.Equal("transcoderfromtestserver", infos[0].RemoteInfo.Transcoder)
 }
 
 func TestPoolSize(t *testing.T) {
@@ -347,8 +347,8 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 	assert.Equal(pool.Size(), 3)
 	orchs, err := pool.GetOrchestrators(context.TODO(), pool.Size(), newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 	for _, o := range orchs {
-		assert.Equal(o.PriceInfo, expPriceInfo)
-		assert.Equal(o.Transcoder, expTranscoder)
+		assert.Equal(o.RemoteInfo.PriceInfo, expPriceInfo)
+		assert.Equal(o.RemoteInfo.Transcoder, expTranscoder)
 	}
 
 	// ensuring orchs exist in DB
@@ -795,8 +795,8 @@ func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
 	}
 	oinfos, err := pool.GetOrchestrators(context.TODO(), 50, newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 	for _, info := range oinfos {
-		assert.Equal(info.PriceInfo, expPriceInfo)
-		assert.Equal(info.Transcoder, expTranscoder)
+		assert.Equal(info.RemoteInfo.PriceInfo, expPriceInfo)
+		assert.Equal(info.RemoteInfo.Transcoder, expTranscoder)
 	}
 
 	assert.Nil(err, "Should not be error")
@@ -912,7 +912,7 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 	assert.Nil(err, "Should not be error")
 	assert.Len(oinfos, 25)
 	for _, info := range oinfos {
-		assert.Equal(info.Transcoder, "goodPriceTranscoder")
+		assert.Equal(info.RemoteInfo.Transcoder, "goodPriceTranscoder")
 	}
 }
 
@@ -1081,8 +1081,8 @@ func TestCachedPool_GetOrchestrators_OnlyActiveOrchestrators(t *testing.T) {
 	}
 	oinfos, err := pool.GetOrchestrators(context.TODO(), 50, newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 	for _, info := range oinfos {
-		assert.Equal(info.PriceInfo, expPriceInfo)
-		assert.Equal(info.Transcoder, expTranscoder)
+		assert.Equal(info.RemoteInfo.PriceInfo, expPriceInfo)
+		assert.Equal(info.RemoteInfo.Transcoder, expTranscoder)
 	}
 
 	assert.Nil(err, "Should not be error")
@@ -1356,8 +1356,8 @@ func TestOrchestratorPool_GetOrchestrators_SuspendedOrchs(t *testing.T) {
 	res, err := pool.GetOrchestrators(context.TODO(), 2, sus, caps, common.ScoreAtLeast(0))
 	assert.Nil(err)
 	assert.Len(res, 2)
-	assert.NotEqual(res[0].GetTranscoder(), "https://127.0.0.1:8938")
-	assert.NotEqual(res[1].GetTranscoder(), "https://127.0.0.1:8938")
+	assert.NotEqual(res[0].RemoteInfo.GetTranscoder(), "https://127.0.0.1:8938")
+	assert.NotEqual(res[1].RemoteInfo.GetTranscoder(), "https://127.0.0.1:8938")
 
 	// include suspended O's if not enough non-suspended O's available
 	wg.Add(len(addresses))
@@ -1366,7 +1366,7 @@ func TestOrchestratorPool_GetOrchestrators_SuspendedOrchs(t *testing.T) {
 	assert.Nil(err)
 	assert.Len(res, 3)
 	// suspended Os are added last
-	assert.Equal(res[2].Transcoder, "https://127.0.0.1:8938")
+	assert.Equal(res[2].RemoteInfo.Transcoder, "https://127.0.0.1:8938")
 
 	// no suspended O's, insufficient non-suspended O's
 	sus = newStubSuspender()
@@ -1383,7 +1383,7 @@ func TestOrchestratorPool_GetOrchestrators_SuspendedOrchs(t *testing.T) {
 	assert.Nil(err)
 	assert.Len(res, 3)
 	// suspended Os are added last
-	assert.Equal(res[2].Transcoder, "https://127.0.0.1:8938")
+	assert.Equal(res[2].RemoteInfo.Transcoder, "https://127.0.0.1:8938")
 
 	// lower penalty is included before a higher penalty
 	wg.Add(len(addresses))
@@ -1393,8 +1393,8 @@ func TestOrchestratorPool_GetOrchestrators_SuspendedOrchs(t *testing.T) {
 	res, err = pool.GetOrchestrators(context.TODO(), 4, sus, caps, common.ScoreAtLeast(0))
 	assert.Nil(err)
 	assert.Len(res, 3)
-	assert.Equal(res[1].Transcoder, "https://127.0.0.1:8937")
-	assert.Equal(res[2].Transcoder, "https://127.0.0.1:8938")
+	assert.Equal(res[1].RemoteInfo.Transcoder, "https://127.0.0.1:8937")
+	assert.Equal(res[2].RemoteInfo.Transcoder, "https://127.0.0.1:8938")
 }
 
 func TestOrchestratorPool_ShuffleGetOrchestrators(t *testing.T) {
@@ -1488,7 +1488,7 @@ func TestOrchestratorPool_GetOrchestratorTimeout(t *testing.T) {
 	// Use a waitgroup to ensure we drain all pending responses
 	// Keeps things pristine for follow-on tests
 	wg := sync.WaitGroup{}
-	getOrchestrators := func(nb int) ([]*net.OrchestratorInfo, error) {
+	getOrchestrators := func(nb int) (common.OrchestratorDescriptors, error) {
 		// requests go out to all Os in the pool, regardless of number requested
 		wg.Add(pool.Size())
 		return pool.GetOrchestrators(context.TODO(), nb, newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
@@ -1609,7 +1609,7 @@ func TestOrchestratorPool_Capabilities(t *testing.T) {
 	assert.True(caps.LegacyOnly()) // sanity check
 	infos, err = pool.GetOrchestrators(context.TODO(), len(responses), sus, caps, common.ScoreAtLeast(0))
 	assert.Nil(err)
-	assert.ElementsMatch(infos, []*net.OrchestratorInfo{i1, i4})
+	assert.ElementsMatch(infos.GetRemoteInfos(), []*net.OrchestratorInfo{i1, i4})
 
 	// non-legacy. only one should pass the filter
 	caps.isLegacy = false
@@ -1617,5 +1617,5 @@ func TestOrchestratorPool_Capabilities(t *testing.T) {
 	infos, err = pool.GetOrchestrators(context.TODO(), len(responses), sus, caps, common.ScoreAtLeast(0))
 	assert.Nil(err)
 	assert.Len(infos, 1)
-	assert.Equal(i4, infos[0])
+	assert.Equal(i4, infos[0].RemoteInfo)
 }

--- a/discovery/suspensionqueue.go
+++ b/discovery/suspensionqueue.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"container/heap"
+	"github.com/livepeer/go-livepeer/common"
 
 	"github.com/livepeer/go-livepeer/net"
 )
@@ -12,6 +13,7 @@ type suspensionQueue []*suspension
 // A suspension is the item we manage in the priority queue.
 type suspension struct {
 	orch    *net.OrchestratorInfo
+	od *common.OrchestratorDescriptor
 	penalty int
 }
 

--- a/discovery/suspensionqueue.go
+++ b/discovery/suspensionqueue.go
@@ -13,7 +13,7 @@ type suspensionQueue []*suspension
 // A suspension is the item we manage in the priority queue.
 type suspension struct {
 	orch    *net.OrchestratorInfo
-	od *common.OrchestratorDescriptor
+	od      *common.OrchestratorDescriptor
 	penalty int
 }
 

--- a/discovery/wh_discovery.go
+++ b/discovery/wh_discovery.go
@@ -11,10 +11,8 @@ import (
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/livepeer/go-livepeer/common"
-	"github.com/livepeer/go-livepeer/net"
-
 	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
 )
 
 type webhookResponse struct {
@@ -89,10 +87,6 @@ func (w *webhookPool) GetInfos() []common.OrchestratorLocalInfo {
 	return infos
 }
 
-func (w *webhookPool) GetInfo(uri string) common.OrchestratorLocalInfo {
-	return w.pool.GetInfo(uri)
-}
-
 func (w *webhookPool) Size() int {
 	return len(w.GetInfos())
 }
@@ -111,7 +105,7 @@ func (w *webhookPool) SizeWith(scorePred common.ScorePred) int {
 }
 
 func (w *webhookPool) GetOrchestrators(ctx context.Context, numOrchestrators int, suspender common.Suspender, caps common.CapabilityComparator,
-	scorePred common.ScorePred) ([]*net.OrchestratorInfo, error) {
+	scorePred common.ScorePred) (common.OrchestratorDescriptors, error) {
 
 	_, err := w.getInfos()
 	if err != nil {

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -724,7 +724,7 @@ func selectOrchestrator(ctx context.Context, n *core.LivepeerNode, params *core.
 		}
 
 		var oScore float32
-		if od.LocalInfo!=nil {
+		if od.LocalInfo != nil {
 			oScore = od.LocalInfo.Score
 		}
 		session := &BroadcastSession{

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -673,8 +673,9 @@ func selectOrchestrator(ctx context.Context, n *core.LivepeerNode, params *core.
 		return nil, errDiscovery
 	}
 
-	tinfos, err := n.OrchestratorPool.GetOrchestrators(ctx, count, sus, params.Capabilities, scorePred)
-	if len(tinfos) <= 0 {
+	ods, err := n.OrchestratorPool.GetOrchestrators(ctx, count, sus, params.Capabilities, scorePred)
+
+	if len(ods) <= 0 {
 		clog.InfofErr(ctx, "No orchestrators found; not transcoding", err)
 		return nil, errNoOrchs
 	}
@@ -684,48 +685,52 @@ func selectOrchestrator(ctx context.Context, n *core.LivepeerNode, params *core.
 
 	var sessions []*BroadcastSession
 
-	for _, tinfo := range tinfos {
+	for _, od := range ods {
 		var (
 			sessionID    string
 			balance      Balance
 			ticketParams *pm.TicketParams
 		)
 
-		if tinfo.AuthToken == nil {
-			clog.Errorf(ctx, "Missing auth token orch=%v", tinfo.Transcoder)
+		if od.RemoteInfo.AuthToken == nil {
+			clog.Errorf(ctx, "Missing auth token orch=%v", od.RemoteInfo.Transcoder)
 			continue
 		}
 
 		if n.Sender != nil {
-			if tinfo.TicketParams == nil {
-				clog.Errorf(ctx, "Missing ticket params orch=%v", tinfo.Transcoder)
+			if od.RemoteInfo.TicketParams == nil {
+				clog.Errorf(ctx, "Missing ticket params orch=%v", od.RemoteInfo.Transcoder)
 				continue
 			}
 
-			ticketParams = pmTicketParams(tinfo.TicketParams)
+			ticketParams = pmTicketParams(od.RemoteInfo.TicketParams)
 			sessionID = n.Sender.StartSession(*ticketParams)
 
 			if n.Balances != nil {
-				balance = core.NewBalance(ticketParams.Recipient, core.ManifestID(tinfo.AuthToken.SessionId), n.Balances)
+				balance = core.NewBalance(ticketParams.Recipient, core.ManifestID(od.RemoteInfo.AuthToken.SessionId), n.Balances)
 			}
 		}
 
 		var orchOS drivers.OSSession
-		if len(tinfo.Storage) > 0 {
-			orchOS = drivers.NewSession(tinfo.Storage[0])
+		if len(od.RemoteInfo.Storage) > 0 {
+			orchOS = drivers.NewSession(od.RemoteInfo.Storage[0])
 		}
 
 		bcastOS := params.OS
 		if bcastOS.IsExternal() {
 			// Give each O its own OS session to prevent front running uploads
-			pfx := fmt.Sprintf("%v/%v", params.ManifestID, tinfo.AuthToken.SessionId)
+			pfx := fmt.Sprintf("%v/%v", params.ManifestID, od.RemoteInfo.AuthToken.SessionId)
 			bcastOS = bcastOS.OS().NewSession(pfx)
 		}
 
+		var oScore float32
+		if od.LocalInfo!=nil {
+			oScore = od.LocalInfo.Score
+		}
 		session := &BroadcastSession{
 			Broadcaster:       core.NewBroadcaster(n),
 			Params:            params,
-			OrchestratorInfo:  tinfo,
+			OrchestratorInfo:  od.RemoteInfo,
 			OrchestratorOS:    orchOS,
 			BroadcasterOS:     bcastOS,
 			Sender:            n.Sender,
@@ -733,7 +738,7 @@ func selectOrchestrator(ctx context.Context, n *core.LivepeerNode, params *core.
 			Balances:          n.Balances,
 			Balance:           balance,
 			lock:              &sync.RWMutex{},
-			OrchestratorScore: n.OrchestratorPool.GetInfo(tinfo.Transcoder).Score, // todo: use score from OrchestratorLocalInfo
+			OrchestratorScore: oScore,
 		}
 
 		sessions = append(sessions, session)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -174,13 +174,8 @@ func (d *stubDiscovery) GetInfos() []common.OrchestratorLocalInfo {
 	return nil
 }
 
-func (d *stubDiscovery) GetInfo(uri string) common.OrchestratorLocalInfo {
-	var res common.OrchestratorLocalInfo
-	return res
-}
-
 func (d *stubDiscovery) GetOrchestrators(ctx context.Context, num int, sus common.Suspender, caps common.CapabilityComparator,
-	scorePred common.ScorePred) ([]*net.OrchestratorInfo, error) {
+	scorePred common.ScorePred) (common.OrchestratorDescriptors, error) {
 
 	if d.waitGetOrch != nil {
 		<-d.waitGetOrch
@@ -192,7 +187,7 @@ func (d *stubDiscovery) GetOrchestrators(ctx context.Context, num int, sus commo
 		err = d.getOrchError
 		d.lock.Unlock()
 	}
-	return d.infos, err
+	return common.FromRemoteInfos(d.infos), err
 }
 
 func (d *stubDiscovery) Size() int {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Issue #2485 
The root cause is the lack of data structure combining B's local info about O with info received from O.
@leszko @RiccardoBiosas sorry, I've closed previous pull request, because realized it adds to technical debt, instead of addressing actual issue.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add OrchestratorDescriptor structure, which combines OrchestratorInfo and OrchestratorLocalInfo
- Remove unnecessary GetInfo() function
- Refactor interfaces to support OrchestratorDescriptor 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->
Issue #2485 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
