### PR TITLE
Parse keystore address without 0x prefix, fix parse error logging

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,7 @@
 #### Transcoder
 
 ### Bug Fixes 🐞
+- \# 2759 Parse keystore address without 0x prefix, fix parse error logging
 
 #### CLI
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -527,7 +527,8 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 	} else {
 		var keystoreDir = filepath.Join(*cfg.Datadir, "keystore")
-		if keystoreInfo, err := parseEthKeystorePath(*cfg.EthKeystorePath); err == nil {
+		keystoreInfo, err := parseEthKeystorePath(*cfg.EthKeystorePath)
+		if err == nil {
 			if keystoreInfo.path != "" {
 				keystoreDir = keystoreInfo.path
 			} else if (keystoreInfo.address != ethcommon.Address{}) {
@@ -541,9 +542,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 					return
 				}
 			}
-		}
-
-		if err != nil {
+		} else {
 			glog.Fatal(fmt.Errorf(err.Error()))
 			return
 		}

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1444,7 +1444,7 @@ func parseEthKeystorePath(ethKeystorePath string) (keystorePath, error) {
 	} else {
 		if keyText, err := common.ReadFromFile(ethKeystorePath); err == nil {
 			if address, err := common.ParseEthAddr(keyText); err == nil {
-				keystore.address = ethcommon.HexToAddress(address)
+				keystore.address = ethcommon.BytesToAddress(ethcommon.FromHex(address))
 			} else {
 				return keystore, errors.New("error parsing address from keyfile")
 			}

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -107,7 +107,8 @@ func TestParse_ParseEthKeystorePathValidFile(t *testing.T) {
 	assert := assert.New(t)
 	tempDir := t.TempDir()
 
-	var addr = "0x0000000000000000000000000000000000000001"
+	//Test without 0x in address
+	var addr = "0000000000000000000000000000000000000001"
 	var fname = "UTC--2023-01-05T00-46-15.503776013Z--" + addr
 	file1, err := os.CreateTemp(tempDir, fname)
 	if err != nil {
@@ -121,7 +122,25 @@ func TestParse_ParseEthKeystorePathValidFile(t *testing.T) {
 
 	assert.Empty(keystoreInfo.path)
 	assert.NotEmpty(keystoreInfo.address)
-	assert.True(addr == keystoreInfo.address.Hex())
+	origAddr := ethcommon.BytesToAddress(ethcommon.FromHex(addr))
+	assert.True(origAddr.Hex() == keystoreInfo.address.Hex())
+	assert.True(err == nil)
+
+	//Test with 0x in address
+	var hexAddr = "0x0000000000000000000000000000000000000001"
+	var fname2 = "UTC--2023-01-05T00-46-15.503776013Z--" + hexAddr
+	file2, err := os.CreateTemp(tempDir, fname2)
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(fname2)
+	file2.WriteString("{\"address\":\"" + addr + "\",\"crypto\":{\"cipher\":\"1\",\"ciphertext\":\"1\",\"cipherparams\":{\"iv\":\"1\"},\"kdf\":\"scrypt\",\"kdfparams\":{\"dklen\":32,\"n\":1,\"p\":1,\"r\":8,\"salt\":\"1\"},\"mac\":\"1\"},\"id\":\"1\",\"version\":3}")
+
+	keystoreInfo, _ = parseEthKeystorePath(file1.Name())
+	assert.Empty(keystoreInfo.path)
+	assert.NotEmpty(keystoreInfo.address)
+	origAddr2 := ethcommon.BytesToAddress(ethcommon.FromHex(addr))
+	assert.True(origAddr2.Hex() == keystoreInfo.address.Hex())
 	assert.True(err == nil)
 }
 

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -122,8 +122,7 @@ func TestParse_ParseEthKeystorePathValidFile(t *testing.T) {
 
 	assert.Empty(keystoreInfo.path)
 	assert.NotEmpty(keystoreInfo.address)
-	origAddr := ethcommon.BytesToAddress(ethcommon.FromHex(addr))
-	assert.True(origAddr.Hex() == keystoreInfo.address.Hex())
+	assert.True(ethcommon.BytesToAddress(ethcommon.FromHex(addr)) == keystoreInfo.address)
 	assert.True(err == nil)
 
 	//Test with 0x in address
@@ -139,8 +138,7 @@ func TestParse_ParseEthKeystorePathValidFile(t *testing.T) {
 	keystoreInfo, _ = parseEthKeystorePath(file1.Name())
 	assert.Empty(keystoreInfo.path)
 	assert.NotEmpty(keystoreInfo.address)
-	origAddr2 := ethcommon.BytesToAddress(ethcommon.FromHex(addr))
-	assert.True(origAddr2.Hex() == keystoreInfo.address.Hex())
+	assert.True(ethcommon.BytesToAddress(ethcommon.FromHex(addr)) == keystoreInfo.address)
 	assert.True(err == nil)
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This resolves a bug from #2713 when parsing keystore addresses without the 0x prefix. Errors from `parseEthKeystorePath` were also not being logged, because `err` was only available within the scope of `if err == nil`. 

**Specific updates (required)**
- Updated logic flow in `starter.go`.
- Changed `ethcommon.HexToAddress` to `ethcommon.BytesToAddress(ethcommon.FromHex(address))` in parseEthKeystorePath().
  - `ethcommon.FromHex` considers the 0x prefix optional.

**How did you test each of these updates (required)**
- Validated error logging by performing a functional test with valid/invalid JSON, file not found, and bad JSON format
- Validated address parsing with/without 0x prefix. 
- Updated unit test `TestParse_ParseEthKeystorePathValidFile`

**Does this pull request close any open issues?**
Fixes #2757 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
