### PR TITLE
feat(ai): add safety check to image-to-video pipeline

### DIFF
--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -1003,8 +1003,10 @@ func (n *LivepeerNode) imageToVideo(ctx context.Context, req worker.ImageToVideo
 			return nil, err
 		}
 
+		//Nsfw is only checked on input image.
 		videos[i] = worker.Media{
-			Url: uri,
+			Url:  uri,
+			Nsfw: batch[0].Nsfw,
 		}
 
 		if len(batch) > 0 {

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -223,7 +223,9 @@ func processImageToVideo(ctx context.Context, params aiRequestParams, req worker
 		videos[i] = worker.Media{
 			Url:  newUrl,
 			Seed: media.Seed,
+			Nsfw: media.Nsfw,
 		}
+
 	}
 
 	resp.Images = videos


### PR DESCRIPTION
This commit enables the NSFW result passthrough on the `image-to-video` pipeline.

Depends on [ai-worker PR #90](https://github.com/livepeer/ai-worker/pull/90#issue-2326377643) 