### PR TITLE
Use multiplier for overall timeout as well as upload

### DIFF
--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -481,6 +481,7 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	}
 	if params.SegUploadTimeoutMultiplier > 1 {
 		uploadTimeout = time.Duration(params.SegUploadTimeoutMultiplier) * uploadTimeout
+		httpTimeout = time.Duration(params.SegUploadTimeoutMultiplier) * httpTimeout
 	}
 
 	ctx, cancel := context.WithTimeout(clog.Clone(context.Background(), ctx), httpTimeout)
@@ -550,7 +551,6 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 
 	data, err = ioutil.ReadAll(resp.Body)
 	tookAllDur := time.Since(start)
-
 	if err != nil {
 		clog.Errorf(ctx, "Unable to read response body for segment orch=%s err=%q", ti.Transcoder, err)
 		if monitor.Enabled {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Applies the timeout multiplier that we're passing in for VOD to the overall request, rather that just the upload

**How did you test each of these updates (required)**
- Ran unit tests


**Does this pull request close any open issues?**
No


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
