### PR TITLE
Retry remote contract calls for unsupported block number errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,7 @@
 
 #### General
 - [#2550](https://github.com/livepeer/go-livepeer/pull/2550) Fix requesting LPT from faucet after the Nitro migration (@leszko)
+- [#2563](https://github.com/livepeer/go-livepeer/pull/2563) Fix unsupported block number errors (@yondonfu)
 
 #### Broadcaster
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"strings"
 	"sync"
+	"time"
 
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -169,6 +170,11 @@ func (b *backend) retryRemoteCall(remoteCall func() ([]byte, error)) (out []byte
 		if err != nil && isRetryableRemoteCallError(err) {
 			glog.Error(err)
 			glog.V(4).Infof("Retrying call to remote ethereum node")
+			// We could use the backoff package to configure an exponential backoff here, but it makes it
+			// more difficult to propagate the result from the call if the remote call is successful because
+			// the backoff functions can only return a single error type.
+			// So, to keep things simple just sleep here for 1 second before trying again.
+			time.Sleep(1 * time.Second)
 		} else {
 			retry = false
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -168,8 +168,7 @@ func (b *backend) retryRemoteCall(remoteCall func() ([]byte, error)) (out []byte
 	for i := 0; i < count && retry; i++ {
 		out, err = remoteCall()
 		if err != nil && isRetryableRemoteCallError(err) {
-			glog.Error(err)
-			glog.V(4).Infof("Retrying call to remote ethereum node")
+			glog.V(4).Infof("Retrying call to remote ethereum node err=%v", err)
 			// We could use the backoff package to configure an exponential backoff here, but it makes it
 			// more difficult to propagate the result from the call if the remote call is successful because
 			// the backoff functions can only return a single error type.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -34,7 +34,7 @@ var abis = []string{
 var abiMap = makeABIMap()
 
 var maxRemoteCallRetries = 6
-var remoteCallRetrySleep = 1 * time.Second
+var remoteCallRetrySleep = 500 * time.Millisecond
 
 type Backend interface {
 	ethereum.ChainStateReader
@@ -174,8 +174,9 @@ func (b *backend) retryRemoteCall(remoteCall func() ([]byte, error)) (out []byte
 			// We could use the backoff package to configure an exponential backoff here, but it makes it
 			// more difficult to propagate the result from the call if the remote call is successful because
 			// the backoff functions can only return a single error type.
-			// So, to keep things simple just sleep here for 1 second before trying again.
-			time.Sleep(remoteCallRetrySleep)
+			// So, we manually implement a simple linear backoff here instead
+			// 500ms, 1s, 1.5s, etc.
+			time.Sleep(time.Duration(i+1) * remoteCallRetrySleep)
 		} else {
 			retry = false
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -181,6 +181,7 @@ func isRetryableRemoteCallError(err error) bool {
 	retryableRemoteCallErrors := []string{
 		"EOF",
 		"tls: use of closed connection",
+		"unsupported block number",
 	}
 
 	for _, errStr := range retryableRemoteCallErrors {

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -102,6 +102,8 @@ func TestIsRetryableRemoteCallError(t *testing.T) {
 	assert.True(isRetryableRemoteCallError(errors.New("EOF a")))
 	assert.True(isRetryableRemoteCallError(errors.New("tls: use of closed connection")))
 	assert.True(isRetryableRemoteCallError(errors.New("tls: use of closed connection a")))
+	assert.True(isRetryableRemoteCallError(errors.New("unsupported block number")))
+	assert.True(isRetryableRemoteCallError(errors.New("unsupported block number a")))
 
 	assert.False(isRetryableRemoteCallError(errors.New("not retryable")))
 }

--- a/eth/backend_test.go
+++ b/eth/backend_test.go
@@ -3,6 +3,7 @@ package eth
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"log"
 	"math/big"
 	"testing"
@@ -92,4 +93,15 @@ func TestSendTransaction_SendErr_DontUpdateNonce(t *testing.T) {
 	nonceLockAfter := bi.(*backend).nonceManager.getNonceLock(fromAddress)
 
 	assert.Equal(t, nonceLockBefore.nonce, nonceLockAfter.nonce)
+}
+
+func TestIsRetryableRemoteCallError(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.True(isRetryableRemoteCallError(errors.New("EOF")))
+	assert.True(isRetryableRemoteCallError(errors.New("EOF a")))
+	assert.True(isRetryableRemoteCallError(errors.New("tls: use of closed connection")))
+	assert.True(isRetryableRemoteCallError(errors.New("tls: use of closed connection a")))
+
+	assert.False(isRetryableRemoteCallError(errors.New("not retryable")))
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

We've occasionally observed an `unsupported block number` error for RPC requests which can cause problems for node operation (see #2560).

According to an [Offchain Labs team member](https://discord.com/channels/585084330037084172/765654444825641001/968910226583584798), an Arb node can return this error if the node is not synced. This situation could occur if:

- A single Arb node has fallen behind the tip of the chain
- If requests are load balanced across a set of nodes and request 1 fetches block number N from node 1, but request 2 that references block number N is routed to node 2 which has only seen block number N - 1

The `unsupported block number` error appears to originate from the [getSnapshot()](https://github.com/OffchainLabs/arbitrum/blob/93340983cc28b9689c67f5117c1a6e42ba3f5332/packages/arb-rpc-node/web3/eth.go#L689) and [getSnapshotForNumberForHash()](https://github.com/OffchainLabs/arbitrum/blob/93340983cc28b9689c67f5117c1a6e42ba3f5332/packages/arb-rpc-node/web3/eth.go#L732) functions in `offchainlabs/arbitrum/packages/arb-rpc-node/web3` which are called by many of the functions implementing the ETH JSON-RPC API [1].

From reviewing Discord conversations, it appears that this error is more likely to happen when sending concurrent RPC requests.

The solution in this PR is to add the `unsupported block number` error to the list of errors that will be retried when sending requests for remote contract calls. Note: This change only applies to contract calls and not other RPC requests which could be affected by this error as well. Addressing this issue with *all* RPC requests requires additional code changes, but since this error is primarily affecting contract calls right now, I've opted to just address this for contract calls.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Added unit tests for helper functions
- Rolled this change to a broadcaster and [observed retries](https://eu-metrics-monitoring.livepeer.live/grafana/explore?orgId=1&left=%5B%22now-30m%22,%22now%22,%22Loki%22,%7B%22expr%22:%22%7Bapp%20%3D~%20%5C%22prod-livepeer-secondary-broadcaster-.%2B%5C%22%7D%20%7C~%20%5C%22unsupported%5C%22%22,%22refId%22:%22A%22,%22range%22:true%7D%5D) for `unsupported block number` errors

**Does this pull request close any open issues?**
<!-- Fixes # -->

Addresses the root cause of #2560 although it could still make sense to update the behavior of the node following the suggestion in the issue.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
