### PR TITLE
build: refactor install_ffmpeg.sh, add macos --> linux support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,43 +14,52 @@ concurrency:
 
 jobs:
   linux-build:
-    name: Build binaries for ${{ matrix.platform.name }}-${{ matrix.hardware.type }}-${{ matrix.arch }}
-    runs-on: ${{ matrix.platform.runner }}
+    name: Build binaries for ${{ matrix.target.GOOS }}-${{ matrix.target.type }}-${{ matrix.target.GOARCH }}
+    runs-on: ${{ matrix.target.runner }}
     container:
-      image: ${{ matrix.hardware.container }}
+      image: ${{ matrix.target.container }}
       env:
         DEBIAN_FRONTEND: noninteractive
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - arm64
-          - amd64
-        platform:
-          - name: linux
+        target:
+          - GOOS: linux
+            GOARCH: amd64
             runner: ubuntu-20.04
-          - name: windows
-            runner: ubuntu-20.04
-        hardware:
-          - type: cpu
             container: ubuntu:20.04
-          - type: gpu
+            type: cpu
+
+          - GOOS: linux
+            GOARCH: arm64
+            runner: ubuntu-20.04
+            container: ubuntu:20.04
+            type: cpu
+
+          - GOOS: linux
+            GOARCH: amd64
+            runner: ubuntu-20.04
             container: livepeerci/cuda:11.7.1-cudnn8-devel-ubuntu20.04
-        exclude:
-          - platform:
-              name: windows
-            arch: arm64
-          - platform:
-              name: windows
-            hardware:
-              type: gpu
+            type: gpu
+
+          - GOOS: linux
+            GOARCH: arm64
+            runner: ubuntu-20.04
+            container: livepeerci/cuda:11.7.1-cudnn8-devel-ubuntu20.04
+            type: gpu
+
+          - GOOS: windows
+            GOARCH: amd64
+            runner: ubuntu-20.04
+            container: ubuntu:22.04
+            type: cpu
 
     steps:
       - name: Setup ubuntu container
         run: |
           apt update
           apt install -yqq build-essential make software-properties-common
-          add-apt-repository -y ppa:git-core/ppa
+          add-apt-repository -y ppa:git-core/candidate
           apt update && apt install -yqq git zip unzip zlib1g-dev zlib1g yasm
 
       - name: Check out code
@@ -74,23 +83,21 @@ jobs:
         uses: actions/cache@v3
         with:
           path: /home/runner/compiled
-          key: ${{ runner.os }}-${{ matrix.platform.name }}-${{ matrix.hardware.type }}-${{ matrix.arch }}-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.platform.name }}-${{ matrix.hardware.type }}-${{ matrix.arch }}-ffmpeg-
+          key: ${{ runner.os }}-${{ matrix.target.GOOS }}-${{ matrix.target.GOARCH }}-${{ matrix.target.type }}-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
 
       - name: Set build environment
         run: |
-          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "GOOS=${{ matrix.platform.name }}" >> $GITHUB_ENV
+          echo "GOARCH=${{ matrix.target.GOARCH }}" >> $GITHUB_ENV
+          echo "GOOS=${{ matrix.target.GOOS }}" >> $GITHUB_ENV
           echo "GO_BUILD_DIR=lp-builds/" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=/github/home/compiled/lib/pkgconfig" >> $GITHUB_ENV
 
       - name: Set GPU build environment
-        if: matrix.hardware.type == 'gpu'
+        if: matrix.target.type == 'gpu'
         run: |
-          echo "CPATH=/usr/local/cuda_${{ matrix.arch }}/include" >> $GITHUB_ENV
-          echo "LIBRARY_PATH=/usr/local/cuda_${{ matrix.arch }}/lib64" >> $GITHUB_ENV
-          echo "CGO_LDFLAGS=-L/usr/local/cuda_${{ matrix.arch }}/lib64" >> $GITHUB_ENV
+          echo "CPATH=/usr/local/cuda_${{ matrix.target.GOARCH }}/include" >> $GITHUB_ENV
+          echo "LIBRARY_PATH=/usr/local/cuda_${{ matrix.target.GOARCH }}/lib64" >> $GITHUB_ENV
+          echo "CGO_LDFLAGS=-L/usr/local/cuda_${{ matrix.target.GOARCH }}/lib64" >> $GITHUB_ENV
           echo "RELEASE_TAG=gpu" >> $GITHUB_ENV
 
       - name: Install dependencies
