### PR TITLE
Add -gateway flag, deprecation warning for -broadcaster

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -139,7 +139,8 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	// Transcoding:
 	cfg.Orchestrator = flag.Bool("orchestrator", *cfg.Orchestrator, "Set to true to be an orchestrator")
 	cfg.Transcoder = flag.Bool("transcoder", *cfg.Transcoder, "Set to true to be a transcoder")
-	cfg.Broadcaster = flag.Bool("broadcaster", *cfg.Broadcaster, "Set to true to be a broadcaster")
+	cfg.Gateway = flag.Bool("gateway", *cfg.Broadcaster, "Set to true to be a gateway")
+	cfg.Broadcaster = flag.Bool("broadcaster", *cfg.Broadcaster, "Set to true to be a broadcaster (**Deprecated**, use -gateway)")
 	cfg.OrchSecret = flag.String("orchSecret", *cfg.OrchSecret, "Shared secret with the orchestrator as a standalone transcoder or path to file")
 	cfg.TranscodingOptions = flag.String("transcodingOptions", *cfg.TranscodingOptions, "Transcoding options for broadcast job, or path to json config")
 	cfg.MaxAttempts = flag.Int("maxAttempts", *cfg.MaxAttempts, "Maximum transcode attempts")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -91,6 +91,7 @@ type LivepeerConfig struct {
 	Orchestrator           *bool
 	Transcoder             *bool
 	AIWorker               *bool
+	Gateway                *bool
 	Broadcaster            *bool
 	OrchSecret             *string
 	TranscodingOptions     *string
@@ -167,6 +168,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultOrchestrator := false
 	defaultTranscoder := false
 	defaultBroadcaster := false
+	defaultGateway := false
 	defaultOrchSecret := ""
 	defaultTranscodingOptions := "P240p30fps16x9,P360p30fps16x9"
 	defaultMaxAttempts := 3
@@ -255,6 +257,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		// Transcoding:
 		Orchestrator:         &defaultOrchestrator,
 		Transcoder:           &defaultTranscoder,
+		Gateway:              &defaultGateway,
 		Broadcaster:          &defaultBroadcaster,
 		OrchSecret:           &defaultOrchSecret,
 		TranscodingOptions:   &defaultTranscodingOptions,
@@ -629,6 +632,9 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	} else if *cfg.Transcoder {
 		n.NodeType = core.TranscoderNode
 	} else if *cfg.Broadcaster {
+		n.NodeType = core.BroadcasterNode
+		glog.Warning("-broadcaster flag is deprecated and will be removed in a future release. Please use -gateway instead")
+	} else if *cfg.Gateway {
 		n.NodeType = core.BroadcasterNode
 	} else if (cfg.Reward == nil || !*cfg.Reward) && !*cfg.InitializeRound {
 		exit("No services enabled; must be at least one of -broadcaster, -transcoder, -orchestrator, -redeemer, -reward or -initializeRound")
@@ -1357,7 +1363,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	case core.OrchestratorNode:
 		glog.Infof("***Livepeer Running in Orchestrator Mode***")
 	case core.BroadcasterNode:
-		glog.Infof("***Livepeer Running in Broadcaster Mode***")
+		glog.Infof("***Livepeer Running in Gateway Mode***")
 		glog.Infof("Video Ingest Endpoint - rtmp://%v", *cfg.RtmpAddr)
 	case core.TranscoderNode:
 		glog.Infof("**Liveepeer Running in Transcoder Mode***")


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds the new -gateway flag while maintaining support for `-broadcaster` with a deprecation warning on startup. This change does not address refactoring associated with variable names and types, which will be addressed in a later change.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates starter.go and livepeer.go to include the `-gateway` flag
- Adds deprecation warning to startup and cli help

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Started a gateway node using the `-gateway` flag
- Started a gateway node using the `-broadcaster` flag, noted deprecation warning

```
W0508 01:33:14.643250  158728 starter.go:636] -broadcaster flag is deprecated and will be removed in a future release. Please use -gateway instead
```

**Does this pull request close any open issues?**
<!-- Fixes # -->
LIV-287 Allow users to use -gateway instead of -broadcaster

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
