### PR TITLE
docker.yaml: Split `builder` image generation to another workflow job

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Cleanup hosted runner
         run: |
-          sudo apt purge -yqq dotnet-* mono-* llvm-* adoptopenjdk-* libllvm* powershell* openjdk-* \
+          sudo apt purge -yqq dotnet-* mono-* llvm-* libllvm* powershell* openjdk-* \
           temurin-* mongodb-* firefox mysql-* \
           hhvm google-chrome-stable \
           libgl1-mesa-dri microsoft-edge-stable \
@@ -89,9 +89,6 @@ jobs:
         with:
           build-args: |
             BUILD_TAGS=${{ steps.build-tag.outputs.build-tags }}
-          # linux/arm64 is disabled until
-          # <https://github.com/livepeer/go-livepeer/issues/2545> gets
-          # resolved
           context: .
           platforms: linux/amd64, linux/arm64
           push: true
@@ -119,7 +116,7 @@ jobs:
 
       - name: Cleanup hosted runner
         run: |
-          sudo apt purge -yqq dotnet-* mono-* llvm-* adoptopenjdk-* libllvm* powershell* openjdk-* \
+          sudo apt purge -yqq dotnet-* mono-* llvm-* libllvm* powershell* openjdk-* \
           temurin-* mongodb-* firefox mysql-* \
           hhvm google-chrome-stable \
           libgl1-mesa-dri microsoft-edge-stable \

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  docker:
     name: Docker image generation
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
@@ -37,12 +37,7 @@ jobs:
           libgl1-mesa-dri microsoft-edge-stable \
           google-cloud-sdk azure-cli
           sudo apt autoremove -y
-
-      - uses: actions-ecosystem/action-regex-match@v2
-        id: match-tag
-        with:
-          text: ${{ github.ref_name }}
-          regex: '^(main|master|v[0-9]+\.\d+\.\d+)$'
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android
 
       - name: Get build tags
         id: build-tag
@@ -89,6 +84,79 @@ jobs:
             type=raw,value=${{ github.event.pull_request.head.ref }}
             type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') }}
 
+      - name: Build and push livepeer docker image
+        uses: docker/build-push-action@v4
+        with:
+          build-args: |
+            BUILD_TAGS=${{ steps.build-tag.outputs.build-tags }}
+          # linux/arm64 is disabled until
+          # <https://github.com/livepeer/go-livepeer/issues/2545> gets
+          # resolved
+          context: .
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          file: "docker/Dockerfile"
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=livepeerci/build:cache
+          cache-to: type=registry,ref=livepeerci/build:cache,mode=max
+
+  builder:
+    name: go-livepeer builder docker image generation
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      packages: write
+      contents: read
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3.5.3
+        with:
+          fetch-depth: 0
+          # Check https://github.com/livepeer/go-livepeer/pull/1891
+          # for ref value discussion
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Cleanup hosted runner
+        run: |
+          sudo apt purge -yqq dotnet-* mono-* llvm-* adoptopenjdk-* libllvm* powershell* openjdk-* \
+          temurin-* mongodb-* firefox mysql-* \
+          hhvm google-chrome-stable \
+          libgl1-mesa-dri microsoft-edge-stable \
+          google-cloud-sdk azure-cli
+          sudo apt autoremove -y
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android
+
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: match-tag
+        with:
+          text: ${{ github.ref_name }}
+          regex: '^(main|master|v[0-9]+\.\d+\.\d+)$'
+
+      - name: Get build tags
+        id: build-tag
+        run: |
+          ./ci_env.sh
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Extract metadata (tags, labels) for builder image
         id: meta-builder
         uses: docker/metadata-action@v4
@@ -117,25 +185,8 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.meta-builder.outputs.tags }}
-          file: 'docker/Dockerfile'
+          file: "docker/Dockerfile"
           target: build
           labels: ${{ steps.meta-builder.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Build and push livepeer docker image
-        uses: docker/build-push-action@v4
-        with:
-          build-args: |
-            BUILD_TAGS=${{ steps.build-tag.outputs.build-tags }}
-          # linux/arm64 is disabled until
-          # <https://github.com/livepeer/go-livepeer/issues/2545> gets
-          # resolved
-          context: .
-          platforms: linux/amd64, linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          file: 'docker/Dockerfile'
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=livepeerci/build:cache
-          cache-to: type=registry,ref=livepeerci/build:cache,mode=max


### PR DESCRIPTION
 - Cleanup hosted runner further as suggested on discord [1]

[1]: https://discord.com/channels/423160867534929930/750796877762527262/1138806765648105544
