### PR TITLE
Return parsing error when failing to parse B prices

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,7 @@
 - #2911 Set default price with livepeer_cli option 20 (@eliteprox)
 - #2928 Added `startupAvailabilityCheck` param to skip the availability check on startup (@stronk-dev)
 - #2905 Add `reward_call_errors` Prometheus metric (@rickstaa)
+- #2958 Return parsing error when failing to parse B prices (@thomshutt)
 
 #### Transcoder
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1437,9 +1437,8 @@ func getBroadcasterPrices(broadcasterPrices string) []BroadcasterPrice {
 	prices, _ := common.ReadFromFile(broadcasterPrices)
 
 	err := json.Unmarshal([]byte(prices), &pricesSet)
-
 	if err != nil {
-		glog.Errorf("broadcaster prices could not be parsed")
+		glog.Errorf("broadcaster prices could not be parsed: %s", err)
 		return nil
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
- Return the parsing error when per-Broadcaster pricing is being specified as a JSON blob and parsing of that blob fails.

**How did you test each of these updates (required)**
- Ran unit tests
- Intentionally misconfigured CLI option and observed error

**Does this pull request close any open issues?**
- No

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
