### PR TITLE
Add monitoring metrics for scene classification

### DIFF
--- a/monitor/census.go
+++ b/monitor/census.go
@@ -180,8 +180,8 @@ type (
 		mFastVerificationUsingCurrentSessions   *stats.Int64Measure
 
 		// Metrics for scene classification
-		kSegClassName     tag.Key
-		mSegmentClassProb *stats.Float64Measure
+		kSegClassName        tag.Key
+		mSegmentClassProb    *stats.Float64Measure
 		mSceneClassification *stats.Int64Measure
 
 		lock        sync.Mutex
@@ -1230,7 +1230,6 @@ func SegSceneClassificationDone(ctx context.Context, seqNo uint64) {
 		clog.Errorf(ctx, "Error recording metrics err=%q", err)
 	}
 }
-
 
 func HTTPClientTimedOut1(ctx context.Context) {
 	if err := stats.RecordWithTags(census.ctx,

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -990,6 +990,9 @@ func transcodeSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSS
 		// for now use detection only in common path
 		if DetectionWebhookURL != nil && len(res.Detections) > 0 {
 			clog.V(common.DEBUG).Infof(ctx, "Got detection result %v", res.Detections)
+			if monitor.Enabled {
+				monitor.SegSceneClassificationDone(ctx, seg.SeqNo)
+			}
 			go func(mid core.ManifestID, config core.DetectionConfig, seqNo uint64, detections []*net.DetectData) {
 				req := common.DetectionWebhookRequest{ManifestID: string(mid), SeqNo: seqNo}
 				for _, detection := range detections {
@@ -1005,6 +1008,9 @@ func transcodeSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSS
 											Name:        name,
 											Probability: prob,
 										})
+									if monitor.Enabled {
+										monitor.SegSceneClassificationResult(ctx, seg.SeqNo, name, prob)
+									}
 								}
 							}
 						}


### PR DESCRIPTION
#2503 

**Testing**
1. Run B and O with content detection and monitoring enabled:
```
./livepeer -monitor -metricsPerStream -broadcaster -rtmpAddr :1935 -cliAddr 127.0.0.1:7937 -nvidia 1,2 -httpAddr 127.0.0.1:8935 -orchAddr localhost:8936 -orchSecret 11111111111 -v 6 -detectContent
./livepeer -transcoder -orchestrator -serviceAddr localhost:8936 -v 6 -maxSessions 20 -monitor -nvidia all -detectContent
```
2. Push the stream:
```
ffmpeg -re -i bbb.mp4 -c:a copy -c:v copy -f hls -hls_time 2 -headers 'Livepeer-Transcode-Configuration:
                                                                      {"detection": {"freq": 2, "sampleRate": 10, "sceneClassification": [{"name": "soccer"},{"name":"adult"}]}}' http://localhost:8935/live/movie3/
```
3. Watch metrics:
```
watch -n1 "curl -s http://localhost:7937/metrics 2>&1|sed '/^#/d'|grep scene"
```
Output:
```
livepeer_segment_scene_class_prob{manifest_id="movie3",node_id="cbrjgwngs2",node_type="bctr",seg_class_name="adult"} 0.010882000438869
livepeer_segment_scene_class_prob{manifest_id="movie3",node_id="cbrjgwngs2",node_type="bctr",seg_class_name="soccer"} 0.00676799938082695
```

**Monitoring**

Dashboard (currently set up with different metric for preview): https://eu-metrics-monitoring.livepeer.monster/grafana/d/oQZqfBd4k/scene-classification-demo?orgId=1

Query to be used in the dashboard, once the code is deployed on staging and content detection is enabled on Os (also requires above parameters passed to node on startup, and configuration header or JSON for the stream) :
```
sort_desc(avg by(manifest_id) (livepeer_segment_scene_class_prob{seg_class_name="soccer"} > 0.5))
```
