### PR TITLE
Allow default price with cli option 20

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,6 +14,8 @@
 
 #### Orchestrator
 
+- #2911 Set default price with livepeer_cli option 20 (@eliteprox)
+
 #### Transcoder
 
 ### Bug Fixes 🐞

--- a/cmd/livepeer_cli/wizard_transcoder.go
+++ b/cmd/livepeer_cli/wizard_transcoder.go
@@ -307,12 +307,12 @@ func (w *wizard) setMaxFaceValue() {
 }
 
 func (w *wizard) setPriceForBroadcaster() {
-	fmt.Println("Enter the ETH address of the broadcaster")
+	fmt.Println("Enter the ETH address of the broadcaster (default=default)")
 	ethaddr := w.readStringAndValidate(func(in string) (string, error) {
 		if "" == in {
-			return "", fmt.Errorf("no broadcaster eth address input")
+			in = "default"
 		}
-		if in[0:2] != "0x" || len(in) != 42 {
+		if in != "default" && (in[0:2] != "0x" || len(in) != 42) {
 			return "", fmt.Errorf("broadcaster eth address input not in correct format")
 		}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This change allows us to set the base price per pixel with option `20. Set price for broadcaster` in `livepeer_cli`. It is simpler to use than `13. Set orchestrator config`.

**Specific updates (required)**
- Updates input validation for `livepeer_cli` to allow _default_ to be used in place of eth address
- Defaults no input for eth address to _default_

**How did you test each of these updates (required)**
- eth address field empty, set price and verified the base price per pixel was set
- invalid eth address and confirmed `Failed to validate input`
- valid eth address and confirmed it was accepted. 
- Ran applicable tests

**Does this pull request close any open issues?**
None

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated