### PR TITLE
ai video deprecate priceperbroadcaster

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -181,6 +181,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	// Unit of pixels for both O's basePriceInfo and B's MaxBroadcastPrice
 	cfg.PixelsPerUnit = flag.Int("pixelsPerUnit", *cfg.PixelsPerUnit, "Amount of pixels per unit. Set to '> 1' to have smaller price granularity than 1 wei / pixel")
 	cfg.AutoAdjustPrice = flag.Bool("autoAdjustPrice", *cfg.AutoAdjustPrice, "Enable/disable automatic price adjustments based on the overhead for redeeming tickets")
+	cfg.PricePerGateway = flag.String("pricePerGateway", *cfg.PricePerGateway, `json list of price per gateway or path to json config file. Example: {"gateways":[{"ethaddress":"address1","priceperunit":1000,"pixelsperunit":1},{"ethaddress":"address2","priceperunit":1200,"pixelsperunit":1}]}`)
 	cfg.PricePerBroadcaster = flag.String("pricePerBroadcaster", *cfg.PricePerBroadcaster, `json list of price per broadcaster or path to json config file. Example: {"broadcasters":[{"ethaddress":"address1","priceperunit":1000,"pixelsperunit":1},{"ethaddress":"address2","priceperunit":1200,"pixelsperunit":1}]}`)
 	// Interval to poll for blocks
 	cfg.BlockPollingInterval = flag.Int("blockPollingInterval", *cfg.BlockPollingInterval, "Interval in seconds at which different blockchain event services poll for blocks")

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -2,6 +2,7 @@ package starter
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -87,19 +88,25 @@ func TestIsLocalURL(t *testing.T) {
 	assert.False(isLocal)
 }
 
-func TestParseGetBroadcasterPrices(t *testing.T) {
+func TestParseGetGatewayPrices(t *testing.T) {
 	assert := assert.New(t)
 
-	j := `{"broadcasters":[{"ethaddress":"0x0000000000000000000000000000000000000000","priceperunit":1000,"pixelsperunit":1}, {"ethaddress":"0x1000000000000000000000000000000000000000","priceperunit":2000,"pixelsperunit":3}]}`
+	// TODO: Keep checking old field for backwards compatibility, remove in future
+	jsonTemplate := `{"%s":[{"ethaddress":"0x0000000000000000000000000000000000000000","priceperunit":1000,"pixelsperunit":1}, {"ethaddress":"0x1000000000000000000000000000000000000000","priceperunit":2000,"pixelsperunit":3}]}`
+	testCases := []string{"gateways", "broadcasters"}
 
-	prices := getBroadcasterPrices(j)
-	assert.NotNil(prices)
-	assert.Equal(2, len(prices))
+	for _, tc := range testCases {
+		jsonStr := fmt.Sprintf(jsonTemplate, tc)
 
-	price1 := big.NewRat(prices[0].PricePerUnit, prices[0].PixelsPerUnit)
-	price2 := big.NewRat(prices[1].PricePerUnit, prices[1].PixelsPerUnit)
-	assert.Equal(big.NewRat(1000, 1), price1)
-	assert.Equal(big.NewRat(2000, 3), price2)
+		prices := getGatewayPrices(jsonStr)
+		assert.NotNil(prices)
+		assert.Equal(2, len(prices))
+
+		price1 := big.NewRat(prices[0].PricePerUnit, prices[0].PixelsPerUnit)
+		price2 := big.NewRat(prices[1].PricePerUnit, prices[1].PixelsPerUnit)
+		assert.Equal(big.NewRat(1000, 1), price1)
+		assert.Equal(big.NewRat(2000, 3), price2)
+	}
 }
 
 // Address provided to keystore file


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request adds the `pricePerGateway` flag and deprecates the `pricePerBroadcaster` flag per core team decision (details: https://discord.com/channels/423160867534929930/1051963444598943784/1210356864643109004). It adds the new `-pricePerGateway` flag while maintaining support for `-pricePerBroadcaster` with a deprecation warning on startup. This change does not address refactoring associated with variable names and types, which will be addressed in a later change.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

- Updates starter.go and livepeer.go to include the `-pricePerGateway` flag
- Updates the `getBroadcasters` function to parse the `gateways` property instead of the `broadcasters` property.
- Adds deprecation warnings to startup and cli help

```bash
W0516 11:37:39.563931   97531 starter.go:785] -PricePerBroadcaster flag is deprecated and will be removed in a future release. Please use -PricePerGateway instead
```

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Started a on-chain orchestrator node using the `-pricePerGateway` flag
- Started a on-chain orchestrator node using the `-pricePerBroadcaster` flag, noted deprecation warning
- Started a on-chain orchestrator node while using the `broadcasters` property in the config specified in the `-pricePerGateway` flag, noted deprecation warning.

**Does this pull request close any open issues?**
<!-- Fixes # -->

[AI-LIV-358](https://linear.app/livepeer-ai-spe/issue/LIV-358/rename-priceperbroadcaster-flag-with-pricepergateway)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated

