### PR TITLE
Binary E2E test for Mist json

### DIFF
--- a/test/e2e/binary_test.go
+++ b/test/e2e/binary_test.go
@@ -1,0 +1,24 @@
+package e2e
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"os/exec"
+	"testing"
+)
+
+func TestMistJson(t *testing.T) {
+	assert := assert.New(t)
+	buildLivepeer(assert)
+	// run
+	lp := exec.Command("./livepeer", "-j")
+	stdoutRes, err := lp.Output()
+	assert.NoError(err)
+
+	// parse output
+	jsonMap := make(map[string](interface{}))
+	err = json.Unmarshal(stdoutRes, &jsonMap)
+	assert.NoError(err)
+	// only check for name element
+	assert.Contains(jsonMap, "name")
+}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"math/big"
 	"net/http"
 	"net/url"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -56,6 +59,13 @@ func setupGeth(t *testing.T, ctx context.Context) *gethContainer {
 func terminateGeth(t *testing.T, ctx context.Context, geth *gethContainer) {
 	err := geth.Terminate(ctx)
 	require.NoError(t, err)
+}
+
+func buildLivepeer(assert *assert.Assertions) {
+	// build app
+	build := exec.Command("go", strings.Split("build ../../cmd/livepeer/livepeer.go", " ")...)
+	err := build.Run()
+	assert.NoError(err)
 }
 
 // Start Livepeer helpers


### PR DESCRIPTION
Build and invoke the binary directly to check if it produces valid JSON. Slightly more "E2E" than existing in-process e2e tests.