### PR TITLE
Decrease the default O's Ticket EV to 1000000000.

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -193,7 +193,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultMaxGasPrice := 0
 	defaultEthController := ""
 	defaultInitializeRound := false
-	defaultTicketEV := "1000000000000"
+	defaultTicketEV := "1000000000"
 	defaultMaxFaceValue := "0"
 	defaultMaxTicketEV := "3000000000000"
 	defaultMaxTotalEV := "20000000000000"

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -193,7 +193,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultMaxGasPrice := 0
 	defaultEthController := ""
 	defaultInitializeRound := false
-	defaultTicketEV := "1000000000"
+	defaultTicketEV := "8000000000"
 	defaultMaxFaceValue := "0"
 	defaultMaxTicketEV := "3000000000000"
 	defaultMaxTotalEV := "20000000000000"


### PR DESCRIPTION
The rationale behind is that the ticket EV should be smaller than the expected payment for the transcoding of 1 segment. Otherwise, B needs to always pay in advance. The new default value is 1000000000 wei, which should cover transcoding of 1 s segment, 30 FPS, 1280x720 with a price 50ppp.