### PR TITLE
.github/workflows: Use path context for docker build action

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -101,6 +101,7 @@ jobs:
         with:
           build-args: |
             BUILD_TAGS=${{ steps.build-tag.outputs.build-tags }}
+          context: .
           platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.meta-builder.outputs.tags }}
@@ -118,6 +119,7 @@ jobs:
           # linux/arm64 is disabled until
           # <https://github.com/livepeer/go-livepeer/issues/2545> gets
           # resolved
+          context: .
           platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/ci_env.sh
+++ b/ci_env.sh
@@ -3,7 +3,7 @@
 # Script to populate some environment variables in various CI processes. Should be
 # invoked by `ci_env.sh [script-name]`.
 
-set -e
+set -eo pipefail
 
 # Populate necessary Windows build path stuff
 if [[ $(uname) == *"MSYS"* ]]; then
@@ -55,6 +55,8 @@ if [[ $generatedVersion != $definedVersion ]]; then
   export BUILD_TAGS="${BUILD_TAGS},experimental"
 fi
 
-echo "::set-output name=build-tags::${BUILD_TAGS}"
+if [[ "$CI" == "true" ]]; then
+  echo "build-tags=${BUILD_TAGS}" >>"$GITHUB_OUTPUT"
+fi
 
 exec "$@"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

The following workflow runs show that the node version string is not correctly generated in Docker images:

https://github.com/livepeer/go-livepeer/actions/runs/3568466200/jobs/5997370167
https://github.com/livepeer/go-livepeer/actions/runs/3575355384/jobs/6011785524

The following fatal error can be observed under "Build and push livepeer docker image" for the first workflow run and under "Build and push livepeer builder" for the second workflow run:

```
#27 [linux/amd64->arm64 build 12/12] RUN	MAKE livepeer livepeer_cli livepeer_bench livepeer_router
#0 0.182 fatal: not a git repository (or any of the parent directories): .git
```

In both cases, we can see that the go build command for the binary is run with an empty string for the node version:

```
#0 0.148 GO111MODULE=on CGO_ENABLED=1 CC="clang --sysroot=/usr/aarch64-linux-gnu" CGO_CFLAGS=" --target=aarch64-linux-gnu" CGO_LDFLAGS=" --target=aarch64-linux-gnu" go build -o /build/ -tags "mainnet,experimental" -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=" cmd/livepeer/*.go
```

The [docker.yaml workflow](https://github.com/livepeer/go-livepeer/blob/b3d931f741f04b77adeb1bfa21547827f5e1ee69/.github/workflows/docker.yaml#L100) uses the [docker/build-push-action](https://github.com/docker/build-push-action) GH action to build the Docker image. By default, the action will use a [git context](https://github.com/docker/build-push-action#git-context) which leverages Docker's ability to build from a git repo. However, the docs for [docker build from git repos](https://docs.docker.com/engine/reference/commandline/build/#git-repositories) note:

"the repository acts as the build context. The system recursively fetches the repository and its submodules. The commit history is not preserved."

The lack of commit history with the git context is problematic because the [print_version.sh](https://github.com/livepeer/go-livepeer/blob/master/print_version.sh) script used to generate the node version string for [at build time](https://github.com/livepeer/go-livepeer/blob/b3d931f741f04b77adeb1bfa21547827f5e1ee69/Makefile#L20)  depends on commit history. As result, whenever the docker.yaml workflow builds a Docker image with the livepeer binary, the node version string ends up being empty.

The solution is to use a [path context](https://github.com/docker/build-push-action#path-context) and specify the current directory instead of using a git context for docker/build-push-action.

After specifying `context: .` for the action in docker.yaml, the following workflow correctly generated the node version string:

https://github.com/livepeer/go-livepeer/actions/runs/3576724322/jobs/6014880176

```
GO111MODULE=on CGO_ENABLED=1 CC="" CGO_CFLAGS="" CGO_LDFLAGS="" go build -o /build/ -ldflags="-X github.com/livepeer/go-livepeer/core.LivepeerVersion=0.5.35-03ba92ce" cmd/livepeer_bench/*.go
```

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

See commit history.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Read workflow run logs.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes https://github.com/livepeer/go-livepeer/issues/2571

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] ~[Pending changelog](./CHANGELOG_PENDING.md) updated~
