### PR TITLE
Orchestrator: add flag to skip the availability check on startup

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,7 @@
 #### Orchestrator
 
 - #2911 Set default price with livepeer_cli option 20 (@eliteprox)
+- #2928 Added `startupAvailabilityCheck` param to skip the availability check on startup (@stronk-dev)
 
 #### Transcoder
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -208,7 +208,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.DetectionWebhookURL = flag.String("detectionWebhookUrl", *cfg.DetectionWebhookURL, "(Experimental) Detection results callback URL")
 
 	// flags
-	cfg.TestOrchAvail = flag.Bool("testOrchAvail", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
+	cfg.TestOrchAvail = flag.Bool("startupAvailabilityCheck", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
 
 	return cfg
 }

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -207,6 +207,9 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.AuthWebhookURL = flag.String("authWebhookUrl", *cfg.AuthWebhookURL, "RTMP authentication webhook URL")
 	cfg.DetectionWebhookURL = flag.String("detectionWebhookUrl", *cfg.DetectionWebhookURL, "(Experimental) Detection results callback URL")
 
+	// flags
+	cfg.TestOrchAvail = flag.Bool("testOrchAvail", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
+
 	return cfg
 }
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -144,6 +144,7 @@ type LivepeerConfig struct {
 	OrchWebhookURL               *string
 	DetectionWebhookURL          *string
 	OrchBlacklist                *string
+	TestOrchAvail                *bool
 }
 
 // DefaultLivepeerConfig creates LivepeerConfig exactly the same as when no flags are passed to the livepeer process.
@@ -232,6 +233,9 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultOrchWebhookURL := ""
 	defaultDetectionWebhookURL := ""
 
+	// Flags
+	defaultTestOrchAvail := true
+
 	return LivepeerConfig{
 		// Network & Addresses:
 		Network:      &defaultNetwork,
@@ -316,6 +320,9 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		AuthWebhookURL:      &defaultAuthWebhookURL,
 		OrchWebhookURL:      &defaultOrchWebhookURL,
 		DetectionWebhookURL: &defaultDetectionWebhookURL,
+
+		// Flags
+		TestOrchAvail: &defaultTestOrchAvail,
 	}
 }
 
@@ -1227,12 +1234,14 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		}()
 
 		// check whether or not the orchestrator is available
-		time.Sleep(2 * time.Second)
-		orchAvail := server.CheckOrchestratorAvailability(orch)
-		if !orchAvail {
-			// shut down orchestrator
-			glog.Infof("Orchestrator not available at %v; shutting down", orch.ServiceURI())
-			tc <- struct{}{}
+		if *cfg.TestOrchAvail {
+			time.Sleep(2 * time.Second)
+			orchAvail := server.CheckOrchestratorAvailability(orch)
+			if !orchAvail {
+				// shut down orchestrator
+				glog.Infof("Orchestrator not available at %v; shutting down", orch.ServiceURI())
+				tc <- struct{}{}
+			}
 		}
 
 	}()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
When booting an Orchestrator, an availability check is performed by sending a Ping GRPC request to the configured service address
On certain setups local loopback might not be available, causing the test to fail even though the Orchestrator is available from remote connections

This change adds a `testOrchAvail` flag to explicitly disable the startup check

**How did you test each of these updates (required)**
Going to use the binaries built by this PR to test this on my Singapore node, which exhibits this issue
