### PR TITLE
cmd+pm: Replace depositMultipler with maxFaceValue for sender

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes 🚨🚨
 
+- The `-depositMultiplier` flag has been removed. This flag was previously used by a broadcaster to configure a maximum face value for ticket params sent by orchestrator by dividing the broadcaster's current deposit by the flag's value. The `-maxFaceValue` flag can now be used to explicitly set the maximum face value for ticket params instead.
+
 ### Features ⚒
 
 #### General
@@ -21,7 +23,8 @@
 #### General
 
 #### Broadcaster
--   [#2573](https://github.com/livepeer/go-livepeer/pull/2573) server: Fix timeout for stream recording background jobs (@victorges)
+- [#2573](https://github.com/livepeer/go-livepeer/pull/2573) server: Fix timeout for stream recording background jobs (@victorges)
+- [#2577](https://github.com/livepeer/go-livepeer/pull/2577) Replace -depositMultiplier flag with -maxFaceValue flag (@yondonfu)
 
 #### Orchestrator
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -137,8 +137,6 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.MaxFaceValue = flag.String("maxFaceValue", *cfg.MaxFaceValue, "set max ticket face value in WEI")
 	// Broadcaster max acceptable ticket EV
 	cfg.MaxTicketEV = flag.String("maxTicketEV", *cfg.MaxTicketEV, "The maximum acceptable expected value for PM tickets")
-	// Broadcaster deposit multiplier to determine max acceptable ticket faceValue
-	cfg.DepositMultiplier = flag.Int("depositMultiplier", *cfg.DepositMultiplier, "The deposit multiplier used to determine max acceptable faceValue for PM tickets")
 	// Orchestrator base pricing info
 	cfg.PricePerUnit = flag.Int("pricePerUnit", 0, "The price per 'pixelsPerUnit' amount pixels")
 	// Broadcaster max acceptable price


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Remove the `-depositMultiplier` flag in favor of re-using the existing `-maxFaceValue` flag to configure the maximum faceValue that will be accepted in ticket params received by a broadcaster. If `-maxFaceValue 100` is set, then a broadcaster will reject ticket params sent from an orchestrator if faceValue > 100`. By default, `-maxFaceValue` is 0 and there will be maximum imposed by the broadcaster.

Previously, the value of the `-depositMultiplier` flag would be used to derive a maxFaceValue as `current deposit / depositMultiplier`. In practice, this feels like a pretty confusing way to configure the maxFaceValue and explicitly setting it for a broadcaster via the existing `-maxFaceValue` flag feels much simpler. I considered keeping the `-depositMultiplier` flag for backwards compatibility, but 1) I suspect that it is not used 2) maintaining support for that flag as well as the use of the `-maxFaceValue` would result in some tech debt code paths that felt inconvenient. Welcome feedback on this point though.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Updated unit tests. 

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
