### PR TITLE
cmd: Use `-gateway` consistently

### DIFF
--- a/cmd/devtool/devtool.go
+++ b/cmd/devtool/devtool.go
@@ -3,14 +3,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/golang/glog"
-	"github.com/livepeer/go-livepeer/cmd/devtool/devtool"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/cmd/devtool/devtool"
 )
 
 var (
@@ -195,7 +196,7 @@ func createRunScript(ethController string, dataDir, serviceHost string, cfg devt
 	} else {
 		args = append(
 			args,
-			"-broadcaster=true",
+			"-gateway=true",
 			fmt.Sprintf("-rtmpAddr %s:%d", serviceHost, rtmpPort),
 		)
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -511,7 +511,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	} else if *cfg.Gateway {
 		n.NodeType = core.BroadcasterNode
 	} else if (cfg.Reward == nil || !*cfg.Reward) && !*cfg.InitializeRound {
-		exit("No services enabled; must be at least one of -broadcaster, -transcoder, -orchestrator, -redeemer, -reward or -initializeRound")
+		exit("No services enabled; must be at least one of -gateway, -transcoder, -orchestrator, -redeemer, -reward or -initializeRound")
 	}
 
 	lpmon.NodeID = *cfg.EthAcctAddr

--- a/doc/verification.md
+++ b/doc/verification.md
@@ -1,6 +1,6 @@
 # Verification
 
-The Livepeer node supports two types of verification when running with the `-broadcaster` flag:
+The Livepeer node supports two types of verification when running with the `-gateway` flag:
 
 - Local verification
     - This currently involves pixel count and signature verification.

--- a/test_args.sh
+++ b/test_args.sh
@@ -37,7 +37,7 @@ res=0
 $TMPDIR/livepeer || res=$?
 [ $res -ne 0 ]
 
-run_lp -broadcaster
+run_lp -gateway
 [ -d "$DEFAULT_DATADIR"/offchain ]
 kill $pid
 
@@ -45,7 +45,7 @@ kill $pid
 [ ! -d "$CUSTOM_DATADIR" ]
 
 # check custom datadir without a network (offchain)
-run_lp -broadcaster -dataDir "$CUSTOM_DATADIR"
+run_lp -gateway -dataDir "$CUSTOM_DATADIR"
 [ -d "$CUSTOM_DATADIR" ]
 [ ! -d "$CUSTOM_DATADIR"/offchain ] # sanity check that network isn't included
 kill $pid
@@ -83,13 +83,13 @@ if [ -z ${MAINNET_ETH_URL+x} ]; then
 else
   # Exit early if -ethUrl is missing
   res=0
-  $TMPDIR/livepeer -broadcaster -network mainnet $ETH_ARGS || res=$?
+  $TMPDIR/livepeer -gateway -network mainnet $ETH_ARGS || res=$?
   [ $res -ne 0 ]
 
   OLD_ETH_ARGS=$ETH_ARGS
   ETH_ARGS="${ETH_ARGS} -ethUrl ${MAINNET_ETH_URL}"
 
-  run_lp -broadcaster -network mainnet $ETH_ARGS
+  run_lp -gateway -network mainnet $ETH_ARGS
   [ -d "$DEFAULT_DATADIR"/mainnet ]
   kill $pid
 
@@ -102,27 +102,27 @@ if [ -z ${RINKEBY_ETH_URL+x} ]; then
 else
   # Exit early if -ethUrl is missing
   res=0
-  $TMPDIR/livepeer -broadcaster -network rinkeby $ETH_ARGS || res=$?
+  $TMPDIR/livepeer -gateway -network rinkeby $ETH_ARGS || res=$?
   [ $res -ne 0 ]
 
   OLD_ETH_ARGS=$ETH_ARGS
   ETH_ARGS="${ETH_ARGS} -ethUrl ${RINKEBY_ETH_URL}"
 
-  run_lp -broadcaster -network rinkeby $ETH_ARGS
+  run_lp -gateway -network rinkeby $ETH_ARGS
   [ -d "$DEFAULT_DATADIR"/rinkeby ]
   kill $pid
 
   # Error if flags to set MaxBroadcastPrice aren't provided correctly
   res=0
-  $TMPDIR/livepeer -broadcaster -network rinkeby $ETH_ARGS -maxPricePerUnit 0 -pixelsPerUnit -5 || res=$?
+  $TMPDIR/livepeer -gateway -network rinkeby $ETH_ARGS -maxPricePerUnit 0 -pixelsPerUnit -5 || res=$?
   [ $res -ne 0 ]
 
-  run_lp -broadcaster -network anyNetwork $ETH_ARGS -v 99
+  run_lp -gateway -network anyNetwork $ETH_ARGS -v 99
   [ -d "$DEFAULT_DATADIR"/anyNetwork ]
   kill $pid
 
   # check custom datadir with a network
-  run_lp -broadcaster -dataDir "$CUSTOM_DATADIR" -network rinkeby $ETH_ARGS
+  run_lp -gateway -dataDir "$CUSTOM_DATADIR" -network rinkeby $ETH_ARGS
   [ ! -d "$CUSTOM_DATADIR"/rinkeby ] # sanity check that network isn't included
   kill $pid
 
@@ -141,22 +141,22 @@ else
 
   # Broadcaster needs a valid rational number for -maxTicketEV
   res=0
-  $TMPDIR/livepeer -broadcaster -maxTicketEV abcd -network rinkeby $ETH_ARGS || res=$?
+  $TMPDIR/livepeer -gateway -maxTicketEV abcd -network rinkeby $ETH_ARGS || res=$?
   [ $res -ne 0 ]
   # Broadcaster needs a non-negative number for -maxTicketEV
   res=0
-  $TMPDIR/livepeer -broadcaster -maxTicketEV -1 -network rinkeby $ETH_ARGS || res=$?
+  $TMPDIR/livepeer -gateway -maxTicketEV -1 -network rinkeby $ETH_ARGS || res=$?
   [ $res -ne 0 ]
   # Broadcaster needs a positive number for -depositMultiplier
   res=0
-  $TMPDIR/livepeer -broadcaster -depositMultiplier 0 -network rinkeby $ETH_ARGS || res=$?
+  $TMPDIR/livepeer -gateway -depositMultiplier 0 -network rinkeby $ETH_ARGS || res=$?
   [ $res -ne 0 ]
 
   # Check that local verification is enabled by default in on-chain mode
-  $TMPDIR/livepeer -broadcaster -transcodingOptions invalid -network rinkeby $ETH_ARGS 2>&1 | grep "Local verification enabled"
+  $TMPDIR/livepeer -gateway -transcodingOptions invalid -network rinkeby $ETH_ARGS 2>&1 | grep "Local verification enabled"
 
   # Check that local verification is disabled via -localVerify in on-chain mode
-  $TMPDIR/livepeer -broadcaster -transcodingOptions invalid -localVerify=false -network rinkeby $ETH_ARGS 2>&1 | grep -v "Local verification enabled"
+  $TMPDIR/livepeer -gateway -transcodingOptions invalid -localVerify=false -network rinkeby $ETH_ARGS 2>&1 | grep -v "Local verification enabled"
 
   ETH_ARGS=$OLD_ETH_ARGS
 fi
@@ -168,101 +168,101 @@ $TMPDIR/livepeer -transcoder || res=$?
 
 # exit early if webhook url is not http
 res=0
-$TMPDIR/livepeer -broadcaster -authWebhookUrl tcp://host/ || res=$?
+$TMPDIR/livepeer -gateway -authWebhookUrl tcp://host/ || res=$?
 [ $res -ne 0 ]
 
 # exit early if webhook url is not properly formatted
 res=0
-$TMPDIR/livepeer -broadcaster -authWebhookUrl http\\://host/ || res=$?
+$TMPDIR/livepeer -gateway -authWebhookUrl http\\://host/ || res=$?
 [ $res -ne 0 ]
 
 # exit early if orchestrator webhook URL is not http
 res=0
-$TMPDIR/livepeer -broadcaster -orchWebhookUrl tcp://host/ || res=$?
+$TMPDIR/livepeer -gateway -orchWebhookUrl tcp://host/ || res=$?
 [ $res -ne 0 ]
 
 # exit early if orchestrator webhook URL is not properly formatted
 res=0
-$TMPDIR/livepeer -broadcaster -orchWebhookUrl http\\://host/ || res=$?
+$TMPDIR/livepeer -gateway -orchWebhookUrl http\\://host/ || res=$?
 [ $res -ne 0 ]
 
 # exit early if maxSessions less or equal to zero
 res=0
-$TMPDIR/livepeer -broadcaster -maxSessions -1 || res=$?
+$TMPDIR/livepeer -gateway -maxSessions -1 || res=$?
 [ $res -ne 0 ]
 
 res=0
-$TMPDIR/livepeer -broadcaster -maxSessions 0 || res=$?
+$TMPDIR/livepeer -gateway -maxSessions 0 || res=$?
 [ $res -ne 0 ]
 
 # Check that pprof is running on CLI port
-run_lp -broadcaster
+run_lp -gateway
 curl -sI http://127.0.0.1:5935/debug/pprof/allocs | grep "200 OK"
 kill $pid
 
 # exit early if verifier URL is not http
 res=0
-$TMPDIR/livepeer -broadcaster -verifierUrl tcp://host/ || res=$?
+$TMPDIR/livepeer -gateway -verifierUrl tcp://host/ || res=$?
 [ $res -ne 0 ]
 
 # exit early if verifier URL is not properly formatted
 res=0
-$TMPDIR/livepeer -broadcaster -verifierUrl http\\://host/ || res=$?
+$TMPDIR/livepeer -gateway -verifierUrl http\\://host/ || res=$?
 [ $res -ne 0 ]
 
 # Check that verifier shared path is required
-$TMPDIR/livepeer -broadcaster -verifierUrl http://host 2>&1 | grep "Requires a path to the"
+$TMPDIR/livepeer -gateway -verifierUrl http://host 2>&1 | grep "Requires a path to the"
 
 # Check OK with verifier shared path
-run_lp -broadcaster -verifierUrl http://host -verifierPath path
+run_lp -gateway -verifierUrl http://host -verifierPath path
 kill $pid
 
 # Check OK with verifier + external storage
-run_lp -broadcaster -verifierUrl http://host -objectStore s3+https://ACCESS_KEY_ID:ACCESS_KEY_PASSWORD@s3api.example.com/bucket-name
+run_lp -gateway -verifierUrl http://host -objectStore s3+https://ACCESS_KEY_ID:ACCESS_KEY_PASSWORD@s3api.example.com/bucket-name
 kill $pid
 
 # Check that HTTP ingest is disabled when -httpAddr is publicly accessible and there is no auth webhook URL and -httpIngest defaults to false
-run_lp -broadcaster -httpAddr 0.0.0.0
+run_lp -gateway -httpAddr 0.0.0.0
 curl -X PUT http://localhost:9935/live/movie/0.ts | grep "404 page not found"
 kill $pid
 
 # Check that HTTP ingest is disabled when -httpAddr is not publicly accessible and -httpIngest is set to false
-run_lp -broadcaster -httpIngest=false
+run_lp -gateway -httpIngest=false
 curl -X PUT http://localhost:9935/live/movie/0.ts | grep "404 page not found"
 kill $pid
 
 # Check that HTTP ingest is disabled when -httpAddr is publicly accessible and there is a auth webhook URL and -httpIngest is set to false
-run_lp -broadcaster -httpAddr 0.0.0.0 -authWebhookUrl http://foo.com -httpIngest=false
+run_lp -gateway -httpAddr 0.0.0.0 -authWebhookUrl http://foo.com -httpIngest=false
 curl -X PUT http://localhost:9935/live/movie/0.ts | grep "404 page not found"
 kill $pid
 
 # Check that HTTP ingest is enabled when -httpIngest is true
-run_lp -broadcaster -httpAddr 0.0.0.0 -httpIngest
+run_lp -gateway -httpAddr 0.0.0.0 -httpIngest
 curl -X PUT http://localhost:9935/live/movie/0.ts | grep -v "404 page not found"
 kill $pid
 
 # Check that HTTP ingest is enabled when -httpAddr sets the hostname to 127.0.0.1
-run_lp -broadcaster -httpAddr 127.0.0.1
+run_lp -gateway -httpAddr 127.0.0.1
 curl -X PUT http://localhost:9935/live/movie/0.ts | grep -v "404 page not found"
 kill $pid
 
 # Check that HTTP ingest is enabled when -httpAddr sets the hostname to localhost
-run_lp -broadcaster -httpAddr localhost
+run_lp -gateway -httpAddr localhost
 curl -X PUT http://localhost:9935/live/movie/0.ts | grep -v "404 page not found"
 kill $pid
 
 # Check that HTTP ingest is enabled when there is an auth webhook URL
-run_lp -broadcaster -httpAddr 0.0.0.0 -authWebhookUrl http://foo.com
+run_lp -gateway -httpAddr 0.0.0.0 -authWebhookUrl http://foo.com
 curl -X PUT http://localhost:9935/live/movie/0.ts | grep -v "404 page not found"
 kill $pid
 
 # Check that the default presets are used
-run_lp -broadcaster
+run_lp -gateway
 curl -s --stderr - http://localhost:5935/getBroadcastConfig | grep P240p30fps16x9,P360p30fps16x9
 kill $pid
 
 # Check that the presets passed in are used
-run_lp -broadcaster -transcodingOptions P144p30fps16x9,P720p30fps16x9
+run_lp -gateway -transcodingOptions P144p30fps16x9,P720p30fps16x9
 curl -s --stderr - http://localhost:5935/getBroadcastConfig | grep P144p30fps16x9,P720p30fps16x9
 kill $pid
 
@@ -270,25 +270,25 @@ kill $pid
 cat >$TMPDIR/profile.json <<PROFILE_JSON
 [{"name":"abc","width":1,"height":2},{"name":"def","width":1,"height":2}]
 PROFILE_JSON
-run_lp -broadcaster -transcodingOptions $TMPDIR/profile.json
+run_lp -gateway -transcodingOptions $TMPDIR/profile.json
 curl -s --stderr - http://localhost:5935/getBroadcastConfig | grep abc,def
 kill $pid
 
 # Check nonexistent profile config file
-$TMPDIR/livepeer -broadcaster -transcodingOptions notarealfile 2>&1 | grep "No transcoding profiles found"
+$TMPDIR/livepeer -gateway -transcodingOptions notarealfile 2>&1 | grep "No transcoding profiles found"
 
 # Check that it fails out on an malformed profiles json
 echo "not json" >$TMPDIR/invalid.json
-$TMPDIR/livepeer -broadcaster -transcodingOptions $TMPDIR/invalid.json 2>&1 | grep "invalid character"
+$TMPDIR/livepeer -gateway -transcodingOptions $TMPDIR/invalid.json 2>&1 | grep "invalid character"
 
 # Check that it fails out on an invalid schema - width / height as strings
 echo '[{"width":"1","height":"2"}]' >$TMPDIR/schema.json
-$TMPDIR/livepeer -broadcaster -transcodingOptions $TMPDIR/schema.json 2>&1 | grep "cannot unmarshal string into Go struct field JsonProfile.width of type int"
+$TMPDIR/livepeer -gateway -transcodingOptions $TMPDIR/schema.json 2>&1 | grep "cannot unmarshal string into Go struct field JsonProfile.width of type int"
 
 # Check that local verification is disabled by default in off-chain mode
-$TMPDIR/livepeer -broadcaster -transcodingOptions invalid 2>&1 | grep -v "Local verification enabled"
+$TMPDIR/livepeer -gateway -transcodingOptions invalid 2>&1 | grep -v "Local verification enabled"
 
 # Check that local verification is enabled via -localVerify in off-chain mode
-$TMPDIR/livepeer -broadcaster -transcodingOptions invalid -localVerify=true 2>&1 | grep "Local verification enabled"
+$TMPDIR/livepeer -gateway -transcodingOptions invalid -localVerify=true 2>&1 | grep "Local verification enabled"
 
 rm -rf $TMPDIR


### PR DESCRIPTION
Avoid references to deprecated CLI flags. See https://github.com/livepeer/go-livepeer/pull/3053

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Changes most `-broadcaster` references (as found by `rg "\-broadcaster"`)  to `-gateway`

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- No functional changes
- A bit of import rearranging done automatically by go-fmt

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