@@ -98,15 +105,15 @@ jobs:
           apt update \
             && apt install -yqq software-properties-common curl apt-transport-https lsb-release \
             && curl -fsSl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-            && add-apt-repository "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-12 main" \
+            && add-apt-repository "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-14 main" \
             && apt update \
             && apt -yqq install \
-              clang-12 clang-tools-12 lld-12 build-essential pkg-config autoconf git python \
-              gcc-multilib gcc-mingw-w64 libgcc-9-dev-arm64-cross mingw-w64-tools gcc-mingw-w64-x86-64
+              nasm clang-14 clang-tools-14 lld-14 build-essential pkg-config autoconf git python3 \
+              gcc-mingw-w64 libgcc-9-dev-arm64-cross mingw-w64-tools gcc-mingw-w64-x86-64
 
-          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 30 \
-            && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 30 \
-            && update-alternatives --install /usr/bin/ld ld /usr/bin/lld-12 30
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 30 \
+            && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 30 \
+            && update-alternatives --install /usr/bin/ld ld /usr/bin/lld-14 30
 
       - name: Install go modules
         if: steps.go.outputs.cache-hit != 'true'
@@ -142,16 +149,18 @@ jobs:
         run: curl -X POST https://holy-bread-207a.livepeer.workers.dev
 
   macos-build:
-    name: Build binaries for ${{ matrix.platform.name }}-${{ matrix.arch }}
-    runs-on: ${{ matrix.platform.runner }}
+    name: Build binaries for ${{ matrix.target.GOOS }}-${{ matrix.target.GOARCH }}
+    runs-on: ${{ matrix.target.runner }}
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - arm64
-          - amd64
-        platform:
-          - name: darwin
+        target:
+          - GOOS: darwin
+            GOARCH: amd64
+            runner: macos-latest
+
+          - GOOS: darwin
+            GOARCH: arm64
             runner: macos-latest
 
     steps:
@@ -173,8 +182,8 @@ jobs:
 
       - name: Set build environment
         run: |
-          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-          echo "GOOS=${{ matrix.platform.name }}" >> $GITHUB_ENV
+          echo "GOARCH=${{ matrix.target.GOARCH }}" >> $GITHUB_ENV
+          echo "GOOS=${{ matrix.target.GOOS }}" >> $GITHUB_ENV
           echo "GO_BUILD_DIR=lp-builds/" >> $GITHUB_ENV
 
       - name: Cache ffmpeg
@@ -182,9 +191,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/compiled
-          key: ${{ runner.os }}-${{ matrix.platform.name }}-${{ matrix.arch }}-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.platform.name }}-${{ matrix.arch }}-ffmpeg-
+          key: ${{ runner.os }}-${{ matrix.target.GOOS }}-${{ matrix.target.GOARCH }}-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
 
       - name: Install dependencies
         run: brew install coreutils pkg-config
@@ -212,7 +219,7 @@ jobs:
           regex: '^(master|main|v[0-9]+\.\d+\.\d+)$'
 
       - name: Codesign and notarize binaries
