### PR TITLE
broadcaster introspection: clog update to add keys

### DIFF
--- a/clog/clog.go
+++ b/clog/clog.go
@@ -29,14 +29,16 @@ const (
 	nonce         = "nonce"
 	seqNo         = "seqNo"
 	orchSessionID = "orchSessionID" // session id generated on orchestrator for broadcaster
+	ethaddress    = "ethaddress"
+	orchestrator  = "orchestrator"
 )
 
 // Verbose is a boolean type that implements Infof (like Printf) etc.
 type Verbose bool
 
 var stdKeys map[string]bool
-var stdKeysOrder = []string{manifestID, sessionID, nonce, seqNo, orchSessionID}
-var publicLogKeys = []string{manifestID, sessionID, orchSessionID, ClientIP}
+var stdKeysOrder = []string{manifestID, sessionID, nonce, seqNo, orchSessionID, ethaddress, orchestrator}
+var publicLogKeys = []string{manifestID, sessionID, orchSessionID, ClientIP, seqNo, ethaddress, orchestrator}
 
 func init() {
 	stdKeys = make(map[string]bool)

--- a/clog/clog_test.go
+++ b/clog/clog_test.go
@@ -47,6 +47,8 @@ func TestPublicLogs(t *testing.T) {
 	ctx := AddManifestID(context.Background(), "fooManID")
 	ctx = AddSessionID(ctx, "fooSessionID")
 	ctx = AddOrchSessionID(ctx, "fooOrchID")
+	ctx = AddVal(ctx, "ethaddress", "0x0")
+	ctx = AddVal(ctx, "orchestrator", "http://127.0.0.1:8935")
 	// These should not be visible:
 	ctx = AddNonce(ctx, 999)
 	ctx = AddSeqNo(ctx, 555)
@@ -61,6 +63,12 @@ func TestPublicLogs(t *testing.T) {
 	assert.Equal("fooSessionID", val)
 	val = GetVal(publicCtx, orchSessionID)
 	assert.Equal("fooOrchID", val)
+	val = GetVal(publicCtx, seqNo)
+	assert.Equal("555", val)
+	val = GetVal(publicCtx, "ethaddress")
+	assert.Equal("0x0", val)
+	val = GetVal(publicCtx, "orchestrator")
+	assert.Equal("http://127.0.0.1:8935", val)
 
 	// Verify random keys cannot be leaked:
 	val = GetVal(publicCtx, nonce)
@@ -72,5 +80,5 @@ func TestPublicLogs(t *testing.T) {
 
 	// Verify [PublicLogs] gets pre-pended:
 	msg, _ := formatMessage(ctx, false, true, "testing message num=%d", 123)
-	assert.Equal("[PublicLogs] manifestID=fooManID sessionID=fooSessionID nonce=999 seqNo=555 orchSessionID=fooOrchID foo=Bar testing message num=123", msg)
+	assert.Equal("[PublicLogs] manifestID=fooManID sessionID=fooSessionID nonce=999 seqNo=555 orchSessionID=fooOrchID ethaddress=0x0 orchestrator=http://127.0.0.1:8935 foo=Bar testing message num=123", msg)
 }

--- a/clog/clog_test.go
+++ b/clog/clog_test.go
@@ -15,16 +15,18 @@ func TestStdKeys(t *testing.T) {
 	ctx = AddNonce(ctx, 1038)
 	ctx = AddOrchSessionID(ctx, "orchID")
 	ctx = AddSeqNo(ctx, 9427)
+	ctx = AddVal(ctx, "ethaddress", "0x0")
+	ctx = AddVal(ctx, "orchestrator", "http://127.0.0.1:8935")
 	ctx = AddVal(ctx, "customKey", "customVal")
 	msg, _ := formatMessage(ctx, false, false, "testing message num=%d", 452)
-	assert.Equal("manifestID=manID sessionID=sessionID nonce=1038 seqNo=9427 orchSessionID=orchID customKey=customVal testing message num=452", msg)
+	assert.Equal("manifestID=manID sessionID=sessionID nonce=1038 seqNo=9427 orchSessionID=orchID ethaddress=0x0 orchestrator=http://127.0.0.1:8935 customKey=customVal testing message num=452", msg)
 	ctxCloned := Clone(context.Background(), ctx)
 	ctxCloned = AddManifestID(ctxCloned, "newManifest")
 	msgCloned, _ := formatMessage(ctxCloned, false, false, "testing message num=%d", 4521)
-	assert.Equal("manifestID=newManifest sessionID=sessionID nonce=1038 seqNo=9427 orchSessionID=orchID customKey=customVal testing message num=4521", msgCloned)
+	assert.Equal("manifestID=newManifest sessionID=sessionID nonce=1038 seqNo=9427 orchSessionID=orchID ethaddress=0x0 orchestrator=http://127.0.0.1:8935 customKey=customVal testing message num=4521", msgCloned)
 	// old context shouldn't change
 	msg, _ = formatMessage(ctx, false, false, "testing message num=%d", 452)
-	assert.Equal("manifestID=manID sessionID=sessionID nonce=1038 seqNo=9427 orchSessionID=orchID customKey=customVal testing message num=452", msg)
+	assert.Equal("manifestID=manID sessionID=sessionID nonce=1038 seqNo=9427 orchSessionID=orchID ethaddress=0x0 orchestrator=http://127.0.0.1:8935 customKey=customVal testing message num=452", msg)
 }
 
 func TestLastErr(t *testing.T) {
@@ -47,11 +49,11 @@ func TestPublicLogs(t *testing.T) {
 	ctx := AddManifestID(context.Background(), "fooManID")
 	ctx = AddSessionID(ctx, "fooSessionID")
 	ctx = AddOrchSessionID(ctx, "fooOrchID")
+	ctx = AddSeqNo(ctx, 555)
 	ctx = AddVal(ctx, "ethaddress", "0x0")
 	ctx = AddVal(ctx, "orchestrator", "http://127.0.0.1:8935")
 	// These should not be visible:
 	ctx = AddNonce(ctx, 999)
-	ctx = AddSeqNo(ctx, 555)
 	ctx = AddVal(ctx, "foo", "Bar")
 
 	publicCtx := PublicCloneCtx(ctx, context.Background(), publicLogKeys)
@@ -72,8 +74,6 @@ func TestPublicLogs(t *testing.T) {
 
 	// Verify random keys cannot be leaked:
 	val = GetVal(publicCtx, nonce)
-	assert.Equal("", val)
-	val = GetVal(publicCtx, seqNo)
 	assert.Equal("", val)
 	val = GetVal(publicCtx, "foo")
 	assert.Equal("", val)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Add Keys to clog.go for ethaddress and orchestrator. Also adds `seqNo` to Public keys.

**Specific updates (required)**
- Add `ethaddress` and `orchestrator` to clog.go keys
- Add `seqNo` to public keys

**How did you test each of these updates (required)**
Ran clog.go test.


**Does this pull request close any open issues?**
No


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
- [ ] All tests in `./test.sh` pass  ran clog.go tests and it passes
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
