### PR TITLE
workflows: Revert to ubuntu-20 to stop selecting self-hosted runners

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,0 +1,1 @@
+discord-webhook

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -245,7 +245,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - macos-build
       - linux-build
@@ -257,6 +257,15 @@ jobs:
           # Check https://github.com/livepeer/go-livepeer/pull/1891
           # for ref value discussion
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up python
+        id: python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: pip
+          cache-dependency-path: .github/requirements.txt
+          update-environment: true
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -311,12 +320,12 @@ jobs:
         env:
           GITHUB_CONTEXT_JSON: ${{ toJson(github) }}
         run: |
-          pip install -U discord-webhook --no-cache-dir
+          pip install -r .github/requirements.txt
           python .github/discord-embed-webhook.py \
-          --ref-name="${{ (github.ref_type == 'tag' && github.ref_name) || (github.event.pull_request.head.sha || github.sha) }}" \
-          --discord-url="${{ secrets.DISCORD_URL }}" \
-          --git-commit="$(git log -1 --pretty=format:'%s')" \
-          --git-committer="$(git log -1 --pretty=format:'%an')"
+            --ref-name="${{ (github.ref_type == 'tag' && github.ref_name) || (github.event.pull_request.head.sha || github.sha) }}" \
+            --discord-url="${{ secrets.DISCORD_URL }}" \
+            --git-commit="$(git log -1 --pretty=format:'%s')" \
+            --git-committer="$(git log -1 --pretty=format:'%an')"
 
       - name: Notify new build upload
         run: curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/.github/workflows/git.yaml
+++ b/.github/workflows/git.yaml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   block-fixup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -124,7 +124,7 @@ jobs:
 
   codeql:
     name: Perform CodeQL analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Check out code
@@ -148,7 +148,7 @@ jobs:
 
   editorconfig:
     name: Run editorconfig checker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
Hopefully it'll stop selecting self-hosted runners for jobs that don't really need them. Ideally, it should be fixed in github's runner selection, but we've no clear route on how to achieve it yet.