-        if: steps.match-tag.outputs.match != '' && matrix.platform.name == 'darwin'
+        if: steps.match-tag.outputs.match != '' && matrix.target.GOOS == 'darwin'
         uses: livepeer/action-gh-codesign-apple@latest
         with:
           developer-certificate-id: ${{ secrets.CI_MACOS_CERTIFICATE_ID }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,13 +67,13 @@ jobs:
           sudo apt update \
             && sudo apt install -yqq software-properties-common curl apt-transport-https lsb-release \
             && curl -fsSl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - \
-            && sudo add-apt-repository "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-12 main" \
+            && sudo add-apt-repository "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-14 main" \
             && sudo apt update \
-            && sudo apt -yqq install clang-12 clang-tools-12 lld-12 build-essential pkg-config autoconf git python
+            && sudo apt -yqq install clang-14 clang-tools-14 lld-14 build-essential pkg-config autoconf git python
 
-          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 30 \
-            && sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 30 \
-            && sudo update-alternatives --install /usr/bin/ld ld /usr/bin/lld-12 30
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 30 \
+            && sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 30 \
+            && sudo update-alternatives --install /usr/bin/ld ld /usr/bin/lld-14 30
 
       - name: Install go modules
         # if: steps.go.outputs.cache-hit != 'true'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,13 +17,13 @@ RUN	apt update \
 	&& curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
 	&& add-apt-repository "deb [arch=${BUILDARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
 	&& curl -fsSl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-	&& add-apt-repository "deb [arch=${BUILDARCH}] https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-12 main" \
+	&& add-apt-repository "deb [arch=${BUILDARCH}] https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-14 main" \
 	&& apt update \
-	&& apt -yqq install clang-12 clang-tools-12 lld-12 build-essential pkg-config autoconf git python docker-ce-cli pciutils gcc-multilib libgcc-8-dev-arm64-cross gcc-mingw-w64-x86-64
+	&& apt -yqq install clang-14 clang-tools-14 lld-14 build-essential pkg-config autoconf git python docker-ce-cli pciutils gcc-multilib libgcc-8-dev-arm64-cross gcc-mingw-w64-x86-64
 
-RUN	update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 30 \
-	&& update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 30 \
-	&& update-alternatives --install /usr/bin/ld ld /usr/bin/lld-12 30
+RUN	update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 30 \
+	&& update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 30 \
+	&& update-alternatives --install /usr/bin/ld ld /usr/bin/lld-14 30
 
 RUN	GRPC_HEALTH_PROBE_VERSION=v0.3.6 \
 	&& curl -fsSL https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} -o /usr/bin/grpc_health_probe \

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,56 +1,96 @@
 #!/usr/bin/env bash
 
-set -ex
+set -exuo pipefail
 
 ROOT="${1:-$HOME}"
-[[ -z "$ARCH" ]] && ARCH="$(uname -m)"
-[[ -z "$UNAME" ]] && UNAME="$(uname)"
 NPROC=${NPROC:-$(nproc)}
 EXTRA_CFLAGS=""
 EXTRA_LDFLAGS=""
 EXTRA_X264_FLAGS=""
 EXTRA_FFMPEG_FLAGS=""
+BUILD_TAGS="${BUILD_TAGS:-}"
 
-
-if [[ "$ARCH" == "arm64" && "$UNAME" == "Darwin" ]]; then
-  # Detect Apple Silicon
-  IS_ARM64=1
+# Build platform flags
+BUILDOS=$(uname -s | tr '[:upper:]' '[:lower:]')
+BUILDARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+if [[ $BUILDARCH == "aarch64" ]]; then
+  BUILDARCH=arm64
+fi
+if [[ $BUILDARCH == "x86_64" ]]; then
+  BUILDARCH=amd64
 fi
 
-if [[ "$ARCH" == "x86_64" && "$UNAME" == "Linux" && "${GOARCH:-}" == "arm64" ]]; then
-  echo "cross-compiling linux-arm64"
-  export CC="clang --sysroot=/usr/aarch64-linux-gnu"
+# Override these for cross-compilation
+export GOOS="${GOOS:-$BUILDOS}"
+export GOARCH="${GOARCH:-$BUILDARCH}"
+
+echo "BUILDOS: $BUILDOS"
+echo "BUILDARCH: $BUILDARCH"
+echo "GOOS: $GOOS"
+echo "GOARCH: $GOARCH"
+
+function check_sysroot() {
+  if ! stat $SYSROOT > /dev/null; then
+    echo "cross-compilation sysroot not found at $SYSROOT, try setting SYSROOT to the correct path"
+    exit 1
+  fi
+}
+
+if [[ "$BUILDARCH" == "amd64" && "$BUILDOS" == "linux" && "$GOARCH" == "arm64" && "$GOOS" == "linux" ]]; then
+  echo "cross-compiling linux-amd64 --> linux-arm64"
+  export CC="clang-14"
+  export STRIP="llvm-strip-14"
+  export AR="llvm-ar-14"
+  export RANLIB="llvm-ranlib-14"
   EXTRA_CFLAGS="--target=aarch64-linux-gnu -I/usr/local/cuda_arm64/include $EXTRA_CFLAGS"
