### PR TITLE
refactor: add -pricePerGateway and deprecate -pricePerBroadcaster

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,7 @@
 
 -   [#3055](https://github.com/livepeer/go-livepeer/pull/3055) census: Rename broadcaster metrics to gateway metrics
 -   [#3053](https://github.com/livepeer/go-livepeer/pull/3053) cli: add `-gateway` flag and deprecate `-broadcaster` flag.
+-   [#3056](https://github.com/livepeer/go-livepeer/pull/3056) cli: add `-pricePerGateway` flag and deprecate `-pricePerBroadcaster` flag.
 
 ### Breaking Changes 🚨🚨
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -179,6 +179,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.PixelsPerUnit = flag.String("pixelsPerUnit", *cfg.PixelsPerUnit, "Amount of pixels per unit. Set to '> 1' to have smaller price granularity than 1 wei / pixel")
 	cfg.PriceFeedAddr = flag.String("priceFeedAddr", *cfg.PriceFeedAddr, "ETH address of the Chainlink price feed contract. Used for custom currencies conversion on -pricePerUnit or -maxPricePerUnit")
 	cfg.AutoAdjustPrice = flag.Bool("autoAdjustPrice", *cfg.AutoAdjustPrice, "Enable/disable automatic price adjustments based on the overhead for redeeming tickets")
+	cfg.PricePerGateway = flag.String("pricePerGateway", *cfg.PricePerGateway, `json list of price per gateway or path to json config file. Example: {"broadcasters":[{"ethaddress":"address1","priceperunit":0.5,"currency":"USD","pixelsperunit":1000000000000},{"ethaddress":"address2","priceperunit":0.3,"currency":"USD","pixelsperunit":1000000000000}]}`)
 	cfg.PricePerBroadcaster = flag.String("pricePerBroadcaster", *cfg.PricePerBroadcaster, `json list of price per broadcaster or path to json config file. Example: {"broadcasters":[{"ethaddress":"address1","priceperunit":0.5,"currency":"USD","pixelsperunit":1000000000000},{"ethaddress":"address2","priceperunit":0.3,"currency":"USD","pixelsperunit":1000000000000}]}`)
 	// Interval to poll for blocks
 	cfg.BlockPollingInterval = flag.Int("blockPollingInterval", *cfg.BlockPollingInterval, "Interval in seconds at which different blockchain event services poll for blocks")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -787,7 +787,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 			n.SetBasePrice("default", autoPrice)
 
-			if cfg.PricePerBroadcaster != nil {
+			if *cfg.PricePerBroadcaster != "" {
 				glog.Warning("-PricePerBroadcaster flag is deprecated and will be removed in a future release. Please use -PricePerGateway instead")
 				cfg.PricePerGateway = cfg.PricePerBroadcaster
 			}

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -126,6 +126,7 @@ type LivepeerConfig struct {
 	PixelsPerUnit           *string
 	PriceFeedAddr           *string
 	AutoAdjustPrice         *bool
+	PricePerGateway         *string
 	PricePerBroadcaster     *string
 	BlockPollingInterval    *int
 	Redeemer                *bool
@@ -204,6 +205,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultPixelsPerUnit := "1"
 	defaultPriceFeedAddr := "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612" // ETH / USD price feed address on Arbitrum Mainnet
 	defaultAutoAdjustPrice := true
+	defaultPricePerGateway := ""
 	defaultPricePerBroadcaster := ""
 	defaultBlockPollingInterval := 5
 	defaultRedeemer := false
@@ -292,6 +294,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		PixelsPerUnit:           &defaultPixelsPerUnit,
 		PriceFeedAddr:           &defaultPriceFeedAddr,
 		AutoAdjustPrice:         &defaultAutoAdjustPrice,
+		PricePerGateway:         &defaultPricePerGateway,
 		PricePerBroadcaster:     &defaultPricePerBroadcaster,
 		BlockPollingInterval:    &defaultBlockPollingInterval,
 		Redeemer:                &defaultRedeemer,
@@ -784,6 +787,11 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 			n.SetBasePrice("default", autoPrice)
 
+			// TODO: Keep old flag for backwards compatibility, remove in the future
+			if cfg.PricePerBroadcaster != nil {
+				glog.Warning("-PricePerBroadcaster flag is deprecated and will be removed in a future release. Please use -PricePerGateway instead")
+				cfg.PricePerGateway = cfg.PricePerBroadcaster
+			}
 			broadcasterPrices := getBroadcasterPrices(*cfg.PricePerBroadcaster)
 			for _, p := range broadcasterPrices {
 				p := p

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -787,7 +787,6 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 			n.SetBasePrice("default", autoPrice)
 
-			// TODO: Keep old flag for backwards compatibility, remove in the future
 			if cfg.PricePerBroadcaster != nil {
 				glog.Warning("-PricePerBroadcaster flag is deprecated and will be removed in a future release. Please use -PricePerGateway instead")
 				cfg.PricePerGateway = cfg.PricePerBroadcaster

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -791,7 +791,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				glog.Warning("-PricePerBroadcaster flag is deprecated and will be removed in a future release. Please use -PricePerGateway instead")
 				cfg.PricePerGateway = cfg.PricePerBroadcaster
 			}
-			broadcasterPrices := getBroadcasterPrices(*cfg.PricePerBroadcaster)
+			broadcasterPrices := getBroadcasterPrices(*cfg.PricePerGateway)
 			for _, p := range broadcasterPrices {
 				p := p
 				pricePerPixel := new(big.Rat).Quo(p.PricePerUnit, p.PixelsPerUnit)
@@ -1489,20 +1489,20 @@ func checkOrStoreChainID(dbh *common.DB, chainID *big.Int) error {
 	return nil
 }
 
-type BroadcasterPrice struct {
+type GatewayPrice struct {
 	EthAddress    string
 	PricePerUnit  *big.Rat
 	Currency      string
 	PixelsPerUnit *big.Rat
 }
 
-func getBroadcasterPrices(broadcasterPrices string) []BroadcasterPrice {
-	if broadcasterPrices == "" {
+func getGatewayPrices(gatewayPrices string) []BroadcasterPrice {
+	if gatewayPrices == "" {
 		return nil
 	}
 
-	// Format of broadcasterPrices json
-	// {"broadcasters":[{"ethaddress":"address1","priceperunit":0.5,"currency":"USD","pixelsperunit":1}, {"ethaddress":"address2","priceperunit":0.3,"currency":"USD","pixelsperunit":3}]}
+	// Format of gatewayPrices json
+	// {"gateways":[{"ethaddress":"address1","priceperunit":0.5,"currency":"USD","pixelsperunit":1}, {"ethaddress":"address2","priceperunit":0.3,"currency":"USD","pixelsperunit":3}]}
 	var pricesSet struct {
 		Broadcasters []struct {
 			EthAddress string `json:"ethaddress"`

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -2,6 +2,7 @@ package starter
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -90,16 +91,22 @@ func TestIsLocalURL(t *testing.T) {
 func TestParseGetBroadcasterPrices(t *testing.T) {
 	assert := assert.New(t)
 
-	j := `{"broadcasters":[{"ethaddress":"0x0000000000000000000000000000000000000000","priceperunit":1000,"pixelsperunit":1}, {"ethaddress":"0x1000000000000000000000000000000000000000","priceperunit":2000,"pixelsperunit":3}]}`
+	// TODO: Keep checking old field for backwards compatibility, remove in future
+	jsonTemplate := `{"%s":[{"ethaddress":"0x0000000000000000000000000000000000000000","priceperunit":1000,"pixelsperunit":1}, {"ethaddress":"0x1000000000000000000000000000000000000000","priceperunit":2000,"pixelsperunit":3}]}`
+	testCases := []string{"gateways", "broadcasters"}
 
-	prices := getBroadcasterPrices(j)
-	assert.NotNil(prices)
-	assert.Equal(2, len(prices))
+	for _, tc := range testCases {
+		jsonStr := fmt.Sprintf(jsonTemplate, tc)
 
-	price1 := new(big.Rat).Quo(prices[0].PricePerUnit, prices[0].PixelsPerUnit)
-	price2 := new(big.Rat).Quo(prices[1].PricePerUnit, prices[1].PixelsPerUnit)
-	assert.Equal(big.NewRat(1000, 1), price1)
-	assert.Equal(big.NewRat(2000, 3), price2)
+		prices := getGatewayPrices(jsonStr)
+		assert.NotNil(prices)
+		assert.Equal(2, len(prices))
+
+		price1 := new(big.Rat).Quo(prices[0].PricePerUnit, prices[0].PixelsPerUnit)
+		price2 := new(big.Rat).Quo(prices[1].PricePerUnit, prices[1].PixelsPerUnit)
+		assert.Equal(big.NewRat(1000, 1), price1)
+		assert.Equal(big.NewRat(2000, 3), price2)
+	}
 }
 
 // Address provided to keystore file

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -88,7 +88,7 @@ func TestIsLocalURL(t *testing.T) {
 	assert.False(isLocal)
 }
 
-func TestParseGetBroadcasterPrices(t *testing.T) {
+func TestParseGetGatewayPrices(t *testing.T) {
 	assert := assert.New(t)
 
 	// TODO: Keep checking old field for backwards compatibility, remove in future


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request adds the `pricePerGateway` flag and deprecates the `pricePerBroadcaster` flag per core team decision (details: https://discord.com/channels/423160867534929930/1051963444598943784/1210356864643109004). It adds the new `-pricePerGateway` flag while maintaining support for `-pricePerBroadcaster` with a deprecation warning on startup. This change does not address refactoring associated with variable names and types, which will be addressed in a later change.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

- Updates starter.go and livepeer.go to include the `-pricePerGateway` flag
- Updates the `getBroadcasters` function to parse the `gateways` property instead of the `broadcasters` property.
- Adds deprecation warnings to startup and cli help

```bash
W0516 11:37:39.563931   97531 starter.go:785] -PricePerBroadcaster flag is deprecated and will be removed in a future release. Please use -PricePerGateway instead
```

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Started a on-chain orchestrator node using the `-pricePerGateway` flag
- Started a on-chain orchestrator node using the `-pricePerBroadcaster` flag, noted deprecation warning
- Started a on-chain orchestrator node while using the `broadcasters` property in the config specified in the `-pricePerGateway` flag, noted deprecation warning.

**Does this pull request close any open issues?**
<!-- Fixes # -->

[AI-LIV-358](https://linear.app/livepeer-ai-spe/issue/LIV-358/rename-priceperbroadcaster-flag-with-pricepergateway)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
    - The `TestSubmitSegment_HttpPostError` server test does fails on my system but I don't think it is related to my changes
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated


<details>
 <summary>Test Logs</summary>

```bash
--- FAIL: TestSubmitSegment_HttpPostError (0.00s)
    segment_rpc_test.go:1708:
                Error Trace:    /home/ricks/development/work/livepeer/ai_spe/go-livepeer/server/segment_rpc_test.go:1708
                Error:          "<html>\r\n<head><title>404 Not Found</title></head>\r\n<body>\r\n<center><h1>404 Not Found</h1></center>\r\n<hr><center>nginx/1.18.0 (Ubuntu)</center>\r\n</body>\r\n</html>" does not contain "connection refused"
                Test:           TestSubmitSegment_HttpPostError
    segment_rpc_test.go:1722:
                Error Trace:    /home/ricks/development/work/livepeer/ai_spe/go-livepeer/server/segment_rpc_test.go:1722
                Error:          "<html>\r\n<head><title>404 Not Found</title></head>\r\n<body>\r\n<center><h1>404 Not Found</h1></center>\r\n<hr><center>nginx/1.18.0 (Ubuntu)</center>\r\n</body>\r\n</html>" does not contain "connection refused"
                Test:           TestSubmitSegment_HttpPostError
    segment_rpc_test.go:1723:
                Error Trace:    /home/ricks/development/work/livepeer/ai_spe/go-livepeer/server/segment_rpc_test.go:1723
                Error:          Should have called with given arguments
                Test:           TestSubmitSegment_HttpPostError
                Messages:       Expected "Credit" to have been called with:
                                [5/1]
                                but actual calls were:
                                        [0/1 0/1]
I0516 11:25:12.911218   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:34711 Submitting segment bytes=0 orch=https://127.0.0.1:34711 timeout=8s uploadTimeout=2s segDur=0
E0516 11:25:12.914238   52957 segment_rpc.go:517] orchSessionID=bar orchestrator=https://127.0.0.1:34711 Error submitting segment code=500 orch=https://127.0.0.1:34711 err="Server error\n"
I0516 11:25:12.914462   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:34711 Submitting segment bytes=0 orch=https://127.0.0.1:34711 timeout=8s uploadTimeout=2s segDur=0
E0516 11:25:12.914745   52957 segment_rpc.go:517] orchSessionID=bar orchestrator=https://127.0.0.1:34711 Error submitting segment code=500 orch=https://127.0.0.1:34711 err="Server error\n"
I0516 11:25:12.915276   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Submitting segment bytes=0 orch=https://127.0.0.1:43067 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:12.918022   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Uploaded segment orch=https://127.0.0.1:43067 dur=2.725044ms
E0516 11:25:12.918049   52957 segment_rpc.go:547] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Unable to parse response for segment orch=https://127.0.0.1:43067 err="proto:\u00a0cannot parse invalid wire-format data"
I0516 11:25:12.918272   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Submitting segment bytes=0 orch=https://127.0.0.1:43067 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:12.918462   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Uploaded segment orch=https://127.0.0.1:43067 dur=174.831µs
E0516 11:25:12.918485   52957 segment_rpc.go:547] orchSessionID=bar orchestrator=https://127.0.0.1:43067 Unable to parse response for segment orch=https://127.0.0.1:43067 err="proto:\u00a0cannot parse invalid wire-format data"
I0516 11:25:12.919131   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Submitting segment bytes=0 orch=https://127.0.0.1:41209 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:12.921861   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Uploaded segment orch=https://127.0.0.1:41209 dur=2.709865ms
E0516 11:25:12.921889   52957 segment_rpc.go:559] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Transcode failed for segment orch=https://127.0.0.1:41209 err="TranscodeResult error"
I0516 11:25:12.922110   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Submitting segment bytes=0 orch=https://127.0.0.1:41209 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:12.922289   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Uploaded segment orch=https://127.0.0.1:41209 dur=163.199µs
E0516 11:25:12.922314   52957 segment_rpc.go:559] orchSessionID=bar orchestrator=https://127.0.0.1:41209 Transcode failed for segment orch=https://127.0.0.1:41209 err="TranscodeResult error"
I0516 11:25:12.922824   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=8s uploadTimeout=2s segDur=0.05
I0516 11:25:12.924557   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=1.714229ms
I0516 11:25:12.924579   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=17.904µs
I0516 11:25:12.924677   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=200ms uploadTimeout=100ms segDur=0.05
E0516 11:25:13.025117   52957 segment_rpc.go:498] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Unable to submit segment orch=https://127.0.0.1:37551 orch=https://127.0.0.1:37551 uploadDur=100.414966ms err="Post \"https://127.0.0.1:37551/segment\": context canceled"
I0516 11:25:13.025248   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=200ms uploadTimeout=100ms segDur=0.05
I0516 11:25:13.075494   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=50.231763ms
I0516 11:25:13.075522   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=21.12µs
I0516 11:25:13.075619   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=200ms uploadTimeout=100ms segDur=0.05
I0516 11:25:13.075762   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=128.954µs
E0516 11:25:13.275808   52957 segment_rpc.go:536] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Unable to read response body for segment orch=https://127.0.0.1:37551 err="context deadline exceeded"
I0516 11:25:13.275975   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=200ms uploadTimeout=100ms segDur=0.05
I0516 11:25:13.276271   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=275.552µs
I0516 11:25:13.276304   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=28.134µs
I0516 11:25:13.276436   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=1s uploadTimeout=100ms segDur=0
I0516 11:25:13.276650   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=191.734µs
I0516 11:25:13.776831   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=500.16207ms
I0516 11:25:13.777007   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=1s uploadTimeout=100ms segDur=-0.01
I0516 11:25:13.777283   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=256.867µs
I0516 11:25:14.277364   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=500.049988ms
I0516 11:25:14.277537   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=1s uploadTimeout=100ms segDur=0.01
I0516 11:25:14.277839   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=282.846µs
I0516 11:25:14.777906   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:37551 dur=500.045339ms
I0516 11:25:14.778077   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Submitting segment bytes=0 orch=https://127.0.0.1:37551 timeout=40ms uploadTimeout=100ms segDur=0.01
I0516 11:25:14.778326   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Uploaded segment orch=https://127.0.0.1:37551 dur=232.811µs
E0516 11:25:14.818109   52957 segment_rpc.go:536] orchSessionID=bar orchestrator=https://127.0.0.1:37551 Unable to read response body for segment orch=https://127.0.0.1:37551 err="context deadline exceeded"
I0516 11:25:14.818821   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=1024 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:14.922630   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=103.782918ms
I0516 11:25:14.922672   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:43311 dur=27.462µs
I0516 11:25:14.922814   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=1024 orch=https://127.0.0.1:43311 timeout=20s uploadTimeout=2.5s segDur=5
I0516 11:25:15.023352   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.519222ms
I0516 11:25:15.023396   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:43311 dur=27.792µs
I0516 11:25:15.023490   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=1024 orch=https://127.0.0.1:43311 timeout=40s uploadTimeout=5s segDur=10
I0516 11:25:15.123756   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.249021ms
I0516 11:25:15.123801   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:43311 dur=32.411µs
I0516 11:25:15.123911   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=1024 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0.5
I0516 11:25:15.224246   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.318522ms
I0516 11:25:15.224279   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:43311 dur=25.688µs
I0516 11:25:15.224399   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=1024 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0.5
I0516 11:25:15.324825   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.403794ms
I0516 11:25:15.324876   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName= seqNo=0 orch=https://127.0.0.1:43311 dur=39.495µs
I0516 11:25:15.325043   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.425445   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.382464ms
I0516 11:25:15.425480   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=24.497µs
I0516 11:25:15.425642   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.525970   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.307711ms
I0516 11:25:15.526032   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=46.739µs
I0516 11:25:15.526401   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.627296   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.866411ms
I0516 11:25:15.627350   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=39.314µs
I0516 11:25:15.627594   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.727966   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.351675ms
I0516 11:25:15.728025   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=39.134µs
I0516 11:25:15.728404   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.828851   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.422889ms
I0516 11:25:15.828920   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=44.735µs
I0516 11:25:15.829336   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:15.929677   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.316568ms
I0516 11:25:15.929729   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=34.215µs
I0516 11:25:15.930003   52957 segment_rpc.go:492] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Submitting segment bytes=3 orch=https://127.0.0.1:43311 timeout=8s uploadTimeout=2s segDur=0
I0516 11:25:16.030328   52957 segment_rpc.go:528] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Uploaded segment orch=https://127.0.0.1:43311 dur=100.307993ms
I0516 11:25:16.030376   52957 segment_rpc.go:609] orchSessionID=bar orchestrator=https://127.0.0.1:43311 Successfully transcoded segment segName=foo seqNo=0 orch=https://127.0.0.1:43311 dur=32.151µs
W0516 11:25:16.032082   52957 selection_algorithm.go:52] No Orchestrators passed min performance score filter, not using the filter
W0516 11:25:16.032119   52957 selection_algorithm.go:52] No Orchestrators passed min performance score filter, not using the filter
W0516 11:25:16.032152   52957 selection_algorithm.go:75] No Orchestrators passed max price filter, not using the filter
I0516 11:25:16.072877   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.072907   52957 broadcast.go:363] [PublicLogs] Swapping from orch=transcoder2 to orch=[transcoder1] for manifestID=test
I0516 11:25:16.072918   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.072925   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 2
I0516 11:25:16.073134   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.073143   52957 broadcast.go:363] [PublicLogs] Swapping from orch=transcoder2 to orch=[transcoder1] for manifestID=test
I0516 11:25:16.073157   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.073164   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.073603   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.073668   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.077030   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:16.077105   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:16.077126   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:16.077149   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:17.677374   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:17.677432   52957 broadcast.go:363] [PublicLogs] Swapping from orch=transcoder2 to orch=[transcoder1] for manifestID=test
I0516 11:25:17.677461   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:18.677563   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:18.677639   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.277711   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.277760   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.277769   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 2
I0516 11:25:20.278154   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278174   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278180   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278195   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278202   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278207   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278214   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278220   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:20.278227   52957 broadcast.go:232] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:21.078470   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:21.078511   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:21.078519   52957 broadcast.go:258] [PublicLogs] Reusing orchestrator reason=performance: segments in flight, latency score of 0 < 1
I0516 11:25:21.878608   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:21.878646   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:21.878652   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 1
I0516 11:25:21.878657   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 2
I0516 11:25:21.878661   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 2
I0516 11:25:21.878665   52957 broadcast.go:269] [PublicLogs] Swapping Orchestrator, reason=performance: no segments in flight, latency score of 0 < 2
FAIL
coverage: 31.5% of statements
FAIL    github.com/livepeer/go-livepeer/server  24.791s
ok      github.com/livepeer/go-livepeer/verification    3.478s  coverage: 3.7% of statements
```
</details>
