### PR TITLE
livepeer: add a `-hevcDecoding` flag

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,7 +2,11 @@
 
 ## vX.X
 
+This release includes a new `-hevcDecoding` flag for transcoders to configure HEVC decoding. If the flag is omitted, the default behavior on GPUs is unchanged, which is to auto-detect HEVC decoding support at transcoder start-up. Transcoders can disable HEVC decoding on GPUs if there is an issue with HEVC jobs via `-hevcDecoding=false`. CPU transcoders now have HEVC decoding disabled by default since processing HEVC jobs is CPU-heavy, but this can be enabled by setting the `-hevcDecoding` flag.
+
 ### Breaking Changes 🚨🚨
+
+- [#3119](https://github.com/livepeer/go-livepeer/pull/3119) CPU transcoders no longer decode HEVC or VP9 by default
 
 ### Features ⚒
 
@@ -13,6 +17,8 @@
 #### Orchestrator
 
 #### Transcoder
+
+- [#3119](https://github.com/livepeer/go-livepeer/pull/3119) Add `-hevcDecoding` flag to toggle HEVC decoding
 
 ### Bug Fixes 🐞
 

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -150,6 +150,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.Nvidia = flag.String("nvidia", *cfg.Nvidia, "Comma-separated list of Nvidia GPU device IDs (or \"all\" for all available devices)")
 	cfg.Netint = flag.String("netint", *cfg.Netint, "Comma-separated list of NetInt device GUIDs (or \"all\" for all available devices)")
 	cfg.TestTranscoder = flag.Bool("testTranscoder", *cfg.TestTranscoder, "Test Nvidia GPU transcoding at startup")
+	cfg.HevcDecoding = flag.Bool("hevcDecoding", *cfg.HevcDecoding, "Enable or disable HEVC decoding")
 
 	// Onchain:
 	cfg.EthAcctAddr = flag.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in the keystore directory")
@@ -236,6 +237,9 @@ func updateNilsForUnsetFlags(cfg starter.LivepeerConfig) starter.LivepeerConfig 
 	}
 	if !isFlagSet["localVerify"] {
 		res.LocalVerify = nil
+	}
+	if !isFlagSet["hevcDecoding"] {
+		res.HevcDecoding = nil
 	}
 
 	return res

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -104,6 +104,7 @@ type LivepeerConfig struct {
 	CurrentManifest         *bool
 	Nvidia                  *string
 	Netint                  *string
+	HevcDecoding            *bool
 	TestTranscoder          *bool
 	EthAcctAddr             *string
 	EthPassword             *string
@@ -181,6 +182,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultCurrentManifest := false
 	defaultNvidia := ""
 	defaultNetint := ""
+	defaultHevcDecoding := false
 	defaultTestTranscoder := true
 
 	// Onchain:
@@ -270,6 +272,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		CurrentManifest:      &defaultCurrentManifest,
 		Nvidia:               &defaultNvidia,
 		Netint:               &defaultNetint,
+		HevcDecoding:         &defaultHevcDecoding,
 		TestTranscoder:       &defaultTestTranscoder,
 
 		// Onchain:
@@ -489,9 +492,29 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			// Initialize LB transcoder
 			n.Transcoder = core.NewLoadBalancingTranscoder(devices, tf)
 		} else {
-			// for local software mode, enable all capabilities
-			transcoderCaps = append(core.DefaultCapabilities(), core.OptionalCapabilities()...)
+			// for local software mode, enable most capabilities but remove expensive decoders and non-H264 encoders
+			capsToRemove := []core.Capability{core.Capability_HEVC_Decode, core.Capability_HEVC_Encode, core.Capability_VP8_Encode, core.Capability_VP9_Decode, core.Capability_VP9_Encode}
+			caps := core.OptionalCapabilities()
+			for _, c := range capsToRemove {
+				caps = core.RemoveCapability(caps, c)
+			}
+			transcoderCaps = append(core.DefaultCapabilities(), caps...)
 			n.Transcoder = core.NewLocalTranscoder(*cfg.Datadir)
+		}
+
+		if cfg.HevcDecoding == nil {
+			// do nothing; keep defaults
+		} else if *cfg.HevcDecoding {
+			if !core.HasCapability(transcoderCaps, core.Capability_HEVC_Decode) {
+				if accel != ffmpeg.Software {
+					glog.Info("Enabling HEVC decoding when the hardware does not support it")
+				} else {
+					glog.Info("Enabling HEVC decoding on CPU, may be slow")
+				}
+				transcoderCaps = core.AddCapability(transcoderCaps, core.Capability_HEVC_Decode)
+			}
+		} else if !*cfg.HevcDecoding {
+			transcoderCaps = core.RemoveCapability(transcoderCaps, core.Capability_HEVC_Decode)
 		}
 	}
 