-  EXTRA_LDFLAGS="--target=aarch64-linux-gnu -L/usr/local/cuda_arm64/lib64 $EXTRA_LDFLAGS"
-  EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --arch=aarch64 --enable-cross-compile --cc=clang --sysroot=/usr/aarch64-linux-gnu"
+  EXTRA_LDFLAGS="-fuse-ld=lld --target=aarch64-linux-gnu -L/usr/local/cuda_arm64/lib64 $EXTRA_LDFLAGS"
+  EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --arch=aarch64 --enable-cross-compile --cc=clang --strip=llvm-strip-14"
   HOST_OS="--host=aarch64-linux-gnu"
-  IS_ARM64=1
 fi
 
-if [[ "$ARCH" == "x86_64" && "$UNAME" == "Linux" && "${GOOS:-}" == "windows" ]]; then
-  echo "cross-compiling windows-amd64"
-  EXTRA_CFLAGS="-L/usr/x86_64-w64-mingw32/lib -I/usr/x86_64-w64-mingw32/include  $EXTRA_CFLAGS"
-  EXTRA_LDFLAGS="-L/usr/x86_64-w64-mingw32/lib $EXTRA_LDFLAGS"
-  EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --arch=x86_64 --enable-cross-compile --cross-prefix=x86_64-w64-mingw32- --target-os=mingw64 --sysroot=/usr/x86_64-w64-mingw32"
-  EXTRA_X264_FLAGS="$EXTRA_X264_FLAGS --cross-prefix=x86_64-w64-mingw32- --sysroot=/usr/x86_64-w64-mingw32"
+if [[ "$BUILDARCH" == "arm64" && "$BUILDOS" == "darwin" && "$GOARCH" == "arm64" && "$GOOS" == "linux" ]]; then
+  SYSROOT="${SYSROOT:-"/tmp/sysroot-aarch64-linux-gnu"}"
+  check_sysroot
+  echo "cross-compiling darwin-arm64 --> linux-arm64"
+  LLVM_PATH="${LLVM_PATH:-/opt/homebrew/opt/llvm/bin}"
+  if [[ ! -f "$LLVM_PATH/ld.lld" ]]; then
+    echo "llvm linker not found at '$LLVM_PATH/ld.lld'. try 'brew install llvm' or set LLVM_PATH to your LLVM bin directory"
+    exit 1
+  fi
+  export CC="$LLVM_PATH/clang --sysroot=$SYSROOT"
+  export AR="/opt/homebrew/opt/llvm/bin/llvm-ar"
+  export RANLIB="/opt/homebrew/opt/llvm/bin/llvm-ranlib"
+  EXTRA_CFLAGS="--target=aarch64-linux-gnu $EXTRA_CFLAGS"
+  EXTRA_LDFLAGS="--target=aarch64-linux-gnu -fuse-ld=$LLVM_PATH/ld.lld $EXTRA_LDFLAGS"
+  EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --arch=aarch64 --enable-cross-compile --cc=$LLVM_PATH/clang --sysroot=$SYSROOT --ar=$AR --ranlib=$RANLIB --target-os=linux"
+  EXTRA_X264_FLAGS="$EXTRA_X264_FLAGS --sysroot=$SYSROOT --ar=$AR --ranlib=$RANLIB"
+  HOST_OS="--host=aarch64-linux-gnu"
+fi
+
+if [[ "$BUILDOS" == "linux" && "$GOARCH" == "amd64" && "$GOOS" == "windows" ]]; then
+  echo "cross-compiling linux-$BUILDARCH --> windows-amd64"
+  SYSROOT="${SYSROOT:-"/usr/x86_64-w64-mingw32"}"
+  check_sysroot
+  EXTRA_CFLAGS="-L$SYSROOT/lib -I$SYSROOT/include  $EXTRA_CFLAGS"
+  EXTRA_LDFLAGS="-L$SYSROOT/lib $EXTRA_LDFLAGS"
+  EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --arch=x86_64 --enable-cross-compile --cross-prefix=x86_64-w64-mingw32- --target-os=mingw64 --sysroot=$SYSROOT"
+  EXTRA_X264_FLAGS="$EXTRA_X264_FLAGS --cross-prefix=x86_64-w64-mingw32- --sysroot=$SYSROOT"
   HOST_OS="--host=mingw64"
   # Workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=967969
   export PKG_CONFIG_LIBDIR="/usr/local/x86_64-w64-mingw32/lib/pkgconfig"
   EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --pkg-config=$(which pkg-config)"
 fi
 
