### PR TITLE
docker: Fix amd64 build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           build-args: |
             BUILD_TAGS=${{ steps.build-tag.outputs.build-tags }}
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           file: 'docker/Dockerfile'

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           build-args: |
             BUILD_TAGS=${{ steps.build-tag.outputs.build-tags }}
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           file: 'docker/Dockerfile'

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,9 @@
 
 #### General
 
+-   [#2544](https://github.com/livepeer/go-livepeer/pull/2544) docker: Fix amd64
+    build (@victorges)
+
 #### Broadcaster
 
 -   [#2541](https://github.com/livepeer/go-livepeer/pull/2541) Enforce a minimum

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,9 +20,6 @@
 
 #### General
 
--   [#2544](https://github.com/livepeer/go-livepeer/pull/2544) docker: Fix amd64
-    build (@victorges)
-
 #### Broadcaster
 
 -   [#2541](https://github.com/livepeer/go-livepeer/pull/2541) Enforce a minimum

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ ENV	BUILD_TAGS=${BUILD_TAGS}
 
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 
-FROM --platform=$TARGETPLATFORM	nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
+FROM --platform=$TARGETPLATFORM	nvidia/cuda:10.1-cudnn7-runtime
 
 ENV	NVIDIA_DRIVER_CAPABILITIES=all
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ ENV	BUILD_TAGS=${BUILD_TAGS}
 
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 
-FROM --platform=$TARGETPLATFORM	docker.io/livepeer/cuda-base:latest
+FROM --platform=$TARGETPLATFORM	nvidia/cuda:10.1-cudnn7-runtime
 
 ENV	NVIDIA_DRIVER_CAPABILITIES=all
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ ENV	BUILD_TAGS=${BUILD_TAGS}
 
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 
-FROM --platform=$TARGETPLATFORM	nvidia/cuda:10.1-cudnn7-runtime
+FROM --platform=$TARGETPLATFORM	livepeer/cuda-base:latest
 
 ENV	NVIDIA_DRIVER_CAPABILITIES=all
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ ENV	BUILD_TAGS=${BUILD_TAGS}
 
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 
-FROM --platform=$TARGETPLATFORM	livepeer/cuda-base:latest
+FROM --platform=$TARGETPLATFORM	docker.io/livepeer/cuda-base:latest
 
 ENV	NVIDIA_DRIVER_CAPABILITIES=all
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Newer CUDA version apparently breaks things,
but armr64 cannot be built without that.

**Specific updates (required)**
Build only amd64 docker images for now with older CUDA.

**How did you test each of these updates (required)**
Just wait for docker images build.

**Does this pull request close any open issues?**
Fixes go-livepeer docker image.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
