### PR TITLE
Fix: transcoders wait forever on orchestrator restart

### DIFF
--- a/server/ot_rpc.go
+++ b/server/ot_rpc.go
@@ -129,11 +129,11 @@ func runTranscoder(n *core.LivepeerNode, orchAddr string, capacity int, caps []c
 			wg.Wait()
 			return err
 		}
-		wg.Add(1)
 		if notify.SegData != nil && notify.SegData.AuthToken != nil && len(notify.SegData.AuthToken.SessionId) > 0 && len(notify.Url) == 0 {
 			// session teardown signal
 			n.Transcoder.EndTranscodingSession(notify.SegData.AuthToken.SessionId)
 		} else {
+			wg.Add(1)
 			go func() {
 				runTranscode(n, orchAddr, httpc, notify)
 				wg.Done()


### PR DESCRIPTION
### What does this pull request do?

Fixes a bug where transcoders would wait forever on a orchestrator restart if they had a previous transcoding session. Fix simply moves the `wg.Add(1)` call so that the wait group is able to reach `0` again

### Specific updates

My thinking is the bug got introduced in this commit: https://github.com/livepeer/go-livepeer/commit/a1fb761474685ae0679e26349e27f19012d95a75#diff-0db7e4513a2e3eb16dedb22ed6a0920e6648e62733004c11dc0ed8a19f314464 so 0.5.34 should still be good,  anything after that should have this issue

### How did you test each of these updates

Ran a split O/T setup on my main Orchestrator and rebooted it while the connected transcoders were busy transcoding or recently completed a transcoding session. Repeated a couple of times and my transcoders reconnected successfully every time

Fix ran in a pool environment in production, all T's were able to restart themselves gracefully when restarting the O numerous times over the past few days!

### Does this pull request close any open issues?

Fixes #2704
