### PR TITLE
Log O AIModels config on startup

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -594,6 +594,12 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 					n.SetBasePriceForCap("default", core.Capability_ImageToVideo, config.ModelID, big.NewRat(config.PricePerUnit, config.PixelsPerUnit))
 				}
+
+				if len(aiCaps) > 0 {
+					capability := aiCaps[len(aiCaps)-1]
+					price := n.GetBasePriceForCap("default", capability, config.ModelID)
+					glog.V(6).Infof("Capability %s (ID: %v) advertised with model constraint %s at price %d per %d unit", config.Pipeline, capability, config.ModelID, price.Num(), price.Denom())
+				}
 			}
 		}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This change logs each advertised capability, model and price from the aiModels config when log level of info or debug is used.

Sample log lines:
```
I0423 23:44:26.940464  544271 starter.go:601] Capability text-to-image (ID: 27) advertised with model constraint ByteDance/SDXL-Lightning at price 4768371 per 1 unit
I0423 23:44:26.940511  544271 starter.go:601] Capability image-to-image (ID: 28) advertised with model constraint ByteDance/SDXL-Lightning at price 4768371 per 1 unit
I0423 23:44:26.940530  544271 starter.go:601] Capability image-to-video (ID: 29) advertised with model constraint stabilityai/stable-video-diffusion-img2vid-xt-1-1 at price 3390842 per 1 unit
```

**Specific updates (required)**
-  Updates `starter.go`, adding a new log line after the `aiModels.json` config is loaded when `-v` 6 is used. 

**How did you test each of these updates (required)**
- Loaded go-livepeer in orchestrator mode with -aiWorker and -aiModels config containing multiple models with different prices. Log result is shown above.

**Does this pull request close any open issues?**
--


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [] [Pending changelog](./CHANGELOG_PENDING.md) updated
