### PR TITLE
add grpc health service to the orchestrator server

### DIFF
--- a/server/rpc.go
+++ b/server/rpc.go
@@ -15,6 +15,9 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
 
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/common"
@@ -177,6 +180,11 @@ func (h *lphttp) Ping(context context.Context, req *net.PingPong) (*net.PingPong
 // XXX do something about the implicit start of the http mux? this smells
 func StartTranscodeServer(orch Orchestrator, bind string, mux *http.ServeMux, workDir string, acceptRemoteTranscoders bool) error {
 	s := grpc.NewServer()
+	reflection.Register(s)
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(s, healthServer)
+
 	lp := lphttp{
 		orchestrator: orch,
 		orchRPC:      s,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
It adds a health service to an orchestrator gRPC server to check the availability of its transcoding service.

**Specific updates (required)**
- Updated `server/rpc.go` 

**How did you test each of these updates (required)**
Successfully run the tests and manually tested the gRPC health service locally with the [gRPC-health-prob utility](https://github.com/grpc-ecosystem/grpc-health-probe) (i.e.: `grpc_health_probe-linux-amd64 -addr=127.0.0.1:8935 -tls=true -tls-no-verify=true`)


**Does this pull request close any open issues?**
https://github.com/livepeer/go-livepeer/issues/2076


**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
