### PR TITLE
server: Use HeaderByNumber() instead of BlockByNumber() in the function requesting LPT from faucet

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,10 +19,11 @@
 #### CLI
 
 #### General
+- [#2550](https://github.com/livepeer/go-livepeer/pull/2550) Fix requesting LPT from faucet after the Nitro migration (@leszko)
 
 #### Broadcaster
 
--   [#2541](https://github.com/livepeer/go-livepeer/pull/2541) Enforce a minimum
+- [#2541](https://github.com/livepeer/go-livepeer/pull/2541) Enforce a minimum
     timeout for segment upload (@victorges)
 
 #### Orchestrator

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1029,13 +1029,13 @@ func requestTokensHandler(client eth.LivepeerEthClient) http.Handler {
 		}
 
 		backend := client.Backend()
-		blk, err := backend.BlockByNumber(r.Context(), nil)
+		h, err := backend.HeaderByNumber(r.Context(), nil)
 		if err != nil {
 			respond500(w, fmt.Sprintf("Unable to get latest block: %v", err))
 			return
 		}
 
-		now := int64(blk.Time())
+		now := int64(h.Time)
 		if nextValidRequest.Int64() != 0 && nextValidRequest.Int64() > now {
 			respond500(w, fmt.Sprintf("Error requesting tokens from faucet: can only request tokens once every hour, please wait %v more minutes", (nextValidRequest.Int64()-now)/60))
 			return


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

After the Arbitrum Nitro migration, the function `BlockByNumber()` from `ethereum/go-ethereum` fails with the following message:
```
Unable to get latest block: transaction type not supported
```
It's related to the fact that Arbitrum uses its own transaction format, and therefore requires its own `go-ethereum` fork [OffchainLabs/go-ethereum](https://github.com/OffchainLabs/go-ethereum).

One option is to use [OffchainLabs/go-ethereum](https://github.com/OffchainLabs/go-ethereum), what we considered in https://github.com/livepeer/go-livepeer/pull/2470. Another option, implemented in this PR, is to find all the chain interactions that fail and fix them. I checked all the transaction executions and actually this one is the one that fails. Therefore, I suggest to continue using `ethereum/go-ethereum` and merge this PR.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Tested in Arbitrum Rinkeby Testnet


**Does this pull request close any open issues?**
<!-- Fixes # -->

fix https://github.com/livepeer/go-livepeer/issues/2547

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~README and other documentation updated~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
