### PR TITLE
Minor spelling mistake

### DIFF
--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -387,7 +387,7 @@ func (h *lphttp) TranscodeResults(w http.ResponseWriter, r *http.Request) {
 		} else {
 			res.Err = fmt.Errorf(string(body))
 		}
-		glog.Errorf("Trascoding error for taskId=%v err=%q", tid, res.Err)
+		glog.Errorf("Transcoding error for taskId=%v err=%q", tid, res.Err)
 		orch.TranscoderResults(tid, &res)
 		return
 	}


### PR DESCRIPTION
`Trascoding` should be `Transcoding`.

**What does this pull request do? Explain your changes. (required)**
Fixes a minor spelling mistake