### PR TITLE
feat: allow Gateways to filter by pre-release

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 # Unreleased Changes
 
+- [#3111](https://github.com/livepeer/go-livepeer/pull/3111) feat: allow Gateways to filter by pre-release
+
 ## vX.X
 
 ### Breaking Changes 🚨🚨

--- a/core/capabilities_test.go
+++ b/core/capabilities_test.go
@@ -339,11 +339,39 @@ func TestCapability_CompatibleWithNetCap(t *testing.T) {
 	orch.version = "0.4.0"
 	assert.False(bcast.CompatibleWith(orch.ToNetCapabilities()))
 
-	// broadcaster is not compatible with orchestrator - the same version
+	// broadcaster is compatible with orchestrator - the same version
 	orch = NewCapabilities(nil, nil)
 	bcast = NewCapabilities(nil, nil)
 	bcast.constraints.minVersion = "0.4.1"
 	orch.version = "0.4.1"
+	assert.True(bcast.CompatibleWith(orch.ToNetCapabilities()))
+
+	// broadcaster is compatible with orchestrator - no pre-release min version suffix
+	orch = NewCapabilities(nil, nil)
+	bcast = NewCapabilities(nil, nil)
+	bcast.constraints.minVersion = "0.4.1"
+	orch.version = "0.4.1-0.21000000000000-06f1f383fb18"
+	assert.True(bcast.CompatibleWith(orch.ToNetCapabilities()))
+
+	// broadcaster is not compatible with orchestrator - no pre-release O's version
+	orch = NewCapabilities(nil, nil)
+	bcast = NewCapabilities(nil, nil)
+	bcast.constraints.minVersion = "0.4.1-0.20000000000000-06f1f383fb18"
+	orch.version = "0.4.1"
+	assert.False(bcast.CompatibleWith(orch.ToNetCapabilities()))
+
+	// broadcaster is not compatible with orchestrator pre-release - old O's version
+	orch = NewCapabilities(nil, nil)
+	bcast = NewCapabilities(nil, nil)
+	bcast.constraints.minVersion = "0.4.1-0.21000000000000-06f1f383fb18"
+	orch.version = "0.4.1-0.20000000000000-06f1f383fb18"
+	assert.False(bcast.CompatibleWith(orch.ToNetCapabilities()))
+
+	// broadcaster is compatible with orchestrator pre-release - higher O's version
+	orch = NewCapabilities(nil, nil)
+	bcast = NewCapabilities(nil, nil)
+	bcast.constraints.minVersion = "0.4.1-0.20000000000000-06f1f383fb18"
+	orch.version = "0.4.1-0.21000000000000-06f1f383fb18"
 	assert.True(bcast.CompatibleWith(orch.ToNetCapabilities()))
 }
 
@@ -567,6 +595,30 @@ func TestLiveeerVersionCompatibleWith(t *testing.T) {
 			broadcasterMinVersion: "0.4.1",
 			transcoderVersion:     "nonparsablesemversion",
 			expected:              false,
+		},
+		{
+			name:                  "broadcaster required version has no pre-release",
+			broadcasterMinVersion: "0.4.1",
+			transcoderVersion:     "0.4.1-0.21000000000000-06f1f383fb18",
+			expected:              true,
+		},
+		{
+			name:                  "transcoder version has no pre-release",
+			broadcasterMinVersion: "0.4.1-0.21000000000000-06f1f383fb18",
+			transcoderVersion:     "0.4.1",
+			expected:              false,
+		},
+		{
+			name:                  "broadcaster required pre-release version is higher than transcoder pre-release version",
+			broadcasterMinVersion: "0.4.1-0.21000000000000-06f1f383fb18",
+			transcoderVersion:     "0.4.1-0.20000000000000-06f1f383fb18",
+			expected:              false,
+		},
+		{
+			name:                  "broadcaster required pre-release version is lower than transcoder pre-release version",
+			broadcasterMinVersion: "0.4.1-0.20000000000000-06f1f383fb18",
+			transcoderVersion:     "0.4.1-0.21000000000000-06f1f383fb18",
+			expected:              true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request gives Gateways the ability to filter by pre-release suffix. When a pre-release suffix is specified in the `OrchMinLivepeerVersion` command line argument the software now also checks the pre-release version suffix on the orchestrator.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Changed the logic in https://github.com/livepeer/go-livepeer/pull/3111/files#diff-fdba37d9bd7a580de9aaa45bf86524a4caa83516a73af118cb116e93d0220c73 to also check the pre-release suffic when present in the `OrchMinLivepeerVersion` CLI argument.
- Updated the tests.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Ensured tests worked. Did not run an off-chain or on-chain transcoding gateway yet but did do this on the AI side.

**Does this pull request close any open issues?**
<!-- Fixes # -->

No but this is required to be able to filter versions on the https://github.com/livepeer/go-livepeer/tree/ai-video branch since we use pre-release suffixes to seperate our versions from the main branhc.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
