### PR TITLE
refactor: add -gateway and deprecate -broadcaster

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,8 @@
 
 ## vX.X
 
+- [#3053](https://github.com/livepeer/go-livepeer/pull/3053) cli: add `-gateway` flag and deprecate `-broadcaster` flag.
+
 ### Breaking Changes 🚨🚨
 
 ### Features ⚒

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -140,7 +140,8 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	// Transcoding:
 	cfg.Orchestrator = flag.Bool("orchestrator", *cfg.Orchestrator, "Set to true to be an orchestrator")
 	cfg.Transcoder = flag.Bool("transcoder", *cfg.Transcoder, "Set to true to be a transcoder")
-	cfg.Broadcaster = flag.Bool("broadcaster", *cfg.Broadcaster, "Set to true to be a broadcaster")
+	cfg.Gateway = flag.Bool("gateway", *cfg.Broadcaster, "Set to true to be a gateway")
+	cfg.Broadcaster = flag.Bool("broadcaster", *cfg.Broadcaster, "Set to true to be a broadcaster (**Deprecated**, use -gateway)")
 	cfg.OrchSecret = flag.String("orchSecret", *cfg.OrchSecret, "Shared secret with the orchestrator as a standalone transcoder or path to file")
 	cfg.TranscodingOptions = flag.String("transcodingOptions", *cfg.TranscodingOptions, "Transcoding options for broadcast job, or path to json config")
 	cfg.MaxAttempts = flag.Int("maxAttempts", *cfg.MaxAttempts, "Maximum transcode attempts")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -87,6 +87,7 @@ type LivepeerConfig struct {
 	HttpIngest              *bool
 	Orchestrator            *bool
 	Transcoder              *bool
+	Gateway                 *bool
 	Broadcaster             *bool
 	OrchSecret              *string
 	TranscodingOptions      *string
@@ -164,6 +165,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultOrchestrator := false
 	defaultTranscoder := false
 	defaultBroadcaster := false
+	defaultGateway := false
 	defaultOrchSecret := ""
 	defaultTranscodingOptions := "P240p30fps16x9,P360p30fps16x9"
 	defaultMaxAttempts := 3
@@ -250,6 +252,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		// Transcoding:
 		Orchestrator:         &defaultOrchestrator,
 		Transcoder:           &defaultTranscoder,
+		Gateway:              &defaultGateway,
 		Broadcaster:          &defaultBroadcaster,
 		OrchSecret:           &defaultOrchSecret,
 		TranscodingOptions:   &defaultTranscodingOptions,
@@ -500,6 +503,9 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	} else if *cfg.Transcoder {
 		n.NodeType = core.TranscoderNode
 	} else if *cfg.Broadcaster {
+		n.NodeType = core.BroadcasterNode
+		glog.Warning("-broadcaster flag is deprecated and will be removed in a future release. Please use -gateway instead")
+	} else if *cfg.Gateway {
 		n.NodeType = core.BroadcasterNode
 	} else if (cfg.Reward == nil || !*cfg.Reward) && !*cfg.InitializeRound {
 		exit("No services enabled; must be at least one of -broadcaster, -transcoder, -orchestrator, -redeemer, -reward or -initializeRound")
@@ -1273,7 +1279,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	case core.OrchestratorNode:
 		glog.Infof("***Livepeer Running in Orchestrator Mode***")
 	case core.BroadcasterNode:
-		glog.Infof("***Livepeer Running in Broadcaster Mode***")
+		glog.Infof("***Livepeer Running in Gateway Mode***")
 		glog.Infof("Video Ingest Endpoint - rtmp://%v", *cfg.RtmpAddr)
 	case core.TranscoderNode:
 		glog.Infof("**Liveepeer Running in Transcoder Mode***")


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request adds the `gateway` flag and deprecates the `broadcaster` flag per core team decision (details: https://discord.com/channels/423160867534929930/1051963444598943784/1210356864643109004). It adds the new `-gateway` flag while maintaining support for `-broadcaster` with a deprecation warning on startup. This change does not address refactoring associated with variable names and types, which will be addressed in a later change.

**Specific updates (required)**

<!--- List out all significant updates your code introduces -->
- Updates starter.go and livepeer.go to include the `-gateway` flag
- Adds deprecation warning to startup and cli help

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Started a gateway node using the `-gateway` flag
- Started a gateway node using the `-broadcaster` flag, noted deprecation warning

```
W0508 01:33:14.643250  158728 starter.go:636] -broadcaster flag is deprecated and will be removed in a future release. Please use -gateway instead
```

**Does this pull request close any open issues?**
<!-- Fixes # -->

[AI-LIV-287](https://linear.app/livepeer-ai-spe/issue/LIV-287/allow-users-to-use-gateway-instead-of-broadcaster)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
    - The `TestSubmitSegment_HttpPostError` server test does fails on my system but I don't think it is related to my changes since it also fails on the master branch (see logs below).  
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated

<details>
 <summary>Test Logs</summary>

```bash
--- FAIL: TestSubmitSegment_HttpPostError (0.00s)
    segment_rpc_test.go:1708:
                Error Trace:    /home/ricks/development/work/livepeer/ai_spe/go-livepeer/server/segment_rpc_test.go:1708
                Error:          "<html>\r\n<head><title>404 Not Found</title></head>\r\n<body>\r\n<center><h1>404 Not Found</h1></center>\r\n<hr><center>nginx/1.18.0 (Ubuntu)</center>\r\n</body>\r\n</html>" does not contain "connection refused"
                Test:           TestSubmitSegment_HttpPostError
    segment_rpc_test.go:1722:
                Error Trace:    /home/ricks/development/work/livepeer/ai_spe/go-livepeer/server/segment_rpc_test.go:1722
                Error:          "<html>\r\n<head><title>404 Not Found</title></head>\r\n<body>\r\n<center><h1>404 Not Found</h1></center>\r\n<hr><center>nginx/1.18.0 (Ubuntu)</center>\r\n</body>\r\n</html>" does not contain "connection refused"
                Test:           TestSubmitSegment_HttpPostError
    segment_rpc_test.go:1723:
                Error Trace:    /home/ricks/development/work/livepeer/ai_spe/go-livepeer/server/segment_rpc_test.go:1723
                Error:          Should have called with given arguments
                Test:           TestSubmitSegment_HttpPostError
                Messages:       Expected "Credit" to have been called with:
                                [5/1]
                                but actual calls were:
                                        [0/1 0/1]
I0516 11:25:12.911218   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:34711 Submitting segment bytes=0 orch=https://127.0.0.1:34711 timeout=8s uploadTimeout=2s segDur=0
E0516 11:25:12.914238   52957 segment_rpc.go:517] orchSessionID=bar orchestrator=https://127.0.0.1:34711 Error submitting segment code=500 orch=https://127.0.0.1:34711 err="Server error\n"
I0516 11:25:12.914462   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:34711 Submitting segment bytes=0 orch=https://127.0.0.1:34711 timeout=8s uploadTimeout=2s segDur=0
E0516 11:25:12.914745   52957 segment_rpc.go:517] orchSessionID=bar orchestrator=https://127.0.0.1:34711 Error submitting segment code=500 orch=https://127.0.0.1:34711 err="Server error\n"
I0516 11:25:12.915276   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Submitting segment bytes=0 orch=https://127.0.0.1:43067 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:12.918022   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Uploaded segment orch=https://127.0.0.1:43067 dur=2.725044ms
E0516 11:25:12.918049   52957 segment_rpc.go:547] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Unable to parse response for segment orch=https://127.0.0.1:43067 err="proto:\u00a0cannot parse invalid wire-format data"
I0516 11:25:12.918272   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Submitting segment bytes=0 orch=https://127.0.0.1:43067 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:12.918462   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Uploaded segment orch=https://127.0.0.1:43067 dur=174.831µs
E0516 11:25:12.918485   52957 segment_rpc.go:547] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Unable to parse response for segment orch=https://127.0.0.1:43067 err="proto:\u00a0cannot parse invalid wire-format data"
I0516 11:25:12.919131   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Submitting segment bytes=0 orch=https://127.0.0.1:41209 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:12.921861   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Uploaded segment orch=https://127.0.0.1:41209 dur=2.709865ms
E0516 11:25:12.921889   52957 segment_rpc.go:559] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Transcode failed for segment orch=https://127.0.0.1:41209 err="TranscodeResult error"
I0516 11:25:12.922110   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Submitting segment bytes=0 orch=https://127.0.0.1:41209 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:12.922289   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Uploaded segment orch=https://127.0.0.1:41209 dur=163.199µs
E0516 11:25:12.922314   52957 segment_rpc.go:559] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Transcode failed for segment orch=https://127.0.0.1:41209 err="TranscodeResult error"
I0516 11:25:12.922824   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=8s uploadTimeout=2s segDur=0.05
I0516 11:25:12.924557   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=1.714229ms
I0516 11:25:12.924579   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=17.904µs
I0516 11:25:12.924677   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=200ms uploadTimeout=100ms segDur=0.05
E0516 11:25:13.025117   52957 segment_rpc.go:498] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Unable to submit segment orch=https://127.0.0.1:37551 orch=https://127.0.0.1:37551 uploadDur=100.414966ms err="Post \"https://127.0.0.1:37551/segment\": context canceled"
I0516 11:25:13.025248   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=200ms uploadTimeout=100ms segDur=0.05
I0516 11:25:13.075494   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=50.231763ms
I0516 11:25:13.075522   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=21.12µs
I0516 11:25:13.075619   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=200ms uploadTimeout=100ms segDur=0.05
I0516 11:25:13.075762   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=128.954µs
E0516 11:25:13.275808   52957 segment_rpc.go:536] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Unable to read response body for segment orch=https://127.0.0.1:37551 err="context deadline exceeded"
I0516 11:25:13.275975   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=200ms uploadTimeout=100ms segDur=0.05
I0516 11:25:13.276271   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=275.552µs
I0516 11:25:13.276304   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=28.134µs
I0516 11:25:13.276436   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=1s uploadTimeout=100ms segDur=0
I0516 11:25:13.276650   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=191.734µs
I0516 11:25:13.776831   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=500.16207ms
I0516 11:25:13.777007   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=1s uploadTimeout=100ms segDur=-0.01
I0516 11:25:13.777283   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=256.867µs
I0516 11:25:14.277364   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=500.049988ms
I0516 11:25:14.277537   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=1s uploadTimeout=100ms segDur=0.01
I0516 11:25:14.277839   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=282.846µs
I0516 11:25:14.777906   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=500.045339ms
I0516 11:25:14.778077   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=40ms uploadTimeout=100ms segDur=0.01
I0516 11:25:14.778326   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=232.811µs
E0516 11:25:14.818109   52957 segment_rpc.go:536] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Unable to read response body for segment orch=https://127.0.0.1:37551 err="context deadline exceeded"
I0516 11:25:14.818821   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=1024 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:14.922630   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=103.782918ms
I0516 11:25:14.922672   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:43311 dur=27.462µs
I0516 11:25:14.922814   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=1024 orch=https://127.0.0.1:43311 timeout=20s uploadTimeout=2.5s segDur=5
I0516 11:25:15.023352   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.519222ms
I0516 11:25:15.023396   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:43311 dur=27.792µs
I0516 11:25:15.023490   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=1024 orch=https://127.0.0.1:43311 timeout=40s uploadTimeout=5s segDur=10
I0516 11:25:15.123756   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.249021ms
I0516 11:25:15.123801   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:43311 dur=32.411µs
I0516 11:25:15.123911   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=1024 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0.5
I0516 11:25:15.224246   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.318522ms
I0516 11:25:15.224279   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:43311 dur=25.688µs
I0516 11:25:15.224399   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=1024 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0.5
I0516 11:25:15.324825   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.403794ms
I0516 11:25:15.324876   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:43311 dur=39.495µs
I0516 11:25:15.325043   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.425445   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.382464ms
I0516 11:25:15.425480   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=24.497µs
I0516 11:25:15.425642   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.525970   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.307711ms
I0516 11:25:15.526032   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=46.739µs
I0516 11:25:15.526401   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.627296   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.866411ms
I0516 11:25:15.627350   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=39.314µs
I0516 11:25:15.627594   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.727966   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.351675ms
I0516 11:25:15.728025   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=39.134µs
I0516 11:25:15.728404   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.828851   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.422889ms
I0516 11:25:15.828920   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=44.735µs
I0516 11:25:15.829336   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.929677   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.316568ms
I0516 11:25:15.929729   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=34.215µs
I0516 11:25:15.930003   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:16.030328   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.307993ms
I0516 11:25:16.030376   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=32.151µs
W0516 11:25:16.032082   52957 selection_algorithm.go:52] No Orchestrators passed min performance score filter, not using the filter
W0516 11:25:16.032119   52957 selection_algorithm.go:52] No Orchestrators passed min performance score filter, not using the filter
W0516 11:25:16.032152   52957 selection_algorithm.go:75] No Orchestrators passed max price filter, not using the filter
I0516 11:25:16.072877   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.072907   52957 broadcast.go:363] [PublicLogs] Swapping from orch=transcoder2 to orch=[transcoder1] for manifestID=test
I0516 11:25:16.072918   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.072925   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 2
I0516 11:25:16.073134   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.073143   52957 broadcast.go:363] [PublicLogs] Swapping from orch=transcoder2 to orch=[transcoder1] for manifestID=test
I0516 11:25:16.073157   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.073164   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.073603   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.073668   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.077030   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:16.077105   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.077126   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:16.077149   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:17.677374   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:17.677432   52957 broadcast.go:363] [PublicLogs] Swapping from orch=transcoder2 to orch=[transcoder1] for manifestID=test
I0516 11:25:17.677461   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:18.677563   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:18.677639   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.277711   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.277760   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.277769   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 2
I0516 11:25:20.278154   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278174   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278180   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278195   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278202   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278207   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278214   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278220   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278227   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:21.078470   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:21.078511   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:21.078519   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:21.878608   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:21.878646   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:21.878652   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:21.878657   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 2
I0516 11:25:21.878661   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 2
I0516 11:25:21.878665   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 2
FAIL
coverage: 31.5% of statements
FAIL    github.com/livepeer/go-livepeer/server  24.791s
ok      github.com/livepeer/go-livepeer/verification    3.478s  coverage: 3.7% of statements
```
</details>
