### PR TITLE
clog: default -v to 3, set info logging to 3

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,6 +24,7 @@
 - \#2804 Bump livepeer-data and go version due to breaking interface change (@victorges)
 
 #### CLI
+- \#2825 Enable quieter logging with -v=2 and -v=1 (@iameli)
 
 #### General
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -36,7 +36,7 @@ func main() {
 	// Help & Log
 	mistJson := flag.Bool("j", false, "Print application info as json")
 	version := flag.Bool("version", false, "Print out the version")
-	verbosity := flag.String("v", "", "Log verbosity.  {4|5|6}")
+	verbosity := flag.String("v", "3", "Log verbosity.  {4|5|6}")
 
 	cfg := parseLivepeerConfig()
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Running a Catalyst node with a broadcaster and orchestrator is absurdly verbose right now. It's like dozens of log lines a second. While we want some of this stuff in production, in many cases I want to disable it; this PR lets me do that with `-v=2`.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
* Sets the default `-v` level to "3"
* Adjusts clog so that the default "INFO" level logs at `-v` level 3, WARNING logs at 2, and ERROR logs at 1.

**How did you test each of these updates (required)**
Ran on my local Catalyst node that I'm developing for Livepeer in a Box v3.



**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
