### PR TITLE
Dynamic ticket EV validation on startup

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -73,6 +73,8 @@ const (
 	TranscoderCliPort   = "6935"
 
 	RefreshPerfScoreInterval = 10 * time.Minute
+
+	MinAITicketEV = "2999999999999"
 )
 
 type LivepeerConfig struct {
@@ -921,6 +923,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 			n.AutoSessionLimit = *cfg.MaxSessions == "auto"
 			n.AutoAdjustPrice = *cfg.AutoAdjustPrice
+
+			if *cfg.AIWorker && *cfg.TicketEV < MinAITicketEV {
+				*cfg.TicketEV = MinAITicketEV
+			}
 
 			ev, _ := new(big.Int).SetString(*cfg.TicketEV, 10)
 			if ev == nil {

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -937,7 +937,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			largestPrice := getLargestPrice(n, constraints, gatewayPrices)
 
 			if new(big.Int).Quo(ev, largestPrice).Cmp(big.NewInt(629145)) < 0 {
-				glog.Errorf("Ticket EV ratio to largest price is too low. Restart the node with a valid value for -ticketEV", *cfg.TicketEV)
+				glog.Errorf("Ticket EV ratio to largest price is too low. Restart the node with a valid value for -ticketEV, consider a ticket EV of %v or higher", new(big.Int).Mul(big.NewInt(629145), ev))
 				return
 			}
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1462,10 +1462,10 @@ func getLargestPrice(n *core.LivepeerNode, constraints map[core.Capability]*core
 		}
 	}
 
-	defaultTransacodePrice := n.GetBasePrice("default")
-	if defaultTransacodePrice != nil {
-		if (defaultTransacodePrice).Cmp(largestPrice) > 0 {
-			largestPrice = defaultTransacodePrice
+	defaultTranscodePrice := n.GetBasePrice("default")
+	if defaultTranscodePrice != nil {
+		if (defaultTranscodePrice).Cmp(largestPrice) > 0 {
+			largestPrice = defaultTranscodePrice
 		}
 	}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This change validates the ticket EV of an orchestrator to ensure it is sufficient for the prices that are set during startup. 

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds `getLargestPrice` to startup.go. This determines the largest price across all models, gateway prices and default price to verify if the `-ticketEV` is large enough.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Started orchestrator:
- Without `-ticketEV 2999999999999` and with model price at `4768372`. Verified it failed validation.
- With `-ticketEV 2999999999999` and verified it passed validation.

However, larger price values will not pass validation without a larger ticket EV being set. I added a recommendation in the log entry based on the current formula. 

This change currently does not prevent dynamic price changes outside of valid ticketEV while the orchestrator is running.

**Does this pull request close any open issues?**
<!-- Fixes # -->
AI-461

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
