### PR TITLE
ci(ai): add temporary ai-video latest binary url upload

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -317,6 +317,17 @@ jobs:
           parent: false
           process_gcloudignore: false
 
+      # Create temporary latest url for the 'ai-video' branch.
+      # TODO: Once 'ai-video' is merged into the main branch, this section should be removed.
+      - name: Upload release archives to latest url
+        if: startsWith(github.ref, 'refs/tags/') && github.ref_name == 'ai-video' && env.current_tag == env.highest_tag
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: "releases"
+          destination: "build.livepeer.live/go-livepeer/ai-video/latest"
+          parent: false
+          process_gcloudignore: false
+
       - name: Trigger discord webhook
         shell: bash
         env:


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request ensures that the `build.yaml` action script also creates a release under a `ai-video/latest` path. This was done to simplify the binary installation in the docs.

> [!WARNING]
> This logic may fail if additional tags are created on the `ai-video` branch. However, because this is a temporary solution and the `ai-video` branch follows a distinct versioning scheme separate from the main branch, investing in extra engineering was deemed unnecessary.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**
<!-- Fixes # -->

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
