### PR TITLE
Add `/healthz` endpoint

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -29,6 +29,12 @@ import (
 const MainnetChainId = 1
 const RinkebyChainId = 4
 
+func (s *LivepeerServer) healthzHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		respondOk(w, nil)
+	})
+}
+
 // Status
 func (s *LivepeerServer) statusHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -199,6 +199,9 @@ func (s *LivepeerServer) StartMediaServer(ctx context.Context, httpAddr string) 
 	// Store ctx to later use as cancel signal for watchdog goroutine
 	s.context = ctx
 
+	// health endpoint
+	s.HTTPMux.Handle("/healthz", s.healthzHandler())
+
 	//LPMS handlers for handling RTMP video
 	s.LPMS.HandleRTMPPublish(createRTMPStreamIDHandler(ctx, s, nil), gotRTMPStreamHandler(s), endRTMPStreamHandler(s))
 	s.LPMS.HandleRTMPPlay(getRTMPStreamHandler(s))

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -35,6 +35,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 	db := s.LivepeerNode.Database
 
 	// Status
+	mux.Handle("/healthz", s.healthzHandler())
 	mux.Handle("/status", s.statusHandler())
 	mux.Handle("/streamID", s.streamIdHandler())
 	mux.Handle("/manifestID", s.manifestIdHandler())

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -35,7 +35,6 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 	db := s.LivepeerNode.Database
 
 	// Status
-	mux.Handle("/healthz", s.healthzHandler())
 	mux.Handle("/status", s.statusHandler())
 	mux.Handle("/streamID", s.streamIdHandler())
 	mux.Handle("/manifestID", s.manifestIdHandler())


### PR DESCRIPTION
Add a simple healthcheck endpoint with the intention to use it for the kubernetes `livenessProbe` / `readinessProbe`.

We already have `/status` endpoint, but it:
- returns a ton of data (we don't need it for k8 health checks)
- does some calculations (we don't want to do a lot of calculations with each healthcheck)