### PR TITLE
Skip transcoding when empty profiles were sent to B

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -939,7 +939,7 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 		attempts  []data.TranscodeAttemptInfo
 		urls      []string
 	)
-	if len(cxn.params.Profiles) == 0 {
+	if cxn.params != nil && len(cxn.params.Profiles) == 0 {
 		return []string{}, nil
 	}
 	for len(attempts) < MaxAttempts {
@@ -1040,10 +1040,6 @@ func transcodeSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSS
 	if len(sessions) == 1 {
 		// shortcut for most common path
 		sess := sessions[0]
-		if len(sess.Params.Profiles) == 0 {
-			// If not profiles were requested, then skip transcoding
-			return []string{}, info, nil
-		}
 		if seg, err = prepareForTranscoding(ctx, cxn, sess, seg, name); err != nil {
 			return nil, info, err
 		}

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -939,6 +939,9 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 		attempts  []data.TranscodeAttemptInfo
 		urls      []string
 	)
+	if len(cxn.params.Profiles) == 0 {
+		return []string{}, nil
+	}
 	for len(attempts) < MaxAttempts {
 		// if transcodeSegment fails, retry; rudimentary
 		var info *data.TranscodeAttemptInfo
@@ -970,6 +973,7 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 		}
 		// recoverable error, retry
 	}
+
 	if MetadataQueue != nil {
 		success := err == nil && len(urls) > 0
 		streamID := string(mid)
@@ -1036,6 +1040,10 @@ func transcodeSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSS
 	if len(sessions) == 1 {
 		// shortcut for most common path
 		sess := sessions[0]
+		if len(sess.Params.Profiles) == 0 {
+			// If not profiles were requested, then skip transcoding
+			return []string{}, info, nil
+		}
 		if seg, err = prepareForTranscoding(ctx, cxn, sess, seg, name); err != nil {
 			return nil, info, err
 		}

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -928,7 +928,7 @@ func TestProcessSegment_MetadataQueueTranscodeEvent(t *testing.T) {
 	}
 	cxn := &rtmpConnection{
 		mid:     "dummy1",
-		params:  &core.StreamParameters{ManifestID: "dummy1", ExternalStreamID: "ext_dummy"},
+		params:  &core.StreamParameters{ManifestID: "dummy1", ExternalStreamID: "ext_dummy", Profiles: BroadcastJobVideoProfiles},
 		profile: &ffmpeg.VideoProfile{Name: "unused"},
 		pl:      &stubPlaylistManager{os: &stubOSSession{}},
 	}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -1032,6 +1032,10 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	default:
 	}
 	if len(urls) == 0 {
+		if len(cxn.params.Profiles) > 0 {
+			clog.Errorf(ctx, "No sessions available name=%s url=%s", fname, r.URL)
+			http.Error(w, "No sessions available", http.StatusServiceUnavailable)
+		}
 		return
 	}
 	renditionData := make([][]byte, len(urls))

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -302,7 +302,7 @@ func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookR
 			profiles = append(profiles, parsedProfiles...)
 
 			// Only set defaults if user did not specify a preset/profile
-			if len(resp.Profiles) <= 0 && len(resp.Presets) <= 0 {
+			if resp.Profiles == nil && len(resp.Presets) <= 0 {
 				profiles = BroadcastJobVideoProfiles
 			}
 
@@ -1032,8 +1032,6 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	default:
 	}
 	if len(urls) == 0 {
-		clog.Errorf(ctx, "No sessions available name=%s url=%s", fname, r.URL)
-		http.Error(w, "No sessions available", http.StatusServiceUnavailable)
 		return
 	}
 	renditionData := make([][]byte, len(urls))


### PR DESCRIPTION
This PR distinguishes between empty profiles and profiles not sent.
- no profiles `{}` => use default profiles
- empty profiles `{"profiles":[]}` => skip transcoding, only source is avaible