### PR TITLE
Add a new header field in the HTTP PUSH endpoint that increases upload timeout

### DIFF
--- a/core/streamdata.go
+++ b/core/streamdata.go
@@ -29,21 +29,22 @@ type DetectionConfig struct {
 }
 
 type StreamParameters struct {
-	ManifestID       ManifestID
-	ExternalStreamID string
-	SessionID        string
-	RtmpKey          string
-	Profiles         []ffmpeg.VideoProfile
-	Resolution       string
-	Format           ffmpeg.Format
-	OS               drivers.OSSession
-	RecordOS         drivers.OSSession
-	Capabilities     *Capabilities
-	Detection        DetectionConfig
-	VerificationFreq uint
-	Nonce            uint64
-	Codec            ffmpeg.VideoCodec
-	PixelFormat      ffmpeg.PixelFormat
+	ManifestID                 ManifestID
+	ExternalStreamID           string
+	SessionID                  string
+	RtmpKey                    string
+	Profiles                   []ffmpeg.VideoProfile
+	Resolution                 string
+	Format                     ffmpeg.Format
+	OS                         drivers.OSSession
+	RecordOS                   drivers.OSSession
+	Capabilities               *Capabilities
+	Detection                  DetectionConfig
+	VerificationFreq           uint
+	Nonce                      uint64
+	Codec                      ffmpeg.VideoCodec
+	PixelFormat                ffmpeg.PixelFormat
+	SegUploadTimeoutMultiplier int // Used in the VOD workflow to allow us to be more lenient with timeouts
 }
 
 func (s *StreamParameters) StreamID() string {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -147,7 +147,7 @@ type authWebhookResponse struct {
 		} `json:"sceneClassification"`
 	} `json:"detection"`
 	VerificationFreq           uint `json:"verificationFreq"`
-	TranscodeTimeoutMultiplier int  `json:"transcodeTimeoutMultiplier"`
+	SegUploadTimeoutMultiplier int  `json:"segUploadTimeoutMultiplier"`
 }
 
 func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bool, transcodingOptions string) (*LivepeerServer, error) {
@@ -866,7 +866,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 		}
 		params := streamParams(appData)
 		if authHeaderConfig != nil {
-			params.SegUploadTimeoutMultiplier = authHeaderConfig.TranscodeTimeoutMultiplier
+			params.SegUploadTimeoutMultiplier = authHeaderConfig.SegUploadTimeoutMultiplier
 		}
 		params.Resolution = r.Header.Get("Content-Resolution")
 		params.Format = format

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -865,7 +865,9 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		params := streamParams(appData)
-		params.SegUploadTimeoutMultiplier = authHeaderConfig.TranscodeTimeoutMultiplier
+		if authHeaderConfig != nil {
+			params.SegUploadTimeoutMultiplier = authHeaderConfig.TranscodeTimeoutMultiplier
+		}
 		params.Resolution = r.Header.Get("Content-Resolution")
 		params.Format = format
 		s.connectionLock.RLock()

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -479,6 +479,9 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	if uploadTimeout < common.MinSegmentUploadTimeout {
 		uploadTimeout = common.MinSegmentUploadTimeout
 	}
+	if params.SegUploadTimeoutMultiplier > 1 {
+		uploadTimeout = time.Duration(params.SegUploadTimeoutMultiplier) * uploadTimeout
+	}
 
 	ctx, cancel := context.WithTimeout(clog.Clone(context.Background(), ctx), httpTimeout)
 	defer cancel()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Allows non-live workflows to specify that they're more tolerant of slow connections to transcoders.

**Specific updates (required)**
- Accept new field `transcodeTimeoutMultiplier` in `Livepeer-Transcode-Configuration` header
- Use value from this (if set) to increase upload timeout

**How did you test each of these updates (required)**
- Ran unit tests
- Tested with local T and confirmed timeout in logs

**Does this pull request close any open issues?**
No


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
