### PR TITLE
fix(ai): prevent insufficient capacity payments

### DIFF
--- a/core/ai.go
+++ b/core/ai.go
@@ -17,6 +17,7 @@ type AI interface {
 	ImageToVideo(context.Context, worker.ImageToVideoMultipartRequestBody) (*worker.VideoResponse, error)
 	Warm(context.Context, string, string, worker.RunnerEndpoint, worker.OptimizationFlags) error
 	Stop(context.Context) error
+	HasCapacity(pipeline, modelID string) bool
 }
 
 type AIModelConfig struct {

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -93,6 +93,11 @@ func (orch *orchestrator) CheckCapacity(mid ManifestID) error {
 	return nil
 }
 
+// CheckAICapacity verifies if the orchestrator can process a request for a specific pipeline and modelID.
+func (orch *orchestrator) CheckAICapacity(pipeline, modelID string) bool {
+	return orch.node.AIWorker.HasCapacity(pipeline, modelID)
+}
+
 func (orch *orchestrator) TranscodeSeg(ctx context.Context, md *SegTranscodingMetadata, seg *stream.HLSSegment) (*TranscodeResult, error) {
 	return orch.node.sendToTranscodeLoop(ctx, md, seg)
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/jaypipes/ghw v0.10.0
 	github.com/jaypipes/pcidb v1.0.0
-	github.com/livepeer/ai-worker v0.0.0-20240416102817-db751cd47fdc
+	github.com/livepeer/ai-worker v0.0.0-20240503212430-b8dc520fb581
 	github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b
 	github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18
 	github.com/livepeer/lpms v0.0.0-20240120150405-de94555cdc69

--- a/go.sum
+++ b/go.sum
@@ -532,8 +532,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-netroute v0.2.0/go.mod h1:Vio7LTzZ+6hoT4CMZi5/6CpY3Snzh2vgZhWgxMNwlQI=
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
-github.com/livepeer/ai-worker v0.0.0-20240416102817-db751cd47fdc h1:wmXT+pkcAshQ5yYiDLpoeIY0+P3Ob4RxHOljbS13FfA=
-github.com/livepeer/ai-worker v0.0.0-20240416102817-db751cd47fdc/go.mod h1:JvUlcQktSgkEfzotuelfw9OpjGi2qZTW/3tWB/klb/c=
+github.com/livepeer/ai-worker v0.0.0-20240503212430-b8dc520fb581 h1:PJLuYUl9N52foLyGq8lay/xSyF8v5FzLrJnVb2TG1Aw=
+github.com/livepeer/ai-worker v0.0.0-20240503212430-b8dc520fb581/go.mod h1:JvUlcQktSgkEfzotuelfw9OpjGi2qZTW/3tWB/klb/c=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b h1:VQcnrqtCA2UROp7q8ljkh2XA/u0KRgVv0S1xoUvOweE=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b/go.mod h1:hwJ5DKhl+pTanFWl+EUpw1H7ukPO/H+MFpgA7jjshzw=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cOQee+WqmaDOgGtP2oDMhcVvR4L0yA=

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -51,6 +51,7 @@ type Orchestrator interface {
 	Sign([]byte) ([]byte, error)
 	VerifySig(ethcommon.Address, string, []byte) bool
 	CheckCapacity(core.ManifestID) error
+	CheckAICapacity(pipeline, modelID string) bool
 	TranscodeSeg(context.Context, *core.SegTranscodingMetadata, *stream.HLSSegment) (*core.TranscodeResult, error)
 	ServeTranscoder(stream net.Transcoder_RegisterTranscoderServer, capacity int, capabilities *net.Capabilities)
 	TranscoderResults(job int64, res *core.RemoteTranscoderResult)


### PR DESCRIPTION
> [!WARNING]
> Depends on https://github.com/livepeer/ai-worker/pull/73 to be merged. Additionally the `mod.go` file should be updated to poitn to the right worker commit.

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This commit enhances the Orchestrator's capacity handling by returningan error prior to processing payments when capacity is insufficient. This prevents that the Gateway overpays for requests.

**Specific updates (required)**

- A new `CheckAICapacity` was added to the `core/orchestrator.go` file.
- The AI `handleAIRequest` method was changed so that the O first checks whether it can process a request before processing a payment.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**

<!-- Fixes # -->

https://linear.app/livepeer-ai-spe/issue/LIV-175/orchestrators-get-paid-for-unsuccessful-jobs

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
