### PR TITLE
Enable tensorflow for content detection in a production build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install ffmpeg
         if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
-        run: BUILD_TAGS=experimental ./install_ffmpeg.sh
+        run: ./install_ffmpeg.sh
 
       - name: Build binaries
         run: |
@@ -201,7 +201,7 @@ jobs:
 
       - name: Install ffmpeg
         if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
-        run: BUILD_TAGS=experimental ./install_ffmpeg.sh
+        run: ./install_ffmpeg.sh
 
       - name: Build binaries
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/compiled
-          key: ${{ runner.os }}-${{ matrix.platform.name }}-${{ matrix.arch }}-tf-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
+          key: ${{ runner.os }}-${{ matrix.platform.name }}-${{ matrix.arch }}-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.platform.name }}-${{ matrix.arch }}-ffmpeg-
 
@@ -90,11 +90,6 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 30 \
             && sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 30 \
             && sudo update-alternatives --install /usr/bin/ld ld /usr/bin/lld-12 30
-
-          LIBTENSORFLOW_VERSION=2.6.3 \
-            && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
-            && sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
-            && sudo ldconfig
 
       - name: Install go modules
         if: steps.go.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,7 @@ jobs:
           echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
           echo "GOOS=${{ matrix.platform.name }}" >> $GITHUB_ENV
           echo "GO_BUILD_DIR=lp-builds/" >> $GITHUB_ENV
+          echo "BUILD_TAGS=experimental" >> $GITHUB_ENV
 
       - name: Install dependencies
         if: matrix.platform.name == 'darwin'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/compiled
-          key: ${{ runner.os }}-${{ matrix.platform.name }}-${{ matrix.arch }}-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
+          key: ${{ runner.os }}-${{ matrix.platform.name }}-${{ matrix.arch }}-tf-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.platform.name }}-${{ matrix.arch }}-ffmpeg-
 
@@ -72,7 +72,6 @@ jobs:
           echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
           echo "GOOS=${{ matrix.platform.name }}" >> $GITHUB_ENV
           echo "GO_BUILD_DIR=lp-builds/" >> $GITHUB_ENV
-          echo "BUILD_TAGS=experimental" >> $GITHUB_ENV
 
       - name: Install dependencies
         if: matrix.platform.name == 'darwin'
@@ -92,13 +91,18 @@ jobs:
             && sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 30 \
             && sudo update-alternatives --install /usr/bin/ld ld /usr/bin/lld-12 30
 
+          LIBTENSORFLOW_VERSION=2.6.3 \
+            && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
+            && sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
+            && sudo ldconfig
+
       - name: Install go modules
         if: steps.go.outputs.cache-hit != 'true'
         run: go mod download
 
       - name: Install ffmpeg
         if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
-        run: ./install_ffmpeg.sh
+        run: BUILD_TAGS=experimental ./install_ffmpeg.sh
 
       - name: Build binaries
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,8 +72,8 @@ RUN apt update && apt install -yqq software-properties-common curl apt-transport
 
 RUN LIBTENSORFLOW_VERSION=2.6.3 \
             && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
-            && sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
-            && sudo ldconfig
+            && tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
+            && ldconfig
 
 RUN	ldconfig
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,15 +2,13 @@ FROM --platform=$BUILDPLATFORM	ubuntu:18.04	as	build
 
 ARG	TARGETARCH
 ARG	BUILDARCH
-ARG	BUILD_TAGS
 
 ENV	GOARCH="$TARGETARCH" \
 	PATH="/usr/local/go/bin:/go/bin:${PATH}" \
 	PKG_CONFIG_PATH="/root/compiled/lib/pkgconfig" \
 	CPATH="/usr/local/cuda/include" \
 	LIBRARY_PATH="/usr/local/cuda/lib64" \
-	DEBIAN_FRONTEND="noninteractive" \
-	BUILD_TAGS=${BUILD_TAGS}
+	DEBIAN_FRONTEND="noninteractive"
 
 RUN	apt update \
 	&& apt install -yqq software-properties-common curl apt-transport-https lsb-release \
@@ -46,6 +44,9 @@ RUN	mkdir -p /go \
 	&& curl -fsSLO https://github.com/livepeer/livepeer-ml/releases/download/v0.3/tasmodel.pb
 
 COPY	./install_ffmpeg.sh	./install_ffmpeg.sh
