### PR TITLE
Fix EndTranscodingSession() call and potential race

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -994,8 +994,8 @@ func (rtm *RemoteTranscoderManager) selectTranscoder(sessionId string, caps *Cap
 // ends transcoding session and releases resources
 func (node *LivepeerNode) EndTranscodingSession(sessionId string) {
 	logCtx := context.TODO()
-	clog.V(common.DEBUG).Infof(logCtx, "Transcoding session ended by the Broadcaster for sessionID=%v", sessionId)
 	node.endTranscodingSession(sessionId, logCtx)
+	clog.V(common.DEBUG).Infof(logCtx, "Transcoding session ended by the Broadcaster for sessionID=%v", sessionId)
 }
 
 func (node *RemoteTranscoderManager) EndTranscodingSession(sessionId string) {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -278,7 +278,7 @@ func EndTranscodingSession(ctx context.Context, sess *BroadcastSession) error {
 	defer conn.Close()
 
 	req, err := genEndSessionRequest(sess)
-	_, err = c.EndTranscodingSession(ctx, req)
+	_, err = c.EndTranscodingSession(context.Background(), req)
 	if err != nil {
 		return errors.Wrapf(err, "Could not end orchestrator session orch=%v", sess.Transcoder())
 	}


### PR DESCRIPTION
Addresses #2732 

Despite all efforts, I was yet unable to reproduce the error locally, however, I added a fix for related issue, and the fix which potentially should address this issue.

**Findings**
- `EndTranscodingSession()` call [here](https://github.com/livepeer/go-livepeer/blob/84c01d9713f20f8da6e96734069a479844510d3d/server/rpc.go#L281) was failing, because of `context cancelled` error. It's not clear why this context, which is, presumably, goes all the way down from `HandlePush()`, is causing that error on gRPC communication, but it's consistently reproducible. Fixed by changing it to `Context.Background()`.
- `EndTranscodingSession()` is called again [here](https://github.com/livepeer/go-livepeer/blob/a5ccafa84e4b49126fd7a7445ede9ff0903094ad/server/mediaserver.go#L623) on stream end. There might be a race condition between [receiving](https://github.com/livepeer/go-livepeer/blob/111563012f9359a0cbc7f8662ff1eb05c03924a4/core/lb.go#L199) from the `stop` channel and [locking](https://github.com/livepeer/go-livepeer/blob/111563012f9359a0cbc7f8662ff1eb05c03924a4/core/lb.go#L132) the mutex to cleanup the session on T. We had reports of noop transcoding jobs (empty segments?), could it be that it caused `EndTranscodingSession()` to be called twice in a very quick succession, if above `context cancelled` issue doesn't happen on all systems? Addressed by removing the session id from the map right in `EndTranscodingSession()` with mutex locked.