### PR TITLE
Detect resolution change and reinit hw session

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -840,6 +840,9 @@ func processSegment(ctx context.Context, cxn *rtmpConnection, seg *stream.HLSSeg
 	}
 
 	clog.V(common.DEBUG).Infof(ctx, "Processing segment dur=%v bytes=%v", seg.Duration, len(seg.Data))
+	if segPar != nil && segPar.ForceSessionReinit {
+		clog.V(common.DEBUG).Infof(ctx, "Requesting HW Session Reinitialization for seg.SeqNo=%v", seg.SeqNo)
+	}
 	if monitor.Enabled {
 		monitor.SegmentEmerged(ctx, nonce, seg.SeqNo, len(BroadcastJobVideoProfiles), seg.Duration)
 	}


### PR DESCRIPTION
It reinitializes the hw session if there is a mismatch in media info between segments.

Note that it does not fix the issue completely, because if the resolution is changed inside a segment, then the given segment is not transcoded correctly. But it makes the issue way less problematic, becuase all consecutive segments are ok.

fix https://linear.app/livepeer/issue/VID-438/analyze-pink-and-green-lines-in-transcoded-video