### PR TITLE
server,discovery: Allow B to use any O in case none match maxPrice

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,6 +11,7 @@
 #### Broadcaster
 
 - [#2995](https://github.com/livepeer/go-livepeer/pull/2995) server: Allow Os price to increase up to 2x mid-session (@victorges)
+- [#2999](https://github.com/livepeer/go-livepeer/pull/2999) server,discovery: Allow B to use any O in case none match maxPrice (@victorges)
 
 #### Orchestrator
 

--- a/common/types.go
+++ b/common/types.go
@@ -105,7 +105,7 @@ type OrchestratorPool interface {
 }
 
 type SelectionAlgorithm interface {
-	Select(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, prices map[ethcommon.Address]*big.Rat, perfScores map[ethcommon.Address]float64) ethcommon.Address
+	Select(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, maxPrice *big.Rat, prices map[ethcommon.Address]*big.Rat, perfScores map[ethcommon.Address]float64) ethcommon.Address
 }
 
 type PerfScore struct {

--- a/common/types.go
+++ b/common/types.go
@@ -3,12 +3,13 @@ package common
 import (
 	"context"
 	"encoding/json"
-	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/livepeer/go-livepeer/net"
-	"github.com/livepeer/m3u8"
 	"math/big"
 	"net/url"
 	"sync"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/livepeer/go-livepeer/net"
+	"github.com/livepeer/m3u8"
 )
 
 type RemoteTranscoderInfo struct {
@@ -104,7 +105,7 @@ type OrchestratorPool interface {
 }
 
 type SelectionAlgorithm interface {
-	Select(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, prices map[ethcommon.Address]float64, perfScores map[ethcommon.Address]float64) ethcommon.Address
+	Select(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, prices map[ethcommon.Address]*big.Rat, perfScores map[ethcommon.Address]float64) ethcommon.Address
 }
 
 type PerfScore struct {

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -16,7 +16,6 @@ import (
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/pm"
-	"github.com/livepeer/go-livepeer/server"
 
 	"github.com/golang/glog"
 )
@@ -71,7 +70,6 @@ func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm
 func (dbo *DBOrchestratorPoolCache) getURLs() ([]*url.URL, error) {
 	orchs, err := dbo.store.SelectOrchs(
 		&common.DBOrchFilter{
-			MaxPrice:       server.BroadcastCfg.MaxPrice(),
 			CurrentRound:   dbo.rm.LastInitializedRound(),
 			UpdatedLastDay: true,
 		},
@@ -120,8 +118,7 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(ctx context.Context, numOrc
 			return false
 		}
 
-		// check if O's price is below B's max price
-		maxPrice := server.BroadcastCfg.MaxPrice()
+		// check if O has a valid price
 		price, err := common.RatPriceInfo(info.PriceInfo)
 		if err != nil {
 			clog.V(common.DEBUG).Infof(ctx, "invalid price info orch=%v err=%q", info.GetTranscoder(), err)
@@ -131,12 +128,8 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(ctx context.Context, numOrc
 			clog.V(common.DEBUG).Infof(ctx, "no price info received for orch=%v", info.GetTranscoder())
 			return false
 		}
-		if maxPrice != nil && price.Cmp(maxPrice) > 0 {
-			clog.V(common.DEBUG).Infof(ctx, "orchestrator's price is too high orch=%v price=%v wei/pixel maxPrice=%v wei/pixel",
-				info.GetTranscoder(),
-				price.FloatString(3),
-				maxPrice.FloatString(3),
-			)
+		if price.Sign() < 0 {
+			clog.V(common.DEBUG).Infof(ctx, "invalid price received for orch=%v price=%v", info.GetTranscoder(), price.RatString())
 			return false
 		}
 		return true
@@ -154,7 +147,6 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(ctx context.Context, numOrc
 func (dbo *DBOrchestratorPoolCache) Size() int {
 	count, _ := dbo.store.OrchCount(
 		&common.DBOrchFilter{
-			MaxPrice:       server.BroadcastCfg.MaxPrice(),
 			CurrentRound:   dbo.rm.LastInitializedRound(),
 			UpdatedLastDay: true,
 		},

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -620,7 +620,7 @@ func TestNewOrchestratorPoolWithPred_TestPredicate(t *testing.T) {
 	assert.False(t, pool.pred(oInfo))
 }
 
-func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) {
+func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsAllOrchestrators(t *testing.T) {
 	// Test setup
 	expPriceInfo := &net.PriceInfo{
 		PricePerUnit:  999,
@@ -698,14 +698,15 @@ func TestCachedPool_AllOrchestratorsTooExpensive_ReturnsEmptyList(t *testing.T) 
 	}
 
 	// check size
-	assert.Equal(0, pool.Size())
+	assert.Equal(50, pool.Size())
 
 	urls := pool.GetInfos()
-	assert.Len(urls, 0)
+	assert.Len(urls, 50)
+
 	infos, err := pool.GetOrchestrators(context.TODO(), len(addresses), newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 
 	assert.Nil(err, "Should not be error")
-	assert.Len(infos, 0)
+	assert.Len(infos, 50)
 }
 
 func TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) {
@@ -899,22 +900,27 @@ func TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *testing.
 		assert.Contains(testOrchs[25:], toOrchTest(o.EthereumAddr, o.ServiceURI, o.PricePerPixel))
 	}
 
-	// check size
-	assert.Equal(25, pool.Size())
+	// check pool returns all Os, not filtering by max price
+	assert.Equal(50, pool.Size())
 
 	infos := pool.GetInfos()
-	assert.Len(infos, 25)
+	assert.Len(infos, 50)
 	for _, info := range infos {
-		assert.Contains(addresses[25:], info.URL.String())
+		assert.Contains(addresses, info.URL.String())
 	}
 
 	oinfos, err := pool.GetOrchestrators(context.TODO(), len(orchestrators), newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
 
 	assert.Nil(err, "Should not be error")
-	assert.Len(oinfos, 25)
+	assert.Len(oinfos, 50)
+
+	seenAddrs := make(map[string]bool)
 	for _, info := range oinfos {
-		assert.Equal(info.RemoteInfo.Transcoder, "goodPriceTranscoder")
+		addr := info.LocalInfo.URL.String()
+		assert.Contains(addresses, addr)
+		seenAddrs[addr] = true
 	}
+	assert.Len(seenAddrs, 50)
 }
 
 func TestCachedPool_GetOrchestrators_TicketParamsValidation(t *testing.T) {

--- a/server/selection.go
+++ b/server/selection.go
@@ -185,6 +185,7 @@ func (s *MinLSSelector) selectUnknownSession(ctx context.Context) *BroadcastSess
 			prices[addr] = big.NewRat(pi.PricePerUnit, pi.PixelsPerUnit)
 		}
 	}
+	maxPrice := BroadcastCfg.MaxPrice()
 
 	stakes, err := s.stakeRdr.Stakes(addrs)
 	if err != nil {
@@ -201,7 +202,7 @@ func (s *MinLSSelector) selectUnknownSession(ctx context.Context) *BroadcastSess
 		s.perfScore.Mu.Unlock()
 	}
 
-	selected := s.selectionAlgorithm.Select(addrs, stakes, prices, perfScores)
+	selected := s.selectionAlgorithm.Select(addrs, stakes, maxPrice, prices, perfScores)
 
 	for i, sess := range s.unknownSessions {
 		if sess.OrchestratorInfo.GetTicketParams() == nil {

--- a/server/selection.go
+++ b/server/selection.go
@@ -3,6 +3,8 @@ package server
 import (
 	"container/heap"
 	"context"
+	"math/big"
+
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/common"
@@ -167,7 +169,7 @@ func (s *MinLSSelector) selectUnknownSession(ctx context.Context) *BroadcastSess
 	}
 
 	var addrs []ethcommon.Address
-	prices := map[ethcommon.Address]float64{}
+	prices := map[ethcommon.Address]*big.Rat{}
 	addrCount := make(map[ethcommon.Address]int)
 	for _, sess := range s.unknownSessions {
 		if sess.OrchestratorInfo.GetTicketParams() == nil {
@@ -180,7 +182,7 @@ func (s *MinLSSelector) selectUnknownSession(ctx context.Context) *BroadcastSess
 		addrCount[addr]++
 		pi := sess.OrchestratorInfo.PriceInfo
 		if pi != nil && pi.PixelsPerUnit != 0 {
-			prices[addr] = float64(pi.PricePerUnit) / float64(pi.PixelsPerUnit)
+			prices[addr] = big.NewRat(pi.PricePerUnit, pi.PixelsPerUnit)
 		}
 	}
 

--- a/server/selection_algorithm.go
+++ b/server/selection_algorithm.go
@@ -1,11 +1,13 @@
 package server
 
 import (
-	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/golang/glog"
 	"math"
+	"math/big"
 	"math/rand"
 	"time"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/golang/glog"
 )
 
 var random = rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -20,7 +22,7 @@ type ProbabilitySelectionAlgorithm struct {
 	PriceExpFactor float64
 }
 
-func (sa ProbabilitySelectionAlgorithm) Select(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, prices map[ethcommon.Address]float64, perfScores map[ethcommon.Address]float64) ethcommon.Address {
+func (sa ProbabilitySelectionAlgorithm) Select(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, prices map[ethcommon.Address]*big.Rat, perfScores map[ethcommon.Address]float64) ethcommon.Address {
 	filtered := sa.filter(addrs, perfScores)
 	probabilities := sa.calculateProbabilities(filtered, stakes, prices)
 	return selectBy(probabilities)
@@ -48,10 +50,10 @@ func (sa ProbabilitySelectionAlgorithm) filter(addrs []ethcommon.Address, scores
 	return res
 }
 
-func (sa ProbabilitySelectionAlgorithm) calculateProbabilities(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, prices map[ethcommon.Address]float64) map[ethcommon.Address]float64 {
+func (sa ProbabilitySelectionAlgorithm) calculateProbabilities(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, prices map[ethcommon.Address]*big.Rat) map[ethcommon.Address]float64 {
 	pricesNorm := map[ethcommon.Address]float64{}
 	for _, addr := range addrs {
-		p := prices[addr]
+		p, _ := prices[addr].Float64()
 		pricesNorm[addr] = math.Exp(-1 * p / sa.PriceExpFactor)
 	}
 

--- a/server/selection_algorithm_test.go
+++ b/server/selection_algorithm_test.go
@@ -14,6 +14,8 @@ func TestFilter(t *testing.T) {
 	tests := []struct {
 		name             string
 		orchMinPerfScore float64
+		maxPrice         float64
+		prices           map[string]float64
 		orchPerfScores   map[string]float64
 		orchestrators    []string
 		want             []string
@@ -87,21 +89,126 @@ func TestFilter(t *testing.T) {
 				"0x0000000000000000000000000000000000000004",
 			},
 		},
+		{
+			name:             "All prices below max price",
+			orchMinPerfScore: 0.7,
+			maxPrice:         2000,
+			prices: map[string]float64{
+				"0x0000000000000000000000000000000000000001": 500,
+				"0x0000000000000000000000000000000000000002": 1500,
+				"0x0000000000000000000000000000000000000003": 1000,
+			},
+			orchPerfScores: map[string]float64{
+				"0x0000000000000000000000000000000000000001": 0.6,
+				"0x0000000000000000000000000000000000000002": 0.8,
+				"0x0000000000000000000000000000000000000003": 0.9,
+			},
+			orchestrators: []string{
+				"0x0000000000000000000000000000000000000001",
+				"0x0000000000000000000000000000000000000002",
+				"0x0000000000000000000000000000000000000003",
+			},
+			want: []string{
+				"0x0000000000000000000000000000000000000002",
+				"0x0000000000000000000000000000000000000003",
+			},
+		},
+		{
+			name:             "All prices above max price",
+			orchMinPerfScore: 0.7,
+			maxPrice:         100,
+			prices: map[string]float64{
+				"0x0000000000000000000000000000000000000001": 500,
+				"0x0000000000000000000000000000000000000002": 1500,
+				"0x0000000000000000000000000000000000000003": 1000,
+			},
+			orchPerfScores: map[string]float64{
+				"0x0000000000000000000000000000000000000001": 0.6,
+				"0x0000000000000000000000000000000000000002": 0.8,
+				"0x0000000000000000000000000000000000000003": 0.9,
+			},
+			orchestrators: []string{
+				"0x0000000000000000000000000000000000000001",
+				"0x0000000000000000000000000000000000000002",
+				"0x0000000000000000000000000000000000000003",
+			},
+			want: []string{
+				"0x0000000000000000000000000000000000000002",
+				"0x0000000000000000000000000000000000000003",
+			},
+		},
+		{
+			name:             "Mix of prices relative to max price",
+			orchMinPerfScore: 0.7,
+			maxPrice:         750,
+			prices: map[string]float64{
+				"0x0000000000000000000000000000000000000001": 500,
+				"0x0000000000000000000000000000000000000002": 1500,
+				"0x0000000000000000000000000000000000000003": 700,
+			},
+			orchPerfScores: map[string]float64{
+				"0x0000000000000000000000000000000000000001": 0.8,
+				"0x0000000000000000000000000000000000000002": 0.6,
+				"0x0000000000000000000000000000000000000003": 0.9,
+			},
+			orchestrators: []string{
+				"0x0000000000000000000000000000000000000001",
+				"0x0000000000000000000000000000000000000002",
+				"0x0000000000000000000000000000000000000003",
+			},
+			want: []string{
+				"0x0000000000000000000000000000000000000001",
+				"0x0000000000000000000000000000000000000003",
+			},
+		},
+		{
+			name:             "Exact match with max price",
+			orchMinPerfScore: 0.7,
+			maxPrice:         1000,
+			prices: map[string]float64{
+				"0x0000000000000000000000000000000000000001": 500,
+				"0x0000000000000000000000000000000000000002": 1000, // exactly max
+				"0x0000000000000000000000000000000000000003": 1500,
+			},
+			orchPerfScores: map[string]float64{
+				"0x0000000000000000000000000000000000000001": 0.8,
+				"0x0000000000000000000000000000000000000002": 0.9,
+				"0x0000000000000000000000000000000000000003": 0.6,
+			},
+			orchestrators: []string{
+				"0x0000000000000000000000000000000000000001",
+				"0x0000000000000000000000000000000000000002",
+				"0x0000000000000000000000000000000000000003",
+			},
+			want: []string{
+				"0x0000000000000000000000000000000000000001",
+				"0x0000000000000000000000000000000000000002",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var addrs []ethcommon.Address
+			var maxPrice *big.Rat
+			prices := map[ethcommon.Address]*big.Rat{}
 			perfScores := map[ethcommon.Address]float64{}
 			for _, o := range tt.orchestrators {
-				perfScores[ethcommon.HexToAddress(o)] = tt.orchPerfScores[o]
-				addrs = append(addrs, ethcommon.HexToAddress(o))
+				addr := ethcommon.HexToAddress(o)
+				addrs = append(addrs, addr)
+				perfScores[addr] = tt.orchPerfScores[o]
+				if price, ok := tt.prices[o]; ok {
+					prices[addr] = new(big.Rat).SetFloat64(price)
+				}
+			}
+			if tt.maxPrice > 0 {
+				maxPrice = new(big.Rat).SetFloat64(tt.maxPrice)
 			}
 			sa := &ProbabilitySelectionAlgorithm{
 				MinPerfScore: tt.orchMinPerfScore,
 			}
 
-			res := sa.filter(addrs, perfScores)
+			res := sa.filter(addrs, maxPrice, prices, perfScores)
 
 			var exp []ethcommon.Address
 			for _, o := range tt.want {

--- a/server/selection_algorithm_test.go
+++ b/server/selection_algorithm_test.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"math/big"
+	"testing"
+
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 const testPriceExpFactor = 100
@@ -160,13 +162,13 @@ func TestCalculateProbabilities(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var orchs []ethcommon.Address
 			stakes := map[ethcommon.Address]int64{}
-			prices := map[ethcommon.Address]float64{}
+			prices := map[ethcommon.Address]*big.Rat{}
 			expProbs := map[ethcommon.Address]float64{}
 			for i, addrStr := range tt.addrs {
 				addr := ethcommon.HexToAddress(addrStr)
 				orchs = append(orchs, addr)
 				stakes[addr] = tt.stakes[i]
-				prices[addr] = tt.prices[i]
+				prices[addr] = new(big.Rat).SetFloat64(tt.prices[i])
 				expProbs[addr] = tt.want[i]
 			}
 

--- a/server/selection_test.go
+++ b/server/selection_test.go
@@ -4,10 +4,12 @@ import (
 	"container/heap"
 	"context"
 	"errors"
+	"math/big"
+	"testing"
+
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/stretchr/testify/require"
-	"testing"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/livepeer/go-livepeer/common"
@@ -89,7 +91,7 @@ func (r *stubStakeReader) SetStakes(stakes map[ethcommon.Address]int64) {
 
 type stubSelectionAlgorithm struct{}
 
-func (sa stubSelectionAlgorithm) Select(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, prices map[ethcommon.Address]float64, perfScores map[ethcommon.Address]float64) ethcommon.Address {
+func (sa stubSelectionAlgorithm) Select(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, prices map[ethcommon.Address]*big.Rat, perfScores map[ethcommon.Address]float64) ethcommon.Address {
 	if len(addrs) == 0 {
 		return ethcommon.Address{}
 	}
@@ -98,7 +100,7 @@ func (sa stubSelectionAlgorithm) Select(addrs []ethcommon.Address, stakes map[et
 		// select lowest price
 		lowest := prices[addr]
 		for _, a := range addrs {
-			if prices[a] < lowest {
+			if prices[a].Cmp(lowest) < 0 {
 				addr = a
 				lowest = prices[a]
 			}

--- a/server/selection_test.go
+++ b/server/selection_test.go
@@ -91,7 +91,7 @@ func (r *stubStakeReader) SetStakes(stakes map[ethcommon.Address]int64) {
 
 type stubSelectionAlgorithm struct{}
 
-func (sa stubSelectionAlgorithm) Select(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, prices map[ethcommon.Address]*big.Rat, perfScores map[ethcommon.Address]float64) ethcommon.Address {
+func (sa stubSelectionAlgorithm) Select(addrs []ethcommon.Address, stakes map[ethcommon.Address]int64, maxPrice *big.Rat, prices map[ethcommon.Address]*big.Rat, perfScores map[ethcommon.Address]float64) ethcommon.Address {
 	if len(addrs) == 0 {
 		return ethcommon.Address{}
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to allow broadcasters to use any Orchestrator in case their maxPrice configuration
is set to a too low number such that no Orchestrators offer that service.

This is a fallback strategy after implementing the feature that makes the price per pixel
dynamic based on an external currency. It mitigates the risk of the price quote changing
drastically and the maxPrice becoming automatically too low. When that happens, the B
is going to fallback to any O for a while until the Os update their own prices.

This is a re-implementation of #2985, doing it inside the selection algorithm itself so that
we still fallback to other Os in case there are a few Os with `price < maxPrice` but that still
can't serve the segments (e.g. perf issues).

**Specific updates (required)**
- Remove logic on `discovery` that filtered Os by maxPrice
- Add logic on selection algorithm to filter by maxPrice 
- At the same time, also include the logic to fallback to ignoring maxPrice, in case none match

**How did you test each of these updates (required)**
- `./test.sh`
- Ran a B and 3 Os with different prices locally. Made sure that:
  - B still selects an O matching the maxPrice, if one is available
  - B selects an O higher than maxPrice, if no lower ones are available
  - B switches mid-stream between a lower and higher priced O, in case the lower ones become unavailable

**Does this pull request close any open issues?**
Implements ENG-1855

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
