### PR TITLE
fix(ai): fix cli prices nil error

### DIFF
--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -219,6 +219,10 @@ func (w *wizard) orchestratorStats() {
 	fmt.Println("+------------------+")
 
 	table := tablewriter.NewWriter(os.Stdout)
+	basePrice := "n/a"
+	if priceInfo != nil {
+		basePrice = fmt.Sprintf("%v wei / %v pixels", priceInfo.Num(), priceInfo.Denom())
+	}
 	data := [][]string{
 		{"Status", t.Status},
 		{"Active", strconv.FormatBool(t.Active)},
@@ -227,7 +231,7 @@ func (w *wizard) orchestratorStats() {
 		{"Reward Cut (%)", eth.FormatPerc(t.RewardCut)},
 		{"Fee Cut (%)", eth.FormatPerc(flipPerc(t.FeeShare))},
 		{"Last Reward Round", t.LastRewardRound.String()},
-		{"Base price per pixel", fmt.Sprintf("%v wei / %v pixels", priceInfo.Num(), priceInfo.Denom())},
+		{"Base price per pixel", basePrice},
 		{"Base price for broadcasters", b_prices},
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This commit ensures that the livepeer_cli does not throw a `nil` error when it tries to retrieve the orchestrator base price.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Ensures that the CLI can handle `nil` price being returned.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Ran the client.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
