### PR TITLE
Allow for out of order nonce

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cespare/cp v1.1.1 // indirect
+	github.com/elliotchance/orderedmap v1.5.0 // indirect
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/golang/glog v0.0.0-20210429001901-424d2337a529

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/allegro/bigcache v1.2.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cespare/cp v1.1.1 // indirect
-	github.com/elliotchance/orderedmap v1.5.0 // indirect
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/fatih/color v1.12.0 // indirect
 	github.com/golang/glog v0.0.0-20210429001901-424d2337a529

--- a/go.sum
+++ b/go.sum
@@ -347,6 +347,8 @@ github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7j
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+github.com/elliotchance/orderedmap v1.5.0 h1:1IsExUsjv5XNBD3ZdC7jkAAqLWOOKdbPTmkHx63OsBg=
+github.com/elliotchance/orderedmap v1.5.0/go.mod h1:wsDwEaX5jEoyhbs7x93zk2H/qv0zwuhg4inXhDkYqys=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,6 @@ github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7j
 github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
-github.com/elliotchance/orderedmap v1.5.0 h1:1IsExUsjv5XNBD3ZdC7jkAAqLWOOKdbPTmkHx63OsBg=
-github.com/elliotchance/orderedmap v1.5.0/go.mod h1:wsDwEaX5jEoyhbs7x93zk2H/qv0zwuhg4inXhDkYqys=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -690,8 +688,6 @@ github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cO
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.4.11 h1:Sv+ss8e4vcscnMWLxcRJ2g3sNIHyQ3RzCtgEelfGPzw=
 github.com/livepeer/livepeer-data v0.4.11/go.mod h1:VIbJRdyH2Tas8EgLVkP79IPMepFDOv0dgHYLEZsCaf4=
-github.com/livepeer/lpms v0.0.0-20221123192553-7cef5fc8c1d2 h1:q9DU5UATq+3zzpG8MmuGkLQKAalqo/ivXpbbimzuk4U=
-github.com/livepeer/lpms v0.0.0-20221123192553-7cef5fc8c1d2/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/lpms v0.0.0-20230106125835-78ae44836422 h1:AIm6737jFdSrUbzUFneCZuxy8OBXllez6k6vRzp93JE=
 github.com/livepeer/lpms v0.0.0-20230106125835-78ae44836422/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -379,7 +379,7 @@ func (r *recipient) updateSenderNonce(rand *big.Int, ticket *Ticket) error {
 		}{make(map[uint32]bool), ticket.ParamsExpirationBlock}
 	}
 	// check nonce map size
-	if len(r.senderNonces[randStr].nonceSeen) > maxSenderNonces-1 {
+	if len(r.senderNonces[randStr].nonceSeen) >= maxSenderNonces {
 		return errors.Errorf("invalid ticket senderNonce: too many values sender=%v nonce=%v", ticket.Sender.Hex(), ticket.SenderNonce)
 	}
 	// add new nonce

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -379,7 +379,7 @@ func (r *recipient) updateSenderNonce(rand *big.Int, ticket *Ticket) error {
 		}{make(map[uint32]byte), ticket.ParamsExpirationBlock}
 	}
 	// check nonce map size
-	if len(r.senderNonces[randStr].nonceSeen) > maxSenderNonces - 1 {
+	if len(r.senderNonces[randStr].nonceSeen) > maxSenderNonces-1 {
 		return errors.Errorf("invalid ticket senderNonce: too many values sender=%v nonce=%v", ticket.Sender.Hex(), ticket.SenderNonce)
 	}
 	// add new nonce

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -671,7 +671,7 @@ func TestSenderNoncesCleanupLoop(t *testing.T) {
 		tm:   tm,
 		quit: make(chan struct{}),
 		senderNonces: make(map[string]*struct {
-			nonceSeen       map[uint32]byte
+			nonceSeen       map[uint32]bool
 			expirationBlock *big.Int
 		}),
 	}
@@ -681,19 +681,19 @@ func TestSenderNoncesCleanupLoop(t *testing.T) {
 	rand1 := "charizard"
 	rand2 := "raichu"
 	r.senderNonces[rand0] = &struct {
-		nonceSeen       map[uint32]byte
+		nonceSeen       map[uint32]bool
 		expirationBlock *big.Int
-	}{map[uint32]byte{1: 1}, big.NewInt(3)}
+	}{map[uint32]bool{1: true}, big.NewInt(3)}
 
 	r.senderNonces[rand1] = &struct {
-		nonceSeen       map[uint32]byte
+		nonceSeen       map[uint32]bool
 		expirationBlock *big.Int
-	}{map[uint32]byte{1: 1}, big.NewInt(2)}
+	}{map[uint32]bool{1: true}, big.NewInt(2)}
 
 	r.senderNonces[rand2] = &struct {
-		nonceSeen       map[uint32]byte
+		nonceSeen       map[uint32]bool
 		expirationBlock *big.Int
-	}{map[uint32]byte{1: 1}, big.NewInt(1)}
+	}{map[uint32]bool{1: true}, big.NewInt(1)}
 
 	go r.senderNoncesCleanupLoop()
 	time.Sleep(20 * time.Millisecond)

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -292,6 +292,22 @@ func pushSegmentsBroadcaster(t *testing.T, b *livepeer, numSegs int) {
 	}
 }
 
+func pushSegmentsParallelBroadcaster(t *testing.T, b *livepeer, numSegs int) {
+	assert := assert.New(t)
+
+	var wg sync.WaitGroup
+	mid := common.RandName()
+	for i := 0; i < numSegs; i++ {
+		wg.Add(1)
+		go func(mid string, seqNo int) {
+			assert.Nil(pushSegmentBroadcaster(b, mid, i))
+			wg.Done()
+		}(mid, i)
+	}
+
+	wg.Wait()
+}
+
 func pushSegmentBroadcaster(b *livepeer, manifestID string, seqNo int) error {
 	data, err := ioutil.ReadFile("test.flv")
 	rdr := bytes.NewReader(data)

--- a/test/e2e/http_push_broadcaster_test.go
+++ b/test/e2e/http_push_broadcaster_test.go
@@ -27,4 +27,7 @@ func TestHTTPPushBroadcaster(t *testing.T) {
 
 	// Sequential requests
 	pushSegmentsBroadcaster(t, b, 3)
+
+	// Parallel requests
+	pushSegmentsParallelBroadcaster(t, b, 5)
 }


### PR DESCRIPTION
Implementation of https://github.com/livepeer/go-livepeer/issues/2661 to fix https://github.com/livepeer/go-livepeer/issues/2614 based on introducing sorted hash map to store seen nonce values. Also added @yondonfu's test from corresponding branch, which now passes.

