### PR TITLE
cmd/livepeer: Add httpIngest, localVerify to default cfg

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,6 +21,7 @@
 #### General
 
 - \#2635 Fix entrypoint path in built docker images (@hjpotter92)
+- \#2646 Include HttpIngest and LocalVerify in param table on startup (@yondonfu)
 
 #### Broadcaster
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/olekukonko/tablewriter"
 	"os"
 	"os/signal"
 	"reflect"
 	"runtime"
 	"time"
+
+	"github.com/olekukonko/tablewriter"
 
 	"github.com/livepeer/go-livepeer/cmd/livepeer/starter"
 	"github.com/livepeer/livepeer-data/pkg/mistconnector"
@@ -119,8 +120,8 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.OrchAddr = flag.String("orchAddr", *cfg.OrchAddr, "Comma-separated list of orchestrators to connect to")
 	cfg.VerifierURL = flag.String("verifierUrl", *cfg.VerifierURL, "URL of the verifier to use")
 	cfg.VerifierPath = flag.String("verifierPath", *cfg.VerifierPath, "Path to verifier shared volume")
-	cfg.LocalVerify = flag.Bool("localVerify", true, "Set to true to enable local verification i.e. pixel count and signature verification.")
-	cfg.HttpIngest = flag.Bool("httpIngest", true, "Set to true to enable HTTP ingest")
+	cfg.LocalVerify = flag.Bool("localVerify", *cfg.LocalVerify, "Set to true to enable local verification i.e. pixel count and signature verification.")
+	cfg.HttpIngest = flag.Bool("httpIngest", *cfg.HttpIngest, "Set to true to enable HTTP ingest")
 
 	// Transcoding:
 	cfg.Orchestrator = flag.Bool("orchestrator", *cfg.Orchestrator, "Set to true to be an orchestrator")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -185,6 +185,12 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultMetadataAmqpExchange := "lp_golivepeer_metadata"
 	defaultMetadataPublishTimeout := 1 * time.Second
 
+	// Ingest:
+	defaultHttpIngest := true
+
+	// Verification:
+	defaultLocalVerify := true
+
 	// Storage:
 	defaultDatadir := ""
 	defaultObjectstore := ""
@@ -255,6 +261,12 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		MetadataQueueUri:       &defaultMetadataQueueUri,
 		MetadataAmqpExchange:   &defaultMetadataAmqpExchange,
 		MetadataPublishTimeout: &defaultMetadataPublishTimeout,
+
+		// Ingest:
+		HttpIngest: &defaultHttpIngest,
+
+		// Verification:
+		LocalVerify: &defaultLocalVerify,
 
 		// Storage:
 		Datadir:     &defaultDatadir,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR sets HttpIngest and LocalVerify in the default Livepeer config which allows the HttpIngest and LocalVerify values to be shown in the param table on startup if non-default values are used for either field.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested manually.

**Does this pull request close any open issues?**
<!-- Fixes # -->

N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
