### PR TITLE
feat(ai): enable AI orchestrator discovery

### DIFF
--- a/doc/ai-subnet.md
+++ b/doc/ai-subnet.md
@@ -381,16 +381,10 @@ To ensure that _AI Gateway_ nodes can discover your _AI Subnet_ Orchestrator, yo
     foundryup
     ```
 
-2. Connect your _Mainnet Transcoding Network_ Orchestrator wallet to the Foundry cast using the following command:
+2. Invoke the `SetServiceURI` function on the [AIServiceRegistry](https://arbiscan.io/address/0x04C0b249740175999E5BF5c9ac1dA92431EF34C5) contract. Use the KeyStore file and password from your _Mainnet Transcoding Network_ Orchestrator wallet to execute this command:
 
     ```bash
-    cast wallet import <WALLET_NAME> --private-key <YOUR_PRIVATE_WALLET_KEY>
-    ```
-
-3. Call the `SetServiceURI` function on the [AIServiceRegistry](https://arbiscan.io/address/0x73f1755F34C2e769209E0F91a0c385722Ed81B9C) contract using the following command:
-
-    ```bash
-    cast send --account <WALLET_NAME> --rpc-url <ARBITRUM_RPC_URI> 0x73f1755F34C2e769209E0F91a0c385722Ed81B9C "setServiceURI(string)" https://<PUBLIC_ORCH_IP_OR_URL>:<PUBLIC_ORCH_PORT>
+    cast send --keystore '<PATH_TO_KEYSTORE_FILE>' --password '<PASSWORD>' --rpc-url <ARBITRUM_RPC_URI> 0x04C0b249740175999E5BF5c9ac1dA92431EF34C5 "setServiceURI(string)" https://<PUBLIC_ORCH_IP_OR_URL>:<PUBLIC_ORCH_PORT>
     ```
 
     If everything was successful, you should see the following output:
@@ -403,10 +397,10 @@ To ensure that _AI Gateway_ nodes can discover your _AI Subnet_ Orchestrator, yo
     effectiveGasPrice       11048000
     ```
 
