### PR TITLE
Dockerfile: Fix path in `ENTRYPOINT` clause.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,8 @@
 
 #### General
 
+- \#2635 Fix entrypoint path in built docker images (@hjpotter92)
+
 #### Broadcaster
 
 #### Orchestrator

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,22 +1,22 @@
 FROM --platform=$BUILDPLATFORM	ubuntu:18.04	as	build
 
 ARG	TARGETARCH
-ARG GOOS
+ARG	BUILDARCH
 
 ENV	GOARCH="$TARGETARCH" \
-	GOOS="$GOOS" \
 	PATH="/usr/local/go/bin:/go/bin:${PATH}" \
 	PKG_CONFIG_PATH="/root/compiled/lib/pkgconfig" \
 	CPATH="/usr/local/cuda/include" \
-	LIBRARY_PATH="/usr/local/cuda/lib64"
+	LIBRARY_PATH="/usr/local/cuda/lib64" \
+	DEBIAN_FRONTEND="noninteractive"
 
 RUN	apt update \
-	&& apt install -yqq software-properties-common curl apt-transport-https \
-	&& curl https://dl.google.com/go/go1.17.6.linux-amd64.tar.gz | tar -C /usr/local -xz \
+	&& apt install -yqq software-properties-common curl apt-transport-https lsb-release \
+	&& curl -fsSL https://dl.google.com/go/go1.17.6.linux-${BUILDARCH}.tar.gz | tar -C /usr/local -xz \
 	&& curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
-	&& add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+	&& add-apt-repository "deb [arch=${BUILDARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
 	&& curl -fsSl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-	&& add-apt-repository "deb [arch=amd64] https://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main" \
+	&& add-apt-repository "deb [arch=${BUILDARCH}] https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-12 main" \
 	&& apt update \
 	&& apt -yqq install clang-12 clang-tools-12 lld-12 build-essential pkg-config autoconf git python docker-ce-cli pciutils gcc-multilib libgcc-8-dev-arm64-cross gcc-mingw-w64-x86-64
 
@@ -25,7 +25,7 @@ RUN	update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 3
 	&& update-alternatives --install /usr/bin/ld ld /usr/bin/lld-12 30
 
 RUN	GRPC_HEALTH_PROBE_VERSION=v0.3.6 \
-	&& curl -L https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 -o /usr/bin/grpc_health_probe \
+	&& curl -fsSL https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} -o /usr/bin/grpc_health_probe \
 	&& chmod +x /usr/bin/grpc_health_probe \
 	&& curl -fsSL https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-2.8.0.tar.gz | tar -C /usr/local -xzf - \
 	&& ldconfig /usr/local/lib
@@ -37,7 +37,7 @@ ENV	GOPATH=/go \
 WORKDIR	/src
 
 RUN	mkdir -p /go \
-	&& curl -LO https://github.com/livepeer/livepeer-ml/releases/download/v0.3/tasmodel.pb
+	&& curl -fsSLO https://github.com/livepeer/livepeer-ml/releases/download/v0.3/tasmodel.pb
 
 COPY	./install_ffmpeg.sh	./install_ffmpeg.sh
 
@@ -46,7 +46,9 @@ RUN	./install_ffmpeg.sh \
 	&& go get -v github.com/jstemmer/go-junit-report
 
 COPY	go.mod	go.sum	./
+
 RUN	go mod download
+
 COPY	.	.
 
 ARG	BUILD_TAGS
@@ -69,4 +71,4 @@ COPY --from=build	/usr/share/misc/pci.ids	/usr/share/misc/pci.ids
 
 RUN	ldconfig
 
-ENTRYPOINT	["/usr/bin/livepeer"]
+ENTRYPOINT	["/usr/local/bin/livepeer"]


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The path to installed version of livepeer wasn't reflected in docker image. This PR achieves that.

**Specific updates (required)**
 - Dockerfile: Fix path in `ENTRYPOINT` clause.
 - Add `DEBIAN_FRONTEND` env for non-interactive setup
 - Use multi-arch installation of go and llvm

**How did you test each of these updates (required)**
CI pipeline for this PR

**Does this pull request close any open issues?**
Fixes #2633 

**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated