### PR TITLE
Netint build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jaypipes/pcidb v1.0.0
 	github.com/livepeer/go-tools v0.0.0-20220805063103-76df6beb6506
 	github.com/livepeer/livepeer-data v0.4.11
-	github.com/livepeer/lpms v0.0.0-20220728084527-dacf4ac6ff13
+	github.com/livepeer/lpms v0.0.0-20221213135212-7b1301e3ed09
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -682,6 +682,8 @@ github.com/livepeer/livepeer-data v0.4.11 h1:Sv+ss8e4vcscnMWLxcRJ2g3sNIHyQ3RzCtg
 github.com/livepeer/livepeer-data v0.4.11/go.mod h1:VIbJRdyH2Tas8EgLVkP79IPMepFDOv0dgHYLEZsCaf4=
 github.com/livepeer/lpms v0.0.0-20220728084527-dacf4ac6ff13 h1:Tex50r/ebDo1JA/WtUvYQrnXw9HqveVRjy7/BNZ4xx0=
 github.com/livepeer/lpms v0.0.0-20220728084527-dacf4ac6ff13/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
+github.com/livepeer/lpms v0.0.0-20221213135212-7b1301e3ed09 h1:sLXI3C0Z3ZEKUJ0w48SaiYebcc8g/qA3s/rk+7JDyUI=
+github.com/livepeer/lpms v0.0.0-20221213135212-7b1301e3ed09/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -134,16 +134,6 @@ if [[ "$UNAME" == "Linux" && "${BUILD_TAGS}" == *"debug-video"* ]]; then
   fi
 fi
 
-# WavPack required for Netint Ffmpeg
-if [[ ! -e "$ROOT/WavPack" ]]; then
-  git clone https://github.com/dbry/WavPack "$ROOT/WavPack"
-  cd "$ROOT/WavPack"
-  git checkout 6cf0e243a33011490099814220ee0b1ac31cd0da
-  ./configure --prefix="$ROOT/compiled"
-  make -j$NPROC
-  make -j$NPROC install
-fi
-
 # Netint codec
 if [[ ! -e "$ROOT/libxcoder_logan" ]]; then
   echo "Please place libxcoder_logan dir from Netint distribution v3.1.0 to $ROOT/libxcoder_logan!"
@@ -200,6 +190,7 @@ if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]]; then
   git checkout adba7845a077c12a99fe35fb96df633528754520
   ./configure ${TARGET_OS:-} $DISABLE_FFMPEG_COMPONENTS --fatal-warnings \
     --enable-libxcoder_logan --enable-ni_logan \
+    --enable-pthreads --extra-libs='-lpthread' \
     --enable-libx264 --enable-gpl --enable-libfreetype \
     --enable-protocol=rtmp,file,pipe \
     --enable-muxer=mpegts,hls,segment,mp4,hevc,matroska,webm,null --enable-demuxer=flv,mpegts,mp4,mov,webm,matroska \
@@ -207,10 +198,10 @@ if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]]; then
     --enable-parser=aac,aac_latm,h264,hevc,vp8,vp9 \
     --enable-filter=abuffer,buffer,abuffersink,buffersink,afifo,fifo,aformat,format \
     --enable-filter=aresample,asetnsamples,fps,scale,hwdownload,select,livepeer_dnn,signature \
-    --enable-encoder=aac,opus,libx264 \
-    --enable-decoder=aac,opus,h264 \
+    --enable-encoder=aac,opus,libx264,h264_ni_logan_enc,h265_ni_logan_enc \
+    --enable-decoder=aac,opus,h264,h264_ni_logan_dec,h265_ni_logan_dec \
     --extra-cflags="-I${ROOT}/compiled/include ${EXTRA_CFLAGS}" \
-    --extra-ldflags="-L${ROOT}/compiled/lib ${EXTRA_FFMPEG_LDFLAGS}" \
+    --extra-ldflags="-lm" --extra-ldflags="-ldl" --extra-ldflags="-L${ROOT}/compiled/lib ${EXTRA_FFMPEG_LDFLAGS}" \
     --prefix="$ROOT/compiled" \
     $EXTRA_FFMPEG_FLAGS \
     $DEV_FFMPEG_FLAGS

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -75,7 +75,7 @@ if [[ "$UNAME" != "Darwin" ]]; then
   if [[ ! -e "$ROOT/nv-codec-headers" ]]; then
     git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git "$ROOT/nv-codec-headers"
     cd $ROOT/nv-codec-headers
-    git checkout n9.1.23.1
+    git checkout n11.1.5.2
     make -e PREFIX="$ROOT/compiled"
     make install -e PREFIX="$ROOT/compiled"
   fi
@@ -145,12 +145,12 @@ if [[ ! -e "$ROOT/WavPack" ]]; then
 fi
 
 # Netint codec
-if [[ ! -e "$ROOT/libxcoder" ]]; then
-  echo "Please obtain Netint LibXcoder sources and place them to $ROOT/libxcoder!"
+if [[ ! -e "$ROOT/libxcoder_logan" ]]; then
+  echo "Please place libxcoder_logan dir from Netint distribution v3.1.0 to $ROOT/libxcoder_logan!"
   exit -1
 else
-  if [[ ! -e "$ROOT/libxcoder/bin/libxcoder.a" ]]; then
-    cd $ROOT/libxcoder
+  if [[ ! -e "$ROOT/libxcoder_logan/bin/libxcoder_logan.a" ]]; then
+    cd $ROOT/libxcoder_logan
     ./configure --libdir=$ROOT/compiled/lib --bindir=$ROOT/compiled/bin \
     --includedir=$ROOT/compiled/include --shareddir=$ROOT/compiled/lib
     make -j$NPROC
@@ -197,8 +197,9 @@ fi
 if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]]; then
   git clone https://github.com/livepeer/FFmpeg.git "$ROOT/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$ROOT/ffmpeg"
-  git checkout 399aed59ec4b5e4ab5cb380120ea9aeae9be0ce1
+  git checkout f78d1dcf5995024ef0c846198e70f18ddc0e9d5e
   ./configure ${TARGET_OS:-} $DISABLE_FFMPEG_COMPONENTS --fatal-warnings \
+    --enable-libxcoder_logan --enable-ni_logan \
     --enable-libx264 --enable-gpl --enable-libfreetype \
     --enable-protocol=rtmp,file,pipe \
     --enable-muxer=mpegts,hls,segment,mp4,hevc,matroska,webm,null --enable-demuxer=flv,mpegts,mp4,mov,webm,matroska \

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -113,7 +113,7 @@ if [[ ! -e "$ROOT/x264" ]]; then
 fi
 
 if [[ "$UNAME" == "Linux" && "${BUILD_TAGS}" == *"debug-video"* ]]; then
-  sudo apt-get install -y libnuma-dev cmake
+  sudo apt-get install -y libnuma-dev cmake libfreetype-dev
   if [[ ! -e "$ROOT/x265" ]]; then
     git clone https://bitbucket.org/multicoreware/x265_git.git "$ROOT/x265"
     cd "$ROOT/x265"

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -204,7 +204,7 @@ if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]]; then
     --enable-muxer=mpegts,hls,segment,mp4,hevc,matroska,webm,null --enable-demuxer=flv,mpegts,mp4,mov,webm,matroska \
     --enable-bsf=h264_mp4toannexb,aac_adtstoasc,h264_metadata,h264_redundant_pps,hevc_mp4toannexb,extract_extradata \
     --enable-parser=aac,aac_latm,h264,hevc,vp8,vp9 \
-    --enable-filter=drawtext,abuffer,buffer,abuffersink,buffersink,afifo,fifo,aformat,format \
+    --enable-filter=abuffer,buffer,abuffersink,buffersink,afifo,fifo,aformat,format \
     --enable-filter=aresample,asetnsamples,fps,scale,hwdownload,select,livepeer_dnn,signature \
     --enable-encoder=aac,opus,libx264 \
     --enable-decoder=aac,opus,h264 \

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -134,6 +134,30 @@ if [[ "$UNAME" == "Linux" && "${BUILD_TAGS}" == *"debug-video"* ]]; then
   fi
 fi
 