-4. To check if your service URI was successfully written to the blockchain, call the `getServiceURI` function on the [AIServiceRegistry](https://arbiscan.io/address/0x73f1755F34C2e769209E0F91a0c385722Ed81B9C) contract using the following command:
+3. To check if your service URI was successfully written to the blockchain, call the `getServiceURI` function on the [AIServiceRegistry](https://arbiscan.io/address/0x5d31637eb0f442376053d5dea2347f663c4019dc) contract using the following command:
 
     ```bash
-    cast call --rpc-url <ARBITRUM_RPC_URI> 0x73f1755F34C2e769209E0F91a0c385722Ed81B9C "getServiceURI(address)" <PUBLIC_WALLET_KEY> | xxd -r -p
+    cast call --rpc-url <ARBITRUM_RPC_URI> 0x04C0b249740175999E5BF5c9ac1dA92431EF34C5 "getServiceURI(address)" <PUBLIC_WALLET_KEY> | xxd -r -p
     ```
 
     If successful, you should see the following output:

--- a/doc/ai-subnet.md
+++ b/doc/ai-subnet.md
@@ -371,7 +371,7 @@ After you have completed these steps, you can start your _Mainnet AI Subnet_ Orc
 
 #### Allow your AI Subnet Orchestrator to be Discovered
 
-To ensure that _AI Gateway_ nodes can discover your _AI Subnet_ Orchestrator, you need to write your service URI to the blockchain. This URI should be in the format `https://<PUBLIC_ORCH_IP_OR_URL>:<PUBLIC_ORCH_PORT>`. To write your service URI to the blockchain, follow these steps:
+To ensure that _AI Gateway_ nodes can discover your _AI Subnet_ Orchestrator, you need to write your service URI to the blockchain. This URI should be in the format `https://<PUBLIC_ORCH_IP_OR_URL>:<PUBLIC_ORCH_PORT>`. To write your service URI to the blockchain, go to the machine that contains your _Mainnet AI Subnet_ Orchestrator wallet and follow these steps:
 
 1. Install the [Foundry](https://book.getfoundry.sh/getting-started/installation) smart contract development toolchain:
 
@@ -381,7 +381,7 @@ To ensure that _AI Gateway_ nodes can discover your _AI Subnet_ Orchestrator, yo
     foundryup
     ```
 
-2. Connect your wallet to the Foundry cast using the following command:
+2. Connect your _Mainnet Transcoding Network_ Orchestrator wallet to the Foundry cast using the following command:
 
     ```bash
     cast wallet import <WALLET_NAME> --private-key <YOUR_PRIVATE_WALLET_KEY>

--- a/doc/ai-subnet.md
+++ b/doc/ai-subnet.md
@@ -369,6 +369,54 @@ The first and **recommended method** is to use the `ethOrchAddr` flag to set the
 
 After you have completed these steps, you can start your _Mainnet AI Subnet_ Orchestrator using the binary or Docker image.
 
+#### Allow your AI Subnet Orchestrator to be Discovered
+
+To ensure that _AI Gateway_ nodes can discover your _AI Subnet_ Orchestrator, you need to write your service URI to the blockchain. This URI should be in the format `https://<PUBLIC_ORCH_IP_OR_URL>:<PUBLIC_ORCH_PORT>`. To write your service URI to the blockchain, follow these steps:
+
+1. Install the [Foundry](https://book.getfoundry.sh/getting-started/installation) smart contract development toolchain:
+
+    ```bash
+    curl -L https://foundry.paradigm.xyz | bash
+    source /home/<USERNAME>/.bashrc
+    foundryup
+    ```
+
+2. Connect your wallet to the Foundry cast using the following command:
+
+    ```bash
+    cast wallet import <WALLET_NAME> --private-key <YOUR_PRIVATE_WALLET_KEY>
+    ```
+
+3. Call the `SetServiceURI` function on the [AIServiceRegistry](https://arbiscan.io/address/0x73f1755F34C2e769209E0F91a0c385722Ed81B9C) contract using the following command:
+
+    ```bash
+    cast send --account <WALLET_NAME> --rpc-url <ARBITRUM_RPC_URI> 0x73f1755F34C2e769209E0F91a0c385722Ed81B9C "setServiceURI(string)" https://<PUBLIC_ORCH_IP_OR_URL>:<PUBLIC_ORCH_PORT>
+    ```
+
+    If everything was successful, you should see the following output:
+
+    ```bash
+    blockHash               0x214a65d2dffd1732e971bd3662dcb681663c2eb0c95a33c8918bab0a44e2d3ed
+    blockNumber             200370198
+    contractAddress
+    cumulativeGasUsed       555214
+    effectiveGasPrice       11048000
+    ```
+
+4. To check if your service URI was successfully written to the blockchain, call the `getServiceURI` function on the [AIServiceRegistry](https://arbiscan.io/address/0x73f1755F34C2e769209E0F91a0c385722Ed81B9C) contract using the following command:
+
+    ```bash
+    cast call --rpc-url <ARBITRUM_RPC_URI> 0x73f1755F34C2e769209E0F91a0c385722Ed81B9C "getServiceURI(address)" <PUBLIC_WALLET_KEY> | xxd -r -p
+    ```
+
+    If successful, you should see the following output:
+
+    ```bash
+    https://<PUBLIC_ORCH_IP_OR_URL>:<PUBLIC_ORCH_PORT>
+    ```
+
+Congratulations! Your _Mainnet AI Subnet_ Orchestrator is now set up to be discovered by _AI Gateway_ nodes on the _AI Subnet_. 🚀
+
 #### Binary Startup Command
 
 To start your _Mainnet AI Subnet_ Orchestrator using the [pre-built binaries](https://discord.com/channels/423160867534929930/577736983036559360), use the following command:

--- a/eth/client.go
+++ b/eth/client.go
@@ -211,12 +211,23 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 
 	glog.V(common.SHORT).Infof("LivepeerToken: %v", c.tokenAddr.Hex())
 
-	// TODO: Replace with call to controller once `AIServiceRegistry` is added to the controller.
-	// serviceRegistryAddr, err := c.GetContract(crypto.Keccak256Hash([]byte("ServiceRegistry")))
-	serviceRegistryAddr := ethcommon.HexToAddress("0x73f1755F34C2e769209E0F91a0c385722Ed81B9C")
+	chainID, err := c.backend.ChainID(context.Background())
 	if err != nil {
-		glog.Errorf("Error getting ServiceRegistry address: %v", err)
+		glog.Errorf("Failed to get chain ID from remote ethereum node: %v", err)
 		return err
+	}
+
+	// TODO: This is a temporary setup for a separate AIServiceRegistry. Revise this when AI subnet merges with the mainnet.
+	var serviceRegistryAddr ethcommon.Address
+	arbitrumOneChainID := big.NewInt(42161)
+	if chainID.Cmp(arbitrumOneChainID) == 0 {
+		serviceRegistryAddr = ethcommon.HexToAddress("0x04C0b249740175999E5BF5c9ac1dA92431EF34C5")
+	} else {
+		serviceRegistryAddr, err = c.GetContract(crypto.Keccak256Hash([]byte("ServiceRegistry")))
+		if err != nil {
+			glog.Errorf("Error getting ServiceRegistry address: %v", err)
+			return err
+		}
 	}
 
 	c.serviceRegistryAddr = serviceRegistryAddr

--- a/eth/client.go
+++ b/eth/client.go
@@ -211,7 +211,9 @@ func (c *client) setContracts(opts *bind.TransactOpts) error {
 
 	glog.V(common.SHORT).Infof("LivepeerToken: %v", c.tokenAddr.Hex())
 
-	serviceRegistryAddr, err := c.GetContract(crypto.Keccak256Hash([]byte("ServiceRegistry")))
+	// TODO: Replace with call to controller once `AIServiceRegistry` is added to the controller.
+	// serviceRegistryAddr, err := c.GetContract(crypto.Keccak256Hash([]byte("ServiceRegistry")))
+	serviceRegistryAddr := ethcommon.HexToAddress("0x73f1755F34C2e769209E0F91a0c385722Ed81B9C")
 	if err != nil {
 		glog.Errorf("Error getting ServiceRegistry address: %v", err)
 		return err


### PR DESCRIPTION
This commit incorporates the AIServiceRegistry contract address, superseding the conventional ServiceRegistry contract address. This strategic alteration streamlines the discovery process of AI Orchestrators within the AI Subnet, thereby bolstering network accessibility and interaction. While this approach serves as a swift workaround to enable the feature without extensive code modification, it's important to note that it may disrupt the existing transcoding discovery mechanism. We have to fix this if we want to merge the two networks in the future.

> [!WARNING]
> Do not merge into the main branch this pull request breaks the discovery of the regular transcoding network.

**What does this pull request do? Explain your changes. (required)**

<!-- A clear and concise description of what this pull request does. -->

This pull request implements https://linear.app/livepeer-ai-spe/issue/LIV-90/design-and-implement-solution-for-advertising-separate-service-uri-for so that AI subnet orchestrators can be found by the AI gateway.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

-  `serviceRegistryAddr` was changed to a newly deployed [AIServiceRegistroyProxy](https://arbiscan.io/address/0x73f1755f34c2e769209e0f91a0c385722ed81b9c) contract. 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I checked if the service URIs of the orchestrators were to the values stored in the [AIServiceRegistroyProxy](https://arbiscan.io/address/0x73f1755f34c2e769209e0f91a0c385722ed81b9c) contract.  I have yet to test if an on-chain broadcaster can still send jobs.

**Does this pull request close any open issues?**

<!-- Fixes # -->

https://linear.app/livepeer-ai-spe/issue/LIV-90/design-and-implement-solution-for-advertising-separate-service-uri-for

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
