### PR TITLE
Add gateway metrics

### DIFF
--- a/monitor/census.go
+++ b/monitor/census.go
@@ -294,7 +294,7 @@ func InitCensus(nodeType NodeType, version string) {
 	census.mSuccessRate = stats.Float64("success_rate", "Success rate", "per")
 	census.mSuccessRatePerStream = stats.Float64("success_rate_per_stream", "Success rate, per stream", "per")
 	census.mTranscodeTime = stats.Float64("transcode_time_seconds", "Transcoding time", "sec")
-	census.mAIRoundtripTime = stats.Float64("inference_time_seconds", "Inference time", "sec")
+	census.mAIRoundtripTime = stats.Float64("ai_roundtrip_time_seconds", "AI Roundtrip time", "sec")
 	census.mTranscodeOverallLatency = stats.Float64("transcode_overall_latency_seconds",
 		"Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest", "sec")
 	census.mUploadTime = stats.Float64("upload_time_seconds", "Upload (to Orchestrator) time", "sec")
@@ -557,7 +557,7 @@ func InitCensus(nodeType NodeType, version string) {
 		{
 			Name:        "ai_roundtrip_time_seconds",
 			Measure:     census.mAIRoundtripTime,
-			Description: "AIRoundtripTime, seconds",
+			Description: "AI Roundtrip time, seconds",
 			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTagsWithManifestIDAndIP...),
 			Aggregation: view.Distribution(0, .250, .500, .750, 1.000, 1.250, 1.500, 2.000, 2.500, 3.000, 3.500, 4.000, 4.500, 5.000, 10.000),
 		},

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -115,7 +115,7 @@ type (
 		kFVErrorType                  tag.Key
 		kPipeline                     tag.Key
 		kModelName                    tag.Key
-		mInferenceTime                *stats.Float64Measure
+		mAIRoundtripTime              *stats.Float64Measure
 		mSegmentSourceAppeared        *stats.Int64Measure
 		mSegmentEmerged               *stats.Int64Measure
 		mSegmentEmergedUnprocessed    *stats.Int64Measure
@@ -294,7 +294,7 @@ func InitCensus(nodeType NodeType, version string) {
 	census.mSuccessRate = stats.Float64("success_rate", "Success rate", "per")
 	census.mSuccessRatePerStream = stats.Float64("success_rate_per_stream", "Success rate, per stream", "per")
 	census.mTranscodeTime = stats.Float64("transcode_time_seconds", "Transcoding time", "sec")
-	census.mInferenceTime = stats.Float64("inference_time_seconds", "Inference time", "sec")
+	census.mAIRoundtripTime = stats.Float64("inference_time_seconds", "Inference time", "sec")
 	census.mTranscodeOverallLatency = stats.Float64("transcode_overall_latency_seconds",
 		"Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest", "sec")
 	census.mUploadTime = stats.Float64("upload_time_seconds", "Upload (to Orchestrator) time", "sec")
@@ -555,10 +555,10 @@ func InitCensus(nodeType NodeType, version string) {
 			Aggregation: view.Distribution(0, .250, .500, .750, 1.000, 1.250, 1.500, 2.000, 2.500, 3.000, 3.500, 4.000, 4.500, 5.000, 10.000),
 		},
 		{
-			Name:        "inference_time_seconds",
-			Measure:     census.mInferenceTime,
-			Description: "InferenceTime, seconds",
-			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTags...),
+			Name:        "ai_roundtrip_time_seconds",
+			Measure:     census.mAIRoundtripTime,
+			Description: "AIRoundtripTime, seconds",
+			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTagsWithManifestIDAndIP...),
 			Aggregation: view.Distribution(0, .250, .500, .750, 1.000, 1.250, 1.500, 2.000, 2.500, 3.000, 3.500, 4.000, 4.500, 5.000, 10.000),
 		},
 		{
@@ -1368,7 +1368,7 @@ func (cen *censusMetricsCounter) aiJobProcessed(Pipeline string, Model string, r
 		return
 	}
 
-	stats.Record(ctx, census.mInferenceTime.M(responseDuration.Seconds()))
+	stats.Record(ctx, census.mAIRoundtripTime.M(responseDuration.Seconds()))
 }
 
 func (cen *censusMetricsCounter) segmentTranscoded(nonce, seqNo uint64, sourceDur time.Duration, transcodeDur time.Duration,

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -113,6 +113,9 @@ type (
 		kOrchestratorURI              tag.Key
 		kOrchestratorAddress          tag.Key
 		kFVErrorType                  tag.Key
+		kPipeline                     tag.Key
+		kModelName                    tag.Key
+		mInferenceTime                *stats.Float64Measure
 		mSegmentSourceAppeared        *stats.Int64Measure
 		mSegmentEmerged               *stats.Int64Measure
 		mSegmentEmergedUnprocessed    *stats.Int64Measure
@@ -254,6 +257,8 @@ func InitCensus(nodeType NodeType, version string) {
 	census.kOrchestratorAddress = tag.MustNewKey("orchestrator_address")
 	census.kFVErrorType = tag.MustNewKey("fverror_type")
 	census.kSegClassName = tag.MustNewKey("seg_class_name")
+	census.kModelName = tag.MustNewKey("model_name")
+	census.kPipeline = tag.MustNewKey("pipeline")
 	census.ctx, err = tag.New(ctx, tag.Insert(census.kNodeType, string(nodeType)), tag.Insert(census.kNodeID, NodeID))
 	if err != nil {
 		glog.Exit("Error creating context", err)
@@ -289,6 +294,7 @@ func InitCensus(nodeType NodeType, version string) {
 	census.mSuccessRate = stats.Float64("success_rate", "Success rate", "per")
 	census.mSuccessRatePerStream = stats.Float64("success_rate_per_stream", "Success rate, per stream", "per")
 	census.mTranscodeTime = stats.Float64("transcode_time_seconds", "Transcoding time", "sec")
+	census.mInferenceTime = stats.Float64("inference_time_seconds", "Inference time", "sec")
 	census.mTranscodeOverallLatency = stats.Float64("transcode_overall_latency_seconds",
 		"Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest", "sec")
 	census.mUploadTime = stats.Float64("upload_time_seconds", "Upload (to Orchestrator) time", "sec")
@@ -546,6 +552,13 @@ func InitCensus(nodeType NodeType, version string) {
 			Measure:     census.mTranscodeTime,
 			Description: "TranscodeTime, seconds",
 			TagKeys:     append([]tag.Key{census.kProfiles, census.kTrusted, census.kVerified}, baseTags...),
+			Aggregation: view.Distribution(0, .250, .500, .750, 1.000, 1.250, 1.500, 2.000, 2.500, 3.000, 3.500, 4.000, 4.500, 5.000, 10.000),
+		},
+		{
+			Name:        "inference_time_seconds",
+			Measure:     census.mInferenceTime,
+			Description: "InferenceTime, seconds",
+			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTags...),
 			Aggregation: view.Distribution(0, .250, .500, .750, 1.000, 1.250, 1.500, 2.000, 2.500, 3.000, 3.500, 4.000, 4.500, 5.000, 10.000),
 		},
 		{
@@ -1339,6 +1352,23 @@ func SegmentTranscoded(ctx context.Context, nonce, seqNo uint64, sourceDur time.
 	trusted, verified bool) {
 
 	census.segmentTranscoded(nonce, seqNo, sourceDur, transcodeDur, profiles, trusted, verified)
+}
+func AiJobProcessed(ctx context.Context, Pipeline string, Model string, responseDuration time.Duration) {
+
+	census.aiJobProcessed(Pipeline, Model, responseDuration)
+}
+
+func (cen *censusMetricsCounter) aiJobProcessed(Pipeline string, Model string, responseDuration time.Duration) {
+	cen.lock.Lock()
+	defer cen.lock.Unlock()
+
+	ctx, err := tag.New(cen.ctx, tag.Insert(cen.kPipeline, Pipeline), tag.Insert(cen.kModelName, Model))
+	if err != nil {
+		glog.Error("Error creating context", err)
+		return
+	}
+
+	stats.Record(ctx, census.mInferenceTime.M(responseDuration.Seconds()))
 }
 
 func (cen *censusMetricsCounter) segmentTranscoded(nonce, seqNo uint64, sourceDur time.Duration, transcodeDur time.Duration,

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-tools/drivers"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
 	"github.com/oapi-codegen/runtime"
@@ -106,6 +107,11 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 
 		took := time.Since(start)
 		clog.Infof(ctx, "Processed TextToImage request prompt=%v model_id=%v took=%v", req.Prompt, *req.ModelId, took)
+
+		//Log round trip time for text-to-image job
+		if monitor.Enabled {
+			monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, took)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -86,6 +86,7 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 		}
 
 		clog.V(common.VERBOSE).Infof(r.Context(), "Received TextToImage request prompt=%v model_id=%v", req.Prompt, *req.ModelId)
+		monitor.RecordModelRequested("text-to-image", *req.ModelId)
 
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,
@@ -108,7 +109,6 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 		took := time.Since(start)
 		clog.Infof(ctx, "Processed TextToImage request prompt=%v model_id=%v took=%v", req.Prompt, *req.ModelId, took)
 
-		//Log round trip time for text-to-image job
 		if monitor.Enabled {
 			monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, took)
 		}
@@ -139,6 +139,7 @@ func (ls *LivepeerServer) ImageToImage() http.Handler {
 		}
 
 		clog.V(common.VERBOSE).Infof(ctx, "Received ImageToImage request imageSize=%v prompt=%v model_id=%v", req.Image.FileSize(), req.Prompt, *req.ModelId)
+		monitor.RecordModelRequested("image-to-image", *req.ModelId)
 
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,
@@ -160,6 +161,9 @@ func (ls *LivepeerServer) ImageToImage() http.Handler {
 
 		took := time.Since(start)
 		clog.V(common.VERBOSE).Infof(ctx, "Processed ImageToImage request imageSize=%v prompt=%v model_id=%v took=%v", req.Image.FileSize(), req.Prompt, *req.ModelId, took)
+		if monitor.Enabled {
+			monitor.AiJobProcessed(ctx, "image-to-image", *req.ModelId, took)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -193,6 +197,7 @@ func (ls *LivepeerServer) ImageToVideo() http.Handler {
 		}
 
 		clog.V(common.VERBOSE).Infof(ctx, "Received ImageToVideo request imageSize=%v model_id=%v async=%v", req.Image.FileSize(), *req.ModelId, async)
+		monitor.RecordModelRequested("image-to-video", *req.ModelId)
 
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,
@@ -217,7 +222,9 @@ func (ls *LivepeerServer) ImageToVideo() http.Handler {
 
 			took := time.Since(start)
 			clog.Infof(ctx, "Processed ImageToVideo request imageSize=%v model_id=%v took=%v", req.Image.FileSize(), *req.ModelId, took)
-
+			if monitor.Enabled {
+				monitor.AiJobProcessed(ctx, "image-to-video", *req.ModelId, took)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(resp)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
This change adds roundtrip time metrics for all pipelines, logging the specific pipeline, model and roundtrip time. 

You can visualize this with a timeseries chart using the following query:

`rate(livepeer_ai_roundtrip_time_seconds_sum[1m]) / rate(livepeer_ai_roundtrip_time_seconds_count[1m])`

Use the following variable for the Legend: `{{pipeline}}, {{model_name}}`

Result:
![image](https://github.com/livepeer/go-livepeer/assets/16746274/8ac88cc3-f1c0-49bb-aab9-c3703891dc2a)


**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates census.go
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
