### PR TITLE
Print set config values on node start

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,6 +19,7 @@
 #### CLI
 
 #### General
+- [#2616](https://github.com/livepeer/go-livepeer/pull/2616) cmd: Echo explicitly set config values on node start
 - [#2583](https://github.com/livepeer/go-livepeer/pull/2583) eth: Set tx GasFeeCap to min(gasPriceEstimate, current GasFeeCap) (@yondonfu)
 - [#2586](https://github.com/livepeer/go-livepeer/pull/2586) Broadcaster: Don't pass a nil context into grpc call or it panics (@thomshutt, @cyberj0g)
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/olekukonko/tablewriter"
 	"os"
 	"os/signal"
+	"reflect"
 	"runtime"
 	"time"
 
@@ -48,8 +50,23 @@ func main() {
 	}
 
 	vFlag.Value.Set(*verbosity)
-
 	cfg = updateNilsForUnsetFlags(cfg)
+
+	// compare current settings with default values, and print the difference
+	defCfg := starter.DefaultLivepeerConfig()
+	vDefCfg := reflect.ValueOf(defCfg)
+	vCfg := reflect.ValueOf(cfg)
+	cfgType := vCfg.Type()
+	paramTable := tablewriter.NewWriter(os.Stdout)
+	for i := 0; i < cfgType.NumField(); i++ {
+		if !vDefCfg.Field(i).IsNil() && vCfg.Field(i).Elem().Interface() != vDefCfg.Field(i).Elem().Interface() {
+			paramTable.Append([]string{cfgType.Field(i).Name, fmt.Sprintf("%v", vCfg.Field(i).Elem())})
+		}
+	}
+	paramTable.SetAlignment(tablewriter.ALIGN_LEFT)
+	paramTable.SetCenterSeparator("*")
+	paramTable.SetColumnSeparator("|")
+	paramTable.Render()
 
 	if *mistJson {
 		mistconnector.PrintMistConfigJson(

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -59,7 +59,7 @@ func main() {
 	cfgType := vCfg.Type()
 	paramTable := tablewriter.NewWriter(os.Stdout)
 	for i := 0; i < cfgType.NumField(); i++ {
-		if !vDefCfg.Field(i).IsNil() && vCfg.Field(i).Elem().Interface() != vDefCfg.Field(i).Elem().Interface() {
+		if !vDefCfg.Field(i).IsNil() && !vCfg.Field(i).IsNil() && vCfg.Field(i).Elem().Interface() != vDefCfg.Field(i).Elem().Interface() {
 			paramTable.Append([]string{cfgType.Field(i).Name, fmt.Sprintf("%v", vCfg.Field(i).Elem())})
 		}
 	}


### PR DESCRIPTION
As discussed in #2613, echo non-nil fields of config object, which changed with CLI arguments, config file or environment variables.