### PR TITLE
segment_rpc: increase log level of payment creation. it's useful!

### DIFF
--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -828,7 +828,7 @@ func genPayment(ctx context.Context, sess *BroadcastSession, numTickets int) (st
 		protoPayment.TicketSenderParams = senderParams
 
 		ratPrice, _ := common.RatPriceInfo(protoPayment.ExpectedPrice)
-		clog.V(common.VERBOSE).Infof(ctx, "Created new payment - manifestID=%v sessionID=%v recipient=%v faceValue=%v winProb=%v price=%v numTickets=%v",
+		clog.Infof(ctx, "Created new payment - manifestID=%v sessionID=%v recipient=%v faceValue=%v winProb=%v price=%v numTickets=%v",
 			sess.Params.ManifestID,
 			sess.OrchestratorInfo.AuthToken.SessionId,
 			batch.Recipient.Hex(),


### PR DESCRIPTION
Increases the log level of payment creation from 6 to 3 - a request from @ecmulli for payment tracking