### PR TITLE
Set a floor of 1.5s for threshold to switch Os

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,7 @@
 #### General
 
 #### Broadcaster
+- \#2837 Set a floor of 1.5s for accepted Orchestrator response times, regardless of segment length (@thomshutt) 
 
 #### Orchestrator
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -238,6 +238,12 @@ func selectSession(ctx context.Context, sessions []*BroadcastSession, exclude []
 			// durMult can be tuned by the caller to tighten/relax the maximum in flight time for the oldest segment
 			maxTimeInFlight := time.Duration(durMult) * oldestSegInFlight.segDur
 
+			// We're more lenient for segments <= 1s in length, since we've found the overheads to make this quite an aggressive target
+			// to consistently meet, so instead set a floor of 1.5s
+			if maxTimeInFlight <= 1*time.Second {
+				maxTimeInFlight = 1500 * time.Millisecond
+			}
+
 			if timeInFlight < maxTimeInFlight {
 				clog.PublicInfof(ctx,
 					"Selected orchestrator reason=%v",

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -447,7 +447,7 @@ func TestSelectSession_MultipleInFlight2(t *testing.T) {
 }
 
 func TestSelectSession_NoSegsInFlight(t *testing.T) {
-	assert := assert.New(t)
+	assert := require.New(t)
 	ctx := context.Background()
 
 	sess := &BroadcastSession{}
@@ -455,7 +455,7 @@ func TestSelectSession_NoSegsInFlight(t *testing.T) {
 
 	// Session has segs in flight
 	sess.SegsInFlight = []SegFlightMetadata{
-		{startTime: time.Now().Add(time.Duration(-1) * time.Second), segDur: 1 * time.Second},
+		{startTime: time.Now().Add(time.Duration(-2) * time.Second), segDur: 1 * time.Second},
 	}
 	s := selectSession(ctx, sessList, nil, 1)
 	assert.Nil(s)

--- a/server/sessionpool_test.go
+++ b/server/sessionpool_test.go
@@ -376,7 +376,7 @@ func TestSelectSession_MultipleInFlight(t *testing.T) {
 	assert.Equal(expectedSess0.OrchestratorInfo, sess0.OrchestratorInfo)
 	assert.Len(pool.lastSess[0].SegsInFlight, 1)
 
-	time.Sleep(110 * time.Millisecond)
+	time.Sleep(1600 * time.Millisecond)
 
 	sess1 = sendSegStub()
 	assert.Equal(pool.lastSess[0], sess1)
@@ -396,7 +396,7 @@ func TestSelectSession_MultipleInFlight(t *testing.T) {
 	assert.Equal(expectedSess1.OrchestratorInfo, sess0.OrchestratorInfo)
 	assert.Len(pool.lastSess[0].SegsInFlight, 1)
 
-	time.Sleep(110 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 
 	sess1 = sendSegStub()
 	assert.Equal(pool.lastSess[0], sess1)
@@ -417,7 +417,7 @@ func TestSelectSession_MultipleInFlight(t *testing.T) {
 	assert.Equal(expectedSess1.OrchestratorInfo, sess0.OrchestratorInfo)
 	assert.Len(pool.lastSess[0].SegsInFlight, 1)
 
-	time.Sleep(210 * time.Millisecond)
+	time.Sleep(1600 * time.Millisecond)
 
 	sess1 = sendSegStub()
 	assert.Nil(sess1)
@@ -504,14 +504,14 @@ func TestSelectSessionMoreThanOne(t *testing.T) {
 	assert.Len(pool.sessList(), 0)
 	assert.Len(sessions[0].SegsInFlight, 1)
 	assert.Len(pool.lastSess[0].SegsInFlight, 1)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(800 * time.Millisecond)
 	sessions2 := sendSegStub(3)
 	assert.Len(sessions2, 3)
 	assert.Len(pool.sessList(), 0)
 	assert.Len(sessions2[0].SegsInFlight, 2)
 	assert.Len(pool.lastSess[1].SegsInFlight, 2)
 	assert.Equal(sessions, sessions2)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(800 * time.Millisecond)
 	sessions3 := sendSegStub(3)
 	assert.Len(sessions3, 0)
 	assert.Len(sessions2[0].SegsInFlight, 2)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
We currently have a threshold of `1*<segment duration>` for decided when to swap to another Orchestrator, to ensure we're transcoding in realtime. 

This has been observed to be overly aggressive for 1s segments however, where even high-performing Orchestrators will sit very close to the limit.

Rather than incurring the overheads of swapping for Os that are otherwise keeping up, we're setting a floor of 1.5s for transcoding duration.

**Specific updates (required)**
- Set a floor of 1.5s on transcode duration before swapping

**How did you test each of these updates (required)**
- I'll deploy to Staging, push through a stream with 1s segments and observe swapping

**Does this pull request close any open issues?**
No

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
