### PR TITLE
workflows: Fix issue when github context is empty for merged commits

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
           apt update && apt install -yqq git zip unzip zlib1g-dev zlib1g yasm
 
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -251,7 +251,7 @@ jobs:
       - linux-build
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -309,7 +309,7 @@ jobs:
       - name: Trigger discord webhook
         shell: bash
         env:
-          GITHUB_CONTEXT_JSON: ${{ toJson(github.event.pull_request) }}
+          GITHUB_CONTEXT_JSON: ${{ toJson(github) }}
         run: |
           pip install -U discord-webhook --no-cache-dir
           python .github/discord-embed-webhook.py \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -269,7 +269,7 @@ jobs:
         uses: livepeer/action-gh-checksum-and-gpg-sign@latest
         with:
           artifacts-dir: releases
-          release-name: ${{ (github.ref_type == 'tag' && github.ref_name) || github.sha }}
+          release-name: ${{ (github.ref_type == 'tag' && github.ref_name) || (github.event.pull_request.head.sha || github.sha) }}
           gpg-key: ${{ secrets.CI_GPG_SIGNING_KEY }}
           gpg-key-passphrase: ${{ secrets.CI_GPG_SIGNING_PASSPHRASE }}
 
@@ -293,7 +293,7 @@ jobs:
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: "releases"
-          destination: "build.livepeer.live/${{ github.event.repository.name }}/${{ (github.ref_type == 'tag' && github.ref_name) || github.sha }}"
+          destination: "build.livepeer.live/${{ github.event.repository.name }}/${{ (github.ref_type == 'tag' && github.ref_name) || (github.event.pull_request.head.sha || github.sha) }}"
           parent: false
           process_gcloudignore: false
 
@@ -313,7 +313,7 @@ jobs:
         run: |
           pip install -U discord-webhook --no-cache-dir
           python .github/discord-embed-webhook.py \
-          --ref-name="${{ (github.ref_type == 'tag' && github.ref_name) || github.sha }}" \
+          --ref-name="${{ (github.ref_type == 'tag' && github.ref_name) || (github.event.pull_request.head.sha || github.sha) }}" \
           --discord-url="${{ secrets.DISCORD_URL }}" \
           --git-commit="$(git log -1 --pretty=format:'%s')" \
           --git-committer="$(git log -1 --pretty=format:'%an')"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: oxford
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891

--- a/.github/workflows/git.yaml
+++ b/.github/workflows/git.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
 
       - name: Block fixup commit merge
         uses: 13rac1/block-fixup-merge-action@v2.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
           sudo apt update && sudo apt install -yqq git zip unzip zlib1g-dev zlib1g
 
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -128,7 +128,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4.1.7
         with:
           # Check https://github.com/livepeer/go-livepeer/pull/1891
           # for ref value discussion


### PR DESCRIPTION
It seems that the github context `github.event.pull_request` is null for merged PRs. This led to build failures for `master` branch (and would subsequently also fail for releases etc.)


From [github docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request):

> The `pull_request` webhook event payload is empty for merged pull requests and pull requests that come from forked repositories.

---

I've updated the workflow to make use of the full `github` context and split based on the type of event that triggers it. :crossed_fingers: 