-if [[ "$ARCH" == "x86_64" && "$UNAME" == "Darwin" && "${GOARCH:-}" == "arm64" ]]; then
-  echo "cross-compiling darwin-arm64"
+if [[ "$BUILDARCH" == "amd64" && "$BUILDOS" == "darwin" && "$GOARCH" == "arm64" && "$GOOS" == "darwin" ]]; then
+  echo "cross-compiling darwin-amd64 --> darwin-arm64"
   EXTRA_CFLAGS="$EXTRA_CFLAGS --target=arm64-apple-macos11"
   EXTRA_LDFLAGS="$EXTRA_LDFLAGS --target=arm64-apple-macos11"
   HOST_OS="--host=aarch64-darwin"
   EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --arch=aarch64 --enable-cross-compile"
-  IS_ARM64=1
 fi
-echo "Arch $ARCH ${IS_ARM64:+(ARM64)}"
 
 # Windows (MSYS2) needs a few tweaks
-if [[ "$UNAME" == *"MSYS"* ]]; then
+if [[ "$BUILDOS" == *"MSYS"* ]]; then
   ROOT="/build"
   export PATH="$PATH:/usr/bin:/mingw64/bin"
   export C_INCLUDE_PATH="${C_INCLUDE_PATH:-}:/mingw64/lib"
@@ -72,7 +112,7 @@ export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-}:$ROOT/compiled/lib/pkgconfig"
 mkdir -p "$ROOT/"
 
 # NVENC only works on Windows/Linux
-if [[ "$UNAME" != "Darwin" ]]; then
+if [[ "$GOOS" != "darwin" ]]; then
   if [[ ! -e "$ROOT/nv-codec-headers" ]]; then
     git clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git "$ROOT/nv-codec-headers"
     cd $ROOT/nv-codec-headers
@@ -82,7 +122,7 @@ if [[ "$UNAME" != "Darwin" ]]; then
   fi
 fi
 
-if [[ "$UNAME" != *"MSYS"* && ! $IS_ARM64 ]]; then
+if [[ "$GOOS" != "windows" && "$GOARCH" == "amd64" ]]; then
   if [[ ! -e "$ROOT/nasm-2.14.02" ]]; then
     # sudo apt-get -y install asciidoc xmlto # this fails :(
     cd "$ROOT"
@@ -101,19 +141,19 @@ fi
 if [[ ! -e "$ROOT/x264" ]]; then
   git clone http://git.videolan.org/git/x264.git "$ROOT/x264"
   cd "$ROOT/x264"
-  if [[ $IS_ARM64 ]]; then
+  if [[ $GOARCH == "arm64" ]]; then
     # newer git master, compiles on Apple Silicon
     git checkout 66a5bc1bd1563d8227d5d18440b525a09bcf17ca
   else
     # older git master, does not compile on Apple Silicon
     git checkout 545de2ffec6ae9a80738de1b2c8cf820249a2530
   fi
-  ./configure --prefix="$ROOT/compiled" --enable-pic --enable-static ${HOST_OS:-} --disable-cli --extra-cflags="$EXTRA_CFLAGS" --extra-asflags="$EXTRA_CFLAGS" --extra-ldflags="$EXTRA_LDFLAGS" --disable-asm $EXTRA_X264_FLAGS || (cat $ROOT/x264/config.log && exit 1)
+  ./configure --prefix="$ROOT/compiled" --enable-pic --enable-static ${HOST_OS:-} --disable-cli --extra-cflags="$EXTRA_CFLAGS" --extra-asflags="$EXTRA_CFLAGS" --extra-ldflags="$EXTRA_LDFLAGS" $EXTRA_X264_FLAGS || (cat $ROOT/x264/config.log && exit 1)
   make -j$NPROC
   make -j$NPROC install-lib-static
 fi
 
