### PR TITLE
Only write session end log message if session exists

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,8 +17,9 @@
 #### Transcoder
 
 ### Bug Fixes 🐞
-- \# 2759 Parse keystore address without 0x prefix, fix parse error logging
-- \# 2764 Call session end asynchronously to avoid unnecessary blocking
+- \#2759 Parse keystore address without 0x prefix, fix parse error logging
+- \#2764 Call session end asynchronously to avoid unnecessary blocking (@mjh1)
+- \#2777 Only write session end log message if session exists (@mjh1)
 
 #### CLI
 

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -660,8 +660,13 @@ func (n *LivepeerNode) transcodeSegmentLoop(logCtx context.Context, md *SegTrans
 
 func (n *LivepeerNode) endTranscodingSession(sessionId string, logCtx context.Context) {
 	// timeout; clean up goroutine here
+	var (
+		exists  bool
+		storage *transcodeConfig
+		sess    *RemoteTranscoder
+	)
 	n.storageMutex.Lock()
-	if storage, exists := n.StorageConfigs[sessionId]; exists {
+	if storage, exists = n.StorageConfigs[sessionId]; exists {
 		storage.OS.EndSession()
 		storage.LocalOS.EndSession()
 		delete(n.StorageConfigs, sessionId)
@@ -671,7 +676,7 @@ func (n *LivepeerNode) endTranscodingSession(sessionId string, logCtx context.Co
 	if n.TranscoderManager != nil {
 		n.TranscoderManager.RTmutex.Lock()
 		// send empty segment to signal transcoder internal session teardown if session exist
-		if sess, exists := n.TranscoderManager.streamSessions[sessionId]; exists {
+		if sess, exists = n.TranscoderManager.streamSessions[sessionId]; exists {
 			segData := &net.SegData{
 				AuthToken: &net.AuthToken{SessionId: sessionId},
 			}
@@ -685,7 +690,7 @@ func (n *LivepeerNode) endTranscodingSession(sessionId string, logCtx context.Co
 	}
 	n.segmentMutex.Lock()
 	mid := ManifestID(sessionId)
-	if _, ok := n.SegmentChans[mid]; ok {
+	if _, exists = n.SegmentChans[mid]; exists {
 		close(n.SegmentChans[mid])
 		delete(n.SegmentChans, mid)
 		if lpmon.Enabled {
@@ -693,6 +698,9 @@ func (n *LivepeerNode) endTranscodingSession(sessionId string, logCtx context.Co
 		}
 	}
 	n.segmentMutex.Unlock()
+	if exists {
+		clog.V(common.DEBUG).Infof(logCtx, "Transcoding session ended by the Broadcaster for sessionID=%v", sessionId)
+	}
 }
 
 func (n *LivepeerNode) serveTranscoder(stream net.Transcoder_RegisterTranscoderServer, capacity int, capabilities *net.Capabilities) {
@@ -980,9 +988,7 @@ func (rtm *RemoteTranscoderManager) selectTranscoder(sessionId string, caps *Cap
 
 // ends transcoding session and releases resources
 func (node *LivepeerNode) EndTranscodingSession(sessionId string) {
-	logCtx := context.TODO()
-	node.endTranscodingSession(sessionId, logCtx)
-	clog.V(common.DEBUG).Infof(logCtx, "Transcoding session ended by the Broadcaster for sessionID=%v", sessionId)
+	node.endTranscodingSession(sessionId, context.TODO())
 }
 
 func (node *RemoteTranscoderManager) EndTranscodingSession(sessionId string) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
We will now only write a session end log message if the session was found on the orchestrator.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Tested sessions locally to check the log message appears when expected.
- Tested on a single O for a few days and observed the expected log messages.

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #2755

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
