### PR TITLE
Rename timeout multiplier param to reflect broader use

### DIFF
--- a/core/streamdata.go
+++ b/core/streamdata.go
@@ -29,22 +29,22 @@ type DetectionConfig struct {
 }
 
 type StreamParameters struct {
-	ManifestID                 ManifestID
-	ExternalStreamID           string
-	SessionID                  string
-	RtmpKey                    string
-	Profiles                   []ffmpeg.VideoProfile
-	Resolution                 string
-	Format                     ffmpeg.Format
-	OS                         drivers.OSSession
-	RecordOS                   drivers.OSSession
-	Capabilities               *Capabilities
-	Detection                  DetectionConfig
-	VerificationFreq           uint
-	Nonce                      uint64
-	Codec                      ffmpeg.VideoCodec
-	PixelFormat                ffmpeg.PixelFormat
-	SegUploadTimeoutMultiplier int // Used in the VOD workflow to allow us to be more lenient with timeouts
+	ManifestID        ManifestID
+	ExternalStreamID  string
+	SessionID         string
+	RtmpKey           string
+	Profiles          []ffmpeg.VideoProfile
+	Resolution        string
+	Format            ffmpeg.Format
+	OS                drivers.OSSession
+	RecordOS          drivers.OSSession
+	Capabilities      *Capabilities
+	Detection         DetectionConfig
+	VerificationFreq  uint
+	Nonce             uint64
+	Codec             ffmpeg.VideoCodec
+	PixelFormat       ffmpeg.PixelFormat
+	TimeoutMultiplier int // Used in the VOD workflow to allow us to be more lenient with timeouts
 }
 
 func (s *StreamParameters) StreamID() string {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -146,8 +146,8 @@ type authWebhookResponse struct {
 			Name string `json:"name"`
 		} `json:"sceneClassification"`
 	} `json:"detection"`
-	VerificationFreq           uint `json:"verificationFreq"`
-	SegUploadTimeoutMultiplier int  `json:"segUploadTimeoutMultiplier"`
+	VerificationFreq  uint `json:"verificationFreq"`
+	TimeoutMultiplier int  `json:"timeoutMultiplier"`
 }
 
 func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bool, transcodingOptions string) (*LivepeerServer, error) {
@@ -865,7 +865,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 		}
 		params := streamParams(appData)
 		if authHeaderConfig != nil {
-			params.SegUploadTimeoutMultiplier = authHeaderConfig.SegUploadTimeoutMultiplier
+			params.TimeoutMultiplier = authHeaderConfig.TimeoutMultiplier
 		}
 		params.Resolution = r.Header.Get("Content-Resolution")
 		params.Format = format

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -479,9 +479,9 @@ func SubmitSegment(ctx context.Context, sess *BroadcastSession, seg *stream.HLSS
 	if uploadTimeout < common.MinSegmentUploadTimeout {
 		uploadTimeout = common.MinSegmentUploadTimeout
 	}
-	if params.SegUploadTimeoutMultiplier > 1 {
-		uploadTimeout = time.Duration(params.SegUploadTimeoutMultiplier) * uploadTimeout
-		httpTimeout = time.Duration(params.SegUploadTimeoutMultiplier) * httpTimeout
+	if params.TimeoutMultiplier > 1 {
+		uploadTimeout = time.Duration(params.TimeoutMultiplier) * uploadTimeout
+		httpTimeout = time.Duration(params.TimeoutMultiplier) * httpTimeout
 	}
 
 	ctx, cancel := context.WithTimeout(clog.Clone(context.Background(), ctx), httpTimeout)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This parameter initially only controlled the upload multiplier but has now expanded in scope. Updated parameter and variable names to reflect this.

**Specific updates (required)**
- Rename JSON parameter
- Rename variables

**How did you test each of these updates (required)**
- Ran unit tests


**Does this pull request close any open issues?**
No


**Checklist:**
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
