### PR TITLE
Fix backwards compatibility of livepeer_cli with prior livepeer version

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,7 @@
 - \#2686 Control non-stream specific scene classification with command line args
 
 ### Bug Fixes 🐞
+- \#2697 Fix backwards compatibility of livepeer_cli with prior livepeer version
 
 #### CLI
 

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -496,9 +496,12 @@ func (w *wizard) getBroadcasterPrices() (string, error) {
 	}
 
 	prices := new(bytes.Buffer)
-	for b, p := range status["BroadcasterPrices"].(map[string]interface{}) {
-		if b != "default" {
-			fmt.Fprintf(prices, "%s: %s per pixel\n", b, p)
+
+	if broadcasterPrices, ok := status["BroadcasterPrices"]; ok {
+		for b, p := range broadcasterPrices.(map[string]interface{}) {
+			if b != "default" {
+				fmt.Fprintf(prices, "%s: %s per pixel\n", b, p)
+			}
 		}
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Resolves a bug when opening livepeer_cli version 0.5.35 with older versions of livepeer that did not have the price per broadcaster functionality.

**Specific updates (required)**
- Checks http response from `/status` for missing field `BroadcasterPrices` before reading it to prevent runtime error on startup.
- Returns a blank string for the field if not provided by livepeer `/status`

**How did you test each of these updates (required)**
- Tested livepeer_cli with old version of livepeer to confirm runtime issue is resolved.
- Tested livepeer_cli with current version and with broadcaster pricing set to confirm it still works as designed. 
- No changes to option 20, but did confirm there's no backwards compatibility issues with that. 

**Does this pull request close any open issues?**
Fixes #2697 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
