### PR TITLE
git.yaml: Use `ubuntu-latest` instead of ubuntu-18 as the runner.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ end_of_line = lf
 [Makefile]
 indent_style = tab
 
+[Dockerfile]
+indent_style = tab
+
 # YAML Files
 [*.{yaml,sh}]
 indent_size = 2

--- a/.github/workflows/git.yaml
+++ b/.github/workflows/git.yaml
@@ -1,11 +1,18 @@
-name: Git Checks
+name: Git checks
 
-on: [pull_request]
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   block-fixup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.2
-    - name: Block Fixup Commit Merge
-      uses: 13rac1/block-fixup-merge-action@v2.0.0
+      - name: Check out code
+        uses: actions/checkout@v3.5.2
+
+      - name: Block fixup commit merge
+        uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "v*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
With github shutting down ubuntu-18 runners, the job consistently fails as there are no active runners.

also updates `test.yaml` to be run for tag (`v*`) pushes; and minor change for handling `Dockerfile` through editorconfig.