### PR TITLE
eth: Set tx GasFeeCap to min(gasPriceEstimate, current GasFeeCap)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,9 +19,10 @@
 #### CLI
 
 #### General
+- [#2583](https://github.com/livepeer/go-livepeer/pull/2583) eth: Set tx GasFeeCap to min(gasPriceEstimate, current GasFeeCap) (@yondonfu)
 
 #### Broadcaster
--   [#2573](https://github.com/livepeer/go-livepeer/pull/2573) server: Fix timeout for stream recording background jobs (@victorges)
+- [#2573](https://github.com/livepeer/go-livepeer/pull/2573) server: Fix timeout for stream recording background jobs (@victorges)
 
 #### Orchestrator
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

At the moment, if the `-maxGasPrice` flag is used the `GasFeeCap` for all txs is also set to the `maxGasPrice` value. The `GasFeeCap` serves as the maximum fee/price that will be charged per unit of gas consumed by a tx. The minimum balance of an account is the `gas used by the tx * GasFeeCap`. If `GasFeeCap` exceeds the actual gas price that is required for txs then a refund will be provided to the account based on the difference between `GasFeeCap` and the actual gas price. But, if the account does not have enough balance cover `gas used by the tx * GasFeeCap` then an `Insufficient funds...` error will be encountered.

In https://github.com/livepeer/go-livepeer/issues/2574, some O operators set a value for `-maxGasPrice` that is quite a bit higher than the actual average gas price paid on Arbitrum (i.e. ~0.1 gwei). As a result, even though their account balances could cover a tx based on the actual gas price paid, their account balances could not cover a tx based on `GasFeeCap = maxGasPrice`. The current available workarounds are to either top off account balances to ensure the balance can cover `gas * GasFeeCap` (with the excess fee refunded to the balance at the end of the successful tx), set a lower value for `-maxGasPrice` or stop using the `-maxGasPrice` flag.

I felt that while there are available workarounds, the way the `-maxGasPrice` flag currently works is a bit weird since it can easily lead to a node operator thinking they are just being safe by setting a high value for `-maxGasPrice`, but then having that high value cause tx issues if they do not have super high account balances. So, I opted to modify the `GasFeeCap` of txs to `min(gasPriceEstimate, current GasFeeCap` where `gasPriceEstimate = baseFee * 2` so that in these cases a node operator doesn't run into tx issues.

See in-line code comments for more details.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested on Arbitrum Rinkeby:

1. Ran a node off the master branch

2. Used `livepeer_cli` to set maxGasPrice = 300 gwei

3. Invoked a LPT transfer and observed an `insufficient funds...` error

```
******************************Eth Transaction******************************

Invoking transaction: "transfer". Inputs: "recipient: 0x3F7bcA8c726Bc34a903ed3e838997d7d3A29B99d  amount: 0"
Transaction Failed: insufficient funds for gas * price + value: address 0x3F7bcA8c726Bc34a903ed3e838997d7d3A29B99d have 6233423641163 want 8282700000000000

***************************************************************************
E0907 22:23:51.538450       1 handlers.go:1421] HTTP Response Error 500: insufficient funds for gas * price + value: address 0x3F7bcA8c726Bc34a903ed3e838997d7d3A29B99d have 6233423641163 want 8282700000000000
```

4. Restarted the node running off of the branch for this PR

5. Used `livepeer_cli` to set maxGasPrice = 300 gwei

6. Invoked a LPT transfer and observed a successful tx.

```
******************************Eth Transaction******************************

Invoking transaction: "transfer". Inputs: "recipient: 0x3F7bcA8c726Bc34a903ed3e838997d7d3A29B99d  amount: 0"  Hash: "0x5db565e84ba009689fd63792f80ecdb3cb16500ce2c23d4249c17dfb26245528".

***************************************************************************
I0907 22:21:12.384937       1 handlers.go:1018] Transferred 0 LPTU to 0x3F7bcA8c726Bc34a903ed3e838997d7d3A29B99d
```


**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #2574 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
