### PR TITLE
ci: protect Docker 'stable' tag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -81,7 +81,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ github.event.pull_request.head.ref }}
-            type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') }}
+            type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') && is_default_branch }}
 
       - name: Build and push livepeer docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This commit introduces a safeguard to ensure that the Docker image
tagged as 'stable' is only pushed when a new tag is created on the stable branch. This prevents unintended updates to the stable Docker image, ensuring consistency and reliability for users relying on the stable tag.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Changes the metadata step in the `docker.yml` action to ensure that the stable tag only gets created when the tag is on the default branch.

**How did you test each of these updates (required)**

<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I tested that this worked on the [ai-video branch](https://github.com/livepeer/go-livepeer/tree/ai-video) see https://github.com/livepeer/go-livepeer/actions/runs/9158262592.

**Does this pull request close any open issues?**
<!-- Fixes # -->

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
