### PR TITLE
build.yaml: Fix extraction of artifacts when preparing for release

### DIFF
--- a/.github/discord-embed-webhook.py
+++ b/.github/discord-embed-webhook.py
@@ -40,7 +40,7 @@ def populate_embeds(embed: DiscordEmbed, ref_name: str, checksums: list[str]):
             version=ref_name,
             filename=filename,
         )
-        title = filename.lstrip("livepeer-").split(".")[0]
+        title = filename.removeprefix("livepeer-").split(".")[0]
         print(f"Adding embed field name={title} value={download_url}")
         embed.add_embed_field(name=title, value=download_url, inline=False)
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,12 @@ jobs:
           name_is_regexp: true
           path: releases/
 
+      - name: Flatten all downloaded artifacts to a single directory
+        shell: bash
+        run: |
+          find . -type f -exec mv '{}' ./ \;
+          find . -type d -empty -delete
+
       - uses: actions-ecosystem/action-regex-match@v2
         id: match-tag
         with:


### PR DESCRIPTION
https://discord.com/channels/423160867534929930/1275180318474895420

This should fix the issue during release step, where downloaded artifacts are being placed inside nested sub-directory since we bumped to `upload-artifacts@v4`.