### PR TITLE
Add support for keyfiles with -ethKeystorePath, update flag descriptions, flagset output to stdout

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,7 +19,7 @@
 #### CLI
 
 #### General
-- \#[] Update cli flag descriptions and print usage to stdout
+- \#2713 Add support for keyfiles with -ethKeystorePath, update flag descriptions, flagset output to stdout
 
 #### Broadcaster
 - \#2709 Add logging for high keyframe interval, reduce log level for discovery loop

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,6 +19,7 @@
 #### CLI
 
 #### General
+- \#[] Update cli flag descriptions and print usage to stdout
 
 #### Broadcaster
 - \#2709 Add logging for high keyframe interval, reduce log level for discovery loop

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -144,7 +144,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	// Onchain:
 	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in keystore directory")
 	cfg.EthPassword = flag.String("ethPassword", *cfg.EthPassword, "Password for existing Eth account address or path to file")
-	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path to ETH keystore directory or keyfile. Defaults to [dataDir]\keystore. If keyfile, overrides -ethAcctAddr and uses parent directory")
+	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path to ETH keystore directory or keyfile. If keyfile, overrides -ethAcctAddr and uses parent directory")
 	cfg.EthOrchAddr = flag.String("ethOrchAddr", *cfg.EthOrchAddr, "ETH address of an on-chain registered orchestrator")
 	cfg.EthUrl = flag.String("ethUrl", *cfg.EthUrl, "Ethereum node JSON-RPC URL")
 	cfg.TxTimeout = flag.Duration("transactionTimeout", *cfg.TxTimeout, "Amount of time to wait for an Ethereum transaction to confirm before timing out")

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -142,9 +142,9 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.DetectionSampleRate = flag.Uint("detectionSampleRate", *cfg.DetectionSampleRate, "Run content detection automatically on every nth frame of each segment, independently of requested stream transcoding configuration.")
 
 	// Onchain:
-	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in keystore directory. Overridden when by providing a valid key file using -ethKeystorePath")
+	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in keystore directory. Overridden when key file provided with -ethKeystorePath")
 	cfg.EthPassword = flag.String("ethPassword", *cfg.EthPassword, "Password for existing Eth account address or path to file")
-	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path to keystore directory or path to ETH key file. If file provided, ethAcctAddr will be set and parent directory will be used for new accounts")
+	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path to ETH keystore directory or keyfile. If valid keyfile, overrides -ethAcctAddr and uses parent directory for keystore path")
 	cfg.EthOrchAddr = flag.String("ethOrchAddr", *cfg.EthOrchAddr, "ETH address of an on-chain registered orchestrator")
 	cfg.EthUrl = flag.String("ethUrl", *cfg.EthUrl, "Ethereum node JSON-RPC URL")
 	cfg.TxTimeout = flag.Duration("transactionTimeout", *cfg.TxTimeout, "Amount of time to wait for an Ethereum transaction to confirm before timing out")

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -144,7 +144,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	// Onchain:
 	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in keystore directory")
 	cfg.EthPassword = flag.String("ethPassword", *cfg.EthPassword, "Password for existing Eth account address or path to file")
-	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path to ETH keystore directory or keyfile. If valid keyfile, overrides -ethAcctAddr and uses parent directory for keystore path")
+	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path to ETH keystore directory or keyfile. Defaults to [dataDir]\keystore. If keyfile, overrides -ethAcctAddr and uses parent directory")
 	cfg.EthOrchAddr = flag.String("ethOrchAddr", *cfg.EthOrchAddr, "ETH address of an on-chain registered orchestrator")
 	cfg.EthUrl = flag.String("ethUrl", *cfg.EthUrl, "Ethereum node JSON-RPC URL")
 	cfg.TxTimeout = flag.Duration("transactionTimeout", *cfg.TxTimeout, "Amount of time to wait for an Ethereum transaction to confirm before timing out")

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -142,7 +142,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.DetectionSampleRate = flag.Uint("detectionSampleRate", *cfg.DetectionSampleRate, "Run content detection automatically on every nth frame of each segment, independently of requested stream transcoding configuration.")
 
 	// Onchain:
-	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in keystore directory. Overridden when key file provided with -ethKeystorePath")
+	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in keystore directory")
 	cfg.EthPassword = flag.String("ethPassword", *cfg.EthPassword, "Password for existing Eth account address or path to file")
 	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path to ETH keystore directory or keyfile. If valid keyfile, overrides -ethAcctAddr and uses parent directory for keystore path")
 	cfg.EthOrchAddr = flag.String("ethOrchAddr", *cfg.EthOrchAddr, "ETH address of an on-chain registered orchestrator")

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -142,9 +142,9 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.DetectionSampleRate = flag.Uint("detectionSampleRate", *cfg.DetectionSampleRate, "Run content detection automatically on every nth frame of each segment, independently of requested stream transcoding configuration.")
 
 	// Onchain:
