### PR TITLE
feat(ai): add AI gateway metrics

### DIFF
--- a/monitor/census.go
+++ b/monitor/census.go
@@ -896,7 +896,7 @@ func InitCensus(nodeType NodeType, version string) {
 			Name:        "ai_request_price",
 			Measure:     census.mAIRequestPrice,
 			Description: "AI request price per unit",
-			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTagsWithOrchInfo...),
+			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTags...),
 			Aggregation: view.LastValue(),
 		},
 		{

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -116,6 +116,7 @@ type (
 		kPipeline                     tag.Key
 		kModelName                    tag.Key
 		mAIRoundtripTime              *stats.Float64Measure
+		mModelsRequested              *stats.Int64Measure
 		mSegmentSourceAppeared        *stats.Int64Measure
 		mSegmentEmerged               *stats.Int64Measure
 		mSegmentEmergedUnprocessed    *stats.Int64Measure
@@ -294,6 +295,7 @@ func InitCensus(nodeType NodeType, version string) {
 	census.mSuccessRate = stats.Float64("success_rate", "Success rate", "per")
 	census.mSuccessRatePerStream = stats.Float64("success_rate_per_stream", "Success rate, per stream", "per")
 	census.mTranscodeTime = stats.Float64("transcode_time_seconds", "Transcoding time", "sec")
+	census.mModelsRequested = stats.Int64("ai_models_requested", "Number of models requested over time", "tot")
 	census.mAIRoundtripTime = stats.Float64("ai_roundtrip_time_seconds", "AI Roundtrip time", "sec")
 	census.mTranscodeOverallLatency = stats.Float64("transcode_overall_latency_seconds",
 		"Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest", "sec")
@@ -560,6 +562,13 @@ func InitCensus(nodeType NodeType, version string) {
 			Description: "AI Roundtrip time, seconds",
 			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTagsWithManifestIDAndIP...),
 			Aggregation: view.Distribution(0, .250, .500, .750, 1.000, 1.250, 1.500, 2.000, 2.500, 3.000, 3.500, 4.000, 4.500, 5.000, 10.000),
+		},
+		{
+			Name:        "ai_models_requested",
+			Measure:     census.mModelsRequested,
+			Description: "Count of Models Requested over time",
+			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTagsWithManifestID...),
+			Aggregation: view.LastValue(),
 		},
 		{
 			Name:        "transcode_overall_latency_seconds",
@@ -968,6 +977,7 @@ func LogDiscoveryError(ctx context.Context, uri, code string) {
 			[]tag.Mutator{tag.Insert(census.kErrorCode, code),
 				tag.Insert(census.kOrchestratorURI, uri)},
 			census.mDiscoveryError.M(1)); err != nil {
+			//0530 18:08:28.399899 1767400 census.go:965] clientIP=192.168.10.155 request_id=d5303ff3 Error recording metrics err="invalid value: only ASCII characters accepted; max length must be 255 characters"
 			clog.Errorf(ctx, "Error recording metrics err=%q", err)
 		}
 	}
@@ -1373,6 +1383,10 @@ func AiJobProcessed(ctx context.Context, Pipeline string, Model string, response
 	census.aiJobProcessed(Pipeline, Model, responseDuration)
 }
 
+func RecordModelRequested(Pipeline string, Model string) {
+	census.recordModelRequested(Pipeline, Model)
+}
+
 func (cen *censusMetricsCounter) aiJobProcessed(Pipeline string, Model string, responseDuration time.Duration) {
 	cen.lock.Lock()
 	defer cen.lock.Unlock()
@@ -1384,6 +1398,15 @@ func (cen *censusMetricsCounter) aiJobProcessed(Pipeline string, Model string, r
 	}
 
 	stats.Record(ctx, census.mAIRoundtripTime.M(responseDuration.Seconds()))
+}
+
+func (cen *censusMetricsCounter) recordModelRequested(pipeline, modelName string) {
+	ctx, err := tag.New(cen.ctx, tag.Insert(census.kPipeline, pipeline), tag.Insert(census.kModelName, modelName))
+	if err != nil {
+		glog.Errorf("Failed to create context with tags: %v", err)
+		return
+	}
+	stats.Record(ctx, census.mModelsRequested.M(1))
 }
 
 func (cen *censusMetricsCounter) segmentTranscoded(nonce, seqNo uint64, sourceDur time.Duration, transcodeDur time.Duration,

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -1784,7 +1784,7 @@ func (cen *censusMetricsCounter) recordAILatencyScore(Pipeline string, Model str
 	defer cen.lock.Unlock()
 
 	if err := stats.RecordWithTags(cen.ctx,
-		[]tag.Mutator{tag.Insert(cen.kPipeline, Pipeline), tag.Insert(cen.kModelName, Model), tag.Insert(cen.kOrchestratorURI, orchInfo.GetTranscoder())},
+		[]tag.Mutator{tag.Insert(cen.kPipeline, Pipeline), tag.Insert(cen.kModelName, Model), tag.Insert(cen.kOrchestratorURI, orchInfo.GetTranscoder()), tag.Insert(census.kOrchestratorAddress, common.BytesToAddress(orchInfo.GetAddress()).String())},
 		cen.mAIRequestLatencyScore.M(latencyScore)); err != nil {
 		glog.Errorf("Error recording metrics err=%q", err)
 	}
@@ -1796,7 +1796,7 @@ func (cen *censusMetricsCounter) recordAIPricePerUnit(Pipeline string, Model str
 	defer cen.lock.Unlock()
 
 	if err := stats.RecordWithTags(cen.ctx,
-		[]tag.Mutator{tag.Insert(cen.kPipeline, Pipeline), tag.Insert(cen.kModelName, Model), tag.Insert(cen.kOrchestratorURI, orchInfo.GetTranscoder())},
+		[]tag.Mutator{tag.Insert(cen.kPipeline, Pipeline), tag.Insert(cen.kModelName, Model), tag.Insert(cen.kOrchestratorURI, orchInfo.GetTranscoder()), tag.Insert(census.kOrchestratorAddress, common.BytesToAddress(orchInfo.GetAddress()).String())},
 		cen.mAIRequestPrice.M(pricePerUnit)); err != nil {
 		glog.Errorf("Error recording metrics err=%q", err)
 	}

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -294,7 +294,7 @@ func InitCensus(nodeType NodeType, version string) {
 	census.mSuccessRate = stats.Float64("success_rate", "Success rate", "per")
 	census.mSuccessRatePerStream = stats.Float64("success_rate_per_stream", "Success rate, per stream", "per")
 	census.mTranscodeTime = stats.Float64("transcode_time_seconds", "Transcoding time", "sec")
-	census.mAIRoundtripTime = stats.Float64("inference_time_seconds", "Inference time", "sec")
+	census.mAIRoundtripTime = stats.Float64("ai_roundtrip_time_seconds", "AI Roundtrip time", "sec")
 	census.mTranscodeOverallLatency = stats.Float64("transcode_overall_latency_seconds",
 		"Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest", "sec")
 	census.mUploadTime = stats.Float64("upload_time_seconds", "Upload (to Orchestrator) time", "sec")
@@ -557,7 +557,7 @@ func InitCensus(nodeType NodeType, version string) {
 		{
 			Name:        "ai_roundtrip_time_seconds",
 			Measure:     census.mAIRoundtripTime,
-			Description: "AIRoundtripTime, seconds",
+			Description: "AI Roundtrip time, seconds",
 			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTagsWithManifestIDAndIP...),
 			Aggregation: view.Distribution(0, .250, .500, .750, 1.000, 1.250, 1.500, 2.000, 2.500, 3.000, 3.500, 4.000, 4.500, 5.000, 10.000),
 		},

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -115,7 +115,7 @@ type (
 		kFVErrorType                  tag.Key
 		kPipeline                     tag.Key
 		kModelName                    tag.Key
-		mInferenceTime                *stats.Float64Measure
+		mAIRoundtripTime              *stats.Float64Measure
 		mSegmentSourceAppeared        *stats.Int64Measure
 		mSegmentEmerged               *stats.Int64Measure
 		mSegmentEmergedUnprocessed    *stats.Int64Measure
@@ -294,7 +294,7 @@ func InitCensus(nodeType NodeType, version string) {
 	census.mSuccessRate = stats.Float64("success_rate", "Success rate", "per")
 	census.mSuccessRatePerStream = stats.Float64("success_rate_per_stream", "Success rate, per stream", "per")
 	census.mTranscodeTime = stats.Float64("transcode_time_seconds", "Transcoding time", "sec")
-	census.mInferenceTime = stats.Float64("inference_time_seconds", "Inference time", "sec")
+	census.mAIRoundtripTime = stats.Float64("inference_time_seconds", "Inference time", "sec")
 	census.mTranscodeOverallLatency = stats.Float64("transcode_overall_latency_seconds",
 		"Transcoding latency, from source segment emerged from segmenter till all transcoded segment apeeared in manifest", "sec")
 	census.mUploadTime = stats.Float64("upload_time_seconds", "Upload (to Orchestrator) time", "sec")
@@ -555,10 +555,10 @@ func InitCensus(nodeType NodeType, version string) {
 			Aggregation: view.Distribution(0, .250, .500, .750, 1.000, 1.250, 1.500, 2.000, 2.500, 3.000, 3.500, 4.000, 4.500, 5.000, 10.000),
 		},
 		{
-			Name:        "inference_time_seconds",
-			Measure:     census.mInferenceTime,
-			Description: "InferenceTime, seconds",
-			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTags...),
+			Name:        "ai_roundtrip_time_seconds",
+			Measure:     census.mAIRoundtripTime,
+			Description: "AIRoundtripTime, seconds",
+			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTagsWithManifestIDAndIP...),
 			Aggregation: view.Distribution(0, .250, .500, .750, 1.000, 1.250, 1.500, 2.000, 2.500, 3.000, 3.500, 4.000, 4.500, 5.000, 10.000),
 		},
 		{
@@ -1383,7 +1383,7 @@ func (cen *censusMetricsCounter) aiJobProcessed(Pipeline string, Model string, r
 		return
 	}
 
-	stats.Record(ctx, census.mInferenceTime.M(responseDuration.Seconds()))
+	stats.Record(ctx, census.mAIRoundtripTime.M(responseDuration.Seconds()))
 }
 
 func (cen *censusMetricsCounter) segmentTranscoded(nonce, seqNo uint64, sourceDur time.Duration, transcodeDur time.Duration,

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -1804,8 +1804,13 @@ func (cen *censusMetricsCounter) recordAIPricePerUnit(Pipeline string, Model str
 
 // AIRequestError records an error during the AI job request
 func AIRequestError(code string, Pipeline string, Model string, orchInfo *lpnet.OrchestratorInfo) {
+	orchAddr := ""
+	if addr := orchInfo.GetAddress(); addr != nil {
+		orchAddr = common.BytesToAddress(addr).String()
+	}
+
 	if err := stats.RecordWithTags(census.ctx,
-		[]tag.Mutator{tag.Insert(census.kErrorCode, code), tag.Insert(census.kPipeline, Pipeline), tag.Insert(census.kModelName, Model), tag.Insert(census.kOrchestratorURI, orchInfo.GetTranscoder()), tag.Insert(census.kOrchestratorAddress, common.BytesToAddress(orchInfo.GetAddress()).String())},
+		[]tag.Mutator{tag.Insert(census.kErrorCode, code), tag.Insert(census.kPipeline, Pipeline), tag.Insert(census.kModelName, Model), tag.Insert(census.kOrchestratorURI, orchInfo.GetTranscoder()), tag.Insert(census.kOrchestratorAddress, orchAddr)},
 		census.mAIRequestError.M(1)); err != nil {
 		glog.Errorf("Error recording metrics err=%q", err)
 	}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -88,6 +88,7 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 		}
 
 		clog.V(common.VERBOSE).Infof(r.Context(), "Received TextToImage request prompt=%v model_id=%v", req.Prompt, *req.ModelId)
+		monitor.RecordModelRequested("text-to-image", *req.ModelId)
 
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,
@@ -110,7 +111,6 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 		took := time.Since(start)
 		clog.Infof(ctx, "Processed TextToImage request prompt=%v model_id=%v took=%v", req.Prompt, *req.ModelId, took)
 
-		//Log round trip time for text-to-image job
 		if monitor.Enabled {
 			monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, took)
 		}
@@ -141,6 +141,7 @@ func (ls *LivepeerServer) ImageToImage() http.Handler {
 		}
 
 		clog.V(common.VERBOSE).Infof(ctx, "Received ImageToImage request imageSize=%v prompt=%v model_id=%v", req.Image.FileSize(), req.Prompt, *req.ModelId)
+		monitor.RecordModelRequested("image-to-image", *req.ModelId)
 
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,
@@ -162,6 +163,9 @@ func (ls *LivepeerServer) ImageToImage() http.Handler {
 
 		took := time.Since(start)
 		clog.V(common.VERBOSE).Infof(ctx, "Processed ImageToImage request imageSize=%v prompt=%v model_id=%v took=%v", req.Image.FileSize(), req.Prompt, *req.ModelId, took)
+		if monitor.Enabled {
+			monitor.AiJobProcessed(ctx, "image-to-image", *req.ModelId, took)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -195,6 +199,7 @@ func (ls *LivepeerServer) ImageToVideo() http.Handler {
 		}
 
 		clog.V(common.VERBOSE).Infof(ctx, "Received ImageToVideo request imageSize=%v model_id=%v async=%v", req.Image.FileSize(), *req.ModelId, async)
+		monitor.RecordModelRequested("image-to-video", *req.ModelId)
 
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,
@@ -219,7 +224,9 @@ func (ls *LivepeerServer) ImageToVideo() http.Handler {
 
 			took := time.Since(start)
 			clog.Infof(ctx, "Processed ImageToVideo request imageSize=%v model_id=%v took=%v", req.Image.FileSize(), *req.ModelId, took)
-
+			if monitor.Enabled {
+				monitor.AiJobProcessed(ctx, "image-to-video", *req.ModelId, took)
+			}
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(resp)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-tools/drivers"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
 	"github.com/oapi-codegen/runtime"
@@ -108,6 +109,11 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 
 		took := time.Since(start)
 		clog.Infof(ctx, "Processed TextToImage request prompt=%v model_id=%v took=%v", req.Prompt, *req.ModelId, took)
+
+		//Log round trip time for text-to-image job
+		if monitor.Enabled {
+			monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, took)
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -13,7 +13,6 @@ import (
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
-	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-tools/drivers"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
 	"github.com/oapi-codegen/runtime"
@@ -88,7 +87,6 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 		}
 
 		clog.V(common.VERBOSE).Infof(r.Context(), "Received TextToImage request prompt=%v model_id=%v", req.Prompt, *req.ModelId)
-		monitor.RecordModelRequested("text-to-image", *req.ModelId)
 
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,
@@ -110,10 +108,6 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 
 		took := time.Since(start)
 		clog.Infof(ctx, "Processed TextToImage request prompt=%v model_id=%v took=%v", req.Prompt, *req.ModelId, took)
-
-		if monitor.Enabled {
-			monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, took)
-		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -141,7 +135,6 @@ func (ls *LivepeerServer) ImageToImage() http.Handler {
 		}
 
 		clog.V(common.VERBOSE).Infof(ctx, "Received ImageToImage request imageSize=%v prompt=%v model_id=%v", req.Image.FileSize(), req.Prompt, *req.ModelId)
-		monitor.RecordModelRequested("image-to-image", *req.ModelId)
 
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,
@@ -163,9 +156,6 @@ func (ls *LivepeerServer) ImageToImage() http.Handler {
 
 		took := time.Since(start)
 		clog.V(common.VERBOSE).Infof(ctx, "Processed ImageToImage request imageSize=%v prompt=%v model_id=%v took=%v", req.Image.FileSize(), req.Prompt, *req.ModelId, took)
-		if monitor.Enabled {
-			monitor.AiJobProcessed(ctx, "image-to-image", *req.ModelId, took)
-		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -199,7 +189,6 @@ func (ls *LivepeerServer) ImageToVideo() http.Handler {
 		}
 
 		clog.V(common.VERBOSE).Infof(ctx, "Received ImageToVideo request imageSize=%v model_id=%v async=%v", req.Image.FileSize(), *req.ModelId, async)
-		monitor.RecordModelRequested("image-to-video", *req.ModelId)
 
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,
@@ -224,9 +213,7 @@ func (ls *LivepeerServer) ImageToVideo() http.Handler {
 
 			took := time.Since(start)
 			clog.Infof(ctx, "Processed ImageToVideo request imageSize=%v model_id=%v took=%v", req.Image.FileSize(), *req.ModelId, took)
-			if monitor.Enabled {
-				monitor.AiJobProcessed(ctx, "image-to-video", *req.ModelId, took)
-			}
+
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(resp)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -88,7 +88,7 @@ func submitTextToImage(ctx context.Context, params aiRequestParams, sess *AISess
 	client, err := worker.NewClientWithResponses(sess.Transcoder(), worker.WithHTTPClient(httpClient))
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "text-to-image", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func submitTextToImage(ctx context.Context, params aiRequestParams, sess *AISess
 	setHeaders, balUpdate, err := prepareAIPayment(ctx, sess, outPixels)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "text-to-image", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func submitTextToImage(ctx context.Context, params aiRequestParams, sess *AISess
 	took := time.Since(start)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "text-to-image", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 	mw, err := worker.NewImageToImageMultipartWriter(&buf, req)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-image", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 	client, err := worker.NewClientWithResponses(sess.Transcoder(), worker.WithHTTPClient(httpClient))
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-image", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -213,14 +213,14 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 	imageRdr, err := req.Image.Reader()
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-image", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
 	config, _, err := image.DecodeConfig(imageRdr)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-image", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -229,7 +229,7 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 	setHeaders, balUpdate, err := prepareAIPayment(ctx, sess, outPixels)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-image", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 	took := time.Since(start)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-image", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -278,7 +278,7 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
 			pricePerUnit = float64(priceInfo.PricePerUnit)
 		}
-		monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+		monitor.AiJobProcessed(ctx, "image-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
 	}
 
 	return resp.JSON200, nil
@@ -325,7 +325,7 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	mw, err := worker.NewImageToVideoMultipartWriter(&buf, req)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-video", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -333,7 +333,7 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	client, err := worker.NewClientWithResponses(sess.Transcoder(), worker.WithHTTPClient(httpClient))
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-video", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -352,7 +352,7 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	setHeaders, balUpdate, err := prepareAIPayment(ctx, sess, outPixels)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-video", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -363,7 +363,7 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	took := time.Since(start)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-video", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -372,7 +372,7 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-video", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -389,7 +389,7 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	var res worker.ImageResponse
 	if err := json.Unmarshal(data, &res); err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "image-to-video", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -408,7 +408,7 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
 			pricePerUnit = float64(priceInfo.PricePerUnit)
 		}
-		monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+		monitor.AiJobProcessed(ctx, "image-to-video", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
 	}
 
 	return &res, nil
@@ -450,7 +450,7 @@ func submitUpscale(ctx context.Context, params aiRequestParams, sess *AISession,
 	mw, err := worker.NewUpscaleMultipartWriter(&buf, req)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "upscale", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -458,7 +458,7 @@ func submitUpscale(ctx context.Context, params aiRequestParams, sess *AISession,
 	client, err := worker.NewClientWithResponses(sess.Transcoder(), worker.WithHTTPClient(httpClient))
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "upscale", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -466,14 +466,14 @@ func submitUpscale(ctx context.Context, params aiRequestParams, sess *AISession,
 	imageRdr, err := req.Image.Reader()
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "upscale", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
 	config, _, err := image.DecodeConfig(imageRdr)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "upscale", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -490,7 +490,7 @@ func submitUpscale(ctx context.Context, params aiRequestParams, sess *AISession,
 	took := time.Since(start)
 	if err != nil {
 		if monitor.Enabled {
-			monitor.AIRequestError(err.Error())
+			monitor.AIRequestError(err.Error(), "upscale", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
@@ -519,7 +519,7 @@ func submitUpscale(ctx context.Context, params aiRequestParams, sess *AISession,
 		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
 			pricePerUnit = float64(priceInfo.PricePerUnit)
 		}
-		monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+		monitor.AiJobProcessed(ctx, "upscale", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
 	}
 
 	return resp.JSON200, nil

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -152,11 +152,12 @@ func submitTextToImage(ctx context.Context, params aiRequestParams, sess *AISess
 	sess.LatencyScore = took.Seconds() / float64(outPixels) / (numImages * numInferenceSteps)
 
 	if monitor.Enabled {
-		pricePerUnit := 0.0
-		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
-			pricePerUnit = float64(priceInfo.PricePerUnit)
+		var pricePerAIUnit float64
+		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil && priceInfo.PixelsPerUnit != 0 {
+			pricePerAIUnit = float64(priceInfo.PricePerUnit) / float64(priceInfo.PixelsPerUnit)
 		}
-		monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+
+		monitor.AIRequestFinished(ctx, "text-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerAIUnit}, sess.OrchestratorInfo)
 	}
 
 	return resp.JSON200, nil
@@ -275,11 +276,12 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 	sess.LatencyScore = took.Seconds() / float64(outPixels) / (numImages * numInferenceSteps)
 
 	if monitor.Enabled {
-		pricePerUnit := 0.0
-		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
-			pricePerUnit = float64(priceInfo.PricePerUnit)
+		var pricePerAIUnit float64
+		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil && priceInfo.PixelsPerUnit != 0 {
+			pricePerAIUnit = float64(priceInfo.PricePerUnit) / float64(priceInfo.PixelsPerUnit)
 		}
-		monitor.AiJobProcessed(ctx, "image-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+
+		monitor.AIRequestFinished(ctx, "image-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerAIUnit}, sess.OrchestratorInfo)
 	}
 
 	return resp.JSON200, nil
@@ -405,11 +407,12 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	sess.LatencyScore = took.Seconds() / float64(outPixels) / numInferenceSteps
 
 	if monitor.Enabled {
-		pricePerUnit := 0.0
-		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
-			pricePerUnit = float64(priceInfo.PricePerUnit)
+		var pricePerAIUnit float64
+		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil && priceInfo.PixelsPerUnit != 0 {
+			pricePerAIUnit = float64(priceInfo.PricePerUnit) / float64(priceInfo.PixelsPerUnit)
 		}
-		monitor.AiJobProcessed(ctx, "image-to-video", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+
+		monitor.AIRequestFinished(ctx, "image-to-video", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerAIUnit}, sess.OrchestratorInfo)
 	}
 
 	return &res, nil
@@ -516,11 +519,12 @@ func submitUpscale(ctx context.Context, params aiRequestParams, sess *AISession,
 	sess.LatencyScore = took.Seconds() / float64(outPixels) / numInferenceSteps
 
 	if monitor.Enabled {
-		pricePerUnit := 0.0
-		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
-			pricePerUnit = float64(priceInfo.PricePerUnit)
+		var pricePerAIUnit float64
+		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil && priceInfo.PixelsPerUnit != 0 {
+			pricePerAIUnit = float64(priceInfo.PricePerUnit) / float64(priceInfo.PixelsPerUnit)
 		}
-		monitor.AiJobProcessed(ctx, "upscale", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+
+		monitor.AIRequestFinished(ctx, "upscale", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerAIUnit}, sess.OrchestratorInfo)
 	}
 
 	return resp.JSON200, nil

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -19,6 +19,7 @@ import (
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-tools/drivers"
 	"github.com/livepeer/lpms/stream"
 )
@@ -86,6 +87,9 @@ func processTextToImage(ctx context.Context, params aiRequestParams, req worker.
 func submitTextToImage(ctx context.Context, params aiRequestParams, sess *AISession, req worker.TextToImageJSONRequestBody) (*worker.ImageResponse, error) {
 	client, err := worker.NewClientWithResponses(sess.Transcoder(), worker.WithHTTPClient(httpClient))
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
@@ -101,6 +105,9 @@ func submitTextToImage(ctx context.Context, params aiRequestParams, sess *AISess
 	outPixels := int64(*req.Height) * int64(*req.Width)
 	setHeaders, balUpdate, err := prepareAIPayment(ctx, sess, outPixels)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 	defer completeBalanceUpdate(sess.BroadcastSession, balUpdate)
@@ -109,6 +116,9 @@ func submitTextToImage(ctx context.Context, params aiRequestParams, sess *AISess
 	resp, err := client.TextToImageWithResponse(ctx, req, setHeaders)
 	took := time.Since(start)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
@@ -139,6 +149,14 @@ func submitTextToImage(ctx context.Context, params aiRequestParams, sess *AISess
 	}
 
 	sess.LatencyScore = took.Seconds() / float64(outPixels) / (numImages * numInferenceSteps)
+
+	if monitor.Enabled {
+		pricePerUnit := 0.0
+		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
+			pricePerUnit = float64(priceInfo.PricePerUnit)
+		}
+		monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+	}
 
 	return resp.JSON200, nil
 }
@@ -178,26 +196,41 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 	var buf bytes.Buffer
 	mw, err := worker.NewImageToImageMultipartWriter(&buf, req)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
 	client, err := worker.NewClientWithResponses(sess.Transcoder(), worker.WithHTTPClient(httpClient))
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
 	imageRdr, err := req.Image.Reader()
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 	config, _, err := image.DecodeConfig(imageRdr)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 	outPixels := int64(config.Height) * int64(config.Width)
 
 	setHeaders, balUpdate, err := prepareAIPayment(ctx, sess, outPixels)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 	defer completeBalanceUpdate(sess.BroadcastSession, balUpdate)
@@ -206,6 +239,9 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 	resp, err := client.ImageToImageWithBodyWithResponse(ctx, mw.FormDataContentType(), &buf, setHeaders)
 	took := time.Since(start)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
@@ -236,6 +272,14 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 	}
 
 	sess.LatencyScore = took.Seconds() / float64(outPixels) / (numImages * numInferenceSteps)
+
+	if monitor.Enabled {
+		pricePerUnit := 0.0
+		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
+			pricePerUnit = float64(priceInfo.PricePerUnit)
+		}
+		monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+	}
 
 	return resp.JSON200, nil
 }
@@ -280,11 +324,17 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	var buf bytes.Buffer
 	mw, err := worker.NewImageToVideoMultipartWriter(&buf, req)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
 	client, err := worker.NewClientWithResponses(sess.Transcoder(), worker.WithHTTPClient(httpClient))
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
@@ -301,6 +351,9 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	outPixels := int64(*req.Height) * int64(*req.Width) * frames
 	setHeaders, balUpdate, err := prepareAIPayment(ctx, sess, outPixels)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 	defer completeBalanceUpdate(sess.BroadcastSession, balUpdate)
@@ -309,12 +362,18 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	resp, err := client.ImageToVideoWithBody(ctx, mw.FormDataContentType(), &buf, setHeaders)
 	took := time.Since(start)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
@@ -329,6 +388,9 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 
 	var res worker.ImageResponse
 	if err := json.Unmarshal(data, &res); err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
@@ -340,6 +402,14 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 		numInferenceSteps = float64(*req.NumInferenceSteps)
 	}
 	sess.LatencyScore = took.Seconds() / float64(outPixels) / numInferenceSteps
+
+	if monitor.Enabled {
+		pricePerUnit := 0.0
+		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
+			pricePerUnit = float64(priceInfo.PricePerUnit)
+		}
+		monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+	}
 
 	return &res, nil
 }
@@ -379,20 +449,32 @@ func submitUpscale(ctx context.Context, params aiRequestParams, sess *AISession,
 	var buf bytes.Buffer
 	mw, err := worker.NewUpscaleMultipartWriter(&buf, req)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
 	client, err := worker.NewClientWithResponses(sess.Transcoder(), worker.WithHTTPClient(httpClient))
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
 	imageRdr, err := req.Image.Reader()
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 	config, _, err := image.DecodeConfig(imageRdr)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 	outPixels := int64(config.Height) * int64(config.Width)
@@ -407,6 +489,9 @@ func submitUpscale(ctx context.Context, params aiRequestParams, sess *AISession,
 	resp, err := client.UpscaleWithBodyWithResponse(ctx, mw.FormDataContentType(), &buf, setHeaders)
 	took := time.Since(start)
 	if err != nil {
+		if monitor.Enabled {
+			monitor.AIRequestError(err.Error())
+		}
 		return nil, err
 	}
 
@@ -428,6 +513,14 @@ func submitUpscale(ctx context.Context, params aiRequestParams, sess *AISession,
 		numInferenceSteps = float64(*req.NumInferenceSteps)
 	}
 	sess.LatencyScore = took.Seconds() / float64(outPixels) / numInferenceSteps
+
+	if monitor.Enabled {
+		pricePerUnit := 0.0
+		if priceInfo := sess.OrchestratorInfo.GetPriceInfo(); priceInfo != nil {
+			pricePerUnit = float64(priceInfo.PricePerUnit)
+		}
+		monitor.AiJobProcessed(ctx, "text-to-image", *req.ModelId, monitor.AIJobInfo{LatencyScore: sess.LatencyScore, PricePerUnit: pricePerUnit}, sess.OrchestratorInfo)
+	}
 
 	return resp.JSON200, nil
 }

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -730,11 +730,21 @@ func prepareAIPayment(ctx context.Context, sess *AISession, outPixels int64) (wo
 
 	payment, err := genPayment(ctx, sess.BroadcastSession, balUpdate.NumTickets)
 	if err != nil {
+		clog.Errorf(ctx, "Could not create payment err=%q", err)
+
+		if monitor.Enabled {
+			monitor.PaymentCreateError(ctx)
+		}
+
 		return nil, nil, err
 	}
 
 	// As soon as the request is sent to the orch consider the balance update's credit as spent
 	balUpdate.Status = CreditSpent
+	if monitor.Enabled {
+		monitor.TicketValueSent(ctx, balUpdate.NewCredit)
+		monitor.TicketsSent(ctx, balUpdate.NumTickets)
+	}
 
 	setHeaders := func(_ context.Context, req *http.Request) error {
 		req.Header.Set(segmentHeader, segCreds)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request introduces new Gateway AI metrics to the `ai-video` branch:
- **Ticket_value_sent**: The value of the AI tickets that are send to the Orchestrators.
- **Tickets_send**: The total amount of tickets send to the Orchestrators.
- **ai_models_requested**: Tracks the number of requests per capability and model.
- **ai_request_latency_score**: Measures latency scores per model request per orchestrator.
- **ai_request_price**: Records the price paid per unit for each model request.
- **ai_request_errors**: Logs AI request errors per orchestrator. If no orchestrator is specified, this indicates a general request scenario where no orchestrators were found.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates `census.go` to include the new Gateway metrics.
- Updates `ai_process` to log these metrics.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, the tests you ran, and their outcomes. -->

I set up both an on-chain and off-chain gateway to validate the metrics. I verified their visibility at `http://localhost:5935/metrics` and ensured they were correctly visualized in Grafana.

**Does this pull request close any open issues?**

This implements the functionality outlined in https://livepeer-ai.productlane.com/roadmap?id=58c9cd5d-1c64-4fb3-b8d0-a7e20b7865a2.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated

#### How to test

1. Check out this pull request.
2. Spin up an on-chain gateway with attached orchestrators.
3. Clone the repository https://github.com/rickstaa/livepeer-monitor-test.
4. Execute the Dockerfile in that repository to launch Prometheus and Grafana servers.
5. Navigate to `http://localhost:5935/metrics` to view the new AI Gateway metrics.
6. Visit `http://localhost:3000` to inspect these metrics in Grafana.