### PR TITLE
Remove -pricePerUnit requirement for -aiWorker flag

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -879,7 +879,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 		if *cfg.Orchestrator {
 			// Set price per pixel base info
-			if cfg.PricePerUnit == nil && *cfg.AIWorker == false {
+			if cfg.PricePerUnit == nil && !*cfg.AIWorker {
 				// Prevent orchestrators from unknowingly providing free transcoding
 				panic(fmt.Errorf("-pricePerUnit must be set"))
 			} else if cfg.PricePerUnit != nil {

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -879,19 +879,16 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 		if *cfg.Orchestrator {
 			// Set price per pixel base info
-			if *cfg.PixelsPerUnit <= 0 {
-				// Can't divide by 0
-				panic(fmt.Errorf("-pixelsPerUnit must be > 0, provided %d", *cfg.PixelsPerUnit))
-			}
-			if cfg.PricePerUnit == nil {
-				// Prevent orchestrators from unknowingly providing free transcoding
+			if cfg.PricePerUnit == nil && *cfg.AIWorker == false {
 				panic(fmt.Errorf("-pricePerUnit must be set"))
+			} else if cfg.PricePerUnit != nil {
+				if *cfg.PricePerUnit < 0 {
+					panic(fmt.Errorf("-pricePerUnit must be >= 0, provided %d", *cfg.PricePerUnit))
+				}
+
+				n.SetBasePrice("default", big.NewRat(int64(*cfg.PricePerUnit), int64(*cfg.PixelsPerUnit)))
+				glog.Infof("Price: %d wei for %d pixels\n ", *cfg.PricePerUnit, *cfg.PixelsPerUnit)
 			}
-			if *cfg.PricePerUnit < 0 {
-				panic(fmt.Errorf("-pricePerUnit must be >= 0, provided %d", *cfg.PricePerUnit))
-			}
-			n.SetBasePrice("default", big.NewRat(int64(*cfg.PricePerUnit), int64(*cfg.PixelsPerUnit)))
-			glog.Infof("Price: %d wei for %d pixels\n ", *cfg.PricePerUnit, *cfg.PixelsPerUnit)
 
 			if *cfg.PricePerBroadcaster != "" {
 				ppb := getBroadcasterPrices(*cfg.PricePerBroadcaster)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -880,6 +880,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		if *cfg.Orchestrator {
 			// Set price per pixel base info
 			if cfg.PricePerUnit == nil && *cfg.AIWorker == false {
+				// Prevent orchestrators from unknowingly providing free transcoding
 				panic(fmt.Errorf("-pricePerUnit must be set"))
 			} else if cfg.PricePerUnit != nil {
 				if *cfg.PricePerUnit < 0 {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

This change removes the requirement for `-pricePerUnit` flag when both `-orchestrator` and `-aiWorker` flag are used. 

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates `starter.go` to check for `-aiWorker` flag before requiring `-pricePerUnit`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Verified go-livepeer starts without error when`-orchestrator`, `-aiWorker` flag are used without `-pricePerUnit`

- Verified go-livepeer still requires `-pricePerUnit` when `-orchestrator` flag is used without `-aiWorker`

- Verified `-pricePerUnit` still sets the default price for transcoding when `-orchestrator` is used without `-aiWorker`

**Does this pull request close any open issues?**
<!-- Fixes # -->
LIV-181 Remove the need for the pricePerUnit flag

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [] README and other documentation updated
- [] [Pending changelog](./CHANGELOG_PENDING.md) updated