+
+ARG	BUILD_TAGS
+ENV BUILD_TAGS=${BUILD_TAGS}
 
 RUN ./install_ffmpeg.sh \
 	&& GO111MODULE=on go get -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.25.0 \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,11 +55,7 @@ ENV	BUILD_TAGS=${BUILD_TAGS}
 
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 
-FROM --platform=$TARGETPLATFORM	nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 AS livepeer-amd64-base
-
-FROM --platform=$TARGETPLATFORM nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 AS livepeer-arm64-base
-
-FROM livepeer-${TARGETARCH}-base
+FROM --platform=${TARGETPLATFORM}	nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 AS livepeer-base
 
 ENV	NVIDIA_DRIVER_CAPABILITIES=all
 
@@ -68,13 +64,13 @@ COPY --from=build	/usr/bin/grpc_health_probe	/usr/local/bin/grpc_health_probe
 COPY --from=build	/src/tasmodel.pb	/tasmodel.pb
 COPY --from=build	/usr/share/misc/pci.ids	/usr/share/misc/pci.ids
 
+# libtensorflow.so is required at runtime, because Ffmpeg DNN filter loads it dynamically
 RUN apt update && apt install -yqq software-properties-common curl apt-transport-https lsb-release
 
+# Tensorflow version needs to be compatible with CUDA and CuDNN of the image
 RUN LIBTENSORFLOW_VERSION=2.6.3 \
             && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
             && tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
             && ldconfig
