### PR TITLE
fix(ia): Update T2I latency score to include num_inference_steps

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -115,7 +115,13 @@ func submitTextToImage(ctx context.Context, params aiRequestParams, sess *AISess
 	if req.NumImagesPerPrompt != nil {
 		numImages = *req.NumImagesPerPrompt
 	}
-	sess.LatencyScore = took.Seconds() / float64(outPixels) / float64(numImages)
+
+	numInferenceSteps := float64(1)
+	if req.NumInferenceSteps != nil {
+		numInferenceSteps = float64(*req.NumInferenceSteps)
+	}
+
+	sess.LatencyScore = took.Seconds() / float64(outPixels) / (float64(numImages) * float64(numInferenceSteps))
 
 	return resp.JSON200, nil
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Updates the formula used to calculate latency score for T2I request so that `num_inference_steps` is included in the measurement.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Update **ai_process.go** to use the formula: 
`took.Seconds() / float64(outPixels) / (float64(numImages) * float64(numInferenceSteps))`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Tested with high-end range values for `num_inference_steps` and `num_images_per_prompt` 
```
Results:

25 inference
0.00000006567261756897  - 1 image
0.00000006524371048584 - 25 images

100 inference
0.00000004808495975494 - 1 image
0.00000004837596923332 - 25 images
```

**Does this pull request close any open issues?**
<!-- Fixes # -->
LIV-362

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