-	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address")
+	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in keystore directory. Overridden when by providing a valid key file using -ethKeystorePath")
 	cfg.EthPassword = flag.String("ethPassword", *cfg.EthPassword, "Password for existing Eth account address or path to file")
-	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path for the Eth Key")
+	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path to keystore directory or path to ETH key file. If file provided, ethAcctAddr will be set and parent directory will be used for new accounts")
 	cfg.EthOrchAddr = flag.String("ethOrchAddr", *cfg.EthOrchAddr, "ETH address of an on-chain registered orchestrator")
 	cfg.EthUrl = flag.String("ethUrl", *cfg.EthUrl, "Ethereum node JSON-RPC URL")
 	cfg.TxTimeout = flag.Duration("transactionTimeout", *cfg.TxTimeout, "Amount of time to wait for an Ethereum transaction to confirm before timing out")

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -167,7 +167,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	// Unit of pixels for both O's basePriceInfo and B's MaxBroadcastPrice
 	cfg.PixelsPerUnit = flag.Int("pixelsPerUnit", *cfg.PixelsPerUnit, "Amount of pixels per unit. Set to '> 1' to have smaller price granularity than 1 wei / pixel")
 	cfg.AutoAdjustPrice = flag.Bool("autoAdjustPrice", *cfg.AutoAdjustPrice, "Enable/disable automatic price adjustments based on the overhead for redeeming tickets")
