### PR TITLE
Return appropriate errors when auth fails, not just 5xx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/ethereum/go-ethereum v1.13.5
 	github.com/golang/glog v1.1.1
@@ -13,7 +14,7 @@ require (
 	github.com/jaypipes/pcidb v1.0.0
 	github.com/livepeer/go-tools v0.0.0-20220805063103-76df6beb6506
 	github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18
-	github.com/livepeer/lpms v0.0.0-20240513161533-11a5584d691d
+	github.com/livepeer/lpms v0.0.0-20240528070257-343a3ddb3748
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.14.18
 	github.com/olekukonko/tablewriter v0.0.5
@@ -41,7 +42,6 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/DataDog/zstd v1.4.5 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Microsoft/hcsshim v0.11.1 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,6 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
-github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -448,12 +446,8 @@ github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cO
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18 h1:4oH3NqV0NvcdS44Ld3zK2tO8IUiNozIggm74yobQeZg=
 github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18/go.mod h1:Jpf4jHK+fbWioBHRDRM1WadNT1qmY27g2YicTdO0Rtc=
-github.com/livepeer/lpms v0.0.0-20240115103113-98566e26c007 h1:0xr1TeIanBDdzI3sE2Zgf2yEV3s+6cPo3lJeyOHKmtM=
-github.com/livepeer/lpms v0.0.0-20240115103113-98566e26c007/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
-github.com/livepeer/lpms v0.0.0-20240402101153-ced71c476bd0 h1:Ch+HRjVJHpNo3kySGJgyDqb+l0KPWehyqZfA1wOafgY=
-github.com/livepeer/lpms v0.0.0-20240402101153-ced71c476bd0/go.mod h1:z5ROP1l5OzAKSoqVRLc34MjUdueil6wHSecQYV7llIw=
-github.com/livepeer/lpms v0.0.0-20240513161533-11a5584d691d h1:RehRsei/f2mv1RCWD1e3FWRkPl/+eKlHq6syU9c4WJE=
-github.com/livepeer/lpms v0.0.0-20240513161533-11a5584d691d/go.mod h1:z5ROP1l5OzAKSoqVRLc34MjUdueil6wHSecQYV7llIw=
+github.com/livepeer/lpms v0.0.0-20240528070257-343a3ddb3748 h1:sucdljv+Wjo24WbuHYNFFzjRFsKlSj/s9bn7qdCkG/Y=
+github.com/livepeer/lpms v0.0.0-20240528070257-343a3ddb3748/go.mod h1:z5ROP1l5OzAKSoqVRLc34MjUdueil6wHSecQYV7llIw=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
@@ -1081,8 +1075,6 @@ google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
-google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
-google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -259,8 +259,7 @@ func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookR
 		// do not replace captured _ctx variable
 		ctx := clog.AddNonce(_ctx, nonce)
 		if resp, err = authenticateStream(AuthWebhookURL, url.String()); err != nil {
-			errMsg := fmt.Sprintf("Forbidden: Authentication denied for streamID url=%s err=%q", url.String(), err)
-			clog.Errorf(ctx, errMsg)
+			clog.Errorf(ctx, fmt.Sprintf("Forbidden: Authentication denied for streamID url=%s err=%q", url.String(), err))
 			return nil, errForbidden
 		}
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -233,8 +233,8 @@ func (s *LivepeerServer) StartMediaServer(ctx context.Context, httpAddr string) 
 }
 
 // RTMP Publish Handlers
