### PR TITLE
Revert accepting pending Os to accept traffic

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,7 @@
 ### Features ⚒
 
 #### General
+- \#2758 Accept only active Os to receive traffic and redeem tickets (@leszko)
 
 #### Broadcaster
 

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -789,7 +789,7 @@ func TestProcessPayment_ActiveOrchestrator(t *testing.T) {
 
 	// orchestrator inactive -> error
 	err := orch.ProcessPayment(context.Background(), defaultPayment(t), ManifestID("some manifest"))
-	expErr := fmt.Sprintf("orchestrator %v is not eligible for payments in round %v, cannot process payments", addr.Hex(), 10)
+	expErr := fmt.Sprintf("orchestrator %v is inactive in round %v, cannot process payments", addr.Hex(), 10)
 	assert.EqualError(err, expErr)
 
 	// orchestrator is active -> no error
@@ -1197,13 +1197,13 @@ func TestIsActive(t *testing.T) {
 	}
 	orch := NewOrchestrator(n, rm)
 
-	ok, err := orch.isPaymentEligible(addr)
+	ok, err := orch.isActive(addr)
 	assert.True(ok)
 	assert.NoError(err)
 
 	// inactive
 	rm.round = big.NewInt(1000)
-	ok, err = orch.isPaymentEligible(addr)
+	ok, err = orch.isActive(addr)
 	assert.False(ok)
 	assert.NoError(err)
 }

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1180,7 +1180,7 @@ func TestProcessPayment_PaymentError_DoesNotIncreaseCreditBalance(t *testing.T) 
 	assert.Nil(orch.node.Balances.Balance(ethcommon.BytesToAddress(payment.Sender), manifestID))
 }
 
-func TestIsPaymentEligible(t *testing.T) {
+func TestIsActive(t *testing.T) {
 	assert := assert.New(t)
 	addr := defaultRecipient
 	dbh, dbraw := tempDBWithOrch(t, &common.DBOrch{

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1185,32 +1185,19 @@ func TestIsPaymentEligible(t *testing.T) {
 	addr := defaultRecipient
 	dbh, dbraw := tempDBWithOrch(t, &common.DBOrch{
 		EthereumAddr:      addr.Hex(),
-		ActivationRound:   2,
+		ActivationRound:   1,
 		DeactivationRound: 999,
 	})
 	defer dbh.Close()
 	defer dbraw.Close()
 
-	// not active yet
 	n, _ := NewLivepeerNode(nil, "", dbh)
 	rm := &stubRoundsManager{
-		round: big.NewInt(0),
+		round: big.NewInt(10),
 	}
 	orch := NewOrchestrator(n, rm)
 
 	ok, err := orch.isPaymentEligible(addr)
-	assert.False(ok)
-	assert.NoError(err)
-
-	// pending activation
-	rm.round = big.NewInt(1)
-	ok, err = orch.isPaymentEligible(addr)
-	assert.True(ok)
-	assert.NoError(err)
-
-	// active
-	rm.round = big.NewInt(10)
-	ok, err = orch.isPaymentEligible(addr)
 	assert.True(ok)
 	assert.NoError(err)
 

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -70,7 +70,7 @@ func (dbo *DBOrchestratorPoolCache) getURLs() ([]*url.URL, error) {
 	orchs, err := dbo.store.SelectOrchs(
 		&common.DBOrchFilter{
 			MaxPrice:       server.BroadcastCfg.MaxPrice(),
-			CurrentRound:   dbo.nextRound(),
+			CurrentRound:   dbo.rm.LastInitializedRound(),
 			UpdatedLastDay: true,
 		},
 	)
@@ -153,7 +153,7 @@ func (dbo *DBOrchestratorPoolCache) Size() int {
 	count, _ := dbo.store.OrchCount(
 		&common.DBOrchFilter{
 			MaxPrice:       server.BroadcastCfg.MaxPrice(),
-			CurrentRound:   dbo.nextRound(),
+			CurrentRound:   dbo.rm.LastInitializedRound(),
 			UpdatedLastDay: true,
 		},
 	)
@@ -185,7 +185,7 @@ func (dbo *DBOrchestratorPoolCache) cacheTranscoderPool() error {
 func (dbo *DBOrchestratorPoolCache) cacheOrchestratorStake() error {
 	orchs, err := dbo.store.SelectOrchs(
 		&common.DBOrchFilter{
-			CurrentRound: dbo.nextRound(),
+			CurrentRound: dbo.rm.LastInitializedRound(),
 		},
 	)
 	if err != nil {
@@ -261,7 +261,7 @@ func (dbo *DBOrchestratorPoolCache) pollOrchestratorInfo(ctx context.Context) er
 func (dbo *DBOrchestratorPoolCache) cacheDBOrchs() error {
 	orchs, err := dbo.store.SelectOrchs(
 		&common.DBOrchFilter{
-			CurrentRound: dbo.nextRound(),
+			CurrentRound: dbo.rm.LastInitializedRound(),
 		},
 	)
 	if err != nil {
@@ -336,13 +336,6 @@ func (dbo *DBOrchestratorPoolCache) cacheDBOrchs() error {
 	}
 
 	return nil
-}
-
-func (dbo *DBOrchestratorPoolCache) nextRound() *big.Int {
-	if dbo.rm.LastInitializedRound() == nil {
-		return nil
-	}
-	return new(big.Int).Add(dbo.rm.LastInitializedRound(), big.NewInt(1))
 }
 
 func parseURI(addr string) (*url.URL, error) {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1071,13 +1071,12 @@ func TestCachedPool_GetOrchestrators_OnlyActiveOrchestrators(t *testing.T) {
 	}
 
 	// check size
-	// 25 active Os + 1 pending O
-	assert.Equal(26, pool.Size())
+	assert.Equal(25, pool.Size())
 
 	infos := pool.GetInfos()
-	assert.Len(infos, 26)
+	assert.Len(infos, 25)
 	for _, info := range infos {
-		assert.Contains(addresses[:26], info.URL.String())
+		assert.Contains(addresses[:25], info.URL.String())
 	}
 	oinfos, err := pool.GetOrchestrators(context.TODO(), 50, newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 	for _, info := range oinfos {
@@ -1086,7 +1085,7 @@ func TestCachedPool_GetOrchestrators_OnlyActiveOrchestrators(t *testing.T) {
 	}
 
 	assert.Nil(err, "Should not be error")
-	assert.Len(infos, 26)
+	assert.Len(infos, 25)
 }
 
 func TestNewWHOrchestratorPoolCache(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

After the Arbitrum migration, we should move to the logic as before, meaning that only active Os can accept transcoding.

Related Discord discussion: https://discord.com/channels/423160867534929930/750796877762527262/1074970658544558092

This PR is an exact revert of these PRs: https://github.com/livepeer/go-livepeer/pull/2188 and https://github.com/livepeer/go-livepeer/pull/2146

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested locally with local dev geth

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] ~README and other documentation updated~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
