### PR TITLE
server: Enforce a minimum timeout for segment upload

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,9 @@
 
 #### Broadcaster
 
+-   [#2541](https://github.com/livepeer/go-livepeer/pull/2541) Enforce a minimum
+    timeout for segment upload (@victorges)
+
 #### Orchestrator
 
 #### Transcoder

--- a/common/util.go
+++ b/common/util.go
@@ -40,8 +40,8 @@ var SegHttpPushTimeoutMultiplier = 4.0
 // SegUploadTimeoutMultiplier used in HTTP connection for uploading the segment
 var SegUploadTimeoutMultiplier = 0.5
 
-// SegmentUploadTimeout timeout used in HTTP connections for uploading the segment duration is not defined
-var SegmentUploadTimeout = 2 * time.Second
+// MinSegmentUploadTimeout defines the minimum timeout enforced for uploading a segment to orchestrators
+var MinSegmentUploadTimeout = 2 * time.Second
 
 // WebhookDiscoveryRefreshInterval defines for long the Webhook Discovery values should be cached
 var WebhookDiscoveryRefreshInterval = 1 * time.Minute

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -477,8 +477,8 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	}
 	// timeout for the segment upload, until HTTP returns OK 200
 	uploadTimeout := time.Duration(common.SegUploadTimeoutMultiplier * seg.Duration * float64(time.Second))
-	if uploadTimeout <= 0 {
-		uploadTimeout = common.SegmentUploadTimeout
+	if uploadTimeout < common.MinSegmentUploadTimeout {
+		uploadTimeout = common.MinSegmentUploadTimeout
 	}
 
 	ctx, cancel := context.WithTimeout(clog.Clone(context.Background(), ctx), httpTimeout)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to fix the segment upload timeout for really short segments, which I 
found to be an issue when investigating frequent timeouts in VOD tests.

In this case ([logs](https://eu-metrics-monitoring.livepeer.live/grafana/explore?orgId=1&left=%5B%221658945061444%22,%221658945187292%22,%22Loki%22,%7B%22exemplar%22:true,%22expr%22:%22%7Bapp%3D%5C%22prod-task-runner%5C%22%7D%20%7C~%20%5C%229c771156-978a-404a-b4f1-66245328fec1%5C%22%22,%22refId%22:%22A%22%7D%5D)), there is a frequent `header timeout` happening in the tests,
and even by increasing the retries and adding some backoff logic, it seems to keep
happening pretty often.

I then noticed that it always happened with the same segment of the test video, and 
when segmenting it locally with the same code I found that this segment has a duration
of `533ms` (and only so short cause it's the last seg in the file).

This means that the upload timeout given to it would be a mere `250ms`, which
can easily be hit for longer round-trip times to orchestrators even if they would be able to
respond healthily.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Make `MinSegmentUploadTimeout` be a minimum instead of just a default

**How did you test each of these updates (required)**
Ran automatic tests. 

**Does this pull request close any open issues?**
No.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