+# WavPack required for Netint Ffmpeg
+if [[ ! -e "$ROOT/WavPack" ]]; then
+  git clone https://github.com/dbry/WavPack "$ROOT/WavPack"
+  cd "$ROOT/WavPack"
+  git checkout 6cf0e243a33011490099814220ee0b1ac31cd0da
+  ./configure --prefix="$ROOT/compiled"
+  make -j$NPROC
+  make -j$NPROC install
+fi
+
+# Netint codec
+if [[ ! -e "$ROOT/libxcoder" ]]; then
+  echo "Please obtain Netint LibXcoder sources and place them to $ROOT/libxcoder!"
+  exit -1
+else
+  if [[ ! -e "$ROOT/libxcoder/bin/libxcoder.a" ]]; then
+    cd $ROOT/libxcoder
+    ./configure --libdir=$ROOT/compiled/lib --bindir=$ROOT/compiled/bin \
+    --includedir=$ROOT/compiled/include --shareddir=$ROOT/compiled/lib
+    make -j$NPROC
+    make -j$NPROC install
+  fi
+fi
+
 DISABLE_FFMPEG_COMPONENTS=""
 EXTRA_FFMPEG_LDFLAGS="$EXTRA_LDFLAGS"
 # all flags which should be present for production build, but should be replaced/removed for debug build
@@ -173,14 +197,14 @@ fi
 if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]]; then
   git clone https://github.com/livepeer/FFmpeg.git "$ROOT/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$ROOT/ffmpeg"
-  git checkout 92c358e21b1616b07a61c634365ed441ee097e8c
+  git checkout 399aed59ec4b5e4ab5cb380120ea9aeae9be0ce1
   ./configure ${TARGET_OS:-} $DISABLE_FFMPEG_COMPONENTS --fatal-warnings \
-    --enable-libx264 --enable-gpl \
+    --enable-libx264 --enable-gpl --enable-libfreetype \
     --enable-protocol=rtmp,file,pipe \
     --enable-muxer=mpegts,hls,segment,mp4,hevc,matroska,webm,null --enable-demuxer=flv,mpegts,mp4,mov,webm,matroska \
     --enable-bsf=h264_mp4toannexb,aac_adtstoasc,h264_metadata,h264_redundant_pps,hevc_mp4toannexb,extract_extradata \
     --enable-parser=aac,aac_latm,h264,hevc,vp8,vp9 \
-    --enable-filter=abuffer,buffer,abuffersink,buffersink,afifo,fifo,aformat,format \
+    --enable-filter=drawtext,abuffer,buffer,abuffersink,buffersink,afifo,fifo,aformat,format \
     --enable-filter=aresample,asetnsamples,fps,scale,hwdownload,select,livepeer_dnn,signature \
     --enable-encoder=aac,opus,libx264 \
     --enable-decoder=aac,opus,h264 \

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -197,7 +197,7 @@ fi
 if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]]; then
   git clone https://github.com/livepeer/FFmpeg.git "$ROOT/ffmpeg" || echo "FFmpeg dir already exists"
   cd "$ROOT/ffmpeg"
-  git checkout f78d1dcf5995024ef0c846198e70f18ddc0e9d5e
+  git checkout adba7845a077c12a99fe35fb96df633528754520
   ./configure ${TARGET_OS:-} $DISABLE_FFMPEG_COMPONENTS --fatal-warnings \
     --enable-libxcoder_logan --enable-ni_logan \
     --enable-libx264 --enable-gpl --enable-libfreetype \


### PR DESCRIPTION
**About**
Include Netint driver build commands and Ffmpeg [branch](https://github.com/livepeer/FFmpeg/tree/livepeer-netint) with Netint support into `install_ffmpeg.sh`. Netint library sources still need to be obtained manually and put to `$ROOT/libxcoder_logan`.

**Testing**
```
go build cmd/livepeer_bench/livepeer_bench.go
./livepeer_bench  -in bbb/source.m3u8 -transcodingOptions P240p30fps16x9 -concurrentSessions 18 -outPrefix /tmp/ -netint 0
```
