### PR TITLE
Fast verification multi-session test

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -36,8 +36,13 @@ func NewOrchestratorPool(bcast common.Broadcaster, uris []*url.URL, score float3
 		glog.Error("Orchestrator pool does not have any URIs")
 	}
 	infos := make([]common.OrchestratorLocalInfo, 0, len(uris))
-	for _, uri := range uris {
-		infos = append(infos, common.OrchestratorLocalInfo{URL: uri, Score: score})
+	if len(uris) == 2 {
+		infos = append(infos, common.OrchestratorLocalInfo{URL: uris[0], Score: common.Score_Trusted})
+		infos = append(infos, common.OrchestratorLocalInfo{URL: uris[1], Score: common.Score_Untrusted})
+	} else {
+		for _, uri := range uris {
+			infos = append(infos, common.OrchestratorLocalInfo{URL: uri, Score: score})
+		}
 	}
 
 	return &orchestratorPool{infos: infos, bcast: bcast}

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -36,15 +36,9 @@ func NewOrchestratorPool(bcast common.Broadcaster, uris []*url.URL, score float3
 		glog.Error("Orchestrator pool does not have any URIs")
 	}
 	infos := make([]common.OrchestratorLocalInfo, 0, len(uris))
-	if len(uris) == 2 {
-		infos = append(infos, common.OrchestratorLocalInfo{URL: uris[0], Score: common.Score_Trusted})
-		infos = append(infos, common.OrchestratorLocalInfo{URL: uris[1], Score: common.Score_Untrusted})
-	} else {
-		for _, uri := range uris {
-			infos = append(infos, common.OrchestratorLocalInfo{URL: uri, Score: score})
-		}
+	for _, uri := range uris {
+		infos = append(infos, common.OrchestratorLocalInfo{URL: uri, Score: score})
 	}
-
 	return &orchestratorPool{infos: infos, bcast: bcast}
 }
 

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -1732,13 +1732,13 @@ func TestVerifcationDoesntRunWhenNoVerifiedSessionPresent(t *testing.T) {
 	b := BroadcastSessionsManager{
 		VerificationFreq: 1,
 	}
-	require.False(t, b.shouldRunVerification(nil))
+	require.False(t, b.shouldSkipVerification(nil))
 
 	b.verifiedSession = &BroadcastSession{
 		LatencyScore: 1.23,
 	}
 
-	require.False(t, b.shouldRunVerification([]*BroadcastSession{}))
+	require.False(t, b.shouldSkipVerification([]*BroadcastSession{}))
 }
 
 func TestVerifcationRunsBasedOnVerificationFrequency(t *testing.T) {
@@ -1754,7 +1754,7 @@ func TestVerifcationRunsBasedOnVerificationFrequency(t *testing.T) {
 
 	var shouldRunCount int
 	for i := 0; i < 10000; i++ {
-		if b.shouldRunVerification([]*BroadcastSession{verifiedSession}) {
+		if b.shouldSkipVerification([]*BroadcastSession{verifiedSession}) {
 			shouldRunCount++
 		}
 	}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -336,8 +336,6 @@ func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookR
 		} else {
 			profiles = BroadcastJobVideoProfiles
 		}
-		//VerificationFreq = 1
-
 		sid := parseStreamID(url.Path)
 		extmid := sid.ManifestID
 		if mid == "" {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -336,6 +336,7 @@ func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookR
 		} else {
 			profiles = BroadcastJobVideoProfiles
 		}
+		//VerificationFreq = 1
 
 		sid := parseStreamID(url.Path)
 		extmid := sid.ManifestID


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
A set of more comprehensive fast verification tests, including:
- selecting and using 'good' untrusted session in case of mismatched hash
- selecting and using 'good' untrusted session in case of mismatched segment data
- selecting and using trusted session if none of untrusted sessions successfully verified
- working with more than 3 sessions

List of changes:
- rename `shouldRunVerification()` to `shouldSkipVerification()` to match semantics
- an option to make multi-session transcoding sequential for testing
- tests and refactoring of the tests 