### PR TITLE
Estimate cost using a framerate of 60 rather than 120

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,6 +10,8 @@
 
 #### Broadcaster
 
+- \#xxx Use FPS of 60, rather then 120 for cost estimation (@thomshutt)
+
 #### Orchestrator
 
 #### Transcoder

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -416,9 +416,9 @@ func TestEstimateFee(t *testing.T) {
 	assert.Zero(fee.Cmp(expFee))
 
 	// Test estimation with fps pass-through
-	// pixels = (256 * 144 * 120 * 3) + (426 * 240 * 30 * 3)
+	// pixels = (256 * 144 * 60 * 3) + (426 * 240 * 30 * 3)
 	profiles[0].Framerate = 0
-	expFee = new(big.Rat).SetInt64(22472640)
+	expFee = new(big.Rat).SetInt64(15837120)
 	expFee.Mul(expFee, new(big.Rat).SetFloat64(pixelEstimateMultiplier))
 	expFee.Mul(expFee, priceInfo)
 	fee, err = estimateFee(&stream.HLSSegment{Duration: 3.0}, profiles, priceInfo)

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -710,7 +710,7 @@ func estimateFee(seg *stream.HLSSegment, profiles []ffmpeg.VideoProfile, priceIn
 		if framerate == 0 {
 			// FPS is being passed through (no fps adjustment)
 			// TODO incorporate the actual number of frames from the input
-			framerate = 120 // conservative estimate of input fps
+			framerate = 60 // conservative estimate of input fps
 		}
 		framerateDen := p.FramerateDen
 		if framerateDen == 0 {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
We've found that in reality, no assets we receive have a framerate of 120 and so as a stopgap improvement until we start pulling the true FPS, we're going to calculate our estimate with a framerate of 60 instead.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Change cost estimation default framerate from 120 -> 60

**How did you test each of these updates (required)**
- Ran test suite


**Does this pull request close any open issues?**
No


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
