### PR TITLE
update currentRound endpoint to return string instead of bytes

### DIFF
--- a/cmd/livepeer_cli/wizard_rounds.go
+++ b/cmd/livepeer_cli/wizard_rounds.go
@@ -23,8 +23,12 @@ func (w *wizard) currentRound() (*big.Int, error) {
 	if err != nil {
 		return nil, err
 	}
+	cr, ok := new(big.Int).SetString(string(body), 10)
+	if !ok {
+		return nil, fmt.Errorf("could not parse current round from response")
+	}
 
-	return new(big.Int).SetBytes(body), nil
+	return cr, nil
 }
 
 func (w *wizard) initializeRound() {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -216,7 +216,7 @@ func currentRoundHandler(client eth.LivepeerEthClient) http.Handler {
 			return
 		}
 
-		respondOk(w, currentRound.Bytes())
+		respondOk(w, []byte(currentRound.String()))
 	}))
 }
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -309,7 +309,9 @@ func TestCurrentRoundHandler_Success(t *testing.T) {
 	status, body := get(handler)
 
 	assert.Equal(http.StatusOK, status)
-	assert.Equal(currentRound, new(big.Int).SetBytes([]byte(body)))
+	cr, _ := new(big.Int).SetString(body, 10)
+
+	assert.Equal(currentRound, cr)
 }
 
 func TestInitializeRoundHandler_InitializeRoundError(t *testing.T) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Updates `currentRound` web endpoint to return a string rather than `big.Int.Bytes()`.  

Makes it easier to pull from livepeer node by curl request and outside call to web endpoint.

**Specific updates (required)**
- currentRound handler updated to return string instead of big.Int.Bytes()
- livepeer_cli updated to handle new return value
- test updated

**How did you test each of these updates (required)**
ran test suite on fork of go-livepeer https://github.com/ad-astra-video/go-livepeer/actions/runs/6109883984


**Does this pull request close any open issues?**
No


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./doc/contributing.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
