### PR TITLE
Remove detailed scores logging

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1574,7 +1574,6 @@ func updatePerfScore(region string, respBody []byte, score *common.PerfScore) {
 			}
 		}
 	}
-	glog.Infof("Scores: %v", score.Scores)
 }
 
 func exit(msg string, args ...any) {


### PR DESCRIPTION
It was a leftover. I think we should not print it, because it's too detailed.
