### PR TITLE
Fix: remote transcoders quietly getting dropped from selection

### DIFF
--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -373,31 +373,39 @@ func TestRemoveFromRemoteTranscoders(t *testing.T) {
 	remoteTranscoderList := []*RemoteTranscoder{}
 	assert := assert.New(t)
 
-	// Create 4 tanscoders
-	tr := make([]*RemoteTranscoder, 4)
-	for i := 0; i < 4; i++ {
+	// Create 6 transcoders
+	tr := make([]*RemoteTranscoder, 5)
+	for i := 0; i < 5; i++ {
 		tr[i] = &RemoteTranscoder{addr: "testAddress" + strconv.Itoa(i)}
 	}
 
 	// Add to list
 	remoteTranscoderList = append(remoteTranscoderList, tr...)
-	assert.Len(remoteTranscoderList, 4)
+	assert.Len(remoteTranscoderList, 5)
 
 	// Remove transcoder froms head of the list
 	remoteTranscoderList = removeFromRemoteTranscoders(tr[0], remoteTranscoderList)
 	assert.Equal(remoteTranscoderList[0], tr[1])
 	assert.Equal(remoteTranscoderList[1], tr[2])
 	assert.Equal(remoteTranscoderList[2], tr[3])
-	assert.Len(remoteTranscoderList, 3)
+	assert.Equal(remoteTranscoderList[3], tr[4])
+	assert.Len(remoteTranscoderList, 4)
 
 	// Remove transcoder from the middle of the list
 	remoteTranscoderList = removeFromRemoteTranscoders(tr[3], remoteTranscoderList)
 	assert.Equal(remoteTranscoderList[0], tr[1])
 	assert.Equal(remoteTranscoderList[1], tr[2])
+	assert.Equal(remoteTranscoderList[2], tr[4])
+	assert.Len(remoteTranscoderList, 3)
+
+	// Remove transcoder from the middle of the list
+	remoteTranscoderList = removeFromRemoteTranscoders(tr[2], remoteTranscoderList)
+	assert.Equal(remoteTranscoderList[0], tr[1])
+	assert.Equal(remoteTranscoderList[1], tr[4])
 	assert.Len(remoteTranscoderList, 2)
 
 	// Remove transcoder from the end of the list
-	remoteTranscoderList = removeFromRemoteTranscoders(tr[2], remoteTranscoderList)
+	remoteTranscoderList = removeFromRemoteTranscoders(tr[4], remoteTranscoderList)
 	assert.Equal(remoteTranscoderList[0], tr[1])
 	assert.Len(remoteTranscoderList, 1)
 

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -929,7 +929,7 @@ func removeFromRemoteTranscoders(rt *RemoteTranscoder, remoteTranscoders []*Remo
 			if i == 0 {
 				return remoteTranscoders[1:]
 			}
-			newRemoteTs = remoteTranscoders[i-1 : i]
+			newRemoteTs = remoteTranscoders[:i]
 			newRemoteTs = append(newRemoteTs, remoteTranscoders[i+1:]...)
 			break
 		}


### PR DESCRIPTION
### What does this pull request do?

Fixes a bug in split O/T setups, where a Transcoder can get dropped from selection alltogether, without any indication on the O or T side

See https://github.com/livepeer/go-livepeer/issues/2706 for more details

### Specific updates

Seems to have been introduced in https://github.com/livepeer/go-livepeer/commit/bf5397d210624b19c643bfbc506f40d8ae1cb325 so a looong time ago

### How did you test each of these updates

Currently running the fix in production on the `video miner` pool. So far no connected transcoder has been dropped from the `remoteTranscoders` set as of yet

### Does this pull request close any open issues?

Fixes #2706

