### PR TITLE
Ai 303/pricing multiple images t2i i2i

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -196,7 +196,7 @@ func handleAIRequest(ctx context.Context, w http.ResponseWriter, r *http.Request
 			width = int64(*v.Width)
 		}
 
-		outPixels = height * width
+		outPixels = height * width * int64(*v.NumImagesPerPrompt)
 	case worker.ImageToImageMultipartRequestBody:
 		pipeline = "image-to-image"
 		cap = core.Capability_ImageToImage
@@ -215,7 +215,8 @@ func handleAIRequest(ctx context.Context, w http.ResponseWriter, r *http.Request
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		outPixels = int64(config.Height) * int64(config.Width)
+
+		outPixels = int64(config.Height) * int64(config.Width) * int64(*v.NumImagesPerPrompt)
 	case worker.UpscaleMultipartRequestBody:
 		pipeline = "upscale"
 		cap = core.Capability_Upscale

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -195,8 +195,13 @@ func handleAIRequest(ctx context.Context, w http.ResponseWriter, r *http.Request
 		if v.Width != nil {
 			width = int64(*v.Width)
 		}
+		// NOTE: Should be enforced by the gateway, added for backwards compatibility.
+		numImages := int64(1)
+		if v.NumImagesPerPrompt != nil {
+			numImages = int64(*v.NumImagesPerPrompt)
+		}
 
-		outPixels = height * width * int64(*v.NumImagesPerPrompt)
+		outPixels = height * width * numImages
 	case worker.ImageToImageMultipartRequestBody:
 		pipeline = "image-to-image"
 		cap = core.Capability_ImageToImage
@@ -215,8 +220,13 @@ func handleAIRequest(ctx context.Context, w http.ResponseWriter, r *http.Request
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		// NOTE: Should be enforced by the gateway, added for backwards compatibility.
+		numImages := int64(1)
+		if v.NumImagesPerPrompt != nil {
+			numImages = int64(*v.NumImagesPerPrompt)
+		}
 
-		outPixels = int64(config.Height) * int64(config.Width) * int64(*v.NumImagesPerPrompt)
+		outPixels = int64(config.Height) * int64(config.Width) * numImages
 	case worker.UpscaleMultipartRequestBody:
 		pipeline = "upscale"
 		cap = core.Capability_Upscale


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The num_images_per_prompt field in text-to-image and image-to-image requests is multiplied by the calculated pixels of a requested image to produce a price proportionate to the request.

**Specific updates (required)**
* adds check for req.NumImagesPerPrompt and is multiplied by outPixels if > 1 ( default )
* removes numImage from latency calculations, as this is already factored into outPixels/
* update AIRequestFinished to factor numImages into pricePerAIUnit
* account for numImages in orchestrator debit fee calculation and add redundant nil check for backward-compatibility

**How did you test each of these updates (required)**

Manual Testing t2i:
aiModels.json
```
[
    {
        "pipeline": "text-to-image",
        "model_id": "ByteDance/SDXL-Lightning",
        "price_per_unit": 5000001,
        "warm": true
    }
]
```
numImages = 1
```
curl -X POST "http://0.0.0.0:8935/text-to-image"     -H "Content-Type: application/json"     -d '{
        "model_id":"ByteDance/SDXL-Lightning",
        "prompt":"A cool cat on the beach",
        "width": 1024,
        "height": 1024,
        "num_images_per_prompt": 1
    }'
```

```I0811 23:46:34.468360  237513 ai_http.go:280] manifestID=27_ByteDance/SDXL-Lightning orchSessionID=dc9cc8a0 clientIP=127.0.0.1 Received request id=bbc26d04 cap=27 modelID=ByteDance/SDXL-Lightning
I0811 23:46:34.471482  237513 orchestrator.go:246] manifestID=27_ByteDance/SDXL-Lightning orchSessionID=dc9cc8a0 clientIP=127.0.0.1 Payment tickets processed sessionID=27_ByteDance/SDXL-Lightning faceValue=600000000000000 WEI winProb=0.0200000000 ev=5999999999998.00
I0811 23:46:37.177075  237513 ai_http.go:321] manifestID=27_ByteDance/SDXL-Lightning orchSessionID=dc9cc8a0 clientIP=127.0.0.1 Processed request id=bbc26d04 cap=27 modelID=ByteDance/SDXL-Lightning took=2.705382698s
```

faceValue=600000000000000 WEI winProb=0.0200000000 ev=5999999999998.00

----

numImages = 3

```
curl -X POST "http://0.0.0.0:8935/text-to-image"     -H "Content-Type: application/json"     -d '{
        "model_id":"ByteDance/SDXL-Lightning",
        "prompt":"A cool cat on the beach",
        "width": 1024,
        "height": 1024,
        "num_images_per_prompt": 3
    }'
```

```
I0811 23:47:24.099706  237513 ai_http.go:280] manifestID=27_ByteDance/SDXL-Lightning orchSessionID=dc9cc8a0 clientIP=127.0.0.1 Received request id=ca8151a6 cap=27 modelID=ByteDance/SDXL-Lightning
I0811 23:47:24.100275  237513 orchestrator.go:468] Setting fixed price=130000026/25 for session=27_ByteDance/SDXL-Lightning
I0811 23:47:24.107618  237513 orchestrator.go:246] manifestID=27_ByteDance/SDXL-Lightning orchSessionID=dc9cc8a0 clientIP=127.0.0.1 Payment tickets processed sessionID=27_ByteDance/SDXL-Lightning faceValue=1800000000000000 WEI winProb=0.0600000000 ev=17999999999994.00
I0811 23:47:28.543152  237513 block_watcher.go:454] Polling blocks from=241909729 to=241909746
I0811 23:47:30.259654  237513 ai_http.go:321] manifestID=27_ByteDance/SDXL-Lightning orchSessionID=dc9cc8a0 clientIP=127.0.0.1 Processed request id=ca8151a6 cap=27 modelID=ByteDance/SDXL-Lightning took=6.151849654s
```
faceValue=1800000000000000 WEI winProb=0.0600000000 ev=17999999999994.00

Note the first response faceValue, winProb, and ev in the second response are the expected 3x values.

**Does this pull request close any open issues?**
Closes AI-303


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] Read the [contribution guide](./CONTRIBUTING.md)
- [ x] `make` runs successfully
- [ ] All tests in `./test.sh` pass ( not passing on ai-video )
- [ x] README and other documentation updated ( updated relevant comments )
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
