### PR TITLE
Add startup flag to specify ai runner docker image

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -154,6 +154,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.AIWorker = flag.Bool("aiWorker", *cfg.AIWorker, "Set to true to run an AI worker")
 	cfg.AIModels = flag.String("aiModels", *cfg.AIModels, "Set models (pipeline:model_id) for AI worker to load upon initialization")
 	cfg.AIModelsDir = flag.String("aiModelsDir", *cfg.AIModelsDir, "Set directory where AI model weights are stored")
+	cfg.AIRunnerImage = flag.String("aiRunnerImage", *cfg.AIRunnerImage, "Set the docker image for the AI runner: Example - livepeer/ai-runner:0.0.1")
 
 	// Onchain:
 	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in the keystore directory")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -61,7 +61,6 @@ var (
 	// The time to live for cached max float values for PM senders (else they will be cleaned up) in seconds
 	smTTL = 172800 // 2 days
 
-	aiWorkerContainerImageID     = "livepeer/ai-runner:latest"
 	aiWorkerContainerStopTimeout = 5 * time.Second
 )
 
@@ -151,6 +150,7 @@ type LivepeerConfig struct {
 	OrchWebhookURL         *string
 	OrchBlacklist          *string
 	TestOrchAvail          *bool
+	AIRunnerImage          *string
 }
 
 // DefaultLivepeerConfig creates LivepeerConfig exactly the same as when no flags are passed to the livepeer process.
@@ -190,6 +190,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultAIWorker := false
 	defaultAIModels := ""
 	defaultAIModelsDir := ""
+	defaultAIRunnerImage := "livepeer/ai-runner:latest"
 
 	// Onchain:
 	defaultEthAcctAddr := ""
@@ -278,9 +279,10 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		TestTranscoder:       &defaultTestTranscoder,
 
 		// AI:
-		AIWorker:    &defaultAIWorker,
-		AIModels:    &defaultAIModels,
-		AIModelsDir: &defaultAIModelsDir,
+		AIWorker:      &defaultAIWorker,
+		AIModels:      &defaultAIModels,
+		AIModelsDir:   &defaultAIModelsDir,
+		AIRunnerImage: &defaultAIRunnerImage,
 
 		// Onchain:
 		EthAcctAddr:            &defaultEthAcctAddr,
@@ -531,7 +533,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			return
 		}
 
-		n.AIWorker, err = worker.NewWorker(aiWorkerContainerImageID, gpus, modelsDir)
+		n.AIWorker, err = worker.NewWorker(*cfg.AIRunnerImage, gpus, modelsDir)
 		if err != nil {
 			glog.Errorf("Error starting AI worker: %v", err)
 			return


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Adds the optional `-aiRunnerImage` flag which can be used to specify the version of ai runner docker image. 

Usage: `-aiRunner livepeer/ai-runner:0.0.1`

If the flag is not set, then `livepeer/ai-runner:latest` is used by default. 

This will help node operators with versioning to prevent accidental upgrades of ai-runner.




**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds startup flag to starter.go
- Adds config flag to livepeer.go

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Started go-livepeer as aiWorker with `-aiRunner livepeer/ai-runner:0.0.1`. Verified this version was launched via  docker ps
- Started go-livepeer without `-aiRunner` flag and verified `livepeer/ai-runner:latest` was launched via docker ps.

**Does this pull request close any open issues?**
<!-- Fixes # -->
LIV-382

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