-	cfg.PricePerBroadcaster = flag.String("pricePerBroadcaster", *cfg.PricePerBroadcaster, `json list of price per broadcaster. or path to json config file. Example: {"broadcasters":[{"ethaddress":"address1","priceperunit":1000,"pixelsperunit":1},{"ethaddress":"address2","priceperunit":1200,"pixelsperunit":1}]}`)
+	cfg.PricePerBroadcaster = flag.String("pricePerBroadcaster", *cfg.PricePerBroadcaster, `json list of price per broadcaster or path to json config file. Example: {"broadcasters":[{"ethaddress":"address1","priceperunit":1000,"pixelsperunit":1},{"ethaddress":"address2","priceperunit":1200,"pixelsperunit":1}]}`)
 	// Interval to poll for blocks
 	cfg.BlockPollingInterval = flag.Int("blockPollingInterval", *cfg.BlockPollingInterval, "Interval in seconds at which different blockchain event services poll for blocks")
 	// Redemption service

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -31,6 +31,7 @@ func main() {
 	vFlag := flag.Lookup("v")
 	//We preserve this flag before resetting all the flags.  Not a scalable approach, but it'll do for now.  More discussions here - https://github.com/livepeer/go-livepeer/pull/617
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	flag.CommandLine.SetOutput(os.Stdout)
 
 	// Help & Log
 	mistJson := flag.Bool("j", false, "Print application info as json")
@@ -127,7 +128,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.Orchestrator = flag.Bool("orchestrator", *cfg.Orchestrator, "Set to true to be an orchestrator")
 	cfg.Transcoder = flag.Bool("transcoder", *cfg.Transcoder, "Set to true to be a transcoder")
 	cfg.Broadcaster = flag.Bool("broadcaster", *cfg.Broadcaster, "Set to true to be a broadcaster")
-	cfg.OrchSecret = flag.String("orchSecret", *cfg.OrchSecret, "Shared secret with the orchestrator as a standalone transcoder")
+	cfg.OrchSecret = flag.String("orchSecret", *cfg.OrchSecret, "Shared secret with the orchestrator as a standalone transcoder or path to file")
 	cfg.TranscodingOptions = flag.String("transcodingOptions", *cfg.TranscodingOptions, "Transcoding options for broadcast job, or path to json config")
 	cfg.MaxAttempts = flag.Int("maxAttempts", *cfg.MaxAttempts, "Maximum transcode attempts")
 	cfg.SelectRandFreq = flag.Float64("selectRandFreq", *cfg.SelectRandFreq, "Frequency to randomly select unknown orchestrators (on-chain mode only)")
@@ -142,7 +143,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 
 	// Onchain:
 	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address")
-	cfg.EthPassword = flag.String("ethPassword", *cfg.EthPassword, "Password for existing Eth account address")
+	cfg.EthPassword = flag.String("ethPassword", *cfg.EthPassword, "Password for existing Eth account address or path to file")
 	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path for the Eth Key")
 	cfg.EthOrchAddr = flag.String("ethOrchAddr", *cfg.EthOrchAddr, "ETH address of an on-chain registered orchestrator")
 	cfg.EthUrl = flag.String("ethUrl", *cfg.EthUrl, "Ethereum node JSON-RPC URL")
@@ -166,7 +167,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	// Unit of pixels for both O's basePriceInfo and B's MaxBroadcastPrice
 	cfg.PixelsPerUnit = flag.Int("pixelsPerUnit", *cfg.PixelsPerUnit, "Amount of pixels per unit. Set to '> 1' to have smaller price granularity than 1 wei / pixel")
 	cfg.AutoAdjustPrice = flag.Bool("autoAdjustPrice", *cfg.AutoAdjustPrice, "Enable/disable automatic price adjustments based on the overhead for redeeming tickets")
-	cfg.PricePerBroadcaster = flag.String("pricePerBroadcaster", *cfg.PricePerBroadcaster, `json list of price per broadcaster. Example: {"broadcasters":[{"ethaddress":"address1","priceperunit":1000,"pixelsperunit":1},{"ethaddress":"address2","priceperunit":1200,"pixelsperunit":1}]}`)
+	cfg.PricePerBroadcaster = flag.String("pricePerBroadcaster", *cfg.PricePerBroadcaster, `json list of price per broadcaster. or path to json config file. Example: {"broadcasters":[{"ethaddress":"address1","priceperunit":1000,"pixelsperunit":1},{"ethaddress":"address2","priceperunit":1200,"pixelsperunit":1}]}`)
 	// Interval to poll for blocks
 	cfg.BlockPollingInterval = flag.Int("blockPollingInterval", *cfg.BlockPollingInterval, "Interval in seconds at which different blockchain event services poll for blocks")
 	// Redemption service

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -142,7 +142,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.DetectionSampleRate = flag.Uint("detectionSampleRate", *cfg.DetectionSampleRate, "Run content detection automatically on every nth frame of each segment, independently of requested stream transcoding configuration.")
 
 	// Onchain:
-	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in keystore directory")
+	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in the keystore directory")
 	cfg.EthPassword = flag.String("ethPassword", *cfg.EthPassword, "Password for existing Eth account address or path to file")
 	cfg.EthKeystorePath = flag.String("ethKeystorePath", *cfg.EthKeystorePath, "Path to ETH keystore directory or keyfile. If keyfile, overrides -ethAcctAddr and uses parent directory")
 	cfg.EthOrchAddr = flag.String("ethOrchAddr", *cfg.EthOrchAddr, "ETH address of an on-chain registered orchestrator")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1419,11 +1419,11 @@ func getBroadcasterPrices(broadcasterPrices string) []BroadcasterPrice {
 }
 
 type KeystorePath struct {
-	path, address interface{}
+	path, address string
 }
 
 func ParseEthKeystorePath(ethKeystorePath string) (KeystorePath, error) {
-	var keystore KeystorePath = KeystorePath{"", ""}
+	var keystore = KeystorePath{"", ""}
 	ethKeystorePath = strings.TrimSuffix(ethKeystorePath, "/")
 
 	if fileInfo, err := os.Stat(ethKeystorePath); !os.IsNotExist(err) && fileInfo != nil {
@@ -1435,12 +1435,12 @@ func ParseEthKeystorePath(ethKeystorePath string) (KeystorePath, error) {
 				if address, err := common.ParseEthAddr(keyText); err == nil {
 					keystore.address = address
 				} else {
-					return keystore, errors.New("Error parsing address from keyfile.")
+					return keystore, errors.New("error parsing address from keyfile")
 				}
 			}
 		}
 	} else {
-		return keystore, errors.New("Provided -ethKeystorePath was not found.")
+		return keystore, errors.New("provided -ethKeystorePath was not found")
 	}
 
 	return keystore, nil

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -486,6 +486,34 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		glog.Fatalf("No services enabled; must be at least one of -broadcaster, -transcoder, -orchestrator, -redeemer, -reward or -initializeRound")
 	}
 
