### PR TITLE
add num inference steps I2I I2V upscale

### DIFF
--- a/core/ai.go
+++ b/core/ai.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -84,4 +85,20 @@ func ParseAIModelConfigs(config string) ([]AIModelConfig, error) {
 	}
 
 	return configs, nil
+}
+
+// parseStepsFromModelID parses the number of inference steps from the model ID suffix.
+func ParseStepsFromModelID(modelID *string, defaultSteps float64) float64 {
+	numInferenceSteps := defaultSteps
+
+	// Regular expression to find "_<number>step" pattern anywhere in the model ID.
+	stepPattern := regexp.MustCompile(`_(\d+)step`)
+	matches := stepPattern.FindStringSubmatch(*modelID)
+	if len(matches) == 2 {
+		if parsedSteps, err := strconv.Atoi(matches[1]); err == nil {
+			numInferenceSteps = float64(parsedSteps)
+		}
+	}
+
+	return numInferenceSteps
 }

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -122,6 +122,11 @@ func submitTextToImage(ctx context.Context, params aiRequestParams, sess *AISess
 	if req.NumInferenceSteps != nil {
 		numInferenceSteps = float64(*req.NumInferenceSteps)
 	}
+	// Handle special case for SDXL-Lightning model.
+	if strings.HasPrefix(*req.ModelId, "ByteDance/SDXL-Lightning") {
+		numInferenceSteps = core.ParseStepsFromModelID(req.ModelId, 8)
+	}
+
 	sess.LatencyScore = took.Seconds() / float64(outPixels) / (numImages * numInferenceSteps)
 
 	return resp.JSON200, nil
@@ -202,13 +207,22 @@ func submitImageToImage(ctx context.Context, params aiRequestParams, sess *AISes
 	}
 
 	// TODO: Refine this rough estimate in future iterations.
-	// TODO: Default values for the number of images is currently hardcoded.
+	// TODO: Default values for the number of images and inference steps are currently hardcoded.
 	// These should be managed by the nethttpmiddleware. Refer to issue LIV-412 for more details.
 	numImages := float64(1)
 	if req.NumImagesPerPrompt != nil {
 		numImages = float64(*req.NumImagesPerPrompt)
 	}
-	sess.LatencyScore = took.Seconds() / float64(outPixels) / numImages
+	numInferenceSteps := float64(100)
+	if req.NumInferenceSteps != nil {
+		numInferenceSteps = float64(*req.NumInferenceSteps)
+	}
+	// Handle special case for SDXL-Lightning model.
+	if strings.HasPrefix(*req.ModelId, "ByteDance/SDXL-Lightning") {
+		numInferenceSteps = core.ParseStepsFromModelID(req.ModelId, 8)
+	}
+
+	sess.LatencyScore = took.Seconds() / float64(outPixels) / (numImages * numInferenceSteps)
 
 	return resp.JSON200, nil
 }
@@ -303,7 +317,13 @@ func submitImageToVideo(ctx context.Context, params aiRequestParams, sess *AISes
 	}
 
 	// TODO: Refine this rough estimate in future iterations
-	sess.LatencyScore = took.Seconds() / float64(outPixels)
+	// TODO: Default values for the number of inference steps is currently hardcoded.
+	// These should be managed by the nethttpmiddleware. Refer to issue LIV-412 for more details.
+	numInferenceSteps := float64(25)
+	if req.NumInferenceSteps != nil {
+		numInferenceSteps = float64(*req.NumInferenceSteps)
+	}
+	sess.LatencyScore = took.Seconds() / float64(outPixels) / numInferenceSteps
 
 	return &res, nil
 }
@@ -383,7 +403,13 @@ func submitUpscale(ctx context.Context, params aiRequestParams, sess *AISession,
 	}
 
 	// TODO: Refine this rough estimate in future iterations
-	sess.LatencyScore = took.Seconds() / float64(outPixels)
+	// TODO: Default values for the number of inference steps is currently hardcoded.
+	// These should be managed by the nethttpmiddleware. Refer to issue LIV-412 for more details.
+	numInferenceSteps := float64(75)
+	if req.NumInferenceSteps != nil {
+		numInferenceSteps = float64(*req.NumInferenceSteps)
+	}
+	sess.LatencyScore = took.Seconds() / float64(outPixels) / numInferenceSteps
 
 	return resp.JSON200, nil
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request enabled the `num_inference_steps` parameter on the I2V, I2I and Upscale pipelines. It also fixes the latencyScore calculation for the https://huggingface.co/ByteDance/SDXL-Lightning model.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates `ai_process` to handle the `num_inference_steps` parameter correctly.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, the tests you ran, and their outcomes. -->

I set up both an on-chain and off-chain gateway to validate the metrics.

**Does this pull request close any open issues?**

This implements the functionality outlined in https://livepeer-ai.productlane.com/roadmap?id=45129f14-62f1-40b6-96c0-944724b47086.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated