### PR TITLE
server: Skip redundant maxPrice check in ongoing session

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,8 @@
 
 #### Broadcaster
 
+- [#2994](https://github.com/livepeer/go-livepeer/pull/2994) server: Skip redundant maxPrice check in ongoing session (@victorges)
+
 #### Orchestrator
 
 #### Transcoder

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -520,13 +520,13 @@ func TestSetOrchestratorPriceInfo(t *testing.T) {
 	assert.Zero(t, s.LivepeerNode.GetBasePrice("default").Cmp(big.NewRat(1, 1)))
 
 	err = s.setOrchestratorPriceInfo("default", "-5", "1", "")
-	assert.EqualErrorf(t, err, err.Error(), "price unit must be greater than or equal to 0, provided %d\n", -5)
+	assert.EqualError(t, err, fmt.Sprintf("price unit must be greater than or equal to 0, provided %d", -5))
 
 	// pixels per unit <= 0
 	err = s.setOrchestratorPriceInfo("default", "1", "0", "")
-	assert.EqualErrorf(t, err, err.Error(), "pixels per unit must be greater than 0, provided %d\n", 0)
+	assert.EqualError(t, err, fmt.Sprintf("pixels per unit must be greater than 0, provided %d", 0))
 	err = s.setOrchestratorPriceInfo("default", "1", "-5", "")
-	assert.EqualErrorf(t, err, err.Error(), "pixels per unit must be greater than 0, provided %d\n", -5)
+	assert.EqualError(t, err, fmt.Sprintf("pixels per unit must be greater than 0, provided %d", -5))
 
 }
 func TestSetPriceForBroadcasterHandler(t *testing.T) {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -553,7 +553,7 @@ func TestGenPayment(t *testing.T) {
 	s.InitialPrice = &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 5}
 	payment, err = genPayment(context.TODO(), s, 1)
 	assert.Equal("", payment)
-	assert.Errorf(err, err.Error(), "Orchestrator price higher than the set maximum price of %v wei per %v pixels", int64(1), int64(5))
+	assert.Errorf(err, "Orchestrator price has changed, Orchestrator price: %v, Orchestrator initial price: %v", "1/3", "1/5")
 
 	s.InitialPrice = nil
 

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -549,13 +549,13 @@ func TestGenPayment(t *testing.T) {
 	sender := &pm.MockSender{}
 	s.Sender = sender
 
-	// Test invalid price
-	BroadcastCfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(1, 5)))
+	// Test changing O price
+	s.InitialPrice = &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 5}
 	payment, err = genPayment(context.TODO(), s, 1)
 	assert.Equal("", payment)
 	assert.Errorf(err, err.Error(), "Orchestrator price higher than the set maximum price of %v wei per %v pixels", int64(1), int64(5))
 
-	BroadcastCfg.SetMaxPrice(nil)
+	s.InitialPrice = nil
 
 	// Test CreateTicketBatch error
 	sender.On("CreateTicketBatch", mock.Anything, mock.Anything).Return(nil, errors.New("CreateTicketBatch error")).Once()
@@ -680,20 +680,8 @@ func TestValidatePrice(t *testing.T) {
 		PMSessionID:      "foo",
 	}
 
-	// B's MaxPrice is nil
+	// O's Initial Price is nil
 	err := validatePrice(s)
-	assert.Nil(err)
-
-	defer BroadcastCfg.SetMaxPrice(nil)
-
-	// B MaxPrice > O Price
-	BroadcastCfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(5, 1)))
-	err = validatePrice(s)
-	assert.Nil(err)
-
-	// B MaxPrice == O Price
-	BroadcastCfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(1, 3)))
-	err = validatePrice(s)
 	assert.Nil(err)
 
 	// O Initial Price == O Price
@@ -710,12 +698,6 @@ func TestValidatePrice(t *testing.T) {
 	s.InitialPrice = &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 10}
 	err = validatePrice(s)
 	assert.ErrorContains(err, "price has changed")
-
-	// B MaxPrice < O Price
-	s.InitialPrice = nil
-	BroadcastCfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(1, 5)))
-	err = validatePrice(s)
-	assert.EqualError(err, fmt.Sprintf("Orchestrator price higher than the set maximum price of %v wei per %v pixels", int64(1), int64(5)))
 
 	// O.PriceInfo is nil
 	s.OrchestratorInfo.PriceInfo = nil

