### PR TITLE
broadcaster introspection: update verification sigverification

### DIFF
--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -56,7 +56,8 @@ func StubBroadcastSession(transcoder string) *BroadcastSession {
 				PricePerUnit:  1,
 				PixelsPerUnit: 1,
 			},
-			AuthToken: stubAuthToken,
+			AuthToken:    stubAuthToken,
+			TicketParams: &net.TicketParams{Recipient: pm.RandAddress().Bytes()},
 		},
 		OrchestratorScore: common.Score_Trusted,
 		lock:              &sync.RWMutex{},
@@ -1733,7 +1734,7 @@ func genBcastSess(ctx context.Context, t *testing.T, url string, os drivers.OSSe
 		Broadcaster:       stubBroadcaster2(),
 		Params:            &core.StreamParameters{ManifestID: mid, Profiles: []ffmpeg.VideoProfile{ffmpeg.P144p30fps16x9}, OS: os},
 		BroadcasterOS:     os,
-		OrchestratorInfo:  &net.OrchestratorInfo{Transcoder: transcoderURL, AuthToken: stubAuthToken},
+		OrchestratorInfo:  &net.OrchestratorInfo{Transcoder: transcoderURL, AuthToken: stubAuthToken, TicketParams: &net.TicketParams{Recipient: pm.RandAddress().Bytes()}},
 		OrchestratorScore: common.Score_Trusted,
 		lock:              &sync.RWMutex{},
 	}

--- a/verification/verify.go
+++ b/verification/verify.go
@@ -184,7 +184,7 @@ func IsRetryable(err error) bool {
 }
 
 func (sv *SegmentVerifier) sigVerification(params *Params) error {
-	if params.Orchestrator == nil || params.Orchestrator.Address == nil {
+	if params.Orchestrator == nil || params.Orchestrator.Address == nil || params.Orchestrator.TicketParams == nil {
 		return nil
 	}
 

--- a/verification/verify.go
+++ b/verification/verify.go
@@ -184,7 +184,7 @@ func IsRetryable(err error) bool {
 }
 
 func (sv *SegmentVerifier) sigVerification(params *Params) error {
-	if params.Orchestrator == nil || params.Orchestrator.TicketParams == nil {
+	if params.Orchestrator == nil || params.Orchestrator.Address == nil {
 		return nil
 	}
 

--- a/verification/verify_test.go
+++ b/verification/verify_test.go
@@ -167,7 +167,7 @@ func TestVerify(t *testing.T) {
 		{Url: "../server/test.flv", Pixels: pxls},
 	}}
 	renditions = [][]byte{}
-	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{Address: pm.RandAddress().Bytes()}, Renditions: renditions})
+	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{Address: pm.RandAddress().Bytes(), TicketParams: &net.TicketParams{}}, Renditions: renditions})
 	assert.Equal(errPMCheckFailed, err)
 	assert.Nil(res)
 
@@ -214,13 +214,13 @@ func TestVerify(t *testing.T) {
 		{Url: "uvw", Pixels: pxls},
 		{Url: "xyz", Pixels: pxls},
 	}}
-	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{Address: []byte("bar")}, Renditions: renditions})
+	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{Address: []byte("bar"), TicketParams: params}, Renditions: renditions})
 	assert.Equal(errPMCheckFailed, err)
 	assert.Nil(res)
 
 	// Check sig verifier runs and fails (due to missing sig) even when policy is nil
 	sv = NewSegmentVerifier(nil)
-	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{Address: []byte("bar")}, Renditions: renditions})
+	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{Address: []byte("bar"), TicketParams: params}, Renditions: renditions})
 	assert.Equal(errPMCheckFailed, err)
 	assert.Nil(res)
 

--- a/verification/verify_test.go
+++ b/verification/verify_test.go
@@ -13,6 +13,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 
 	"github.com/livepeer/go-livepeer/net"
+	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/go-tools/drivers"
 	"github.com/livepeer/lpms/ffmpeg"
 )
@@ -166,7 +167,7 @@ func TestVerify(t *testing.T) {
 		{Url: "../server/test.flv", Pixels: pxls},
 	}}
 	renditions = [][]byte{}
-	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{TicketParams: &net.TicketParams{}}, Renditions: renditions})
+	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{Address: pm.RandAddress().Bytes()}, Renditions: renditions})
 	assert.Equal(errPMCheckFailed, err)
 	assert.Nil(res)
 
@@ -174,6 +175,7 @@ func TestVerify(t *testing.T) {
 	// We use this stubVerifier to make sure that ffmpeg doesnt try to read from a file
 	// Verify sig against ticket recipient address
 	recipientAddr := ethcommon.BytesToAddress([]byte("foo"))
+	orchAddr := ethcommon.Address{}
 	sv = &SegmentVerifier{policy: &Policy{Verifier: &stubVerifier{
 		results: nil,
 		err:     nil,
@@ -188,12 +190,12 @@ func TestVerify(t *testing.T) {
 
 	renditions = [][]byte{{0}, {0}}
 	params := &net.TicketParams{Recipient: recipientAddr.Bytes()}
-	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{TicketParams: params}, Renditions: renditions})
+	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{Address: orchAddr.Bytes(), TicketParams: params}, Renditions: renditions})
 	assert.Nil(err)
 	assert.NotNil(res)
 
 	// Verify sig against orchestrator provided address
-	orchAddr := ethcommon.BytesToAddress([]byte("bar"))
+	orchAddr = ethcommon.BytesToAddress([]byte("bar"))
 	sv = &SegmentVerifier{
 		policy:    &Policy{Verifier: &stubVerifier{}, Retries: 2},
 		verifySig: func(addr ethcommon.Address, msg []byte, sig []byte) bool { return addr == orchAddr },
@@ -212,13 +214,13 @@ func TestVerify(t *testing.T) {
 		{Url: "uvw", Pixels: pxls},
 		{Url: "xyz", Pixels: pxls},
 	}}
-	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{TicketParams: &net.TicketParams{}}, Renditions: renditions})
+	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{Address: []byte("bar")}, Renditions: renditions})
 	assert.Equal(errPMCheckFailed, err)
 	assert.Nil(res)
 
 	// Check sig verifier runs and fails (due to missing sig) even when policy is nil
 	sv = NewSegmentVerifier(nil)
-	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{TicketParams: &net.TicketParams{}}, Renditions: renditions})
+	res, err = sv.Verify(&Params{Results: data, Orchestrator: &net.OrchestratorInfo{Address: []byte("bar")}, Renditions: renditions})
 	assert.Equal(errPMCheckFailed, err)
 	assert.Nil(res)
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Update verification to exit early if `OrchestratorInfo.Address` is nil rather than `OrchestratorInfo.TicketParams.Recipient`.

This is a PR that will allow to log the on chain Orchestrator eth address with broadcaster introspection.

For additional discussion: https://github.com/livepeer/go-livepeer/pull/2840#issuecomment-1682202650

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Change `sigVerification` function to exit early if `OrchestratorInfo.Address` is nil rather than `OrchestratorInfo.TicketParams.Recipient`.
- Update tests to 
- 

**How did you test each of these updates (required)**
- Ran test suite github action
- Tested transcoding 4 segments


**Does this pull request close any open issues?**
No


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
