### PR TITLE
add Transcoding session ended log message

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -29,5 +29,6 @@
 
 #### Orchestrator
 - \#2639 Increase IdleTimeout for HTTP connections (@leszko)
+- \#2685 Add a log message when sessions are closed by the Broadcaster. Increase transcode loop timeout (@mj1)
 
 #### Transcoder

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -991,7 +991,9 @@ func (rtm *RemoteTranscoderManager) selectTranscoder(sessionId string, caps *Cap
 
 // ends transcoding session and releases resources
 func (node *LivepeerNode) EndTranscodingSession(sessionId string) {
-	node.endTranscodingSession(sessionId, context.TODO())
+	logCtx := context.TODO()
+	clog.V(common.DEBUG).Infof(logCtx, "Transcoding session ended for sessionID=%v", sessionId)
+	node.endTranscodingSession(sessionId, logCtx)
 }
 
 func (node *RemoteTranscoderManager) EndTranscodingSession(sessionId string) {

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -36,7 +36,7 @@ import (
 
 const maxSegmentChannels = 4
 
-var transcodeLoopTimeout = 1 * time.Minute
+var transcodeLoopTimeout = 70 * time.Second
 
 // Gives us more control of "timeout" / cancellation behavior during testing
 var transcodeLoopContext = func() (context.Context, context.CancelFunc) {

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -36,6 +36,8 @@ import (
 
 const maxSegmentChannels = 4
 
+// this is set to be higher than httpPushTimeout in server/mediaserver.go so that B has a chance to end the session
+// based on httpPushTimeout before transcodeLoopTimeout is reached
 var transcodeLoopTimeout = 70 * time.Second
 
 // Gives us more control of "timeout" / cancellation behavior during testing

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -992,7 +992,7 @@ func (rtm *RemoteTranscoderManager) selectTranscoder(sessionId string, caps *Cap
 // ends transcoding session and releases resources
 func (node *LivepeerNode) EndTranscodingSession(sessionId string) {
 	logCtx := context.TODO()
-	clog.V(common.DEBUG).Infof(logCtx, "Transcoding session ended for sessionID=%v", sessionId)
+	clog.V(common.DEBUG).Infof(logCtx, "Transcoding session ended by the Broadcaster for sessionID=%v", sessionId)
 	node.endTranscodingSession(sessionId, logCtx)
 }
 

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -327,6 +327,7 @@ func getOrchestrator(orch Orchestrator, req *net.OrchestratorRequest) (*net.Orch
 }
 
 func endTranscodingSession(node *core.LivepeerNode, orch Orchestrator, req *net.EndTranscodingSessionRequest) (*net.EndTranscodingSessionResponse, error) {
+	// TODO log message here
 	verifyToken := orch.AuthToken(req.AuthToken.SessionId, req.AuthToken.Expiration)
 	if !bytes.Equal(verifyToken.Token, req.AuthToken.Token) {
 		return nil, fmt.Errorf("Invalid auth token")

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -327,7 +327,6 @@ func getOrchestrator(orch Orchestrator, req *net.OrchestratorRequest) (*net.Orch
 }
 
 func endTranscodingSession(node *core.LivepeerNode, orch Orchestrator, req *net.EndTranscodingSessionRequest) (*net.EndTranscodingSessionResponse, error) {
-	// TODO log message here
 	verifyToken := orch.AuthToken(req.AuthToken.SessionId, req.AuthToken.Expiration)
 	if !bytes.Equal(verifyToken.Token, req.AuthToken.Token) {
 		return nil, fmt.Errorf("Invalid auth token")


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Adding a log line to make it clear on the O end when B ends a session

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- add a log message when transcoding sessions end
- make transcode loop timeout greater than http push timeout on B so that we're less likely to see the segment loop timeouts for graceful session ends


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
I ran B/O/T locally, pushed an rtmp stream, waited 15 seconds or so then stopped the rtmp input, observed the new log message as shown below:

```
I1209 13:58:03.008992   98749 orchestrator.go:594] manifestID=foo seqNo=5 orchSessionID=2dcd9996 clientIP=127.0.0.1 sender=0x494E245a669C5cb119568E6c59FE82b6fC058db0 Transcoded segment profile=P360p30fps16x9 bytes=300236
I1209 13:58:03.013062   98749 player.go:105] LPMS got HTTP request @ /stream/2dcd9996/P360p30fps16x9/5.ts
I1209 13:58:03.013095   98749 player.go:105] LPMS got HTTP request @ /stream/2dcd9996/P240p30fps16x9/5.ts
I1209 13:58:03.316575   98749 orchestrator.go:995] Transcoding session ended for sessionID=2dcd9996
I1209 13:58:26.796064   98749 roundinitializer.go:124] New round - preparing to initialize round to join active set, current round is 801
```

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #2641

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
