### PR TITLE
Get rid of glog.fatal

### DIFF
--- a/clog/clog.go
+++ b/clog/clog.go
@@ -146,14 +146,6 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 	glog.ErrorDepth(1, msg)
 }
 
-func Fatalf(ctx context.Context, format string, args ...interface{}) {
-	if !glog.V(0) {
-		return
-	}
-	msg, _ := formatMessage(ctx, false, false, format, args...)
-	glog.FatalDepth(1, msg)
-}
-
 func Infof(ctx context.Context, format string, args ...interface{}) {
 	infof(ctx, false, false, format, args...)
 }

--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -88,7 +88,7 @@ func main() {
 
 	tmp, err := ioutil.TempDir("", "livepeer")
 	if err != nil {
-		glog.Fatalf("Can't create temporary directory: %v", err)
+		glog.Exitf("Can't create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(tmp)
 
@@ -100,13 +100,13 @@ func main() {
 	dataDir := filepath.Join(*baseDataDir, t+"_"+acc)
 	err = os.MkdirAll(dataDir, 0755)
 	if err != nil {
-		glog.Fatalf("Can't create directory %v", err)
+		glog.Exitf("Can't create directory %v", err)
 	}
 
 	keystoreDir := filepath.Join(dataDir, "keystore")
 	err = moveDir(tempKeystoreDir, keystoreDir)
 	if err != nil {
-		glog.Fatal(err)
+		glog.Exit(err)
 	}
 	cfg.KeystoreDir = keystoreDir
 	cfg.IsBroadcaster = isBroadcaster
@@ -130,7 +130,7 @@ func main() {
 		tDataDir := filepath.Join(*baseDataDir, "transcoder_"+acc)
 		err = os.MkdirAll(tDataDir, 0755)
 		if err != nil {
-			glog.Fatalf("Can't create directory %v", err)
+			glog.Exitf("Can't create directory %v", err)
 		}
 		createTranscoderRunScript(acc, tDataDir, serviceHost)
 	}

--- a/cmd/devtool/devtool/devtool_utils.go
+++ b/cmd/devtool/devtool/devtool_utils.go
@@ -74,7 +74,7 @@ func RemoteConsole(cfg DevtoolConfig) (string, error) {
 
 	client, err := rpc.Dial(cfg.Endpoint)
 	if err != nil {
-		glog.Fatalf("Unable to attach to remote geth: %v", err)
+		glog.Exitf("Unable to attach to remote geth: %v", err)
 		return "", err
 	}
 	// get mining account
@@ -83,11 +83,11 @@ func RemoteConsole(cfg DevtoolConfig) (string, error) {
 		var accounts []string
 		err = client.Call(&accounts, "eth_accounts")
 		if err != nil {
-			glog.Fatalf("Error finding mining account: %v", err)
+			glog.Exitf("Error finding mining account: %v", err)
 			return "", err
 		}
 		if len(accounts) == 0 {
-			glog.Fatal("Can't find mining account")
+			glog.Exit("Can't find mining account")
 			return "", errors.New("can't find mining account")
 		}
 		gethMiningAccount = accounts[0]
@@ -96,7 +96,7 @@ func RemoteConsole(cfg DevtoolConfig) (string, error) {
 
 	tmp, err := ioutil.TempDir("", "console")
 	if err != nil {
-		glog.Fatalf("Can't create temporary directory: %v", err)
+		glog.Exitf("Can't create temporary directory: %v", err)
 		return "", err
 	}
 	defer os.RemoveAll(tmp)
@@ -111,7 +111,7 @@ func RemoteConsole(cfg DevtoolConfig) (string, error) {
 
 	console, err := console.New(config)
 	if err != nil {
-		glog.Fatalf("Failed to start the JavaScript console: %v", err)
+		glog.Exitf("Failed to start the JavaScript console: %v", err)
 		return "", err
 	}
 	defer console.Stop(false)
@@ -131,7 +131,7 @@ func RemoteConsole(cfg DevtoolConfig) (string, error) {
 		glog.Infof("Running eth script: %s", getEthControllerScript)
 		console.Evaluate(getEthControllerScript)
 		if printer.Len() == 0 {
-			glog.Fatal("Can't find deployed controller")
+			glog.Exit("Can't find deployed controller")
 			return "", errors.New("can't find deployed controller")
 		}
 		ethController = strings.Split(printer.String(), "\n")[0]
@@ -361,7 +361,7 @@ func CreateKey(keystoreDir string) string {
 
 	account, err := keyStore.NewAccount(passphrase)
 	if err != nil {
-		glog.Fatal(err)
+		glog.Exit(err)
 	}
 	glog.Infof("Using ETH account: %v", account.Address.Hex())
 	return account.Address.Hex()

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -48,7 +48,7 @@ func main() {
 		ff.WithConfigFileParser(ff.PlainParser),
 	)
 	if err != nil {
-		glog.Fatal("Error parsing config: ", err)
+		glog.Exit("Error parsing config: ", err)
 	}
 
 	vFlag.Value.Set(*verbosity)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -322,28 +322,24 @@ func DefaultLivepeerConfig() LivepeerConfig {
 func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	if *cfg.MaxSessions == "auto" && *cfg.Orchestrator {
 		if *cfg.Transcoder {
-			glog.Fatal("-maxSessions 'auto' cannot be used when both -orchestrator and -transcoder are specified")
-			return
+			glog.Exit("-maxSessions 'auto' cannot be used when both -orchestrator and -transcoder are specified")
 		}
 		core.MaxSessions = 0
 	} else {
 		intMaxSessions, err := strconv.Atoi(*cfg.MaxSessions)
 		if err != nil || intMaxSessions <= 0 {
-			glog.Fatal("-maxSessions must be 'auto' or greater than zero")
-			return
+			glog.Exit("-maxSessions must be 'auto' or greater than zero")
 		}
 
 		core.MaxSessions = intMaxSessions
 	}
 
 	if *cfg.Netint != "" && *cfg.Nvidia != "" {
-		glog.Fatal("both -netint and -nvidia arguments specified, this is not supported")
-		return
+		glog.Exit("both -netint and -nvidia arguments specified, this is not supported")
 	}
 
 	if *cfg.DetectionSampleRate <= 0 {
-		glog.Fatal("-detectionSampleRate must be greater than zero")
-		return
+		glog.Exit("-detectionSampleRate must be greater than zero")
 	}
 
 	blockPollingTime := time.Duration(*cfg.BlockPollingInterval) * time.Second
@@ -476,8 +472,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			if *cfg.TestTranscoder {
 				transcoderCaps, err = core.TestTranscoderCapabilities(devices, tf)
 				if err != nil {
-					glog.Fatal(err)
-					return
+					glog.Exit(err)
 				}
 			} else {
 				// no capability test was run, assume default capabilities
@@ -585,18 +580,16 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				if (ethAcctAddr == ethcommon.Address{}.Hex()) || ethKeystoreAddr == ethAcctAddr {
 					*cfg.EthAcctAddr = ethKeystoreAddr
 				} else {
-					glog.Fatal("-ethKeystorePath and -ethAcctAddr were both provided, but ethAcctAddr does not match the address found in keystore")
-					return
+					glog.Exit("-ethKeystorePath and -ethAcctAddr were both provided, but ethAcctAddr does not match the address found in keystore")
 				}
 			}
 		} else {
-			glog.Fatal(fmt.Errorf(err.Error()))
-			return
+			glog.Exit(fmt.Errorf(err.Error()))
 		}
 
 		//Get the Eth client connection information
 		if *cfg.EthUrl == "" {
-			glog.Fatal("Need to specify an Ethereum node JSON-RPC URL using -ethUrl")
+			glog.Exit("Need to specify an Ethereum node JSON-RPC URL using -ethUrl")
 		}
 
 		//Set up eth client
@@ -1037,7 +1030,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	if *cfg.AuthWebhookURL != "" {
 		parsedUrl, err := validateURL(*cfg.AuthWebhookURL)
 		if err != nil {
-			glog.Fatal("Error setting auth webhook URL ", err)
+			glog.Exit("Error setting auth webhook URL ", err)
 		}
 		glog.Info("Using auth webhook URL ", parsedUrl.Redacted())
 		server.AuthWebhookURL = parsedUrl
@@ -1046,7 +1039,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	if *cfg.DetectionWebhookURL != "" {
 		parsedUrl, err := validateURL(*cfg.DetectionWebhookURL)
 		if err != nil {
-			glog.Fatal("Error setting detection webhook URL ", err)
+			glog.Exit("Error setting detection webhook URL ", err)
 		}
 		glog.Info("Using detection webhook URL ", parsedUrl.Redacted())
 		server.DetectionWebhookURL = parsedUrl
@@ -1086,7 +1079,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		if *cfg.OrchWebhookURL != "" {
 			whurl, err := validateURL(*cfg.OrchWebhookURL)
 			if err != nil {
-				glog.Fatal("Error setting orch webhook URL ", err)
+				glog.Exit("Error setting orch webhook URL ", err)
 			}
 			glog.Info("Using orchestrator webhook URL ", whurl)
 			n.OrchestratorPool = discovery.NewWebhookPool(bcast, whurl)
@@ -1125,7 +1118,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		if *cfg.VerifierURL != "" {
 			_, err := validateURL(*cfg.VerifierURL)
 			if err != nil {
-				glog.Fatal("Error setting verifier URL ", err)
+				glog.Exit("Error setting verifier URL ", err)
 			}
 			glog.Info("Using the Epic Labs classifier for verification at ", *cfg.VerifierURL)
 			server.Policy = &verification.Policy{Retries: 2, Verifier: &verification.EpicClassifier{Addr: *cfg.VerifierURL}}
@@ -1133,7 +1126,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			// Set the verifier path. Remove once [1] is implemented!
 			// [1] https://github.com/livepeer/verification-classifier/issues/64
 			if drivers.NodeStorage == nil && *cfg.VerifierPath == "" {
-				glog.Fatal("Requires a path to the verifier shared volume when local storage is in use; use -verifierPath or -objectStore")
+				glog.Exit("Requires a path to the verifier shared volume when local storage is in use; use -verifierPath or -objectStore")
 			}
 			verification.VerifierPath = *cfg.VerifierPath
 		} else if localVerify {
@@ -1149,14 +1142,14 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 		suri, err := getServiceURI(n, *cfg.ServiceAddr)
 		if err != nil {
-			glog.Fatal("Error getting service URI: ", err)
+			glog.Exit("Error getting service URI: ", err)
 		}
 		n.SetServiceURI(suri)
 		// if http addr is not provided, listen to all ifaces
 		// take the port to listen to from the service URI
 		*cfg.HttpAddr = defaultAddr(*cfg.HttpAddr, "", n.GetServiceURI().Port())
 		if !*cfg.Transcoder && n.OrchSecret == "" {
-			glog.Fatal("Running an orchestrator requires an -orchSecret for standalone mode or -transcoder for orchestrator+transcoder mode")
+			glog.Exit("Running an orchestrator requires an -orchSecret for standalone mode or -transcoder for orchestrator+transcoder mode")
 		}
 	} else if n.NodeType == core.TranscoderNode {
 		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", TranscoderCliPort)
@@ -1246,10 +1239,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 	if n.NodeType == core.TranscoderNode {
 		if n.OrchSecret == "" {
-			glog.Fatal("Missing -orchSecret")
+			glog.Exit("Missing -orchSecret")
 		}
 		if len(orchURLs) <= 0 {
-			glog.Fatal("Missing -orchAddr")
+			glog.Exit("Missing -orchAddr")
 		}
 
 		go server.RunTranscoder(n, orchURLs[0].Host, core.MaxSessions, transcoderCaps)

--- a/cmd/livepeer_bench/livepeer_bench.go
+++ b/cmd/livepeer_bench/livepeer_bench.go
@@ -54,15 +54,15 @@ func main() {
 
 	f, err := os.Open(*in)
 	if err != nil {
-		glog.Fatal("Couldn't open input manifest: ", err)
+		glog.Exit("Couldn't open input manifest: ", err)
 	}
 	p, _, err := m3u8.DecodeFrom(bufio.NewReader(f), true)
 	if err != nil {
-		glog.Fatal("Couldn't decode input manifest: ", err)
+		glog.Exit("Couldn't decode input manifest: ", err)
 	}
 	pl, ok := p.(*m3u8.MediaPlaylist)
 	if !ok {
-		glog.Fatalf("Expecting media playlist in the input %s", *in)
+		glog.Exitf("Expecting media playlist in the input %s", *in)
 	}
 
 	accel := ffmpeg.Software
@@ -72,7 +72,7 @@ func main() {
 		accel = ffmpeg.Nvidia
 		devices, err = common.ParseAccelDevices(*nvidia, accel)
 		if err != nil {
-			glog.Fatalf("Error while parsing '-nvidia %v' flag: %v", *nvidia, err)
+			glog.Exitf("Error while parsing '-nvidia %v' flag: %v", *nvidia, err)
 		}
 	}
 
@@ -81,7 +81,7 @@ func main() {
 		accel = ffmpeg.Netint
 		devices, err = common.ParseAccelDevices(*netint, accel)
 		if err != nil {
-			glog.Fatalf("Error while parsing '-netint %v' flag: %v", *netint, err)
+			glog.Exitf("Error while parsing '-netint %v' flag: %v", *netint, err)
 		}
 	}
 
@@ -144,7 +144,7 @@ func main() {
 			detectorTc, err = ffmpeg.NewTranscoderWithDetector(detectionOpts.Detector, d)
 			end := time.Now()
 			if err != nil {
-				glog.Fatalf("Could not initialize detector profiles")
+				glog.Exitf("Could not initialize detector profiles")
 			}
 			fmt.Printf("InitDetectorSession time %0.4v\n", end.Sub(t).Seconds())
 			defer detectorTc.StopTranscoder()
@@ -170,7 +170,7 @@ func main() {
 					end := time.Now()
 					fmt.Printf("InitDetectorSession time %0.4v for session %v\n", end.Sub(t).Seconds(), i)
 					if err != nil {
-						glog.Fatalf("Could not initialize detector")
+						glog.Exitf("Could not initialize detector")
 					}
 				} else {
 					tc = ffmpeg.NewTranscoder()
@@ -225,7 +225,7 @@ func main() {
 					res, err := tc.Transcode(in, out)
 					end := time.Now()
 					if err != nil {
-						glog.Fatalf("Transcoding failed for session %d segment %d: %v", k, j, err)
+						glog.Exitf("Transcoding failed for session %d segment %d: %v", k, j, err)
 					}
 					if *detectionFreq > 0 && j%*detectionFreq == 0 {
 						fmt.Printf("%s,%d,%d,%0.4v,%0.4v,%v\n", end.Format("2006-01-02 15:04:05.9999"), k, j, v.Duration, end.Sub(t).Seconds(), res.Encoded[len(res.Encoded)-1].DetectData)
@@ -254,7 +254,7 @@ func main() {
 		}
 		wg.Wait()
 		if segCount == 0 || srcDur == 0.0 {
-			glog.Fatal("Input manifest has no segments or total duration is 0s")
+			glog.Exit("Input manifest has no segments or total duration is 0s")
 		}
 		statsTable := tablewriter.NewWriter(os.Stderr)
 		stats := [][]string{
@@ -285,7 +285,7 @@ func parseVideoProfiles(inp string) []ffmpeg.VideoProfile {
 			var parsingError error
 			profiles, parsingError = ffmpeg.ParseProfiles(content)
 			if parsingError != nil {
-				glog.Fatal(parsingError)
+				glog.Exit(parsingError)
 			}
 		} else {
 			// check the built-in profiles
@@ -298,7 +298,7 @@ func parseVideoProfiles(inp string) []ffmpeg.VideoProfile {
 			}
 		}
 		if len(profiles) <= 0 {
-			glog.Fatalf("No transcoding options provided")
+			glog.Exitf("No transcoding options provided")
 		}
 	}
 	return profiles

--- a/cmd/livepeer_cli/wizard_stream.go
+++ b/cmd/livepeer_cli/wizard_stream.go
@@ -29,7 +29,6 @@ func (w *wizard) stream() {
 	_, err = ioutil.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
-		// glog.Fatal(err)
 		fmt.Println(err)
 		return
 	}

--- a/cmd/livepeer_router/livepeer_router.go
+++ b/cmd/livepeer_router/livepeer_router.go
@@ -40,7 +40,7 @@ func main() {
 
 	usr, err := user.Current()
 	if err != nil {
-		glog.Fatalf("Cannot find current user: %v", err)
+		glog.Exitf("Cannot find current user: %v", err)
 	}
 
 	if *datadir == "" {
@@ -54,23 +54,23 @@ func main() {
 	if _, err := os.Stat(*datadir); os.IsNotExist(err) {
 		glog.Infof("Creating datadir: %v", *datadir)
 		if err = os.MkdirAll(*datadir, 0755); err != nil {
-			glog.Fatalf("Error creating datadir: %v", err)
+			glog.Exitf("Error creating datadir: %v", err)
 		}
 	}
 
 	if *serviceAddr == "" {
-		glog.Fatal("Missing -serviceAddr")
+		glog.Exit("Missing -serviceAddr")
 	}
 
 	serviceURI, err := url.ParseRequestURI("https://" + *serviceAddr)
 	if err != nil {
-		glog.Fatalf("Could not parse -serviceAddr: %v", err)
+		glog.Exitf("Could not parse -serviceAddr: %v", err)
 	}
 
 	*httpAddr = defaultAddr(*httpAddr, "0.0.0.0", serviceURI.Port())
 	uri, err := url.ParseRequestURI("https://" + *httpAddr)
 	if err != nil {
-		glog.Fatalf("Could not parse -httpAddr: %v", err)
+		glog.Exitf("Could not parse -httpAddr: %v", err)
 	}
 
 	var uris []*url.URL
@@ -82,7 +82,7 @@ func main() {
 			}
 			uri, err := url.ParseRequestURI(addr)
 			if err != nil {
-				glog.Fatalf("Could not parse orchestrator URI: %v", err)
+				glog.Exitf("Could not parse orchestrator URI: %v", err)
 			}
 			uris = append(uris, uri)
 		}

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -253,7 +253,7 @@ func InitCensus(nodeType NodeType, version string) {
 	census.kSegClassName = tag.MustNewKey("seg_class_name")
 	census.ctx, err = tag.New(ctx, tag.Insert(census.kNodeType, string(nodeType)), tag.Insert(census.kNodeID, NodeID))
 	if err != nil {
-		glog.Fatal("Error creating context", err)
+		glog.Exit("Error creating context", err)
 	}
 	census.mHTTPClientTimeout1 = stats.Int64("http_client_timeout_1", "Number of times HTTP connection was dropped before transcoding complete", "tot")
 	census.mHTTPClientTimeout2 = stats.Int64("http_client_timeout_2", "Number of times HTTP connection was dropped before transcoded segments was sent back to client", "tot")
@@ -346,7 +346,7 @@ func InitCensus(nodeType NodeType, version string) {
 		tag.Insert(compiler, runtime.Compiler), tag.Insert(goarch, runtime.GOARCH), tag.Insert(goos, runtime.GOOS),
 		tag.Insert(goversion, runtime.Version()), tag.Insert(livepeerversion, version))
 	if err != nil {
-		glog.Fatal("Error creating tagged context", err)
+		glog.Exit("Error creating tagged context", err)
 	}
 	baseTags := []tag.Key{census.kNodeID, census.kNodeType}
 	baseTagsWithManifestID := baseTags
@@ -829,7 +829,7 @@ func InitCensus(nodeType NodeType, version string) {
 
 	// Register the views
 	if err := view.Register(views...); err != nil {
-		glog.Fatalf("Failed to register views: %v", err)
+		glog.Exitf("Failed to register views: %v", err)
 	}
 	registry := rprom.NewRegistry()
 	registry.MustRegister(rprom.NewProcessCollector(rprom.ProcessCollectorOpts{}))
@@ -839,7 +839,7 @@ func InitCensus(nodeType NodeType, version string) {
 		Registry:  registry,
 	})
 	if err != nil {
-		glog.Fatalf("Failed to create the Prometheus stats exporter: %v", err)
+		glog.Exitf("Failed to create the Prometheus stats exporter: %v", err)
 	}
 
 	// Register the Prometheus exporters as a stats exporter.
@@ -847,7 +847,7 @@ func InitCensus(nodeType NodeType, version string) {
 	stats.Record(ctx, mVersions.M(1))
 	ctx, err = tag.New(census.ctx, tag.Insert(census.kErrorCode, "LostSegment"))
 	if err != nil {
-		glog.Fatal("Error creating context", err)
+		glog.Exit("Error creating context", err)
 	}
 	if !unitTestMode {
 		go census.timeoutWatcher(ctx)


### PR DESCRIPTION
We should not use `glog.fatal()`, because its behavior changed in the `glog` library and now it prints the stack dump of each goroutine. This results in too many logs printed even if you enter a wrong parameter in your configuration.