### PR TITLE
server,discovery: Fallback to using any O in case none match maxPrice 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,8 @@
 
 #### Broadcaster
 
+- [#2985](https://github.com/livepeer/go-livepeer/pull/2985) Fallback to using any O in case none match maxPrice (@victorges)
+
 #### Orchestrator
 
 #### Transcoder

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -81,6 +81,7 @@ func (dbo *DBOrchestratorPoolCache) getURLs() (uris []*url.URL, ignoredMaxPrice 
 	}
 	// If there are no Os matching the max price per pixel, we accept any O to avoid disrupting service
 	if len(orchs) == 0 {
+		// TODO: log when this happens so we can alert
 		ignoredMaxPrice = true
 		orchs, err = dbo.store.SelectOrchs(
 			&common.DBOrchFilter{
@@ -176,6 +177,7 @@ func (dbo *DBOrchestratorPoolCache) Size() int {
 	)
 	// If there are no Os matching the max price per pixel, we accept any O to avoid disrupting service
 	if count == 0 {
+		// TODO: log when this happens so we can alert
 		count, _ = dbo.store.OrchCount(
 			&common.DBOrchFilter{
 				CurrentRound:   dbo.rm.LastInitializedRound(),

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -620,7 +620,7 @@ func TestNewOrchestratorPoolWithPred_TestPredicate(t *testing.T) {
 	assert.False(t, pool.pred(oInfo))
 }
 
-func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) {
+func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsAll(t *testing.T) {
 	// Test setup
 	expPriceInfo := &net.PriceInfo{
 		PricePerUnit:  999,
@@ -697,15 +697,15 @@ func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) 
 		assert.Contains(testOrchs, test)
 	}
 
-	// check size
-	assert.Equal(0, pool.Size())
+	// Functions should return all Os to avoid service disruption
+	assert.Equal(50, pool.Size())
 
 	urls := pool.GetInfos()
-	assert.Len(urls, 0)
+	assert.Len(urls, 50)
 	infos, err := pool.GetOrchestrators(context.TODO(), len(addresses), newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 
 	assert.Nil(err, "Should not be error")
-	assert.Len(infos, 0)
+	assert.Len(infos, 50)
 }
 
 func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -520,13 +520,13 @@ func TestSetOrchestratorPriceInfo(t *testing.T) {
 	assert.Zero(t, s.LivepeerNode.GetBasePrice("default").Cmp(big.NewRat(1, 1)))
 
 	err = s.setOrchestratorPriceInfo("default", "-5", "1", "")
-	assert.EqualErrorf(t, err, err.Error(), "price unit must be greater than or equal to 0, provided %d\n", -5)
+	assert.EqualError(t, err, fmt.Sprintf("price unit must be greater than or equal to 0, provided %d", -5))
 
 	// pixels per unit <= 0
 	err = s.setOrchestratorPriceInfo("default", "1", "0", "")
-	assert.EqualErrorf(t, err, err.Error(), "pixels per unit must be greater than 0, provided %d\n", 0)
+	assert.EqualError(t, err, fmt.Sprintf("pixels per unit must be greater than 0, provided %d", 0))
 	err = s.setOrchestratorPriceInfo("default", "1", "-5", "")
-	assert.EqualErrorf(t, err, err.Error(), "pixels per unit must be greater than 0, provided %d\n", -5)
+	assert.EqualError(t, err, fmt.Sprintf("pixels per unit must be greater than 0, provided %d", -5))
 
 }
 func TestSetPriceForBroadcasterHandler(t *testing.T) {

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -1684,7 +1684,7 @@ func TestSubmitSegment_GenPaymentError_ValidatePriceError(t *testing.T) {
 
 	_, err := SubmitSegment(context.TODO(), s, &stream.HLSSegment{}, nil, 0, false, true)
 
-	assert.EqualErrorf(t, err, err.Error(), "Orchestrator price higher than the set maximum price of %v wei per %v pixels", int64(1), int64(5))
+	assert.EqualError(t, err, fmt.Sprintf("Orchestrator price higher than the set maximum price of %v wei per %v pixels", int64(1), int64(5)))
 	balance.AssertCalled(t, "Credit", existingCredit)
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to allow broadcasters to use any Orchestrator, in case their maxPrice configuration
is set to a too low number such that no Orchestrators offer that service.

This is a fallback strategy after implementing the feature that makes the price per pixel
dynamic based on an external currency. It mitigates the risk of the price quote changing 
drastically and the maxPrice becoming automatically too low. When that happens, the B
is going to fallback to any O for a while until the Os update their own prices.

We should also have an alert whenever this happens.

**Specific updates (required)**
- Make `DBOrchestratorPoolCache` fetch all Os in case no Os match `maxPrice`
- Make `segment_rpc` allow O price to be higher than maxPrice, but only if initial price was already higher
- Make `segment_rpc` allow O price to increase up to 2x before dropping the session

**How did you test each of these updates (required)**
 - `./test.sh`
 - TODO: Run a couple B<->Os with changing prices and see what happens

**Does this pull request close any open issues?**
Implements ENG-1855

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
