### PR TITLE
Fixed a transcoding bug that occurred when remote transcoder was removed

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,13 +15,13 @@
 #### Transcoder
 
 ### Bug Fixes 🐞
+- #2746 Fixed a transcoding bug that occured when remote transcoder was removed
 
 #### CLI
 
 #### General
 
 #### Broadcaster
-- \#2709 Add logging for high keyframe interval, reduce log level for discovery loop
 - \#2684 Fix transcode success rate metric
 
 #### Orchestrator

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,7 +15,7 @@
 #### Transcoder
 
 ### Bug Fixes 🐞
-- #2746 Fixed a transcoding bug that occurred when remote transcoder was removed
+- #2747 Fixed a transcoding bug that occurred when remote transcoder was removed
 
 #### CLI
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,7 +15,7 @@
 #### Transcoder
 
 ### Bug Fixes 🐞
-- #2746 Fixed a transcoding bug that occured when remote transcoder was removed
+- #2746 Fixed a transcoding bug that occurred when remote transcoder was removed
 
 #### CLI
 

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -429,13 +429,14 @@ func TestRemoveFromRemoteTranscoders_StreamFailover(t *testing.T) {
 	var transcoder_2 = &StubTranscoderServer{manager: rtm}
 
 	assert.Nil(rtm.liveTranscoders[transcoder_1])
+	assert.Nil(rtm.liveTranscoders[transcoder_2])
 	assert.Empty(rtm.remoteTranscoders)
 
 	// register 2 transcoders, 8 stream capacity each
 	go func() { rtm.Manage(transcoder_1, 8, capabilities.ToNetCapabilities()) }()
-	time.Sleep(1 * time.Millisecond) // allow time for first stream to register
+	time.Sleep(1 * time.Millisecond) // allow time for remote T to connect
 	go func() { rtm.Manage(transcoder_2, 8, capabilities.ToNetCapabilities()) }()
-	time.Sleep(1 * time.Millisecond) // allow time for second stream to register
+	time.Sleep(1 * time.Millisecond) // allow time for remote T to connect
 
 	//Validate two transcoders exist
 	assert.NotNil(rtm.liveTranscoders[transcoder_1])
@@ -446,7 +447,6 @@ func TestRemoveFromRemoteTranscoders_StreamFailover(t *testing.T) {
 	for i := 0; i < 8; i++ {
 		testSessionId := fmt.Sprintf("%s%d", "testID", i)
 		rtm.selectTranscoder(testSessionId, nil)
-		time.Sleep(1 * time.Millisecond) // allow time for second stream to register
 	}
 
 	t1 := rtm.liveTranscoders[transcoder_1]
@@ -465,7 +465,6 @@ func TestRemoveFromRemoteTranscoders_StreamFailover(t *testing.T) {
 	for i := 0; i < 8; i++ {
 		testSessionId := fmt.Sprintf("%s%d", "testID", i)
 		rtm.selectTranscoder(testSessionId, nil)
-		time.Sleep(1 * time.Millisecond) // allow time for second stream to register
 	}
 
 	t1 = rtm.liveTranscoders[transcoder_1]

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -419,62 +419,6 @@ func TestRemoveFromRemoteTranscoders(t *testing.T) {
 	assert.Equal(remoteTranscoderList, emptyTList)
 }
 
-//Validates that selectTranscoder will shift all streams to another valid transcoder if transcoder fails.
-func TestRemoveFromRemoteTranscoders_StreamFailover(t *testing.T) {
-	rtm := NewRemoteTranscoderManager()
-	assert := assert.New(t)
-	capabilities := NewCapabilities(append(DefaultCapabilities(), OptionalCapabilities()...), []Capability{})
-
-	var transcoder_1 = &StubTranscoderServer{manager: rtm}
-	var transcoder_2 = &StubTranscoderServer{manager: rtm}
-
-	assert.Nil(rtm.liveTranscoders[transcoder_1])
-	assert.Nil(rtm.liveTranscoders[transcoder_2])
-	assert.Empty(rtm.remoteTranscoders)
-
-	// register 2 transcoders, 8 stream capacity each
-	go func() { rtm.Manage(transcoder_1, 8, capabilities.ToNetCapabilities()) }()
-	time.Sleep(1 * time.Millisecond) // allow time for remote T to connect
-	go func() { rtm.Manage(transcoder_2, 8, capabilities.ToNetCapabilities()) }()
-	time.Sleep(1 * time.Millisecond) // allow time for remote T to connect
-
-	//Validate two transcoders exist
-	assert.NotNil(rtm.liveTranscoders[transcoder_1])
-	assert.NotNil(rtm.liveTranscoders[transcoder_2])
-	assert.Len(rtm.remoteTranscoders, 2)
-
-	//Load up streams on transcoders
-	for i := 0; i < 8; i++ {
-		testSessionId := fmt.Sprintf("%s%d", "testID", i)
-		rtm.selectTranscoder(testSessionId, nil)
-	}
-
-	t1 := rtm.liveTranscoders[transcoder_1]
-	t2 := rtm.liveTranscoders[transcoder_2]
-
-	//Validate 4 streams per transcoder
-	assert.Equal(4, t1.load)
-	assert.Equal(4, t2.load)
-
-	//Break connection to transcoder by deleting live transcoder map entry
-	rtm.RTmutex.Lock()
-	delete(rtm.liveTranscoders, t1.stream)
-	rtm.RTmutex.Unlock()
-
-	//Repeat selectTranscoder for existing session ids - will remove transcoder and shift streams to another transcoder
-	for i := 0; i < 8; i++ {
-		testSessionId := fmt.Sprintf("%s%d", "testID", i)
-		rtm.selectTranscoder(testSessionId, nil)
-	}
-
-	t1 = rtm.liveTranscoders[transcoder_1]
-	t2 = rtm.liveTranscoders[transcoder_2]
-
-	//Validate all 8 streams on opposite transcoder
-	assert.Empty(t1)
-	assert.Equal(8, t2.load)
-}
-
 func TestTranscoderManagerTranscoding(t *testing.T) {
 	m := NewRemoteTranscoderManager()
 	s := &StubTranscoderServer{manager: m}

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -913,7 +913,7 @@ func (rtm *RemoteTranscoderManager) Manage(stream net.Transcoder_RegisterTransco
 
 func removeFromRemoteTranscoders(rt *RemoteTranscoder, remoteTranscoders []*RemoteTranscoder) []*RemoteTranscoder {
 	if len(remoteTranscoders) == 0 {
-		// No transocerds to remove, return
+		// No transcoders to remove, return
 		return remoteTranscoders
 	}
 

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -917,21 +917,10 @@ func removeFromRemoteTranscoders(rt *RemoteTranscoder, remoteTranscoders []*Remo
 		return remoteTranscoders
 	}
 
-	lastIndex := len(remoteTranscoders) - 1
-	last := remoteTranscoders[lastIndex]
-	if rt == last {
-		return remoteTranscoders[:lastIndex]
-	}
-
 	newRemoteTs := make([]*RemoteTranscoder, 0)
-	for i, t := range remoteTranscoders {
-		if t == rt {
-			if i == 0 {
-				return remoteTranscoders[1:]
-			}
-			newRemoteTs = remoteTranscoders[:i]
-			newRemoteTs = append(newRemoteTs, remoteTranscoders[i+1:]...)
-			break
+	for _, t := range remoteTranscoders {
+		if t != rt {
+			newRemoteTs = append(newRemoteTs, t)
 		}
 	}
 	return newRemoteTs


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This change fixes a bug that caused an orchestrator to lose all transcoders when one of it's transcoders disconnects unexpectedly. 

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Simplified logic in `removeFromRemoteTranscoders` so that correct transcoder is removed from RemoteTranscoderManager

**How did you test each of these updates (required)**
We tested up to 4 streams going to an orchestrator with up to 4 remote transcoders. We stopped one of the transcoders in the following scenarios and observed streams move to another transcoder without disconnecting any other transcoders.
- 1 stream on each of the 4 remote transcoders
- 2 streams on each of 2 remote transcoders
- 4 streams on 1 transcoder with 3 additional transcoders having 0 load. 

In every case we observed the streams safely move to another available transcoder without causing other transcoders to break.

**Does this pull request close any open issues?**
<!-- Fixes # -->
#2605
#2706

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
