### PR TITLE
core: Return from transcode loop if seg chan closed

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,12 +15,12 @@
 #### Transcoder
 
 ### Bug Fixes 🐞
-- [#2586](https://github.com/livepeer/go-livepeer/pull/2586) Broadcaster: Don't pass a nil context into grpc call or it panics
 
 #### CLI
 
 #### General
 - [#2583](https://github.com/livepeer/go-livepeer/pull/2583) eth: Set tx GasFeeCap to min(gasPriceEstimate, current GasFeeCap) (@yondonfu)
+- [#2586](https://github.com/livepeer/go-livepeer/pull/2586) Broadcaster: Don't pass a nil context into grpc call or it panics (@thomshutt, @cyberj0g)
 
 #### Broadcaster
 - [#2573](https://github.com/livepeer/go-livepeer/pull/2573) server: Fix timeout for stream recording background jobs (@victorges)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,5 +27,6 @@
 - [#2586](https://github.com/livepeer/go-livepeer/pull/2586) Refactor RTMP connection object management to prevent race conditions (@cyberj0g)
 
 #### Orchestrator
+- [#2591](https://github.com/livepeer/go-livepeer/pull/2591) Return from transcode loop if transcode session is ended by B (@yondonfu)
 
 #### Transcoder

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -646,8 +646,9 @@ func (bsm *BroadcastSessionsManager) collectResults(submitResultsCh chan *Submit
 // the caller needs to ensure bsm.sessLock is acquired before calling this.
 func (bsm *BroadcastSessionsManager) completeSessionUnsafe(ctx context.Context, sess *BroadcastSession, tearDown bool) {
 	if tearDown {
-		err := EndTranscodingSession(ctx, sess)
-		clog.Errorf(ctx, "Error completing transcoding session: %q", err)
+		if err := EndTranscodingSession(ctx, sess); err != nil {
+			clog.Errorf(ctx, "Error completing transcoding session: %q", err)
+		}
 	}
 	if sess.OrchestratorScore == common.Score_Untrusted {
 		bsm.untrustedPool.completeSession(sess)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR updates the transcode loop to exit the loop if the segment channel is closed.

https://github.com/livepeer/go-livepeer/commit/a1fb761474685ae0679e26349e27f19012d95a75 introduced the possibility of the segment channel being closed via a EndTranscodingSession RPC call. When that happens, the bug described in [this comment](https://github.com/livepeer/go-livepeer/issues/2589#issuecomment-1249591252) can occur.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

[45bf1e1](https://github.com/livepeer/go-livepeer/pull/2591/commits/45bf1e1faf9a42d50aba551ea6787282d96c22a2) contains a small update to avoid logging a nil error if there was no error when B calls EndTranscodingSession.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Added a unit test that checks of the goroutine for the transcode loop is cleaned up after the transcode session is ended
- Ran manual tests with an offchain B & O [mediaserver.httpTimeout](https://github.com/livepeer/go-livepeer/blob/5d4e145b4d2f6efbbcca0f5cd6f8481163ac8e81/server/mediaserver.go#L74) set to 30 seconds so B always sends an EndTranscodingSession RPC call before O's transcode loop times out
     - Test 1: Build B & O off `master`
     - Test 2: Build B & O off this branch
     - After both tests, I ran `kill -ABRT <PID>` where `<PID>` was the process ID for O to dump a stack trace of goroutines
     - The stack trace for test 1 showed 1 `core.transcodeSegmentLoop()` goroutine which indicates that the goroutine was not cleaned up properly after the transcoding session was ended
     - The stack trace for test 2 showed 0 `core.transcodeSegmentLoop()` goroutines which indiciates that the goroutine was cleaned up properly after the transcoding session was ended

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #2589 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
