### PR TITLE
test: add `LIVEPEER_HTTP_PORT` test env variable

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,8 @@
 
 #### General
 
+- #2936 Add `LIVEPEER_HTTP_PORT` test env variable (@rickstaa)
+
 #### Broadcaster
 
 - \#xxx Use FPS of 60, rather then 120 for cost estimation (@thomshutt)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,14 +25,15 @@ create your own, or submit a PR with the updates you want to see.
 If you're interested in updating user (e.g., node operator) documentation, please refer to [the relevant documentation on livepeer.org](https://docs.livepeer.org/contributing/overview).
 
 #### 💬 Getting involved in issues
-As a starting point, check out the issues that we've labeled as 
+
+As a starting point, check out the issues that we've labeled as
 [help wanted](https://github.com/livepeer/go-livepeer/labels/help%20wanted)
 and
 [good first issues](https://github.com/livepeer/go-livepeer/labels/good%20first%20issue).
 
 Many issues are open discussions. Feel free to add your own concerns, ideas, and
 workarounds. If you don't see what you're looking for, you can always open a new
-issue. 
+issue.
 
 #### 🐛 Fixing bugs, 🕶️ adding feature/enhancements, or 👌 improving code quality
 
@@ -42,7 +43,7 @@ or taking on a
 [feature request](https://github.com/livepeer/go-livepeer/issues?q=is%3Aissue+is%3Aopen+label%3A%22type%3A+feature%22+).
 
 If picking up issues isn't your thing, no worries -- you can always add more
-tests to improve coverage or refactor code to increase maintainability. 
+tests to improve coverage or refactor code to increase maintainability.
 
 > Note: Bonus points if you can delete code instead of adding it! 👾
 
@@ -78,17 +79,18 @@ it'd be good to have some proficiency with go.
 - **If you are opening an issue...**
 
   - Fill out all required sections for your issue type. Issues that are not
-    filled out properly will be flagged as `need: more info` and will be closed if not
-    updated.
+        filled out properly will be flagged as `need: more info` and will be closed if not
+        updated.
   - _Keep your issue simple, clear, and to-the-point_. Most issues do not
-    require many paragraphs of text. In fact, if you write too much, it's
-    difficult to understand what you are actually trying to communicate.
-    **Consider
-    [starting a discussion](https://github.com/livepeer/go-livepeer/discussions/new)
-    if you're not clear on something or want feedback from the community.**
+        require many paragraphs of text. In fact, if you write too much, it's
+        difficult to understand what you are actually trying to communicate.
+        **Consider
+        [starting a discussion](https://github.com/livepeer/go-livepeer/discussions/new)
+        if you're not clear on something or want feedback from the community.**
 
 - **If you are submitting a pull request...**
   - Write tests to increase code coverage
+  - Make sure all tests pass (you can use the `LIVEPEER_HTTP_PORT` environment variable to change the port used for testing)
   - Tag the issue(s) your PR is closing or relating to
   - Make sure your PR is up-to-date with `master` (rebase please 🙏)
   - Wait for a maintainer to review your PR
@@ -99,14 +101,13 @@ it'd be good to have some proficiency with go.
     - For a small changesets, the Github "squash and merge" option can be an acceptable
     - For larger changesets, the Github "rebase and merge" option is preferable and a maintainer may request you do a local rebase first to cleanup the branch commit history before merging
 
-
 ### Changelog
 
 Every change (feature, bug fix, etc.) should be made in a PR that includes an update to the `CHANGELOG_PENDING.md` file which tracks the set of changes that will be included in the next release.
 
 Changelog entries should be formatted as follows:
 
-```
+```md
 - \#xxx Description of the change (@contributor)
 ```
 
@@ -115,7 +116,6 @@ Changelog entries should be formatted as follows:
 Changelog entries should be classified based on the `livepeer` mode of operation that they pertain to i.e. General, Broadcaster, Orchestrator, Transcoder.
 
 Breaking changes should be documented in the "Breaking changes" section. Any changes that involve pending deprecations (i.e. a flag will be removed in the next release) should be documented in the "Upcoming changes" section.
-
 
 ### When is it appropriate to follow up?
 
@@ -137,7 +137,7 @@ suggestion or merge a PR. If that happens, maintainer will still...
 
 - Thank you for your contribution.
 - Explain why it doesn’t fit into the scope of the project and offer clear
-  suggestions for improvement, if possible.
+    suggestions for improvement, if possible.
 - Link to relevant documentation, if it exists.
 - Close the issue/request.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,6 @@
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] Read the [contribution guide](./CONTRIBUTING.md)
 - [ ] `make` runs successfully
-- [ ] All tests in `./test.sh` pass
+- [ ] All tests in `./test.sh` pass (you can use the `LIVEPEER_HTTP_PORT` environment variable to change the port used for testing)
 - [ ] README and other documentation updated
 - [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated

--- a/test_args.sh
+++ b/test_args.sh
@@ -2,6 +2,9 @@
 
 set -eux
 
+# Retrieve environment variables
+LIVEPEER_HTTP_PORT=${LIVEPEER_HTTP_PORT:-8935}
+
 # set a clean slate "home dir" for testing
 TMPDIR=$PWD/tmp/livepeer-test-"$RANDOM"
 DEFAULT_DATADIR="$TMPDIR"/.lpData
@@ -67,14 +70,14 @@ $TMPDIR/livepeer -orchestrator -orchSecret asdf -serviceAddr "hibye" 2>&1 | gr
 
 # check that orchestrators require -orchSecret or -transcoder
 # sanity check with -transcoder
-run_lp -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder
+run_lp -orchestrator -serviceAddr 127.0.0.1:${LIVEPEER_HTTP_PORT} -transcoder
 kill $pid
 # sanity check with -orchSecret
-run_lp -orchestrator -serviceAddr 127.0.0.1:8935 -orchSecret asdf
+run_lp -orchestrator -serviceAddr 127.0.0.1:${LIVEPEER_HTTP_PORT} -orchSecret asdf
 kill $pid
 # XXX need a better way of confirming the error type. specialized exit code?
 res=0
-$TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 || res=$?
+$TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:${LIVEPEER_HTTP_PORT} || res=$?
 [ $res -ne 0 ]
 
 # Run mainnet tests
@@ -127,16 +130,16 @@ else
   kill $pid
 
   # Check that -pricePerUnit needs to be set
-  $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pricePerUnit must be set"
+  $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:${LIVEPEER_HTTP_PORT} -transcoder -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pricePerUnit must be set"
   # Orchestrator needs PricePerUnit > 0
-  $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pricePerUnit -5 -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pricePerUnit must be >= 0, provided -5"
+  $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:${LIVEPEER_HTTP_PORT} -transcoder -pricePerUnit -5 -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pricePerUnit must be >= 0, provided -5"
   # Orchestrator needs PixelsPerUnit > 0
-  $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pixelsPerUnit 0 -pricePerUnit 5 -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pixelsPerUnit must be > 0, provided 0"
-  $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pixelsPerUnit -5 -pricePerUnit 5 -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pixelsPerUnit must be > 0, provided -5"
+  $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:${LIVEPEER_HTTP_PORT} -transcoder -pixelsPerUnit 0 -pricePerUnit 5 -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pixelsPerUnit must be > 0, provided 0"
+  $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:${LIVEPEER_HTTP_PORT} -transcoder -pixelsPerUnit -5 -pricePerUnit 5 -network rinkeby $ETH_ARGS 2>&1 | grep -e "-pixelsPerUnit must be > 0, provided -5"
 
   # Check that price can be set to 0 with -pricePerUnit 0
   res=0
-  $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:8935 -transcoder -pricePerUnit 0 -network rinkeby $ETH_ARGS || res=$?
+  $TMPDIR/livepeer -orchestrator -serviceAddr 127.0.0.1:${LIVEPEER_HTTP_PORT} -transcoder -pricePerUnit 0 -network rinkeby $ETH_ARGS || res=$?
   [ $res -ne 0 ]
 
   # Broadcaster needs a valid rational number for -maxTicketEV


### PR DESCRIPTION
This pull request adds the `LIVEPEER_HTTP_PORT` environment variable, which can set the HTTP port used by the Livepeer binary in the `test_args.sh` script. This is useful if another service already uses this port.

**What does this pull request do? Could you explain your changes? (required)**

I already have an orchestrator running on the default port. This port is therefore not available to be used for the tests.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

- Adds the `LIVEPEER_HTTP_PORT` environment variable, which can set the HTTP port used by the Livepeer binary in the `test_args.sh` script.

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment and the tests you ran to see how your change affects other areas of the code, etc. -->

By setting `LIVEPEER_HTTP_PORT` environment variable and running the `test_args.sh` script.

**Does this pull request close any open issues?**

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
