### PR TITLE
Fix runtime error in aiWorker when pricePerUnit is unset

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -334,7 +334,7 @@ func (orch *orchestrator) priceInfo(sender ethcommon.Address, manifestID Manifes
 
 	basePrice := big.NewRat(0, 1)
 	if caps == nil {
-		if transcodePrice == nil {
+		if transcodePrice != nil {
 			basePrice = transcodePrice
 		}
 	} else {

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -332,12 +332,13 @@ func (orch *orchestrator) priceInfo(sender ethcommon.Address, manifestID Manifes
 		transcodePrice = orch.node.GetBasePrice("default")
 	}
 
-	var basePrice *big.Rat
+	basePrice := big.NewRat(0, 1)
 	if caps == nil {
-		basePrice = transcodePrice
+		if transcodePrice == nil {
+			basePrice = transcodePrice
+		}
 	} else {
 		// The base price is the sum of the prices of individual capability + model ID pairs
-		basePrice = big.NewRat(0, 1)
 		for cap := range caps.Capacities {
 			// If the capability does not have constraints (and thus any model constraints) skip it
 			// because we only price a capability together with a model ID right now
@@ -359,7 +360,7 @@ func (orch *orchestrator) priceInfo(sender ethcommon.Address, manifestID Manifes
 
 		// If no priced capabilities were signaled by the broadcaster assume that they are requesting
 		// transcoding and set the base price to the transcode price
-		if transcodePrice != nil && (basePrice == nil || basePrice.Cmp(big.NewRat(0, 1)) == 0) {
+		if transcodePrice != nil && basePrice.Cmp(big.NewRat(0, 1)) == 0 {
 			basePrice = transcodePrice
 		}
 	}

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -359,7 +359,7 @@ func (orch *orchestrator) priceInfo(sender ethcommon.Address, manifestID Manifes
 
 		// If no priced capabilities were signaled by the broadcaster assume that they are requesting
 		// transcoding and set the base price to the transcode price
-		if basePrice.Cmp(big.NewRat(0, 1)) == 0 {
+		if transcodePrice != nil && (basePrice == nil || basePrice.Cmp(big.NewRat(0, 1)) == 0) {
 			basePrice = transcodePrice
 		}
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Fixes a fatal runtime error when `-pricePerUnit` is not set, which is allowed with `-aiWorker` flag in #3047


**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Checks if basePrice is nil before comparing if it is equal to zero. 
- I also added a check if transcodePrice is nil before using it, just in case that condition occurs. Though it shouldn't happen because of startup checks that require `-pricePerUnit` when `-aiWorker` is not set

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Verified that ai jobs process at the correct price from aiModels.json
- Verified `-pricePerBroadcaster` prices are set correctly for transcoding work
- Verified `-pricePerUnit` price is used for transcode jobs when `-pricePerBroadcaster` is unset for the broadcasting address
- Verified that `-autoAdjustPrice` still works correctly in all cases

**Does this pull request close any open issues?**
<!-- Fixes # -->
#3057

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
