### PR TITLE
Control scene classification with T command line args

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,6 +13,7 @@
 #### Orchestrator
 
 #### Transcoder
+- \#2686 Control non-stream specific scene classification with command line args
 
 ### Bug Fixes 🐞
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -137,7 +137,8 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.Netint = flag.String("netint", *cfg.Netint, "Comma-separated list of NetInt device GUIDs (or \"all\" for all available devices)")
 	cfg.TestTranscoder = flag.Bool("testTranscoder", *cfg.TestTranscoder, "Test Nvidia GPU transcoding at startup")
 	cfg.SceneClassificationModelPath = flag.String("sceneClassificationModelPath", *cfg.SceneClassificationModelPath, "Path to scene classification model")
-	cfg.DetectContent = flag.Bool("detectContent", *cfg.DetectContent, "Set to true to enable content type detection")
+	cfg.DetectContent = flag.Bool("detectContent", *cfg.DetectContent, "Enables content type detection capability and automatic detection. If not specified, transcoder won't advertise corresponding capabilities and receive such jobs.")
+	cfg.DetectionSampleRate = flag.Uint("detectionSampleRate", *cfg.DetectionSampleRate, "Run content detection automatically on every nth frame of each segment, independently of requested stream transcoding configuration.")
 
 	// Onchain:
 	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address")

--- a/core/lb.go
+++ b/core/lb.go
@@ -100,10 +100,13 @@ func (lb *LoadBalancingTranscoder) createSession(ctx context.Context, md *SegTra
 	// Acquire transcode session. Map to job id + assigned transcoder
 	key := job + "_" + transcoder
 	costEstimate := calculateCost(md.Profiles)
+
+	// create the transcoder - with AI capabilities, if required by local or stream configuration
 	var lpmsSession TranscoderSession
-	if md.DetectorEnabled {
+	setEffectiveDetectorConfig(md)
+	if md.DetectorEnabled && len(md.DetectorProfiles) == 1 {
 		var err error
-		lpmsSession, err = lb.newDetectorT(DetectorProfile, transcoder)
+		lpmsSession, err = lb.newDetectorT(md.DetectorProfiles[0], transcoder)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
1. Add `-detectionSampleRate` parameter to control non-stream specific scene classification on T
2. Log scene classification results on B, even if not requested for the stream
3. Minor refactoring and cleanup