--- a/core/capabilities.go
+++ b/core/capabilities.go
@@ -188,6 +188,20 @@ func MandatoryOCapabilities() []Capability {
 	}
 }
 
+func RemoveCapability(haystack []Capability, needle Capability) []Capability {
+	for i, c := range haystack {
+		if c == needle {
+			// TODO use slices.Delete once go-livepeer updates to latest golang
+			return append(haystack[:i], haystack[i+1:]...)
+		}
+	}
+	return haystack
+}
+
+func AddCapability(caps []Capability, newCap Capability) []Capability {
+	return append(caps, newCap)
+}
+
 func NewCapabilityString(caps []Capability) CapabilityString {
 	capStr := CapabilityString{}
 	for _, v := range caps {

--- a/core/capabilities_test.go
+++ b/core/capabilities_test.go
@@ -489,6 +489,50 @@ func TestCapabilities_LegacyCheck(t *testing.T) {
 	assert.Len(legacyCapabilities, legacyLen) // sanity check no modifications
 }
 
+func TestCapability_RemoveCapability(t *testing.T) {
+	tests := []struct {
+		name     string
+		caps     []Capability
+		toRemove Capability
+		expect   []Capability
+	}{{
+		name:     "empty capability list",
+		caps:     nil,
+		toRemove: Capability_H264,
+		expect:   nil,
+	}, {
+		name:     "capability not in list",
+		caps:     []Capability{Capability_H264, Capability_MPEGTS},
+		toRemove: Capability_MP4,
+		expect:   []Capability{Capability_H264, Capability_MPEGTS},
+	}, {
+		name:     "capability at beginning of list",
+		caps:     []Capability{Capability_H264, Capability_MPEGTS},
+		toRemove: Capability_H264,
+		expect:   []Capability{Capability_MPEGTS},
+	}, {
+		name:     "capability in middle of list",
+		caps:     []Capability{Capability_H264, Capability_MP4, Capability_MPEGTS},
+		toRemove: Capability_MP4,
+		expect:   []Capability{Capability_H264, Capability_MPEGTS},
+	}, {
+		name:     "capability at end of list",
+		caps:     []Capability{Capability_H264, Capability_MPEGTS},
+		toRemove: Capability_MPEGTS,
+		expect:   []Capability{Capability_H264},
+	}, {
+		name:     "last capability",
+		caps:     []Capability{Capability_H264},
+		toRemove: Capability_H264,
+		expect:   []Capability{},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expect, RemoveCapability(tt.caps, tt.toRemove))
+		})
+	}
+}
+
 func TestLiveeerVersionCompatibleWith(t *testing.T) {
 	tests := []struct {
 		name                  string


### PR DESCRIPTION
Adds a new boolean flag `-hevcDecoding` to better configure the existing HEVC support.

If the flag is omitted, the default behavior on GPUs is unchanged, which is to auto-detect HEVC decoding support at transcoder start-up.

GPU transcoders can disable HEVC decoding if there is an issue with HEVC jobs via `-hevcDecoding=false`.

CPU transcoders now have HEVC decoding disabled by default since processing HEVC jobs is CPU-heavy, so operators are not caught off-guard once we start putting HEVC jobs into the network. This is technically a breaking change, and some un-upgraded transcoders may still be surprised anyway.

Note that LPMS already has CPU HEVC decoding compiled into the ffmpeg build, however this is implicitly derived from other compile-time flags. For the sake of explicitness we should add the native HEVC decoder to `install_ffmpeg.sh` but that can be added later .

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds a `-hevcDecoding` flag
- Disables HEVC decoding (and non-H264 encoding)  by default on CPUs 
- Depends on #3118

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Manual testing with the following flags
  - `-transcoder -nvidia all -hevcDecoding=false` (correctly removes HEVC decoding from capabilities)
  - `-transcoder -nvidia all` (HEVC is enabled; no change from today)
  - `-transcoder` (HEVC is disabled)
  - `-transcoder -hevcDecoding` (HEVC is enabled)
- Light unit testing for a new `RemoveCapability` function

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
