### PR TITLE
Add logging for high keyframe interval, reduce log level for discovery loop

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,7 @@
 #### General
 
 #### Broadcaster
+- \#2709 Add logging for high keyframe interval, reduce log level for discovery loop
 
 #### Orchestrator
 

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -101,7 +101,7 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 			return
 		}
 		if err != nil && !errors.Is(err, context.Canceled) {
-			clog.Errorf(ctx, "err=%q", err)
+			clog.V(common.DEBUG).Infof(ctx, "err=%q", err)
 			if monitor.Enabled {
 				monitor.LogDiscoveryError(ctx, od.LocalInfo.URL.String(), err.Error())
 			}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -38,6 +38,7 @@ import (
 	lpmscore "github.com/livepeer/lpms/core"
 	ffmpeg "github.com/livepeer/lpms/ffmpeg"
 	"github.com/livepeer/lpms/segmenter"
+	videosegmenter "github.com/livepeer/lpms/segmenter"
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/lpms/vidplayer"
 	"github.com/livepeer/m3u8"
@@ -456,6 +457,9 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 			err := s.RTMPSegmenter.SegmentRTMPToHLS(context.Background(), rtmpStrm, hlsStrm, segOptions)
 			if err != nil {
 				// Stop the incoming RTMP connection.
+				if err == videosegmenter.ErrSegmenterTimeout {
+					glog.Info("RTMP Timeout: Ensure keyframe interval is less than 8 seconds")
+				}
 				// TODO retry segmentation if err != SegmenterTimeout; may be recoverable
 				rtmpStrm.Close()
 			}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -38,7 +38,6 @@ import (
 	lpmscore "github.com/livepeer/lpms/core"
 	ffmpeg "github.com/livepeer/lpms/ffmpeg"
 	"github.com/livepeer/lpms/segmenter"
-	videosegmenter "github.com/livepeer/lpms/segmenter"
 	"github.com/livepeer/lpms/stream"
 	"github.com/livepeer/lpms/vidplayer"
 	"github.com/livepeer/m3u8"
@@ -457,7 +456,7 @@ func gotRTMPStreamHandler(s *LivepeerServer) func(url *url.URL, rtmpStrm stream.
 			err := s.RTMPSegmenter.SegmentRTMPToHLS(context.Background(), rtmpStrm, hlsStrm, segOptions)
 			if err != nil {
 				// Stop the incoming RTMP connection.
-				if err == videosegmenter.ErrSegmenterTimeout {
+				if err == segmenter.ErrSegmenterTimeout {
 					glog.Info("RTMP Timeout: Ensure keyframe interval is less than 8 seconds")
 				}
 				// TODO retry segmentation if err != SegmenterTimeout; may be recoverable


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
- Added logging to `SegmenterTimeout` error in `media_server.go` to suggest for the broadcaster to lower their keyframe interval. Confirmed this error often occurs when the keyframe interval is 8 seconds or higher. 

  - `RTMP Timeout: Ensure keyframe interval is less than 8 seconds`

- Reduced log level for orchestrator discovery loop during streaming to `debug`, this helps prevent excessive logging when broadcaster has only a few orchestrators. Example of issue: [Broadcaster Discovery Loop Errors.txt](https://github.com/livepeer/go-livepeer/files/10350167/Broadcaster.Discovery.Loop.Errors.txt)

**How did you test each of these updates (required)**

1. Broadcasted with and without `-orchAddr` using low deposit.
2. Changed log level with `-v` flag. Confirmed discovery loop error logs will appear only if `-v 5` or higher is used.
3. Captured log behavior while streaming [New Broadcasting Logs.txt](https://github.com/livepeer/go-livepeer/files/10350139/New.Broadcasting.Logs.txt)

**Does this pull request close any open issues?**
<!-- Fixes # -->
None

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
