### PR TITLE
fix I2I latency score

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -201,8 +201,14 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 		balUpdate.Status = ReceivedChange
 	}
 
-	// TODO: Refine this rough estimate in future iterations
-	sess.LatencyScore = took.Seconds() / float64(outPixels)
+	// TODO: Refine this rough estimate in future iterations.
+	// TODO: Default values for the number of images is currently hardcoded.
+	// These should be managed by the nethttpmiddleware. Refer to issue LIV-412 for more details.
+	numImages := float64(1)
+	if req.NumImagesPerPrompt != nil {
+		numImages = float64(*req.NumImagesPerPrompt)
+	}
+	sess.LatencyScore = took.Seconds() / float64(outPixels) / numImages
 
 	return resp.JSON200, nil
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request ensures that the number of requested output images are also taken into account for the I2I pipeline. This is already done for the T2I pipeline but this logic was missing in the I2I pipeline causing the latency score to be incorrect.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

- Update the I2I latency score calculated by the gateway and used in the selection algorithm to include the number of requested output images.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Run the code locally.

**Does this pull request close any open issues?**
<!-- Fixes # -->

AI-504

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
