### PR TITLE
Introduce configurable blacklist

### DIFF
--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -36,9 +36,10 @@ type DBOrchestratorPoolCache struct {
 	ticketParamsValidator ticketParamsValidator
 	rm                    common.RoundsManager
 	bcast                 common.Broadcaster
+	orchBlacklist         []string
 }
 
-func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm common.RoundsManager) (*DBOrchestratorPoolCache, error) {
+func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm common.RoundsManager, orchBlacklist []string) (*DBOrchestratorPoolCache, error) {
 	if node.Eth == nil {
 		return nil, fmt.Errorf("could not create DBOrchestratorPoolCache: LivepeerEthClient is nil")
 	}
@@ -49,6 +50,7 @@ func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm
 		ticketParamsValidator: node.Sender,
 		rm:                    rm,
 		bcast:                 core.NewBroadcaster(node),
+		orchBlacklist:         orchBlacklist,
 	}
 
 	if err := dbo.cacheTranscoderPool(); err != nil {
@@ -140,7 +142,7 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(ctx context.Context, numOrc
 		return true
 	}
 
-	orchPool := NewOrchestratorPoolWithPred(dbo.bcast, uris, pred, common.Score_Untrusted)
+	orchPool := NewOrchestratorPoolWithPred(dbo.bcast, uris, pred, common.Score_Untrusted, dbo.orchBlacklist)
 	orchInfos, err := orchPool.GetOrchestrators(ctx, numOrchestrators, suspender, caps, scorePred)
 	if err != nil || len(orchInfos) <= 0 {
 		return nil, err

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -3,10 +3,12 @@ package discovery
 import (
 	"container/heap"
 	"context"
+	"encoding/hex"
 	"errors"
 	"math"
 	"math/rand"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/livepeer/go-livepeer/clog"
@@ -25,12 +27,13 @@ var maxGetOrchestratorCutoffTimeout = 6 * time.Second
 var serverGetOrchInfo = server.GetOrchestratorInfo
 
 type orchestratorPool struct {
-	infos []common.OrchestratorLocalInfo
-	pred  func(info *net.OrchestratorInfo) bool
-	bcast common.Broadcaster
+	infos         []common.OrchestratorLocalInfo
+	pred          func(info *net.OrchestratorInfo) bool
+	bcast         common.Broadcaster
+	orchBlacklist []string
 }
 
-func NewOrchestratorPool(bcast common.Broadcaster, uris []*url.URL, score float32) *orchestratorPool {
+func NewOrchestratorPool(bcast common.Broadcaster, uris []*url.URL, score float32, orchBlacklist []string) *orchestratorPool {
 	if len(uris) <= 0 {
 		// Should we return here?
 		glog.Error("Orchestrator pool does not have any URIs")
@@ -39,13 +42,13 @@ func NewOrchestratorPool(bcast common.Broadcaster, uris []*url.URL, score float3
 	for _, uri := range uris {
 		infos = append(infos, common.OrchestratorLocalInfo{URL: uri, Score: score})
 	}
-	return &orchestratorPool{infos: infos, bcast: bcast}
+	return &orchestratorPool{infos: infos, bcast: bcast, orchBlacklist: orchBlacklist}
 }
 
 func NewOrchestratorPoolWithPred(bcast common.Broadcaster, addresses []*url.URL,
-	pred func(*net.OrchestratorInfo) bool, score float32) *orchestratorPool {
+	pred func(*net.OrchestratorInfo) bool, score float32, orchBlacklist []string) *orchestratorPool {
 
-	pool := NewOrchestratorPool(bcast, addresses, score)
+	pool := NewOrchestratorPool(bcast, addresses, score, orchBlacklist)
 	pool.pred = pred
 	return pool
 }
@@ -78,6 +81,15 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 	// the assumption that all orchestrators support capability discovery.
 	legacyCapsOnly := caps.LegacyOnly()
 
+	isBlacklisted := func(info *net.OrchestratorInfo) bool {
+		for _, blacklisted := range o.orchBlacklist {
+			if strings.TrimPrefix(blacklisted, "0x") == hex.EncodeToString(info.Address) {
+				return true
+			}
+		}
+		return false
+	}
+
 	isCompatible := func(info *net.OrchestratorInfo) bool {
 		if o.pred != nil && !o.pred(info) {
 			return false
@@ -95,7 +107,7 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 	}
 	getOrchInfo := func(ctx context.Context, od common.OrchestratorDescriptor, infoCh chan common.OrchestratorDescriptor, errCh chan error) {
 		info, err := serverGetOrchInfo(ctx, o.bcast, od.LocalInfo.URL)
-		if err == nil && isCompatible(info) {
+		if err == nil && !isBlacklisted(info) && isCompatible(info) {
 			od.RemoteInfo = info
 			infoCh <- od
 			return
@@ -156,6 +168,7 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 	}
 	cancel()
 
+	// consider suspended orchestrators if we have an insufficient number of non-suspended ones
 	if len(ods) < numOrchestrators {
 		diff := numOrchestrators - len(ods)
 		for i := 0; i < diff && suspendedInfos.Len() > 0; i++ {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"math"
@@ -42,7 +43,7 @@ func TestNewDBOrchestratorPoolCache_NilEthClient_ReturnsError(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	assert.Nil(pool)
 	assert.EqualError(err, "could not create DBOrchestratorPoolCache: LivepeerEthClient is nil")
 }
@@ -72,7 +73,7 @@ func TestDeadLock(t *testing.T) {
 	uris := stringsToURIs(addresses)
 	assert := assert.New(t)
 	wg.Add(len(uris))
-	pool := NewOrchestratorPool(nil, uris, common.Score_Trusted)
+	pool := NewOrchestratorPool(nil, uris, common.Score_Trusted, []string{})
 	infos, err := pool.GetOrchestrators(context.TODO(), 1, newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 	assert.Nil(err, "Should not be error")
 	assert.Len(infos, 1, "Should return one orchestrator")
@@ -119,7 +120,7 @@ func TestDeadLock_NewOrchestratorPoolWithPred(t *testing.T) {
 	}
 
 	wg.Add(len(uris))
-	pool := NewOrchestratorPoolWithPred(nil, uris, pred, common.Score_Trusted)
+	pool := NewOrchestratorPoolWithPred(nil, uris, pred, common.Score_Trusted, []string{})
 	infos, err := pool.GetOrchestrators(context.TODO(), 1, newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 
 	assert.Nil(err, "Should not be error")
@@ -131,12 +132,12 @@ func TestPoolSize(t *testing.T) {
 	addresses := stringsToURIs([]string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"})
 
 	assert := assert.New(t)
-	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted)
+	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted, []string{})
 	assert.Equal(3, pool.Size())
 
 	// will results in len(uris) <= 0 -> log Error
 	errorLogsBefore := glog.Stats.Error.Lines()
-	pool = NewOrchestratorPool(nil, nil, common.Score_Trusted)
+	pool = NewOrchestratorPool(nil, nil, common.Score_Trusted, []string{})
 	errorLogsAfter := glog.Stats.Error.Lines()
 	assert.Equal(0, pool.Size())
 	assert.NotZero(t, errorLogsAfter-errorLogsBefore)
@@ -162,7 +163,7 @@ func TestDBOrchestratorPoolCacheSize(t *testing.T) {
 		goleak.VerifyNone(t, common.IgnoreRoutines()...)
 	}()
 
-	emptyPool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	emptyPool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	require.NoError(err)
 	require.NotNil(emptyPool)
 	assert.Equal(0, emptyPool.Size())
@@ -173,7 +174,7 @@ func TestDBOrchestratorPoolCacheSize(t *testing.T) {
 		dbh.UpdateOrch(ethOrchToDBOrch(o))
 	}
 
-	nonEmptyPool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	nonEmptyPool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	require.NoError(err)
 	require.NotNil(nonEmptyPool)
 	assert.Equal(len(addresses), nonEmptyPool.Size())
@@ -217,7 +218,7 @@ func TestNewDBOrchestorPoolCache_NoEthAddress(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, rm)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, rm, []string{})
 	require.Nil(err)
 
 	// Check that serverGetOrchInfo returns early and the orchestrator isn't updated
@@ -271,7 +272,7 @@ func TestNewDBOrchestratorPoolCache_InvalidPrices(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, rm)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, rm, []string{})
 	require.Nil(err)
 
 	// priceInfo.PixelsPerUnit = 0
@@ -342,7 +343,7 @@ func TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t
 
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil).Times(3)
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	require.NoError(err)
 	assert.Equal(pool.Size(), 3)
 	orchs, err := pool.GetOrchestrators(context.TODO(), pool.Size(), newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
@@ -412,7 +413,7 @@ func TestNewDBOrchestratorPoolCache_TestURLs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	require.NoError(err)
 	// bad URLs are inserted in the database but are not included in the working set, as there is no returnable query for getting their priceInfo
 	// And if URL is updated it won't be picked up until next cache update
@@ -445,7 +446,7 @@ func TestNewDBOrchestratorPoolCache_TestURLs_Empty(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	require.NoError(err)
 	assert.Equal(0, pool.Size())
 	infos := pool.GetInfos()
@@ -530,7 +531,7 @@ func TestNewDBOrchestorPoolCache_PollOrchestratorInfo(t *testing.T) {
 	origCacheRefreshInterval := cacheRefreshInterval
 	cacheRefreshInterval = 200 * time.Millisecond
 	defer func() { cacheRefreshInterval = origCacheRefreshInterval }()
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	require.NoError(err)
 
 	// Ensure orchestrators exist in DB
@@ -568,7 +569,7 @@ func TestNewOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *
 	assert := assert.New(t)
 
 	// creating NewOrchestratorPool with orch addresses
-	offchainOrch := NewOrchestratorPool(nil, addresses, common.Score_Trusted)
+	offchainOrch := NewOrchestratorPool(nil, addresses, common.Score_Trusted, []string{})
 
 	for i, info := range offchainOrch.infos {
 		assert.Equal(info.URL.String(), addresses[i].String())
@@ -594,7 +595,7 @@ func TestNewOrchestratorPoolWithPred_TestPredicate(t *testing.T) {
 	}
 	uris := stringsToURIs(addresses)
 
-	pool := NewOrchestratorPoolWithPred(nil, uris, pred, common.Score_Trusted)
+	pool := NewOrchestratorPoolWithPred(nil, uris, pred, common.Score_Trusted, []string{})
 
 	oInfo := &net.OrchestratorInfo{
 		PriceInfo: &net.PriceInfo{
@@ -684,7 +685,7 @@ func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) 
 
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	require.NoError(err)
 
 	// ensuring orchs exist in DB
@@ -773,7 +774,7 @@ func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
 
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	require.NoError(err)
 
 	// ensuring orchs exist in DB
@@ -879,7 +880,7 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	require.NoError(err)
 
 	// ensuring orchs exist in DB
@@ -964,7 +965,7 @@ func TestCachedPool_GetOrchestrators_TicketParamsValidation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{})
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{})
 	require.NoError(err)
 
 	// Test 25 out of 50 orchs pass ticket params validation
@@ -1058,7 +1059,7 @@ func TestCachedPool_GetOrchestrators_OnlyActiveOrchestrators(t *testing.T) {
 
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{round: big.NewInt(24)})
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{round: big.NewInt(24)}, []string{})
 	require.NoError(err)
 
 	// ensuring orchs exist in DB
@@ -1276,7 +1277,7 @@ func TestOrchestratorPool_GetOrchestrators(t *testing.T) {
 		}, err
 	}
 
-	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted)
+	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted, []string{})
 
 	// Check that we receive everything
 	wg.Add(len(addresses))
@@ -1341,7 +1342,7 @@ func TestOrchestratorPool_GetOrchestrators_SuspendedOrchs(t *testing.T) {
 		}, err
 	}
 
-	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted)
+	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted, []string{})
 
 	// suspend https://127.0.0.1:8938
 	sus := newStubSuspender()
@@ -1410,7 +1411,7 @@ func TestOrchestratorPool_ShuffleGetOrchestrators(t *testing.T) {
 		return &net.OrchestratorInfo{Transcoder: server.String()}, nil
 	}
 
-	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted)
+	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted, []string{})
 
 	// Check that randomization happens: check for elements in a different order
 	// Could fail sometimes due to scheduling; the order of execution is undefined
@@ -1477,7 +1478,7 @@ func TestOrchestratorPool_GetOrchestratorTimeout(t *testing.T) {
 	getOrchestratorsTimeoutLoop = 1 * time.Millisecond
 	defer func() { getOrchestratorsTimeoutLoop = oldTimeout }()
 
-	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted)
+	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted, []string{})
 
 	timedOut := func(start, end time.Time) bool {
 		return end.Sub(start).Milliseconds() >= getOrchestratorsTimeoutLoop.Milliseconds()
@@ -1565,10 +1566,14 @@ func TestOrchestratorPool_Capabilities(t *testing.T) {
 	i3 := &net.OrchestratorInfo{Capabilities: &net.Capabilities{Bitstring: []uint64{1}}}
 	// should succeed: compatible caps
 	i4 := &net.OrchestratorInfo{Capabilities: &net.Capabilities{Bitstring: capCompatString}}
+	// should be blacklisted
+	address, err := hex.DecodeString("40B28ee755260ae2735950Fe1BD0a64326ce58b0")
+	assert.NoError(err)
+	i5 := &net.OrchestratorInfo{Capabilities: &net.Capabilities{Bitstring: capCompatString}, Address: address}
 
-	responses := []*net.OrchestratorInfo{i1, i2, i3, i4}
-	addresses := stringsToURIs([]string{"a://b", "a://b", "a://b", "a://b"})
-	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted)
+	responses := []*net.OrchestratorInfo{i1, i2, i3, i4, i5}
+	addresses := stringsToURIs([]string{"a://b", "a://b", "a://b", "a://b", "a://b"})
+	pool := NewOrchestratorPool(nil, addresses, common.Score_Trusted, []string{hex.EncodeToString(address)})
 
 	// some sanity checks
 	assert.Len(addresses, len(responses))


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Implement a configurable orchestrator blacklist. This has been requested so that we can exclude permanently poor performing orchestrators.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
The blacklist is set via a command line argument (comma separated list of addresses) and is eventually used by the discovery logic when choosing an orchestrator.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- existing unit tests adapted to cover this new scenario.
- testing with a locally running version of B/O/T to confirm the changes work as expected in the overall app. Tested blacklisting my single O and observed no segments then being sent.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