+	lpmon.NodeID = *cfg.EthAcctAddr
+	if lpmon.NodeID != "" {
+		lpmon.NodeID += "-"
+	}
+	hn, _ := os.Hostname()
+	lpmon.NodeID += hn
+
+	if *cfg.Monitor {
+		if *cfg.MetricsExposeClientIP {
+			*cfg.MetricsPerStream = true
+		}
+		lpmon.Enabled = true
+		lpmon.PerStreamMetrics = *cfg.MetricsPerStream
+		lpmon.ExposeClientIP = *cfg.MetricsExposeClientIP
+		nodeType := lpmon.Default
+		switch n.NodeType {
+		case core.BroadcasterNode:
+			nodeType = lpmon.Broadcaster
+		case core.OrchestratorNode:
+			nodeType = lpmon.Orchestrator
+		case core.TranscoderNode:
+			nodeType = lpmon.Transcoder
+		case core.RedeemerNode:
+			nodeType = lpmon.Redeemer
+		}
+		lpmon.InitCensus(nodeType, core.LivepeerVersion)
+	}
+
 	watcherErr := make(chan error)
 	serviceErr := make(chan error)
 	var timeWatcher *watchers.TimeWatcher
@@ -959,33 +987,8 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	}
 
 	core.MaxSessions = *cfg.MaxSessions