--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -826,10 +826,6 @@ func validatePrice(sess *BroadcastSession) error {
 		return errors.New("missing orchestrator price")
 	}
 
-	maxPrice := BroadcastCfg.MaxPrice()
-	if maxPrice != nil && oPrice.Cmp(maxPrice) == 1 {
-		return fmt.Errorf("Orchestrator price higher than the set maximum price of %v wei per %v pixels", maxPrice.Num().Int64(), maxPrice.Denom().Int64())
-	}
 	iPrice, err := common.RatPriceInfo(sess.InitialPrice)
 	if err == nil && iPrice != nil && oPrice.Cmp(iPrice) == 1 {
 		return fmt.Errorf("Orchestrator price has changed, Orchestrator price: %v, Orchestrator initial price: %v", oPrice, iPrice)

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -1685,7 +1685,7 @@ func TestSubmitSegment_GenPaymentError_ValidatePriceError(t *testing.T) {
 
 	_, err := SubmitSegment(context.TODO(), s, &stream.HLSSegment{}, nil, 0, false, true)
 
-	assert.EqualError(t, err, fmt.Sprintf("Orchestrator price higher than the set maximum price of %v wei per %v pixels", int64(1), int64(5)))
+	assert.EqualError(t, err, fmt.Sprintf("Orchestrator price has changed, Orchestrator price: %v, Orchestrator initial price: %v", "1/3", "1/5"))
 	balance.AssertCalled(t, "Credit", existingCredit)
 }
 

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -1677,10 +1677,11 @@ func TestSubmitSegment_GenPaymentError_ValidatePriceError(t *testing.T) {
 		Sender:           sender,
 		Balance:          balance,
 		OrchestratorInfo: oinfo,
+		InitialPrice: &net.PriceInfo{
+			PricePerUnit:  1,
+			PixelsPerUnit: 5,
+		},
 	}
-
-	BroadcastCfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(1, 5)))
-	defer BroadcastCfg.SetMaxPrice(nil)
 
 	_, err := SubmitSegment(context.TODO(), s, &stream.HLSSegment{}, nil, 0, false, true)
 

--- a/server/segment_rpc_test.go
+++ b/server/segment_rpc_test.go
@@ -1685,7 +1685,7 @@ func TestSubmitSegment_GenPaymentError_ValidatePriceError(t *testing.T) {
 
 	_, err := SubmitSegment(context.TODO(), s, &stream.HLSSegment{}, nil, 0, false, true)
 
-	assert.EqualErrorf(t, err, err.Error(), "Orchestrator price higher than the set maximum price of %v wei per %v pixels", int64(1), int64(5))
+	assert.EqualError(t, err, fmt.Sprintf("Orchestrator price higher than the set maximum price of %v wei per %v pixels", int64(1), int64(5)))
 	balance.AssertCalled(t, "Credit", existingCredit)
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
After #2981, we started allowing both Bs and Os to updated their prices dynamically over time
based on an external currency. This creates a problem for Bs, given their `maxPrice` could 
become lower than an Os `price` in the middle of a session. Even though we want the price to
be dynamic, we want a given session prices to be negotiated in the beginning of the session,
and don't want to drop a session mid-transcoding because the prices were updated.

The initial intuition was to save the "initial max price" on the `BroadcastSession` object as well,
but we realized that this logic would be redundant given we already check for the max price when
the session is estabilished in the first place, and disallow the O to increase prices mid-session.
It goes something like this:

- On session start, we already check `O price <= B maxPrice`
- We save the O price as `initialPrice`, and would save B price as `initialMaxPrice`
  - Thus we have that `O initialPrice <= B initialMaxPrice`
- During session, we also already check that `O price <= O initialPrice` (kept this check on the same `validatePrice` func)
- So this means `O price <= O initialPrice <= B initialMaxPrice`
- i.e. necessarily `O price <= B initialMaxPrice`, which means we don't need a separate check for that (nor even saving the `initialMaxPrice`, as that would be its only use)

**Specific updates (required)**
- Remove `maxPrice` check from `validatePrice`
- Fix tests

**How did you test each of these updates (required)**
Ran automated tests.

**Does this pull request close any open issues?**
Related to ENG-1855 but a bit parallel to that

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
