### PR TITLE
Ai video cli endpoint for pool info

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -226,7 +226,6 @@ func (s *LivepeerServer) getAIPoolsHandler() http.Handler {
 			//get warmPool info
 			warmPoolInfo["Size"] = pool.warmPool.Size()
 			warmPoolInfo["InUse"] = len(pool.warmPool.inUseSess)
-			warmPoolInfo["Suspended"] = len(pool.warmPool.suspender.list)
 			if showDetail != "" {
 				var warmOrchInfos []interface{}
 				for _, sess := range pool.warmPool.sessMap {
@@ -234,7 +233,6 @@ func (s *LivepeerServer) getAIPoolsHandler() http.Handler {
 					orchInfo["Url"] = sess.Transcoder()
 					orchInfo["Latency"] = sess.LatencyScore
 					orchInfo["InFlight"] = len(sess.SegsInFlight)
-
 					warmOrchInfos = append(warmOrchInfos, orchInfo)
 				}
 				warmPoolInfo["Orchestrators"] = warmOrchInfos
@@ -243,7 +241,6 @@ func (s *LivepeerServer) getAIPoolsHandler() http.Handler {
 			//get coldPool info
 			coldPoolInfo["Size"] = pool.coldPool.Size()
 			coldPoolInfo["InUse"] = len(pool.coldPool.inUseSess)
-			coldPoolInfo["Suspended"] = len(pool.coldPool.suspender.list)
 			if showDetail != "" {
 				var coldOrchInfos []interface{}
 				for _, sess := range pool.coldPool.sessMap {
@@ -251,12 +248,20 @@ func (s *LivepeerServer) getAIPoolsHandler() http.Handler {
 					orchInfo["Url"] = sess.Transcoder()
 					orchInfo["Latency"] = sess.LatencyScore
 					orchInfo["InFlight"] = len(sess.SegsInFlight)
-
 					coldOrchInfos = append(coldOrchInfos, orchInfo)
 				}
 				coldPoolInfo["Orchestrators"] = coldOrchInfos
 			}
 			capPools["Cold"] = coldPoolInfo
+			//get info on suspended orchestrators
+			suspendedInfo := make(map[string]interface{})
+			suspendedInfo["Count"] = len(pool.suspender.list)
+			suspendedInfo["CurrentRefresh"] = pool.suspender.count
+			if showDetail != "" {
+				suspendedInfo["Orchestrators"] = pool.suspender.list
+			}
+
+			capPools["Suspended"] = suspendedInfo
 
 			aiPoolInfoResp[cap] = capPools
 		}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -213,16 +213,17 @@ func getAvailableTranscodingOptionsHandler() http.Handler {
 func (s *LivepeerServer) getAIPoolsHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		aiPoolInfoResp := make(map[string]interface{})
-		capPools := make(map[string]interface{})
-		warmPoolInfo := make(map[string]interface{})
-		coldPoolInfo := make(map[string]interface{})
 
 		glog.V(common.DEBUG).Infof("getting AI pool info for %d selectors", len(s.AISessionManager.selectors))
 		s.AISessionManager.mu.Lock()
 		defer s.AISessionManager.mu.Unlock()
 		showDetail := r.Header.Get("Show-Detail")
 		for cap, pool := range s.AISessionManager.selectors {
+			capPools := make(map[string]interface{})
 			glog.Infof("getting AI pool info for %s", cap)
+
+			warmPoolInfo := make(map[string]interface{})
+			coldPoolInfo := make(map[string]interface{})
 			//get warmPool info
 			warmPoolInfo["Size"] = pool.warmPool.Size()
 			warmPoolInfo["InUse"] = len(pool.warmPool.inUseSess)

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -49,6 +49,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 	mux.Handle("/setBroadcastConfig", mustHaveFormParams(setBroadcastConfigHandler()))
 	mux.Handle("/getBroadcastConfig", getBroadcastConfigHandler())
 	mux.Handle("/getAvailableTranscodingOptions", getAvailableTranscodingOptionsHandler())
+	mux.Handle("/getAIPools", s.getAIPoolsHandler())
 
 	// Rounds
 	mux.Handle("/currentRound", currentRoundHandler(client))


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds a cli webserver endpoint `/getAIPools` to provide some data on warm and cold pools for each selector ( [capability]_[model id] ).

Note that selectors are built after first request for capability/model.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add route to webserver.go and handler to handlers.go in server package
- Including header of "Show-Detail" adds the `Orchestrators` field to the warm and cold pools.  If not included, only the `InUse`,  Size` and `Suspended` fields are included in the response.


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Added endpoint, requested a AI job and ran:
`curl -H "Show-Detail: yes" http://127.0.0.1:5935/getAIPools`
Response:
`{"27_ByteDance/SDXL-Lightning":{"Cold":{"InUse":0,"Orchestrators":[{"InFlight":0,"Latency":0,"Url":"https://ai-testnet.ad-astra.video:9955"}],"Size":1,"Suspended":2},"Warm":{"InUse":0,"Orchestrators":null,"Size":0,"Suspended":2}}}`commits and

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
