### PR TITLE
ci: add protoc on build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,11 +109,14 @@ jobs:
             && apt update \
             && apt -yqq install \
               nasm clang-14 clang-tools-14 lld-14 build-essential pkg-config autoconf git python3 \
-              gcc-mingw-w64 libgcc-9-dev-arm64-cross mingw-w64-tools gcc-mingw-w64-x86-64
+              gcc-mingw-w64 libgcc-9-dev-arm64-cross mingw-w64-tools gcc-mingw-w64-x86-64 \
+              protobuf-compiler
 
           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 30 \
             && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 30 \
             && update-alternatives --install /usr/bin/ld ld /usr/bin/lld-14 30
+
+          go install github.com/golang/protobuf/protoc-gen-go@v1.3.5
 
       - name: Install go modules
         if: steps.go.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -116,7 +116,7 @@ jobs:
             && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 30 \
             && update-alternatives --install /usr/bin/ld ld /usr/bin/lld-14 30
 
-          go install github.com/golang/protobuf/protoc-gen-go@v1.3.5
+          go install github.com/golang/protobuf/protoc-gen-go@v1.3.5 && which protoc-gen-go
 
       - name: Install go modules
         if: steps.go.outputs.cache-hit != 'true'


### PR DESCRIPTION
So... this shouldn't be necessary. `protoc` is needed to build the files in `net` like `net/lp_rpc.pb.go`. Those files are committed to the repo; `make` shouldn't be rebuilding them. And yet, every so often, we get an error on build that [looks like this](https://github.com/livepeer/go-livepeer/actions/runs/6630250258/job/18011282601?pr=2886):

```
protoc -I=. --go_out=plugins=grpc:. net/lp_rpc.proto
/bin/bash: line 1: protoc: command not found
make: *** [Makefile:7: net/lp_rpc.pb.go] Error 127
Error: Process completed with exit code 2.
```

I don't know why that happens. It doesn't happen once you rebuild. But... regenerating those files is harmless, I guess, so this will stop that for everybody forever. IDK.