-if [[ "$UNAME" == "Linux" && "${BUILD_TAGS}" == *"debug-video"* ]]; then
+if [[ "$GOOS" == "linux" && "$BUILD_TAGS" == *"debug-video"* ]]; then
   sudo apt-get install -y libnuma-dev cmake
   if [[ ! -e "$ROOT/x265" ]]; then
     git clone https://bitbucket.org/multicoreware/x265_git.git "$ROOT/x265"
@@ -138,22 +178,22 @@ fi
 DISABLE_FFMPEG_COMPONENTS=""
 EXTRA_FFMPEG_LDFLAGS="$EXTRA_LDFLAGS"
 # all flags which should be present for production build, but should be replaced/removed for debug build
-DEV_FFMPEG_FLAGS="--disable-programs"
+DEV_FFMPEG_FLAGS=""
 
-if [[ "$UNAME" == "Darwin" ]]; then
+if [[ "$BUILDOS" == "darwin" && "$GOOS" == "darwin" ]]; then
   EXTRA_FFMPEG_LDFLAGS="$EXTRA_FFMPEG_LDFLAGS -framework CoreFoundation -framework Security"
-elif [[ "${GOOS:-}" == "windows" ]]; then
+elif [[ "$GOOS" == "windows" ]]; then
   EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_cuda,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
 elif [[ -e "/usr/local/cuda/lib64" ]]; then
   echo "CUDA SDK detected, building with GPU support"
   EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-nonfree --enable-cuda-nvcc --enable-libnpp --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvenc --enable-decoder=h264_cuvid,hevc_cuvid,vp8_cuvid,vp9_cuvid --enable-filter=scale_npp,signature_cuda,hwupload_cuda --enable-encoder=h264_nvenc,hevc_nvenc"
-  if [[ ! -e "${ROOT}/compiled/lib/libtensorflow_framework.so" ]]; then
+  if [[ "$GOARCH" == "amd64" && ! -e "${ROOT}/compiled/lib/libtensorflow_framework.so" ]]; then
     LIBTENSORFLOW_VERSION=2.12.1 &&
       curl -LO https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
       tar -C ${ROOT}/compiled/ -xzf libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz &&
       rm libtensorflow-gpu-linux-x86_64-${LIBTENSORFLOW_VERSION}.tar.gz
+    EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-libtensorflow"
   fi
-  EXTRA_FFMPEG_FLAGS="$EXTRA_FFMPEG_FLAGS --enable-libtensorflow"
 else
   echo "No CUDA SDK detected, building without GPU support"
 fi
@@ -187,7 +227,8 @@ if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" ]]; then
     --extra-ldflags="${EXTRA_FFMPEG_LDFLAGS} -L${ROOT}/compiled/lib -L/usr/local/cuda/lib64" \
     --prefix="$ROOT/compiled" \
     $EXTRA_FFMPEG_FLAGS \
-    $DEV_FFMPEG_FLAGS
+    $DEV_FFMPEG_FLAGS || (tail -100 ${ROOT}/ffmpeg/ffbuild/config.log && exit 1)
+    # If configure fails, then print the last 100 log lines for debugging and exit.
 fi
 
 if [[ ! -e "$ROOT/ffmpeg/libavcodec/libavcodec.a" || $BUILD_TAGS == *"debug-video"* ]]; then


### PR DESCRIPTION
This implements macOS --> Linux cross-compilation support for hacking on go-livepeer in livepeer-in-a-box.

Just M1/arm64 support for the moment. I assume the process for adding amd64 would be very similar, but I don't have one handy to test.

Specific changes:
* Refactored install_ffmpeg.sh a bit. It will now have four variables defined in all cases: `BUILDOS`, `BUILDARCH`, `GOOS`, and `GOARCH`. This makes it much easier to implement conditional checks later on.
* The Makefile has those variables now also.
* Added a new conditional block for `darwin-arm64 --> linux-arm64` compilation.