### PR TITLE
Reduce livepeer image size

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -190,7 +190,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 30 \
             && sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 30
 
-          LIBTENSORFLOW_VERSION=2.6.3 \
+          LIBTENSORFLOW_VERSION=2.3.4 \
             && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
             && sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
             && sudo ldconfig
@@ -213,7 +213,7 @@ jobs:
 
       - name: Install libtensorflow
         run: |
-          LIBTENSORFLOW_VERSION=2.6.3 \
+          LIBTENSORFLOW_VERSION=2.3.4 \
             && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
             && sudo tar -C /usr/local -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
             && sudo ldconfig

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN	GRPC_HEALTH_PROBE_VERSION=v0.3.6 \
 	&& ldconfig /usr/local/lib
 
 # note: for runtime, Tensorflow version needs to be compatible with CUDA and CuDNN of the image
-RUN LIBTENSORFLOW_VERSION=2.6.3 \
+RUN LIBTENSORFLOW_VERSION=2.3.4 \
             && curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz \
             && mkdir /tf && tar -C /tf -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz
 
@@ -60,7 +60,7 @@ COPY	.	.
 
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 
-FROM --platform=${TARGETPLATFORM}	nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 AS livepeer-base
+FROM --platform=${TARGETPLATFORM}	nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04 AS livepeer-base
 
 ENV	NVIDIA_DRIVER_CAPABILITIES=all
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,7 +60,11 @@ COPY	.	.
 
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 
-FROM --platform=${TARGETPLATFORM}	nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04 AS livepeer-base
+FROM --platform=$TARGETPLATFORM	nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04 AS livepeer-amd64-base
+
+FROM --platform=$TARGETPLATFORM nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 AS livepeer-arm64-base
+
+FROM livepeer-${TARGETARCH}-base
 
 ENV	NVIDIA_DRIVER_CAPABILITIES=all
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,7 +61,7 @@ COPY	.	.
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 
 # cuda 10.2 image is 1.4 Gb smaller, which is critical for our root partition size
-FROM --platform=$TARGETPLATFORM	nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04 AS livepeer-amd64-base
+FROM --platform=$TARGETPLATFORM	nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04 AS livepeer-amd64-base
 
 FROM --platform=$TARGETPLATFORM nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 AS livepeer-arm64-base
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,6 +60,7 @@ COPY	.	.
 
 RUN	make livepeer livepeer_cli livepeer_bench livepeer_router
 
+# cuda 10.2 image is 1.4 Gb smaller, which is critical for our root partition size
 FROM --platform=$TARGETPLATFORM	nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04 AS livepeer-amd64-base
 
 FROM --platform=$TARGETPLATFORM nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04 AS livepeer-arm64-base

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -147,7 +147,7 @@ else
     echo "clang detected, building with GPU and Tensorflow support"
     EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_cuda,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
     if [[ ! -e "${ROOT}/compiled/lib/libtensorflow_framework.so" ]]; then
-      LIBTENSORFLOW_VERSION=2.6.3 &&
+      LIBTENSORFLOW_VERSION=2.3.4 &&
         curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
         tar -C ${ROOT}/compiled/ -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
         rm libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz


### PR DESCRIPTION
A quick fix for reducing the size of the docker image: switched back to CUDA 10 for `amd64` build. A proper fix would be to have:
1. An image for Broadcaster, which doesn't include `./lib/*` from Tensorflow distribution, but compiles with Tensorflow headers to avoid the risks and added complexity of having binaries built with different configurations depending on node type
2. A separate Tensorflow image, which will additionally include `./lib/*` from Tensorflow distribution