### PR TITLE
lpms: Update to 9d6ea5f

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,8 @@
 
 This release includes a new `-hevcDecoding` flag for transcoders to configure HEVC decoding. If the flag is omitted, the default behavior on GPUs is unchanged, which is to auto-detect HEVC decoding support at transcoder start-up. Transcoders can disable HEVC decoding on GPUs if there is an issue with HEVC jobs via `-hevcDecoding=false`. CPU transcoders now have HEVC decoding disabled by default since processing HEVC jobs is CPU-heavy, but this can be enabled by setting the `-hevcDecoding` flag.
 
+The transcoder now support mid-stream input rotations, rather than crashing or outputting cropped video as it did before.
+
 ### Breaking Changes 🚨🚨
 
 - [#3119](https://github.com/livepeer/go-livepeer/pull/3119) CPU transcoders no longer decode HEVC or VP9 by default
@@ -31,3 +33,7 @@ This release includes a new `-hevcDecoding` flag for transcoders to configure HE
 #### Orchestrator
 
 #### Transcoder
+
+- [#418](https://github.com/livepeer/lpms/pull/418) lpms: Fix CUVID crash on resolution change
+- [#417](https://github.com/livepeer/lpms/pull/417) lpms: Clamp resolutions in filter expression
+- [#416](https://github.com/livepeer/lpms/pull/416) lpms: Rescale DTS better during FPS passthrough

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jaypipes/pcidb v1.0.0
 	github.com/livepeer/go-tools v0.0.0-20220805063103-76df6beb6506
 	github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18
-	github.com/livepeer/lpms v0.0.0-20240711034524-d9c78b62effd
+	github.com/livepeer/lpms v0.0.0-20240819180416-f87352959b85
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.14.18
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,8 @@ github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cO
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18 h1:4oH3NqV0NvcdS44Ld3zK2tO8IUiNozIggm74yobQeZg=
 github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18/go.mod h1:Jpf4jHK+fbWioBHRDRM1WadNT1qmY27g2YicTdO0Rtc=
-github.com/livepeer/lpms v0.0.0-20240711034524-d9c78b62effd h1:IdSZM8gUW7N4pHln8PyUFmvch6oK01QXyknYpycGA80=
-github.com/livepeer/lpms v0.0.0-20240711034524-d9c78b62effd/go.mod h1:z5ROP1l5OzAKSoqVRLc34MjUdueil6wHSecQYV7llIw=
+github.com/livepeer/lpms v0.0.0-20240819180416-f87352959b85 h1:E8hJhT1nEW1jneK+Re3KyJcsITFYS9oa0vgyA6bLmKE=
+github.com/livepeer/lpms v0.0.0-20240819180416-f87352959b85/go.mod h1:z5ROP1l5OzAKSoqVRLc34MjUdueil6wHSecQYV7llIw=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo 'WARNING: downloading and executing lpms/install_ffmpeg.sh, use it directly in case of issues'
-curl https://raw.githubusercontent.com/livepeer/lpms/bd7f8b07600446f018eab6075c22601aa3301bf6/install_ffmpeg.sh | bash -s $1
+curl https://raw.githubusercontent.com/livepeer/lpms/d9c78b62effdb4f5c8fc438b6033da1090d04a03/install_ffmpeg.sh | bash -s $1

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo 'WARNING: downloading and executing lpms/install_ffmpeg.sh, use it directly in case of issues'
-curl https://raw.githubusercontent.com/livepeer/lpms/d9c78b62effdb4f5c8fc438b6033da1090d04a03/install_ffmpeg.sh | bash -s $1
+curl https://raw.githubusercontent.com/livepeer/lpms/bd7f8b07600446f018eab6075c22601aa3301bf6/install_ffmpeg.sh | bash -s $1

--- a/verification/verify_test.go
+++ b/verification/verify_test.go
@@ -310,8 +310,7 @@ func TestPixels(t *testing.T) {
 
 	p, err := pixels("foo")
 	// Early codec check didn't find video in missing input file so
-	//  we get `TranscoderInvalidVideo` err instead of `No such file or directory`
-	assert.EqualError(err, "TranscoderInvalidVideo")
+	assert.EqualError(err, "No such file or directory")
 	assert.Equal(int64(0), p)
 
 	// Assume that ffmpeg.Transcode3() returns the correct pixel count so we just


### PR DESCRIPTION

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Updates LPMS

Also updates go-livepeer pixel verification test to match changed LPMS error reporting

**Specific updates (required)**

* f87352959  ffmpeg: Clamp resolutions in filter expression
* 9d6ea5f718 Plug memory leak when printing filter graph.
* 20131b673f Fix CUVID crash on resolution change
* 0e6fd2e7e2 (origin/ja/resolution-change-crash, ja/resolution-change-crash) ffmpeg: Add tests for rotation.
* def71fab18 ffmpeg: Handle EAGAIN from decoder and drain
* f03385968e ffmpeg: Reset the flush packet after each keyframe.
* 808675b414 ffmpeg: Re-init encoder on resolution change.
* be728e92af ffmpeg: Flush filters before re-initialization.
* b5181eb92c ffmpeg: Rescale DTS better during FPS passthrough
* c3330413a4 ffmpeg: Estimate duration for some audio formats in GetCodecInfoBytes
* e67ff9f4ee Add media duration to lpms_get_codec_info for GetCodecInfo
* 46dd338141 ffmpeg: Support image2 demuxer
* d5161b8104 ffmpeg: Use helper to check for video metadata
* bd7f8b0760 install_ffmpeg: Compile in more stuff for AI
* a50164a87b docs: improve test instructions
* 409f6e0d87 Merge pull request #411 from livepeer/improve_docs
* 4b092b8fc6 chore: fix some typos in comment
* 5d250f1833 Fixed typo in vidplayer logging
* 956ccf4d08 Fix  typo in params field
* 144a983869 Remove unused transcoder2
* 24ce26985c docs: update README with extra dev info

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Unit tests pass

**Does this pull request close any open issues?**
<!-- Fixes # -->

- Fixes B-frame detection with Mist
- Fixed transcoder crash during mid-stream rotations

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
