### PR TITLE
Broadcaster: Don't pass a nil context into grpc call or it panics

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,7 @@
 #### Transcoder
 
 ### Bug Fixes 🐞
+- [#2586](https://github.com/livepeer/go-livepeer/pull/2586) Broadcaster: Don't pass a nil context into grpc call or it panics
 
 #### CLI
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,6 +24,7 @@
 
 #### Broadcaster
 - [#2573](https://github.com/livepeer/go-livepeer/pull/2573) server: Fix timeout for stream recording background jobs (@victorges)
+- [#2586](https://github.com/livepeer/go-livepeer/pull/2586) Refactor RTMP connection object management to prevent race conditions (@cyberj0g)
 
 #### Orchestrator
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -582,7 +582,7 @@ func (s *LivepeerServer) registerConnection(ctx context.Context, rtmpStrm stream
 	s.lastManifestID = mid
 	s.lastHLSStreamID = hlsStrmID
 	s.serverLock.Unlock()
-	
+
 	// connection is ready, only monitoring below
 	close(cxn.initializing)
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -550,7 +550,7 @@ func (s *LivepeerServer) registerConnection(ctx context.Context, rtmpStrm stream
 	if exists {
 		// We can only have one concurrent stream per ManifestID
 		s.connectionLock.Unlock()
-		cxn.sessManager.cleanup(nil)
+		cxn.sessManager.cleanup(context.Background())
 		return oldCxn, errAlreadyExists
 	}
 	s.rtmpConnections[mid] = cxn

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -576,14 +576,14 @@ func (s *LivepeerServer) registerConnection(ctx context.Context, rtmpStrm stream
 	// success, populate other fields and mark connection initialized
 	s.lastManifestID = mid
 	s.lastHLSStreamID = hlsStrmID
-	sessionsNumber := len(s.rtmpConnections)
 
 	// connection is ready, only monitoring below
 	close(cxn.initializing)
 
-	// need lock because of a loop in countStreamsWithFastVerificationEnabled
+	// need lock to access rtmpConnections
 	s.connectionLock.RLock()
 	defer s.connectionLock.RUnlock()
+	sessionsNumber := len(s.rtmpConnections)
 	fastVerificationEnabled, fastVerificationUsing := countStreamsWithFastVerificationEnabled(s.rtmpConnections)
 
 	if monitor.Enabled {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Stops a panic in the case we detect an existing session after creating one

**Specific updates (required)**
- Pass `context.Background()` instead of `nil` into the gRPC call

**How did you test each of these updates (required)**
- Ran unit tests


**Does this pull request close any open issues?**
Fixes #2585


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