-
-RUN	ldconfig
 
 ENTRYPOINT	["/usr/local/bin/livepeer"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,11 @@ RUN	GRPC_HEALTH_PROBE_VERSION=v0.3.6 \
 	&& chmod +x /usr/bin/grpc_health_probe \
 	&& ldconfig /usr/local/lib
 
+# note: for runtime, Tensorflow version needs to be compatible with CUDA and CuDNN of the image
+RUN LIBTENSORFLOW_VERSION=2.6.3 \
+            && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
+            && mkdir /tf && tar -C /tf -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz
+
 ENV	GOPATH=/go \
 	GO_BUILD_DIR=/build/ \
 	GOFLAGS="-mod=readonly"
@@ -63,14 +68,7 @@ COPY --from=build	/build/	/usr/local/bin/
 COPY --from=build	/usr/bin/grpc_health_probe	/usr/local/bin/grpc_health_probe
 COPY --from=build	/src/tasmodel.pb	/tasmodel.pb
 COPY --from=build	/usr/share/misc/pci.ids	/usr/share/misc/pci.ids
-
 # libtensorflow.so is required at runtime, because Ffmpeg DNN filter loads it dynamically
-RUN apt update && apt install -yqq software-properties-common curl apt-transport-https lsb-release
-
-# Tensorflow version needs to be compatible with CUDA and CuDNN of the image
-RUN LIBTENSORFLOW_VERSION=2.6.3 \
-            && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
-            && tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
-            && ldconfig
+COPY --from=build	/tf/	/usr/local/
 
 ENTRYPOINT	["/usr/local/bin/livepeer"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,7 @@ ENV	BUILD_TAGS=${BUILD_TAGS}
 
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 
-FROM --platform=$TARGETPLATFORM	nvidia/cuda:10.1-cudnn7-runtime AS livepeer-amd64-base
+FROM --platform=$TARGETPLATFORM	nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 AS livepeer-amd64-base
 
 FROM --platform=$TARGETPLATFORM nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 AS livepeer-arm64-base
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,15 @@ FROM --platform=$BUILDPLATFORM	ubuntu:18.04	as	build
 
 ARG	TARGETARCH
 ARG	BUILDARCH
+ARG	BUILD_TAGS
 
 ENV	GOARCH="$TARGETARCH" \
 	PATH="/usr/local/go/bin:/go/bin:${PATH}" \
 	PKG_CONFIG_PATH="/root/compiled/lib/pkgconfig" \
 	CPATH="/usr/local/cuda/include" \
 	LIBRARY_PATH="/usr/local/cuda/lib64" \
-	DEBIAN_FRONTEND="noninteractive"
+	DEBIAN_FRONTEND="noninteractive" \
+	BUILD_TAGS=${BUILD_TAGS}
 
 RUN	apt update \
 	&& apt install -yqq software-properties-common curl apt-transport-https lsb-release \
@@ -45,7 +47,7 @@ RUN	mkdir -p /go \
 
 COPY	./install_ffmpeg.sh	./install_ffmpeg.sh
 
-RUN BUILD_TAGS=experimental	./install_ffmpeg.sh \
+RUN ./install_ffmpeg.sh \
 	&& GO111MODULE=on go get -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.25.0 \
 	&& go get -v github.com/jstemmer/go-junit-report
 
@@ -54,9 +56,6 @@ COPY	go.mod	go.sum	./
 RUN	go mod download
 
 COPY	.	.
-
-ARG	BUILD_TAGS
-ENV	BUILD_TAGS=${BUILD_TAGS}
 
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,6 @@ RUN	update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 3
 RUN	GRPC_HEALTH_PROBE_VERSION=v0.3.6 \
 	&& curl -fsSL https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} -o /usr/bin/grpc_health_probe \
 	&& chmod +x /usr/bin/grpc_health_probe \
-	&& curl -fsSL https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-2.8.0.tar.gz | tar -C /usr/local -xzf - \
 	&& ldconfig /usr/local/lib
 
 ENV	GOPATH=/go \
@@ -41,7 +40,7 @@ RUN	mkdir -p /go \
 
 COPY	./install_ffmpeg.sh	./install_ffmpeg.sh
 
-RUN	./install_ffmpeg.sh \
+RUN BUILD_TAGS=experimental	./install_ffmpeg.sh \
 	&& GO111MODULE=on go get -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.25.0 \
 	&& go get -v github.com/jstemmer/go-junit-report
 
@@ -68,6 +67,11 @@ COPY --from=build	/build/	/usr/local/bin/
 COPY --from=build	/usr/bin/grpc_health_probe	/usr/local/bin/grpc_health_probe
 COPY --from=build	/src/tasmodel.pb	/tasmodel.pb
 COPY --from=build	/usr/share/misc/pci.ids	/usr/share/misc/pci.ids
+
+RUN LIBTENSORFLOW_VERSION=2.6.3 \
+            && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
+            && sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
+            && sudo ldconfig
 
 RUN	ldconfig
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,6 +68,8 @@ COPY --from=build	/usr/bin/grpc_health_probe	/usr/local/bin/grpc_health_probe
 COPY --from=build	/src/tasmodel.pb	/tasmodel.pb
 COPY --from=build	/usr/share/misc/pci.ids	/usr/share/misc/pci.ids
 
+RUN apt update && apt install -yqq software-properties-common curl apt-transport-https lsb-release
+
 RUN LIBTENSORFLOW_VERSION=2.6.3 \
             && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
             && sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -147,7 +147,7 @@ else
     echo "clang detected, building with GPU support"
     EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_cuda,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
     if [[ $BUILD_TAGS == *"experimental"* ]]; then
-      if [[ ! -e "/usr/local/lib/libtensorflow_framework.so" ]]; then
+      if [[ ! -e "${ROOT}/compiled/lib/libtensorflow_framework.so" ]]; then
         LIBTENSORFLOW_VERSION=2.6.3 &&
           curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
           tar -C ${ROOT}/compiled/ -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -144,18 +144,15 @@ if [[ "$UNAME" == "Darwin" ]]; then
 else
   # If we have clang, we can compile with CUDA support!
   if which clang >/dev/null; then
-    echo "clang detected, building with GPU support"
+    echo "clang detected, building with GPU and Tensorflow support"
     EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_cuda,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
-    if [[ $BUILD_TAGS == *"experimental"* ]]; then
-      if [[ ! -e "${ROOT}/compiled/lib/libtensorflow_framework.so" ]]; then
-        LIBTENSORFLOW_VERSION=2.6.3 &&
-          curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
-          tar -C ${ROOT}/compiled/ -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
-          rm libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz
-      fi
-      echo "experimental tag detected, building with Tensorflow support"
-      EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-libtensorflow"
+    if [[ ! -e "${ROOT}/compiled/lib/libtensorflow_framework.so" ]]; then
+      LIBTENSORFLOW_VERSION=2.6.3 &&
+        curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
+        tar -C ${ROOT}/compiled/ -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
+        rm libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz
     fi
+    EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-libtensorflow"
   fi
 fi
 

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -150,7 +150,7 @@ else
       if [[ ! -e "/usr/local/lib/libtensorflow_framework.so" ]]; then
         LIBTENSORFLOW_VERSION=2.6.3 &&
           curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
-          tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
+          tar -C ${ROOT}/compiled/ -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
           rm libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz
       fi
       echo "experimental tag detected, building with Tensorflow support"

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -150,7 +150,7 @@ else
       if [[ ! -e "/usr/local/lib/libtensorflow_framework.so" ]]; then
         LIBTENSORFLOW_VERSION=2.6.3 &&
           curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
-          sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
+          tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
           rm libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz
       fi
       echo "experimental tag detected, building with Tensorflow support"


### PR DESCRIPTION
Changes:
- `install_ffmpeg.sh` now installs Tensorflow library and enables it for Ffmpeg without `experimental` BUILD_TAGS (no side effects when running in non-Nvidia environment)
- `Dockerfile` copies Tensorflow distribution files to final container, because libtensorflow.so is loaded at runtime by Ffmpeg DNN filter and is not linked statically inside `livepeer` binary, like the rest of dependencies

Kudos to @hjpotter92 for helping to figure out Docker stuff.