-	lpmon.NodeID = *cfg.EthAcctAddr
-	if lpmon.NodeID != "" {
-		lpmon.NodeID += "-"
-	}
-	hn, _ := os.Hostname()
-	lpmon.NodeID += hn
-
-	if *cfg.Monitor {
-		if *cfg.MetricsExposeClientIP {
-			*cfg.MetricsPerStream = true
-		}
-		lpmon.Enabled = true
-		lpmon.PerStreamMetrics = *cfg.MetricsPerStream
-		lpmon.ExposeClientIP = *cfg.MetricsExposeClientIP
+	if lpmon.Enabled {
 		lpmon.MaxSessions(core.MaxSessions)
-		nodeType := lpmon.Default
-		switch n.NodeType {
-		case core.BroadcasterNode:
-			nodeType = lpmon.Broadcaster
-		case core.OrchestratorNode:
-			nodeType = lpmon.Orchestrator
-		case core.TranscoderNode:
-			nodeType = lpmon.Transcoder
-		case core.RedeemerNode:
-			nodeType = lpmon.Redeemer
-		}
-		lpmon.InitCensus(nodeType, core.LivepeerVersion)
 	}
 
 	if *cfg.AuthWebhookURL != "" {

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -544,6 +544,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 		} else {
 			glog.Fatal(fmt.Errorf(err.Error()))
+			return
 		}
 
 		//Get the Eth client connection information
@@ -1421,12 +1422,12 @@ func getBroadcasterPrices(broadcasterPrices string) []BroadcasterPrice {
 	return pricesSet.Prices
 }
 
-type KeystorePath struct {
+type keystorePath struct {
 	path    string
 	address ethcommon.Address
 }
 
-func ParseEthKeystorePath(ethKeystorePath string) (KeystorePath, error) {
+func parseEthKeystorePath(ethKeystorePath string) (KeystorePath, error) {
 	var keystore = KeystorePath{"", ethcommon.Address{}}
 	if ethKeystorePath == "" {
 		return keystore, nil

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -538,10 +538,8 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 					*cfg.EthAcctAddr = ethKeystoreAddr
 				} else {
 					glog.Fatal("-ethKeystorePath and -ethAcctAddr were both provided, but ethAcctAddr does not match the address found in keystore")
+					return
 				}
-			} else {
-				glog.Fatal(fmt.Errorf(err.Error()))
-				return
 			}
 		}
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -531,7 +531,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			keystoreInfo, err := ParseEthKeystorePath(*cfg.EthKeystorePath)
 			if keystoreInfo.path.(string) != "" {
 				keystoreDir = keystoreInfo.path.(string)
-				if keystoreInfo.address != "" && err != nil {
+				if keystoreInfo.address.(string) != "" && err == nil {
 					*cfg.EthAcctAddr = keystoreInfo.address.(string)
 				}
 			} else {

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -529,10 +529,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		var keystoreDir = filepath.Join(*cfg.Datadir, "keystore")
 		if *cfg.EthKeystorePath != "" {
 			keystoreInfo, err := ParseEthKeystorePath(*cfg.EthKeystorePath)
-			if keystoreInfo.path.(string) != "" {
-				keystoreDir = keystoreInfo.path.(string)
-				if keystoreInfo.address.(string) != "" && err == nil {
-					*cfg.EthAcctAddr = keystoreInfo.address.(string)
+			if keystoreInfo.path != "" {
+				keystoreDir = keystoreInfo.path
+				if keystoreInfo.address != "" && err == nil {
+					*cfg.EthAcctAddr = keystoreInfo.address
 				}
 			} else {
 				keystoreDir = filepath.Join(*cfg.Datadir, "keystore")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -530,8 +530,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		if keystoreInfo, err := parseEthKeystorePath(*cfg.EthKeystorePath); err == nil {
 			if keystoreInfo.path != "" {
 				keystoreDir = keystoreInfo.path
-
-				if (keystoreInfo.address != ethcommon.Address{}) {
+			} else if (keystoreInfo.address != ethcommon.Address{}) {
 					ethKeystoreAddr := keystoreInfo.address.Hex()
 					ethAcctAddr := ethcommon.HexToAddress(*cfg.EthAcctAddr).Hex()
 
@@ -1442,7 +1441,6 @@ func parseEthKeystorePath(ethKeystorePath string) (keystorePath, error) {
 	if fileInfo.IsDir() {
 		keystore.path = ethKeystorePath
 	} else {
-		keystore.path, _ = filepath.Split(ethKeystorePath)
 		if keyText, err := common.ReadFromFile(ethKeystorePath); err == nil {
 			if address, err := common.ParseEthAddr(keyText); err == nil {
 				keystore.address = ethcommon.HexToAddress(address)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -531,17 +531,21 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			if keystoreInfo.path != "" {
 				keystoreDir = keystoreInfo.path
 			} else if (keystoreInfo.address != ethcommon.Address{}) {
-					ethKeystoreAddr := keystoreInfo.address.Hex()
-					ethAcctAddr := ethcommon.HexToAddress(*cfg.EthAcctAddr).Hex()
+				ethKeystoreAddr := keystoreInfo.address.Hex()
+				ethAcctAddr := ethcommon.HexToAddress(*cfg.EthAcctAddr).Hex()
 
-					if (ethAcctAddr == ethcommon.Address{}.Hex()) || ethKeystoreAddr == ethAcctAddr {
-						*cfg.EthAcctAddr = ethKeystoreAddr
-					} else {
-						glog.Fatal("-ethKeystorePath and -ethAcctAddr were both provided, but ethAcctAddr does not match the address found in keystore")
-					}
+				if (ethAcctAddr == ethcommon.Address{}.Hex()) || ethKeystoreAddr == ethAcctAddr {
+					*cfg.EthAcctAddr = ethKeystoreAddr
+				} else {
+					glog.Fatal("-ethKeystorePath and -ethAcctAddr were both provided, but ethAcctAddr does not match the address found in keystore")
 				}
+			} else {
+				glog.Fatal(fmt.Errorf(err.Error()))
+				return
 			}
-		} else {
+		}
+
+		if err != nil {
 			glog.Fatal(fmt.Errorf(err.Error()))
 			return
 		}

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -527,7 +527,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 	} else {
 		var keystoreDir = filepath.Join(*cfg.Datadir, "keystore")
-		if keystoreInfo, err := ParseEthKeystorePath(*cfg.EthKeystorePath); err == nil {
+		if keystoreInfo, err := parseEthKeystorePath(*cfg.EthKeystorePath); err == nil {
 			if keystoreInfo.path != "" {
 				keystoreDir = keystoreInfo.path
 
@@ -1427,8 +1427,8 @@ type keystorePath struct {
 	address ethcommon.Address
 }
 
-func parseEthKeystorePath(ethKeystorePath string) (KeystorePath, error) {
-	var keystore = KeystorePath{"", ethcommon.Address{}}
+func parseEthKeystorePath(ethKeystorePath string) (keystorePath, error) {
+	var keystore = keystorePath{"", ethcommon.Address{}}
 	if ethKeystorePath == "" {
 		return keystore, nil
 	}

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -106,7 +106,7 @@ func TestParseGetBroadcasterPrices(t *testing.T) {
 func TestFlag_KeystorePath_File(t *testing.T) {
 	assert := assert.New(t)
 
-	var addr = "0000000000000000000000000000000000000000"
+	var addr = "0x0000000000000000000000000000000000000001"
 	var fname = "UTC--2023-01-05T00-46-15.503776013Z--" + addr
 	tempDir := t.TempDir()
 	file1, err := ioutil.TempFile(tempDir, fname)
@@ -117,11 +117,11 @@ func TestFlag_KeystorePath_File(t *testing.T) {
 	file1.WriteString("{\"address\":\"" + addr + "\"}")
 
 	var keystoreInfo KeystorePath
-	keystoreInfo, err = ParseEthKeystorePath(file1.Name())
+	keystoreInfo, _ = ParseEthKeystorePath(file1.Name())
 
 	assert.NotEmpty(keystoreInfo.path)
 	assert.NotEmpty(keystoreInfo.address)
-	assert.True(addr == keystoreInfo.address.(string))
+	assert.True(addr == keystoreInfo.address.Hex())
 }
 
 func TestFlag_KeystorePath_FileBadAddress(t *testing.T) {
@@ -129,7 +129,7 @@ func TestFlag_KeystorePath_FileBadAddress(t *testing.T) {
 	tempDir := t.TempDir()
 
 	//Create test file
-	var addr = "0000000000000000000000000000000000000000"
+	var addr = "0x0000000000000000000000000000000000000001"
 	var fname = "UTC--2023-01-05T00-46-15.503776013Z--" + addr
 	badJsonfile, err := ioutil.TempFile(tempDir, fname)
 	if err != nil {
@@ -143,7 +143,7 @@ func TestFlag_KeystorePath_FileBadAddress(t *testing.T) {
 	keystoreInfo, err = ParseEthKeystorePath(badJsonfile.Name())
 	assert.NotEmpty(keystoreInfo.path)
 	assert.Empty(keystoreInfo.address)
-	assert.True(err.Error() == "Error parsing address from keyfile.")
+	assert.True(err.Error() == "error parsing address from keyfile")
 }
 
 func TestFlag_KeystorePath_Directory(t *testing.T) {
@@ -163,5 +163,5 @@ func TestFlag_KeystorePath_PathNotFound(t *testing.T) {
 	var keystoreInfo KeystorePath
 	keystoreInfo, err := ParseEthKeystorePath(filepath.Join(tempDir, "missing path"))
 	assert.Empty(keystoreInfo.path)
-	assert.True(err.Error() == "Provided -ethKeystorePath was not found.")
+	assert.True(err.Error() == "provided -ethKeystorePath was not found")
 }

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -103,17 +103,16 @@ func TestParseGetBroadcasterPrices(t *testing.T) {
 	assert.Equal(big.NewRat(2000, 3), price2)
 }
 
-func TestFlag_KeystorePath_File(t *testing.T) {
+func TestParseEthKeystorePath(t *testing.T) {
 	assert := assert.New(t)
 
 	var addr = "0x0000000000000000000000000000000000000001"
 	var fname = "UTC--2023-01-05T00-46-15.503776013Z--" + addr
-	tempDir := t.TempDir()
-	file1, err := ioutil.TempFile(tempDir, fname)
+	file1, err := os.CreateTemp("", "")
 	if err != nil {
 		panic(err)
 	}
-	defer syscall.Unlink(fname)
+	defer os.Remove(fname)
 	file1.WriteString("{\"address\":\"" + addr + "\"}")
 
 	var keystoreInfo KeystorePath
@@ -124,7 +123,7 @@ func TestFlag_KeystorePath_File(t *testing.T) {
 	assert.True(addr == keystoreInfo.address.Hex())
 }
 
-func TestFlag_KeystorePath_FileBadAddress(t *testing.T) {
+func TestParseEthKeystorePathIncorrectAddress(t *testing.T) {
 	assert := assert.New(t)
 	tempDir := t.TempDir()
 
@@ -146,7 +145,7 @@ func TestFlag_KeystorePath_FileBadAddress(t *testing.T) {
 	assert.True(err.Error() == "error parsing address from keyfile")
 }
 
-func TestFlag_KeystorePath_Directory(t *testing.T) {
+func TestParseEthKeystorePathIncorrectAddressDirectory(t *testing.T) {
 	assert := assert.New(t)
 	tempDir := t.TempDir()
 
@@ -156,7 +155,7 @@ func TestFlag_KeystorePath_Directory(t *testing.T) {
 	assert.True(err == nil)
 }
 
-func TestFlag_KeystorePath_PathNotFound(t *testing.T) {
+func TestParseEthKeystorePathNotFound(t *testing.T) {
 	assert := assert.New(t)
 	tempDir := t.TempDir()
 

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -2,11 +2,9 @@ package starter
 
 import (
 	"errors"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -131,12 +129,12 @@ func TestParseEthKeystorePathIncorrectAddress(t *testing.T) {
 	//Create test file
 	var addr = "0x0000000000000000000000000000000000000001"
 	var fname = "UTC--2023-01-05T00-46-15.503776013Z--" + addr
-	badJsonfile, err := ioutil.TempFile(tempDir, fname)
+	badJsonfile, err := os.CreateTemp(tempDir, fname)
 	if err != nil {
 		panic(err)
 	}
 
-	defer syscall.Unlink(fname)
+	defer os.Remove(fname)
 	badJsonfile.WriteString("{{\"address_broken_json\":\"" + addr + "\"}")
 
 	var keystoreInfo keystorePath

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"math/big"
+	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -115,8 +116,8 @@ func TestParseEthKeystorePath(t *testing.T) {
 	defer os.Remove(fname)
 	file1.WriteString("{\"address\":\"" + addr + "\"}")
 
-	var keystoreInfo KeystorePath
-	keystoreInfo, _ = ParseEthKeystorePath(file1.Name())
+	var keystoreInfo keystorePath
+	keystoreInfo, _ = parseEthKeystorePath(file1.Name())
 
 	assert.NotEmpty(keystoreInfo.path)
 	assert.NotEmpty(keystoreInfo.address)
@@ -138,8 +139,8 @@ func TestParseEthKeystorePathIncorrectAddress(t *testing.T) {
 	defer syscall.Unlink(fname)
 	badJsonfile.WriteString("{{\"address_broken_json\":\"" + addr + "\"}")
 
-	var keystoreInfo KeystorePath
-	keystoreInfo, err = ParseEthKeystorePath(badJsonfile.Name())
+	var keystoreInfo keystorePath
+	keystoreInfo, err = parseEthKeystorePath(badJsonfile.Name())
 	assert.NotEmpty(keystoreInfo.path)
 	assert.Empty(keystoreInfo.address)
 	assert.True(err.Error() == "error parsing address from keyfile")
@@ -149,8 +150,8 @@ func TestParseEthKeystorePathIncorrectAddressDirectory(t *testing.T) {
 	assert := assert.New(t)
 	tempDir := t.TempDir()
 
-	var keystoreInfo KeystorePath
-	keystoreInfo, err := ParseEthKeystorePath(tempDir)
+	var keystoreInfo keystorePath
+	keystoreInfo, err := parseEthKeystorePath(tempDir)
 	assert.NotEmpty(keystoreInfo.path)
 	assert.True(err == nil)
 }
@@ -159,8 +160,8 @@ func TestParseEthKeystorePathNotFound(t *testing.T) {
 	assert := assert.New(t)
 	tempDir := t.TempDir()
 
-	var keystoreInfo KeystorePath
-	keystoreInfo, err := ParseEthKeystorePath(filepath.Join(tempDir, "missing path"))
+	var keystoreInfo keystorePath
+	keystoreInfo, err := parseEthKeystorePath(filepath.Join(tempDir, "missing path"))
 	assert.Empty(keystoreInfo.path)
 	assert.True(err.Error() == "provided -ethKeystorePath was not found")
 }

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -168,7 +168,6 @@ func TestParse_ParseEthKeystorePathFileNotFound(t *testing.T) {
 	keystoreInfo, err := parseEthKeystorePath(filepath.Join(tempDir, "missing_keyfile"))
 	assert.Empty(keystoreInfo.path)
 	assert.Empty(keystoreInfo.address)
-	//assert.True(err.Error() == "error opening keystore")
 	assert.True(err.Error() == "provided -ethKeystorePath was not found")
 
 	//Test missing key file directory

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -103,7 +103,7 @@ func TestParseGetBroadcasterPrices(t *testing.T) {
 }
 
 // Address provided to keystore file
-func TestFlag_ParseEthKeystorePath_ValidFile(t *testing.T) {
+func TestParse_ParseEthKeystorePathValidFile(t *testing.T) {
 	assert := assert.New(t)
 	tempDir := t.TempDir()
 
@@ -125,7 +125,7 @@ func TestFlag_ParseEthKeystorePath_ValidFile(t *testing.T) {
 	assert.True(err == nil)
 }
 
-func TestFlag_ParseEthKeystorePath_ValidDirectory(t *testing.T) {
+func TestParse_ParseEthKeystorePathValidDirectory(t *testing.T) {
 	assert := assert.New(t)
 	tempDir := t.TempDir()
 
@@ -137,7 +137,7 @@ func TestFlag_ParseEthKeystorePath_ValidDirectory(t *testing.T) {
 }
 
 // Keystore file exists, but address cannot be parsed
-func TestFlag_ParseEthKeystorePath_InvalidJSON(t *testing.T) {
+func TestParse_ParseEthKeystorePathInvalidJSON(t *testing.T) {
 	assert := assert.New(t)
 	tempDir := t.TempDir()
 
@@ -160,7 +160,7 @@ func TestFlag_ParseEthKeystorePath_InvalidJSON(t *testing.T) {
 }
 
 // Keystore path or file doesn't exist
-func TestFlag_ParseEthKeystorePath_FileNotFound(t *testing.T) {
+func TestParse_ParseEthKeystorePathFileNotFound(t *testing.T) {
 	assert := assert.New(t)
 	tempDir := t.TempDir()
 	var keystoreInfo keystorePath

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -114,7 +114,7 @@ func TestParse_ParseEthKeystorePathValidFile(t *testing.T) {
 		panic(err)
 	}
 	defer os.Remove(fname)
-	file1.WriteString("{\"address\":\"" + addr + "\"}")
+	file1.WriteString("{\"address\":\"" + addr + "\",\"crypto\":{\"cipher\":\"1\",\"ciphertext\":\"1\",\"cipherparams\":{\"iv\":\"1\"},\"kdf\":\"scrypt\",\"kdfparams\":{\"dklen\":32,\"n\":1,\"p\":1,\"r\":8,\"salt\":\"1\"},\"mac\":\"1\"},\"id\":\"1\",\"version\":3}")
 
 	var keystoreInfo keystorePath
 	keystoreInfo, _ = parseEthKeystorePath(file1.Name())

--- a/common/util.go
+++ b/common/util.go
@@ -521,9 +521,9 @@ func ParseAccelDevices(devices string, acceleration ffmpeg.Acceleration) ([]stri
 }
 
 func ParseEthAddr(strJsonKey string) (string, error) {
-	var keyJson map[string]interface{}
+	var keyJson map[string]string
 	if err := json.Unmarshal([]byte(strJsonKey), &keyJson); err == nil {
-		if address, ok := keyJson["address"].(string); ok {
+		if address, ok := keyJson["address"]; ok {
 			return address, nil
 		}
 	}

--- a/common/util.go
+++ b/common/util.go
@@ -521,9 +521,9 @@ func ParseAccelDevices(devices string, acceleration ffmpeg.Acceleration) ([]stri
 }
 
 func ParseEthAddr(strJsonKey string) (string, error) {
-	var keyJson map[string]string
+	var keyJson map[string]interface{}
 	if err := json.Unmarshal([]byte(strJsonKey), &keyJson); err == nil {
-		if address, ok := keyJson["address"]; ok {
+		if address, ok := keyJson["address"].(string); ok {
 			return address, nil
 		}
 	}

--- a/common/util.go
+++ b/common/util.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -517,4 +518,14 @@ func ParseAccelDevices(devices string, acceleration ffmpeg.Acceleration) ([]stri
 		return detectNvidiaDevices()
 	}
 	return strings.Split(devices, ","), nil
+}
+
+func ParseEthAddr(strJsonKey string) (string, error) {
+	var keyJson map[string]interface{}
+	if err := json.Unmarshal([]byte(strJsonKey), &keyJson); err == nil {
+		if address, ok := keyJson["address"].(string); ok {
+			return address, nil
+		}
+	}
+	return "", errors.New("Error parsing address from keyfile")
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
- Updates various flag descriptions that a file can be used in place of a string.
- Changes the default flagset output to `os.StdOut`. This has the effect of enabling users to grep --help output, 
- Add support for keystore file with `-ethKeystorePath`. This can be used alternatively to `ethAcctAddr`
  - ETH address is parsed from keyfile. `-ethAcctAddr` is optional, but if provided the address must match with the one found in the keyfile.

**Specific updates (required)**
- Updated flag descriptions for `OrchSecret`, `EthAcctAddr`, `EthPassword`, `EthKeystorePath` and `PricePerBroadcaster`
- Changed command line output for flagset to os.StdOut
- Parse ETH address from keyfile when a file is provided to `-ethKeystorePath`
- Validates ethAcctAddr and keystore address match or that ethAcctAddr is not provided, before using address from keystore
- Added test coverage

**How did you test each of these updates (required)**
I tested the `ethKeystorePath` and `ethAcctAddr` flags in the following ways:
- With a directory and with a valid file. Eth account is properly found from keystore
- When set to a directory: `keystoreDir` was set to same path and `ethAcctAddr` flag still works for selecting eth account.
- When set to a valid key file: `keystoreDir` was set to parent directory of the file and ETH address is parsed. If `-ethAcctAddr` flag is also provided, the address parsed from keyfile must match the ethAcctAddr, otherwise error: `-ethKeystorePath and -ethAcctAddr were both provided, but ethAcctAddr does not match the address found in keystore`
- With a missing file or directory: `provided -ethKeystorePath was not found`
- With invalid json in file: `error opening keystore`

**Does this pull request close any open issues?**
fix #2689 cli help is printed to stderr instead of stdout
fix #2690 cli help didn't mention -ethPassword and -orchSecret can be file path
fix #2691 Usage for -ethKeystorePath option is confusing

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
