### PR TITLE
feat(monitor): add reward service error metric

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,7 @@
 
 - #2911 Set default price with livepeer_cli option 20 (@eliteprox)
 - #2928 Added `startupAvailabilityCheck` param to skip the availability check on startup (@stronk-dev)
+- \#xxx Add `reward_call_errors` Prometheus metric (@rickstaa)
 
 #### Transcoder
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,7 +18,7 @@
 
 - #2911 Set default price with livepeer_cli option 20 (@eliteprox)
 - #2928 Added `startupAvailabilityCheck` param to skip the availability check on startup (@stronk-dev)
-- \#xxx Add `reward_call_errors` Prometheus metric (@rickstaa)
+- #2905 Add `reward_call_errors` Prometheus metric (@rickstaa)
 
 #### Transcoder
 

--- a/eth/rewardservice.go
+++ b/eth/rewardservice.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/monitor"
 )
 
 var (
@@ -57,6 +58,9 @@ func (s *RewardService) Start(ctx context.Context) error {
 				err := s.tryReward()
 				if err != nil {
 					glog.Errorf("Error trying to call reward err=%q", err)
+					if monitor.Enabled {
+						monitor.RewardCallError(err.Error())
+					}
 				}
 			}()
 		case <-cancelCtx.Done():

--- a/eth/rewardservice.go
+++ b/eth/rewardservice.go
@@ -57,7 +57,7 @@ func (s *RewardService) Start(ctx context.Context) error {
 			go func() {
 				err := s.tryReward()
 				if err != nil {
-					glog.Errorf("Error trying to call reward err=%q", err)
+					glog.Errorf("Error trying to call reward for round %v err=%q", s.tw.LastInitializedRound(), err)
 					if monitor.Enabled {
 						monitor.RewardCallError(err.Error())
 					}


### PR DESCRIPTION
**What does this pull request do? Could you explain your changes? (required)**

This pull request introduces the `reward_call_errors` Prometheus metric to enhance user monitoring capabilities. The metric is added to the `localhost:7935/metrics` endpoint.

**Specific updates (required)**

- Added a new metric, `reward_call_error`, in [census.go](https://github.com/livepeer/go-livepeer/blob/master/monitor/census.go).
- Implemented logic in [rewardservice.go](https://github.com/livepeer/go-livepeer/blob/master/eth/rewardservice.go) to set the `reward_call_error` metric when monitoring is enabled and a reward call fails.

**How did you test each of these updates (required)**

I haven't had the chance to run tests on the feature yet. I'd appreciate some guidance on the optimal testing approach for this new functionality.

**Does this pull request close any open issues?**

No, it does not.

**Checklist:**

- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated - Documentation for the new metrics is pending and will be added.
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated

#### Test Logs

<details>
<summary>Test Logs</summary>

```bash
++ go list ./...
++ grep -v test/e2e
+ go test -coverprofile cover.out github.com/livepeer/go-livepeer/build github.com/livepeer/go-livepeer/clog github.com/livepeer/go-livepeer/cmd/devtool github.com/livepeer/go-livepeer/cmd/devtool/devtool github.com/livepeer/go-livepeer/cmd/livepeer github.com/livepeer/go-livepeer/cmd/livepeer/starter github.com/livepeer/go-livepeer/cmd/livepeer_bench github.com/livepeer/go-livepeer/cmd/livepeer_cli github.com/livepeer/go-livepeer/cmd/livepeer_router github.com/livepeer/go-livepeer/cmd/scripts github.com/livepeer/go-livepeer/cmd/simple_auth_server github.com/livepeer/go-livepeer/common github.com/livepeer/go-livepeer/core github.com/livepeer/go-livepeer/crypto github.com/livepeer/go-livepeer/discovery github.com/livepeer/go-livepeer/eth github.com/livepeer/go-livepeer/eth/blockwatch github.com/livepeer/go-livepeer/eth/contracts github.com/livepeer/go-livepeer/eth/types github.com/livepeer/go-livepeer/eth/watchers github.com/livepeer/go-livepeer/monitor github.com/livepeer/go-livepeer/net github.com/livepeer/go-livepeer/pm github.com/livepeer/go-livepeer/server github.com/livepeer/go-livepeer/verification
?   	github.com/livepeer/go-livepeer/build	[no test files]
# github.com/livepeer/lpms/ffmpeg
extras.c: In function ‘lpms_compare_sign_bypath’:
extras.c:202:13: warning: implicit declaration of function ‘avfilter_compare_sign_bypath’; did you mean ‘lpms_compare_sign_bypath’? [-Wimplicit-function-declaration]
  202 |   int ret = avfilter_compare_sign_bypath(signpath1, signpath2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |             lpms_compare_sign_bypath
extras.c: In function ‘lpms_compare_sign_bybuffer’:
extras.c:213:13: warning: implicit declaration of function ‘avfilter_compare_sign_bybuff’; did you mean ‘lpms_compare_sign_bybuffer’? [-Wimplicit-function-declaration]
  213 |   int ret = avfilter_compare_sign_bybuff(buffer1, len1, buffer2, len2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |             lpms_compare_sign_bybuffer
?   	github.com/livepeer/go-livepeer/cmd/devtool	[no test files]
?   	github.com/livepeer/go-livepeer/cmd/devtool/devtool	[no test files]
ok  	github.com/livepeer/go-livepeer/clog	0.008s	coverage: 69.5% of statements
# github.com/livepeer/go-livepeer/eth/watchers.test
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-3184988398/000021.o: in function `lpms_compare_sign_bypath':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:202: undefined reference to `avfilter_compare_sign_bypath'
/usr/bin/ld: /tmp/go-link-3184988398/000021.o: in function `lpms_compare_sign_bybuffer':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:213: undefined reference to `avfilter_compare_sign_bybuff'
collect2: error: ld returned 1 exit status

# github.com/livepeer/go-livepeer/eth.test
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-1388600829/000025.o: in function `lpms_compare_sign_bypath':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:202: undefined reference to `avfilter_compare_sign_bypath'
/usr/bin/ld: /tmp/go-link-1388600829/000025.o: in function `lpms_compare_sign_bybuffer':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:213: undefined reference to `avfilter_compare_sign_bybuff'
collect2: error: ld returned 1 exit status

# github.com/livepeer/go-livepeer/common.test
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-4231523545/000018.o: in function `lpms_compare_sign_bypath':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:202: undefined reference to `avfilter_compare_sign_bypath'
/usr/bin/ld: /tmp/go-link-4231523545/000018.o: in function `lpms_compare_sign_bybuffer':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:213: undefined reference to `avfilter_compare_sign_bybuff'
collect2: error: ld returned 1 exit status

# github.com/livepeer/go-livepeer/cmd/livepeer_cli.test
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-1643420494/000012.o: in function `lpms_compare_sign_bypath':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:202: undefined reference to `avfilter_compare_sign_bypath'
/usr/bin/ld: /tmp/go-link-1643420494/000012.o: in function `lpms_compare_sign_bybuffer':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:213: undefined reference to `avfilter_compare_sign_bybuff'
collect2: error: ld returned 1 exit status

# github.com/livepeer/go-livepeer/cmd/livepeer/starter.test
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-3205396144/000017.o: in function `lpms_compare_sign_bypath':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:202: undefined reference to `avfilter_compare_sign_bypath'
/usr/bin/ld: /tmp/go-link-3205396144/000017.o: in function `lpms_compare_sign_bybuffer':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:213: undefined reference to `avfilter_compare_sign_bybuff'
collect2: error: ld returned 1 exit status

# github.com/livepeer/go-livepeer/discovery.test
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-622095218/000018.o: in function `lpms_compare_sign_bypath':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:202: undefined reference to `avfilter_compare_sign_bypath'
/usr/bin/ld: /tmp/go-link-622095218/000018.o: in function `lpms_compare_sign_bybuffer':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:213: undefined reference to `avfilter_compare_sign_bybuff'
collect2: error: ld returned 1 exit status

# github.com/livepeer/go-livepeer/cmd/livepeer.test
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-3710243153/000017.o: in function `lpms_compare_sign_bypath':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:202: undefined reference to `avfilter_compare_sign_bypath'
/usr/bin/ld: /tmp/go-link-3710243153/000017.o: in function `lpms_compare_sign_bybuffer':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:213: undefined reference to `avfilter_compare_sign_bybuff'
collect2: error: ld returned 1 exit status

FAIL	github.com/livepeer/go-livepeer/cmd/livepeer [build failed]
FAIL	github.com/livepeer/go-livepeer/cmd/livepeer/starter [build failed]
?   	github.com/livepeer/go-livepeer/cmd/livepeer_bench	[no test files]
?   	github.com/livepeer/go-livepeer/cmd/livepeer_router	[no test files]
?   	github.com/livepeer/go-livepeer/cmd/scripts	[no test files]
?   	github.com/livepeer/go-livepeer/cmd/simple_auth_server	[no test files]
FAIL	github.com/livepeer/go-livepeer/cmd/livepeer_cli [build failed]
FAIL	github.com/livepeer/go-livepeer/common [build failed]
# github.com/livepeer/go-livepeer/verification.test
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-3628309214/000006.o: in function `lpms_compare_sign_bypath':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:202: undefined reference to `avfilter_compare_sign_bypath'
/usr/bin/ld: /tmp/go-link-3628309214/000006.o: in function `lpms_compare_sign_bybuffer':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:213: undefined reference to `avfilter_compare_sign_bybuff'
collect2: error: ld returned 1 exit status

# github.com/livepeer/go-livepeer/core.test
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-3164035277/000006.o: in function `lpms_compare_sign_bypath':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:202: undefined reference to `avfilter_compare_sign_bypath'
/usr/bin/ld: /tmp/go-link-3164035277/000006.o: in function `lpms_compare_sign_bybuffer':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:213: undefined reference to `avfilter_compare_sign_bybuff'
collect2: error: ld returned 1 exit status

FAIL	github.com/livepeer/go-livepeer/core [build failed]
?   	github.com/livepeer/go-livepeer/eth/contracts	[no test files]
?   	github.com/livepeer/go-livepeer/net	[no test files]
# github.com/livepeer/go-livepeer/server.test
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: /tmp/go-link-1786446998/000006.o: in function `lpms_compare_sign_bypath':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:202: undefined reference to `avfilter_compare_sign_bypath'
/usr/bin/ld: /tmp/go-link-1786446998/000006.o: in function `lpms_compare_sign_bybuffer':
/home/ricks/go/pkg/mod/github.com/livepeer/lpms@v0.0.0-20231002131146-663c62246a3c/ffmpeg/extras.c:213: undefined reference to `avfilter_compare_sign_bybuff'
collect2: error: ld returned 1 exit status

ok  	github.com/livepeer/go-livepeer/crypto	0.013s	coverage: 90.0% of statements
FAIL	github.com/livepeer/go-livepeer/discovery [build failed]
FAIL	github.com/livepeer/go-livepeer/eth [build failed]
ok  	github.com/livepeer/go-livepeer/eth/blockwatch	0.232s	coverage: 66.0% of statements
ok  	github.com/livepeer/go-livepeer/eth/types	0.008s	coverage: 66.2% of statements
FAIL	github.com/livepeer/go-livepeer/eth/watchers [build failed]
ok  	github.com/livepeer/go-livepeer/monitor	0.032s	coverage: 54.5% of statements
ok  	github.com/livepeer/go-livepeer/pm	4.878s	coverage: 83.5% of statements
FAIL	github.com/livepeer/go-livepeer/server [build failed]
FAIL	github.com/livepeer/go-livepeer/verification [build failed]
FAIL
```

</details>