### PR TITLE
FIX: pricePerBroadcaster JSON file line breaks parsing bug

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,8 @@
 
 ### Bug Fixes 🐞
 
+- \[#2914](https://github.com/livepeer/go-livepeer/issues/2912) fixes a bug that prevented `pricePerBroadcaster` JSON files with line-breaks from being parsed correctly (@rickstaa).
+
 #### CLI
 
 #### General

--- a/common/readfromfile.go
+++ b/common/readfromfile.go
@@ -16,9 +16,7 @@ func ReadFromFile(s string) (string, error) {
 		return s, err
 	}
 	if info.IsDir() {
-		// If the supplied string is a directory,
-		// assume it is the pass and return it
-		// along with an appropriate error.
+		// If the supplied string is a directory, return it along with an appropriate error.
 		return s, fmt.Errorf("supplied path is a directory")
 	}
 	bytes, err := os.ReadFile(s)

--- a/common/readfromfile.go
+++ b/common/readfromfile.go
@@ -1,9 +1,9 @@
 package common
 
 import (
-	"bufio"
 	"fmt"
 	"os"
+	"strings"
 )
 
 // ReadFromFile attempts to read a file at the supplied location.
@@ -18,23 +18,18 @@ func ReadFromFile(s string) (string, error) {
 	if info.IsDir() {
 		// If the supplied string is a directory,
 		// assume it is the pass and return it
-		// along with an approptiate error.
+		// along with an appropriate error.
 		return s, fmt.Errorf("supplied path is a directory")
 	}
-	file, err := os.Open(s)
+	bytes, err := os.ReadFile(s)
 	if err != nil {
 		return s, err
 	}
-	scanner := bufio.NewScanner(file)
-	scanner.Split(bufio.ScanLines)
+	txt := strings.TrimSpace(string(bytes))
 
-	scanner.Scan()
-	txtline := scanner.Text()
-	file.Close()
-
-	if len(txtline) == 0 {
+	if len(txt) <= 0 {
 		return s, fmt.Errorf("supplied file is empty")
 	}
 
-	return txtline, nil
+	return txt, nil
 }

--- a/common/readfromfile_test.go
+++ b/common/readfromfile_test.go
@@ -88,14 +88,29 @@ func TestReadFromFile_FileExistsOneLine(t *testing.T) {
 	assert.Equal(expectedOutput, output)
 }
 
+// Check that we can reliably read a single line value from the file, even when it ends in a newline / whitespace
+func TestReadFromFile_FileExistsEndsInNewline(t *testing.T) {
+	input :=
+		`something
+`
+	f, err := os.CreateTemp(os.TempDir(), "TestReadFromFile_FileExistsEndsInNewline*")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	_, err = f.WriteString(input)
+	require.NoError(t, err)
+
+	output, err := ReadFromFile(f.Name())
+	require.NoError(t, err)
+	require.Equal(t, "something", output)
+}
+
 func TestReadFromFile_FileExistsMultiline(t *testing.T) {
-	assert := assert.New(t)
 	require := require.New(t)
 
 	input :=
 		`something
 somethingelse`
-	expectedOutput := "something"
 
 	tmpFile := "TestReadFromFile_FileExistsMultiline.txt"
 
@@ -112,7 +127,7 @@ somethingelse`
 
 	output, err := ReadFromFile(tmpFile)
 
-	assert.Nil(err)
+	require.NoError(err)
 	// ReadFromFile should the first line of the text file
-	assert.Equal(expectedOutput, output)
+	require.Equal(input, output)
 }


### PR DESCRIPTION
!! Based on https://github.com/livepeer/go-livepeer/pull/2913 from @rickstaa !!

**What does this pull request do? Explain your changes. (required)**
The current go-livepeer livepeer binary does not correctly parse pricePerBroadcaster files if they contain line breaks.

This pull request ensures that the pricePerBroadcaster flag also works with JSON files that contain line breaks as is often done to improve readability.

As far as I could tell, the previous iteration was done as a way to make sure single line + newline files that contained e.g a password parsed correctly and didn't bring in the newline.

**Specific updates (required)**
* The common.ReadFromFile was changed so JSON files with line breaks and JSON strings are parsed correctly.


**How did you test each of these updates (required)**
* Ran unit tests, tried parsing multiline JSON files.


**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/go-livepeer/issues/2912


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
