### PR TITLE
fix: fix `pricePerBroadcaster` JSON file line breaks parsing bug

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,8 @@
 
 ### Bug Fixes 🐞
 
+- \[#2913](https://github.com/livepeer/go-livepeer/issues/2912) fixes a bug that prevented `pricePerBroadcaster` JSON files with line-breaks from being parsed correctly (@rickstaa).
+
 #### CLI
 
 #### General

--- a/common/readfromfile.go
+++ b/common/readfromfile.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"bufio"
 	"fmt"
 	"os"
 )
@@ -18,23 +17,18 @@ func ReadFromFile(s string) (string, error) {
 	if info.IsDir() {
 		// If the supplied string is a directory,
 		// assume it is the pass and return it
-		// along with an approptiate error.
+		// along with an appropriate error.
 		return s, fmt.Errorf("supplied path is a directory")
 	}
-	file, err := os.Open(s)
+	bytes, err := os.ReadFile(s)
 	if err != nil {
 		return s, err
 	}
-	scanner := bufio.NewScanner(file)
-	scanner.Split(bufio.ScanLines)
+	txt := string(bytes)
 
-	scanner.Scan()
-	txtline := scanner.Text()
-	file.Close()
-
-	if len(txtline) == 0 {
+	if len(txt) == 0 {
 		return s, fmt.Errorf("supplied file is empty")
 	}
 
-	return txtline, nil
+	return txt, nil
 }


### PR DESCRIPTION
This pull request ensures that the `pricePerBroadcaster` flag also correctly parses JSON files when they contain line breaks (see #2912).

**What does this pull request do? Explain your changes. (required)**

The current `go-livepeer` `livepeer` binary does not correctly parse `pricePerBroadcaster` files if they contain line breaks. 

<!-- A clear and concise description of what this pull request does. -->

This pull request ensures that the `pricePerBroadcaster` flag also works with JSON files that contain line breaks as is often done to improve readability.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

- The `common.ReadFromFile` was changed so JSON files with line breaks and JSON strings are parsed correctly.

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment and the tests you ran to see how your change affects other areas of the code, etc. -->

I debugged the changed code with both the JSON file and JSON string format in Vscode.

**Does this pull request close any open issues?**

<!-- Fixes # -->

Fixes #2912.

**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] ❌ All tests in `./test.sh` pass
- ~~[ ] README and other documentation updated~~
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