-func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookResponseOverride *authWebhookResponse) func(url *url.URL) (strmID stream.AppData) {
-	return func(url *url.URL) (strmID stream.AppData) {
+func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookResponseOverride *authWebhookResponse) func(url *url.URL) (strmID stream.AppData, e error) {
+	return func(url *url.URL) (strmID stream.AppData, e error) {
 		//Check HTTP header for ManifestID
 		//If ManifestID is passed in HTTP header, use that one
 		//Else check webhook for ManifestID
@@ -256,8 +256,9 @@ func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookR
 		// do not replace captured _ctx variable
 		ctx := clog.AddNonce(_ctx, nonce)
 		if resp, err = authenticateStream(AuthWebhookURL, url.String()); err != nil {
-			clog.Errorf(ctx, "Authentication denied for streamID url=%s err=%q", url.String(), err)
-			return nil
+			errMsg := fmt.Sprintf("Forbidden: Authentication denied for streamID url=%s err=%q", url.String(), err)
+			clog.Errorf(ctx, errMsg)
+			return nil, fmt.Errorf(errMsg)
 		}
 
 		// If we've received auth in header AND callback URL forms then for now, we reject cases where they're
@@ -265,7 +266,7 @@ func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookR
 		if resp != nil && webhookResponseOverride != nil {
 			if !resp.areProfilesEqual(*webhookResponseOverride) {
 				clog.Errorf(ctx, "Received auth header with profiles that don't match those in callback URL response")
-				return nil
+				return nil, fmt.Errorf("Received auth header with profiles that don't match those in callback URL response")
 			}
 		}
 
@@ -287,8 +288,9 @@ func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookR
 
 			parsedProfiles, err := ffmpeg.ParseProfilesFromJsonProfileArray(resp.Profiles)
 			if err != nil {
-				clog.Errorf(ctx, "Failed to parse JSON video profile for streamID url=%s err=%q", url.String(), err)
-				return nil
+				errMsg := fmt.Sprintf("Failed to parse JSON video profile for streamID url=%s err=%q", url.String(), err)
+				clog.Errorf(ctx, errMsg)
+				return nil, fmt.Errorf(errMsg)
 			}
 			profiles = append(profiles, parsedProfiles...)
 
@@ -301,16 +303,18 @@ func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookR
 			if resp.ObjectStore != "" {
 				os, err = drivers.ParseOSURL(resp.ObjectStore, false)
 				if err != nil {
-					clog.Errorf(ctx, "Failed to parse object store url for streamID url=%s err=%q", url.String(), err)
-					return nil
+					errMsg := fmt.Sprintf("Failed to parse object store url for streamID url=%s err=%q", url.String(), err)
+					clog.Errorf(ctx, errMsg)
+					return nil, fmt.Errorf(errMsg)
 				}
 			}
 			// set Recording OS if it was provided
 			if resp.RecordObjectStore != "" {
 				ros, err = drivers.ParseOSURL(resp.RecordObjectStore, true)
 				if err != nil {
-					clog.Errorf(ctx, "Failed to parse recording object store url for streamID url=%s err=%q", url.String(), err)
-					return nil
+					errMsg := fmt.Sprintf("Failed to parse recording object store url for streamID url=%s err=%q", url.String(), err)
+					clog.Errorf(ctx, errMsg)
+					return nil, fmt.Errorf(errMsg)
 				}
 			}
 
@@ -346,8 +350,10 @@ func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookR
 		s.connectionLock.RLock()
 		defer s.connectionLock.RUnlock()
 		if core.MaxSessions > 0 && len(s.rtmpConnections) >= core.MaxSessions {
-			clog.Errorf(ctx, "Too many connections for streamID url=%s err=%q", url.String(), err)
-			return nil
+			errMsg := fmt.Sprintf("Too many connections for streamID url=%s err=%q", url.String(), err)
+			clog.Errorf(ctx, errMsg)
+			return nil, fmt.Errorf(errMsg)
+
 		}
 		return &core.StreamParameters{
 			ManifestID:       mid,
@@ -360,7 +366,7 @@ func createRTMPStreamIDHandler(_ctx context.Context, s *LivepeerServer, webhookR
 			RecordOS:         ross,
 			VerificationFreq: VerificationFreq,
 			Nonce:            nonce,
-		}
+		}, nil
 	}
 }
 
@@ -820,10 +826,15 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 
 	// Check for presence and register if a fresh cxn
 	if !exists {
-		appData := (createRTMPStreamIDHandler(ctx, s, authHeaderConfig))(r.URL)
-		if appData == nil {
-			errorOut(http.StatusInternalServerError, "Could not create stream ID: url=%s", r.URL)
-			return
+		appData, err := (createRTMPStreamIDHandler(ctx, s, authHeaderConfig))(r.URL)
+		if err != nil {
+			if strings.HasPrefix(err.Error(), "Forbidden") {
+				errorOut(http.StatusForbidden, "Could not create stream ID: url=%s", r.URL)
+				return
+			} else {
+				errorOut(http.StatusInternalServerError, "Could not create stream ID: url=%s", r.URL)
+				return
+			}
 		}
 		params := streamParams(appData)
 		if authHeaderConfig != nil {

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -451,7 +451,7 @@ func TestCreateRTMPStreamHandlerCap(t *testing.T) {
 	s.rtmpConnections[core.ManifestID("id1")] = nil
 	// capped case
 	params, err := createSid(u)
-	require.NoError(t, err)
+	require.Error(t, err)
 	if params != nil {
 		t.Error("Stream should be denied because of capacity cap")
 	}
@@ -473,7 +473,7 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	AuthWebhookURL = mustParseUrl(t, "http://localhost:8938/notexisting")
 	u := mustParseUrl(t, "http://hot/something/id1")
 	sid, err := createSid(u)
-	assert.NoError(err)
+	assert.Error(err)
 	assert.Nil(sid, "Webhook auth failed")
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -509,14 +509,14 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	ts2 := makeServer(`{"manifestID":""}`)
 	defer ts2.Close()
 	sid, err = createSid(u)
-	assert.NoError(err)
+	assert.Error(err)
 	assert.Nil(sid, "Should not pass if returned manifest id is empty")
 
 	// invalid json
 	ts3 := makeServer(`{manifestID:"XX"}`)
 	defer ts3.Close()
 	sid, err = createSid(u)
-	assert.NoError(err)
+	assert.Error(err)
 	assert.Nil(sid, "Should not pass if returned json is invalid")
 
 	// set manifestID
@@ -613,7 +613,7 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 		{"name": "prof2", "bitrate": 765, "fps": 876, "width": 456, "height": "hello"}]}`)
 	defer ts8.Close()
 	appData, err := createSid(u)
-	require.NoError(t, err)
+	require.Error(t, err)
 	params, ok := appData.(*core.StreamParameters)
 	assert.False(ok)
 	assert.Nil(params)
@@ -667,14 +667,14 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	ts15 := makeServer(`{"manifestID":"a2", "objectStore": "invalid://object.store", "recordObjectStore": ""}`)
 	defer ts15.Close()
 	sid, err = createSid(u)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Nil(sid)
 
 	// do not create stream if RecordObjectStore URL is invalid
 	ts16 := makeServer(`{"manifestID":"a2", "objectStore": "", "recordObjectStore": "invalid://object.store"}`)
 	defer ts16.Close()
 	sid, err = createSid(u)
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Nil(sid)
 
 	ts17 := makeServer(`{"manifestID":"a3", "objectStore": "s3+http://us:pass@object.store/path", "recordObjectStore": "s3+http://us:pass@record.store"}`)

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -438,7 +438,9 @@ func TestCreateRTMPStreamHandlerCap(t *testing.T) {
 	oldMaxSessions := core.MaxSessions
 	core.MaxSessions = 1
 	// happy case
-	sid := createSid(u).(*core.StreamParameters)
+	id, err := createSid(u)
+	require.NoError(t, err)
+	sid := id.(*core.StreamParameters)
 	mid := sid.ManifestID
 	if mid != "id1" {
 		t.Error("Stream should be allowd", sid)
@@ -448,7 +450,8 @@ func TestCreateRTMPStreamHandlerCap(t *testing.T) {
 	}
 	s.rtmpConnections[core.ManifestID("id1")] = nil
 	// capped case
-	params := createSid(u)
+	params, err := createSid(u)
+	require.NoError(t, err)
 	if params != nil {
 		t.Error("Stream should be denied because of capacity cap")
 	}
@@ -460,7 +463,7 @@ type authWebhookReq struct {
 }
 
 func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
-	assert := assert.New(t)
+	assert := require.New(t)
 	s, cancel := setupServerWithCancel()
 	defer serverCleanup(s)
 	defer cancel()
@@ -469,7 +472,8 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 
 	AuthWebhookURL = mustParseUrl(t, "http://localhost:8938/notexisting")
 	u := mustParseUrl(t, "http://hot/something/id1")
-	sid := createSid(u)
+	sid, err := createSid(u)
+	assert.NoError(err)
 	assert.Nil(sid, "Webhook auth failed")
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -486,7 +490,8 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	}))
 	defer ts.Close()
 	AuthWebhookURL = mustParseUrl(t, ts.URL)
-	sid = createSid(u)
+	sid, err = createSid(u)
+	assert.NoError(err)
 	assert.NotNil(sid, "On empty response with 200 code should pass")
 
 	// local helper to reduce boilerplate
@@ -503,19 +508,23 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	// empty manifestID
 	ts2 := makeServer(`{"manifestID":""}`)
 	defer ts2.Close()
-	sid = createSid(u)
+	sid, err = createSid(u)
+	assert.NoError(err)
 	assert.Nil(sid, "Should not pass if returned manifest id is empty")
 
 	// invalid json
 	ts3 := makeServer(`{manifestID:"XX"}`)
 	defer ts3.Close()
-	sid = createSid(u)
+	sid, err = createSid(u)
+	assert.NoError(err)
 	assert.Nil(sid, "Should not pass if returned json is invalid")
 
 	// set manifestID
 	ts4 := makeServer(`{"manifestID":"xy"}`)
 	defer ts4.Close()
-	params := createSid(u).(*core.StreamParameters)
+	p, err := createSid(u)
+	assert.NoError(err)
+	params := p.(*core.StreamParameters)
 	mid := params.ManifestID
 	assert.Equal(core.ManifestID("xy"), mid, "Should set manifest id to one provided by webhook")
 
@@ -526,7 +535,9 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	// set manifestID + streamKey
 	ts5 := makeServer(`{"manifestID":"xyz", "streamKey":"zyx"}`)
 	defer ts5.Close()
-	params = createSid(u).(*core.StreamParameters)
+	id, err := createSid(u)
+	require.NoError(t, err)
+	params = id.(*core.StreamParameters)
 	mid = params.ManifestID
 	assert.Equal(core.ManifestID("xyz"), mid, "Should set manifest to one provided by webhook")
 	assert.Equal("xyz/zyx", params.StreamID(), "Should set streamkey to one provided by webhook")
@@ -535,7 +546,9 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	// set presets (with some invalid)
 	ts6 := makeServer(`{"manifestID":"a", "presets":["P240p30fps16x9", "unknown", "P720p30fps16x9"]}`)
 	defer ts6.Close()
-	params = createSid(u).(*core.StreamParameters)
+	strmID, err := createSid(u)
+	require.NoError(t, err)
+	params = strmID.(*core.StreamParameters)
 	assert.Len(params.Profiles, 2)
 	assert.Equal(params.Profiles, []ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9,
 		ffmpeg.P720p30fps16x9}, "Did not have matching presets")
@@ -547,7 +560,9 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 		{"name": "passthru_fps", "bitrate": 890, "width": 789, "height": 654, "profile": "H264ConstrainedHigh", "gop":"123"},
 		{"name": "gop0", "bitrate": 800, "width": 400, "height": 220, "profile": "H264ConstrainedHigh", "gop":"0.0"}]}`)
 	defer ts7.Close()
-	params = createSid(u).(*core.StreamParameters)
+	data, err := createSid(u)
+	require.NoError(t, err)
+	params = data.(*core.StreamParameters)
 	assert.Len(params.Profiles, 4)
 
 	expectedProfiles := []ffmpeg.VideoProfile{
@@ -597,7 +612,9 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 		{"name": "prof1", "bitrate": 432, "fps": 560, "width": 123, "height": 456},
 		{"name": "prof2", "bitrate": 765, "fps": 876, "width": 456, "height": "hello"}]}`)
 	defer ts8.Close()
-	params, ok := createSid(u).(*core.StreamParameters)
+	appData, err := createSid(u)
+	require.NoError(t, err)
+	params, ok := appData.(*core.StreamParameters)
 	assert.False(ok)
 	assert.Nil(params)
 
@@ -609,7 +626,9 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 		{"name": "gop0", "bitrate": 800, "width": 400, "height": 220, "profile": "H264ConstrainedHigh", "gop":"0.0"}]}`)
 
 	defer ts9.Close()
-	params = createSid(u).(*core.StreamParameters)
+	i, err := createSid(u)
+	require.NoError(t, err)
+	params = i.(*core.StreamParameters)
 	jointProfiles := append([]ffmpeg.VideoProfile{ffmpeg.P240p30fps16x9, ffmpeg.P720p30fps16x9}, expectedProfiles...)
 
 	assert.Len(params.Profiles, 6)
@@ -618,7 +637,9 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	// all invalid presets in webhook should lead to empty set
 	ts10 := makeServer(`{"manifestID":"a", "presets":["very", "unknown"]}`)
 	defer ts10.Close()
-	params = createSid(u).(*core.StreamParameters)
+	id2, err := createSid(u)
+	require.NoError(t, err)
+	params = id2.(*core.StreamParameters)
 	assert.Len(params.Profiles, 0, "Unexpected value in presets")
 
 	// invalid gops
@@ -636,25 +657,31 @@ func TestCreateRTMPStreamHandlerWebhook(t *testing.T) {
 	// intra only gop
 	ts14 := makeServer(`{"manifestID":"a", "profiles": [ {"gop": "intra" }]}`)
 	defer ts14.Close()
-	params = createSid(u).(*core.StreamParameters)
+	id3, err := createSid(u)
+	require.NoError(t, err)
+	params = id3.(*core.StreamParameters)
 	assert.Len(params.Profiles, 1)
 	assert.Equal(ffmpeg.GOPIntraOnly, params.Profiles[0].GOP)
 
 	// do not create stream if ObjectStore URL is invalid
 	ts15 := makeServer(`{"manifestID":"a2", "objectStore": "invalid://object.store", "recordObjectStore": ""}`)
 	defer ts15.Close()
-	sid = createSid(u)
+	sid, err = createSid(u)
+	require.NoError(t, err)
 	assert.Nil(sid)
 
 	// do not create stream if RecordObjectStore URL is invalid
 	ts16 := makeServer(`{"manifestID":"a2", "objectStore": "", "recordObjectStore": "invalid://object.store"}`)
 	defer ts16.Close()
-	sid = createSid(u)
+	sid, err = createSid(u)
+	require.NoError(t, err)
 	assert.Nil(sid)
 
 	ts17 := makeServer(`{"manifestID":"a3", "objectStore": "s3+http://us:pass@object.store/path", "recordObjectStore": "s3+http://us:pass@record.store"}`)
 	defer ts17.Close()
-	params = createSid(u).(*core.StreamParameters)
+	id4, err := createSid(u)
+	require.NoError(t, err)
+	params = id4.(*core.StreamParameters)
 	assert.Equal(core.ManifestID("a3"), params.ManifestID)
 	assert.NotNil(params.OS)
 	assert.True(params.OS.IsExternal())
@@ -689,30 +716,41 @@ func TestCreateRTMPStreamHandler(t *testing.T) {
 	u := mustParseUrl(t, "rtmp://localhost/"+expectedSid.String()) // with key
 
 	rand.Seed(123)
-	sid := createSid(u)
+	sid, err := createSid(u)
+	require.NoError(t, err)
 	sap := sid.(*core.StreamParameters)
 	assert.Equal(t, uint64(0x4a68998bed5c40f1), sap.Nonce)
 
-	if sid := createSid(u); sid.StreamID() != expectedSid.String() {
+	sid, err = createSid(u)
+	require.NoError(t, err)
+	if sid.StreamID() != expectedSid.String() {
 		t.Error("Unexpected streamid", sid.StreamID())
 	}
 	u = mustParseUrl(t, "rtmp://localhost/stream/"+expectedSid.String()) // with stream
-	if sid := createSid(u); sid.StreamID() != expectedSid.String() {
+	sid, err = createSid(u)
+	require.NoError(t, err)
+	if sid.StreamID() != expectedSid.String() {
 		t.Error("Unexpected streamid")
 	}
 	expectedMid := "mnopq"
 	key := common.RandomIDGenerator(StreamKeyBytes)
 	u = mustParseUrl(t, "rtmp://localhost/"+string(expectedMid)) // without key
-	if sid := createSid(u); sid.StreamID() != string(expectedMid)+"/"+key {
+	sid, err = createSid(u)
+	require.NoError(t, err)
+	if sid.StreamID() != string(expectedMid)+"/"+key {
 		t.Error("Unexpected streamid", sid.StreamID())
 	}
 	u = mustParseUrl(t, "rtmp://localhost/stream/"+string(expectedMid)) // with stream, without key
-	if sid := createSid(u); sid.StreamID() != string(expectedMid)+"/"+key {
+	sid, err = createSid(u)
+	require.NoError(t, err)
+	if sid.StreamID() != string(expectedMid)+"/"+key {
 		t.Error("Unexpected streamid", sid.StreamID())
 	}
 	// Test normal case
 	u = mustParseUrl(t, "rtmp://localhost")
-	st := stream.NewBasicRTMPVideoStream(createSid(u))
+	id, err := createSid(u)
+	require.NoError(t, err)
+	st := stream.NewBasicRTMPVideoStream(id)
 	if st.GetStreamID() == "" {
 		t.Error("Empty streamid")
 	}
@@ -721,14 +759,18 @@ func TestCreateRTMPStreamHandler(t *testing.T) {
 		t.Error("Handler failed ", err)
 	}
 	// Test collisions via stream reuse
-	if sid := createSid(u); sid == nil {
+	sid, err = createSid(u)
+	require.NoError(t, err)
+	if sid == nil {
 		t.Error("Did not expect a failure due to naming collision")
 	}
 	// Ensure the stream ID is reusable after the stream ends
 	if err := endHandler(u, st); err != nil {
 		t.Error("Could not clean up stream")
 	}
-	if sid := createSid(u); sid.StreamID() != st.GetStreamID() {
+	sid, err = createSid(u)
+	require.NoError(t, err)
+	if sid.StreamID() != st.GetStreamID() {
 		t.Error("Mismatched streamid during stream reuse", sid.StreamID(), st.GetStreamID())
 	}
 
@@ -739,7 +781,9 @@ func TestCreateRTMPStreamHandler(t *testing.T) {
 		// This isn't a great test because if the query param ever changes,
 		// this test will still pass
 		u := mustParseUrl(t, "rtmp://localhost/"+inp)
-		if sid := createSid(u); sid.StreamID() != st.GetStreamID() {
+		sid, err = createSid(u)
+		require.NoError(t, err)
+		if sid.StreamID() != st.GetStreamID() {
 			t.Errorf("Unexpected StreamID for '%v' ; expected '%v' for input '%v'", sid, st.GetStreamID(), inp)
 		}
 	}
@@ -804,7 +848,8 @@ func TestCreateRTMPStreamHandlerWithAuthHeader(t *testing.T) {
 	expectedSid := core.MakeStreamIDFromString("override-manifest-id", "abcdef")
 	u := mustParseUrl(t, "rtmp://localhost/"+expectedSid.String()) // with key
 
-	sid := createSid(u)
+	sid, err := createSid(u)
+	require.NoError(t, err)
 	require.NotNil(t, sid)
 	require.Equal(t, expectedSid.String(), sid.StreamID())
 
@@ -874,7 +919,8 @@ func TestCreateRTMPStreamHandlerWithAuthHeader_DifferentProfilesToCallbackURL(t 
 	expectedSid := core.MakeStreamIDFromString("override-manifest-id", "abcdef")
 	u := mustParseUrl(t, "rtmp://localhost/"+expectedSid.String()) // with key
 
-	sid := createSid(u)
+	sid, err := createSid(u)
+	require.Error(t, err)
 	require.Nil(t, sid)
 }
 
@@ -887,7 +933,8 @@ func TestEndRTMPStreamHandler(t *testing.T) {
 	handler := gotRTMPStreamHandler(s)
 	endHandler := endRTMPStreamHandler(s)
 	u := mustParseUrl(t, "rtmp://localhost")
-	sid := createSid(u)
+	sid, err := createSid(u)
+	require.NoError(t, err)
 	st := stream.NewBasicRTMPVideoStream(sid)
 
 	// Nonexistent stream
@@ -998,7 +1045,9 @@ func TestMultiStream(t *testing.T) {
 	createSid := createRTMPStreamIDHandler(context.TODO(), s, nil)
 
 	handleStream := func(i int) {
-		st := stream.NewBasicRTMPVideoStream(createSid(u))
+		id, err := createSid(u)
+		require.NoError(t, err)
+		st := stream.NewBasicRTMPVideoStream(id)
 		if err := handler(u, st); err != nil {
 			t.Error("Could not handle stream ", i, err)
 		}
@@ -1229,7 +1278,8 @@ func TestBroadcastSessionManagerWithStreamStartStop(t *testing.T) {
 
 	// create BasicRTMPVideoStream and extract ManifestID
 	u := mustParseUrl(t, "rtmp://localhost")
-	sid := createSid(u)
+	sid, err := createSid(u)
+	assert.NoError(err)
 	st := stream.NewBasicRTMPVideoStream(sid)
 	mid := streamParams(st.AppData()).ManifestID
 
@@ -1238,8 +1288,8 @@ func TestBroadcastSessionManagerWithStreamStartStop(t *testing.T) {
 	assert.Equal(exists, false)
 
 	// assert stream starts successfully
-	err := handler(u, st)
-	assert.Nil(err)
+	err = handler(u, st)
+	assert.NoError(err)
 
 	// assert sessManager is running and has right number of sessions
 	cxn, exists := s.rtmpConnections[mid]

--- a/server/push_test.go
+++ b/server/push_test.go
@@ -1037,7 +1037,7 @@ func TestPush_ForAuthWebhookFailure(t *testing.T) {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	require.Nil(t, err)
-	assert.Equal(http.StatusInternalServerError, resp.StatusCode)
+	assert.Equal(http.StatusForbidden, resp.StatusCode)
 	assert.Contains(strings.TrimSpace(string(body)), "Could not create stream ID")
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Have the Broadcaster return appropriate HTTP status codes on auth failure paths, to make monitoring and diagnosis of issues easier.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Bring in a new version of LPMS that includes an error return value in the auth method
- Handle this value and convert to HTTP statuses where appropriate

**How did you test each of these updates (required)**
- Ran unit tests


**Does this pull request close any open issues?**
- No


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
