### PR TITLE
server: Fix timeout for stream recording background jobs 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,6 +21,7 @@
 #### General
 
 #### Broadcaster
+-   [#2573](https://github.com/livepeer/go-livepeer/pull/2573) server: Fix timeout for stream recording background jobs (@victorges)
 
 #### Orchestrator
 

--- a/clog/clog.go
+++ b/clog/clog.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/golang/glog"
 )
@@ -66,6 +67,11 @@ func Clone(parentCtx, logCtx context.Context) context.Context {
 		cmap.mu.RUnlock()
 	}
 	return context.WithValue(parentCtx, clogContextKey, newCmap)
+}
+
+func WithTimeout(parentCtx, logCtx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	ctx := Clone(parentCtx, logCtx)
+	return context.WithTimeout(ctx, timeout)
 }
 
 func AddManifestID(ctx context.Context, val string) context.Context {

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -40,6 +40,8 @@ var maxDurationSec = common.MaxDuration.Seconds()
 // Max threshold for # of broadcast sessions under which we will refresh the session list
 var maxRefreshSessionsThreshold = 8.0
 
+var recordSegmentsMaxTimeout = 1 * time.Minute
+
 var Policy *verification.Policy
 var BroadcastCfg = &BroadcastConfig{}
 var MaxAttempts = 3
@@ -787,6 +789,8 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 	hasZeroVideoFrame := seg.IsZeroFrame
 	if ros != nil && !hasZeroVideoFrame {
 		go func() {
+			ctx, cancel := clog.WithTimeout(context.Background(), ctx, recordSegmentsMaxTimeout)
+			defer cancel()
 			now := time.Now()
 			uri, err := drivers.SaveRetried(ctx, ros, name, seg.Data, map[string]string{"duration": segDurMs}, 2)
 			took := time.Since(now)
@@ -1184,6 +1188,8 @@ func downloadResults(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSe
 
 		if bros != nil {
 			go func() {
+				ctx, cancel := clog.WithTimeout(context.Background(), ctx, recordSegmentsMaxTimeout)
+				defer cancel()
 				ext, _ := common.ProfileFormatExtension(profile.Format)
 				name := fmt.Sprintf("%s/%d%s", profile.Name, seg.SeqNo, ext)
 				segDurMs := getSegDurMsString(seg)

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -792,7 +792,7 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 			ctx, cancel := clog.WithTimeout(context.Background(), ctx, recordSegmentsMaxTimeout)
 			defer cancel()
 			now := time.Now()
-			uri, err := drivers.SaveRetried(ctx, ros, name, seg.Data, map[string]string{"duration": segDurMs}, 2)
+			uri, err := drivers.SaveRetried(ctx, ros, name, seg.Data, map[string]string{"duration": segDurMs}, 3)
 			took := time.Since(now)
 			if err != nil {
 				clog.Errorf(ctx, "Error saving name=%s bytes=%d to record store err=%q",
@@ -1194,7 +1194,7 @@ func downloadResults(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSe
 				name := fmt.Sprintf("%s/%d%s", profile.Name, seg.SeqNo, ext)
 				segDurMs := getSegDurMsString(seg)
 				now := time.Now()
-				uri, err := drivers.SaveRetried(ctx, bros, name, data, map[string]string{"duration": segDurMs}, 2)
+				uri, err := drivers.SaveRetried(ctx, bros, name, data, map[string]string{"duration": segDurMs}, 3)
 				took := time.Since(now)
 				if err != nil {
 					clog.Errorf(ctx, "Error saving nonce=%d manifestID=%s name=%s to record store err=%q", nonce, cxn.mid, name, err)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
We noticed a couple errors that happen when saving transcoded segments for livestream recordings.
These occur especially in `staging` for some reason, but the underlying cause can easily happen in
production as well ([and it often does](https://eu-metrics-monitoring.livepeer.live/grafana/explore?orgId=1&left=%5B%22now-2d%22,%22now%22,%22Loki%22,%7B%22exemplar%22:true,%22expr%22:%22%7Bapp%3D~%5C%22prod-livepeer-broadcaster.*%5C%22%7D%20%7C%3D%20%5C%22Error%20saving%20nonce%5C%22%22,%22refId%22:%22A%22%7D%5D)).

In short terms, the issue is caused because saving the recorded segments is performed in a background
routine, while at the same time this routine uses the same `context.Context` to handle cancellation of the
task behind the scenes. This means that one the transcode request is finished (which is where the current
`ctx` comes from, the `http.Request`), the background saving operations will also be cancelled.

This fixes it by enforcing a separate timeout on the background saves, independent of the request.

**Specific updates (required)**
- Use a separate timeout context for the segment recording operations
- Increase the number of saving attempts to 3 instead of 2 

**How did you test each of these updates (required)**
Automated tests. Pretty simple change as well, will check effect in staging on catalyst tests.

**Does this pull request close any open issues?**
https://github.com/livepeer/catalyst/issues/126

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
