### PR TITLE
print error message on gateway for bad request lora errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/jaypipes/ghw v0.10.0
 	github.com/jaypipes/pcidb v1.0.0
-	github.com/livepeer/ai-worker v0.5.0
+	github.com/livepeer/ai-worker v0.6.0
 	github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b
 	github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18
 	github.com/livepeer/lpms v0.0.0-20240819180416-f87352959b85

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/jaypipes/ghw v0.10.0
 	github.com/jaypipes/pcidb v1.0.0
-	github.com/livepeer/ai-worker v0.5.0
+	github.com/livepeer/ai-worker v0.5.1-0.20240922221144-eb03c8387b7f
 	github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b
 	github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18
 	github.com/livepeer/lpms v0.0.0-20240819180416-f87352959b85
@@ -238,3 +238,5 @@ require (
 	lukechampine.com/blake3 v1.2.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/livepeer/ai-worker => github.com/livepeer/ai-worker v0.5.1-0.20240922221144-eb03c8387b7f

--- a/go.mod
+++ b/go.mod
@@ -238,5 +238,3 @@ require (
 	lukechampine.com/blake3 v1.2.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-replace github.com/livepeer/ai-worker => github.com/livepeer/ai-worker v0.5.1-0.20240922221144-eb03c8387b7f

--- a/go.sum
+++ b/go.sum
@@ -623,8 +623,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-netroute v0.2.0/go.mod h1:Vio7LTzZ+6hoT4CMZi5/6CpY3Snzh2vgZhWgxMNwlQI=
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
-github.com/livepeer/ai-worker v0.5.0 h1:dgO6j9QVFPOq9omIcgB1YmgVSlhV94BMb6QO4WUocX8=
-github.com/livepeer/ai-worker v0.5.0/go.mod h1:91lMzkzVuwR9kZ0EzXwf+7yVhLaNVmYAfmBtn7t3cQA=
+github.com/livepeer/ai-worker v0.5.1-0.20240922221144-eb03c8387b7f h1:dRo6iaNj8R+eQyn8lxNqQqKB19pbN7lJNmmz+lQKnpw=
+github.com/livepeer/ai-worker v0.5.1-0.20240922221144-eb03c8387b7f/go.mod h1:91lMzkzVuwR9kZ0EzXwf+7yVhLaNVmYAfmBtn7t3cQA=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b h1:VQcnrqtCA2UROp7q8ljkh2XA/u0KRgVv0S1xoUvOweE=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b/go.mod h1:hwJ5DKhl+pTanFWl+EUpw1H7ukPO/H+MFpgA7jjshzw=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cOQee+WqmaDOgGtP2oDMhcVvR4L0yA=

--- a/go.sum
+++ b/go.sum
@@ -623,8 +623,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-netroute v0.2.0/go.mod h1:Vio7LTzZ+6hoT4CMZi5/6CpY3Snzh2vgZhWgxMNwlQI=
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
-github.com/livepeer/ai-worker v0.5.0 h1:dgO6j9QVFPOq9omIcgB1YmgVSlhV94BMb6QO4WUocX8=
-github.com/livepeer/ai-worker v0.5.0/go.mod h1:91lMzkzVuwR9kZ0EzXwf+7yVhLaNVmYAfmBtn7t3cQA=
+github.com/livepeer/ai-worker v0.6.0 h1:sGldUavfbTXPQDKc1a80/zgK8G1VdYRAxiuFTP0YyOU=
+github.com/livepeer/ai-worker v0.6.0/go.mod h1:91lMzkzVuwR9kZ0EzXwf+7yVhLaNVmYAfmBtn7t3cQA=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b h1:VQcnrqtCA2UROp7q8ljkh2XA/u0KRgVv0S1xoUvOweE=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b/go.mod h1:hwJ5DKhl+pTanFWl+EUpw1H7ukPO/H+MFpgA7jjshzw=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cOQee+WqmaDOgGtP2oDMhcVvR4L0yA=

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -98,9 +98,14 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 		start := time.Now()
 		resp, err := processTextToImage(ctx, params, req)
 		if err != nil {
+			var badReqErr *BadRequestError
 			var e *ServiceUnavailableError
 			if errors.As(err, &e) {
 				respondJsonError(ctx, w, err, http.StatusServiceUnavailable)
+				return
+			}
+			if errors.As(err, &badReqErr) {
+				respondJsonError(ctx, w, err, http.StatusBadRequest)
 				return
 			}
 			respondJsonError(ctx, w, err, http.StatusInternalServerError)
@@ -146,9 +151,14 @@ func (ls *LivepeerServer) ImageToImage() http.Handler {
 		start := time.Now()
 		resp, err := processImageToImage(ctx, params, req)
 		if err != nil {
+			var badReqErr *BadRequestError
 			var e *ServiceUnavailableError
 			if errors.As(err, &e) {
 				respondJsonError(ctx, w, err, http.StatusServiceUnavailable)
+				return
+			}
+			if errors.As(err, &badReqErr) {
+				respondJsonError(ctx, w, err, http.StatusBadRequest)
 				return
 			}
 			respondJsonError(ctx, w, err, http.StatusInternalServerError)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -98,13 +98,13 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 		start := time.Now()
 		resp, err := processTextToImage(ctx, params, req)
 		if err != nil {
-			var badReqErr *BadRequestError
-			var e *ServiceUnavailableError
-			if errors.As(err, &e) {
+			var serviceUnavailableErr *ServiceUnavailableError
+			var badRequestErr *BadRequestError
+			if errors.As(err, &serviceUnavailableErr) {
 				respondJsonError(ctx, w, err, http.StatusServiceUnavailable)
 				return
 			}
-			if errors.As(err, &badReqErr) {
+			if errors.As(err, &badRequestErr) {
 				respondJsonError(ctx, w, err, http.StatusBadRequest)
 				return
 			}
@@ -151,13 +151,13 @@ func (ls *LivepeerServer) ImageToImage() http.Handler {
 		start := time.Now()
 		resp, err := processImageToImage(ctx, params, req)
 		if err != nil {
-			var badReqErr *BadRequestError
-			var e *ServiceUnavailableError
-			if errors.As(err, &e) {
+			var serviceUnavailableErr *ServiceUnavailableError
+			var badRequestErr *BadRequestError
+			if errors.As(err, &serviceUnavailableErr) {
 				respondJsonError(ctx, w, err, http.StatusServiceUnavailable)
 				return
 			}
-			if errors.As(err, &badReqErr) {
+			if errors.As(err, &badRequestErr) {
 				respondJsonError(ctx, w, err, http.StatusBadRequest)
 				return
 			}
@@ -212,12 +212,16 @@ func (ls *LivepeerServer) ImageToVideo() http.Handler {
 
 			resp, err := processImageToVideo(ctx, params, req)
 			if err != nil {
-				var e *ServiceUnavailableError
-				if errors.As(err, &e) {
+				var serviceUnavailableErr *ServiceUnavailableError
+				var badRequestErr *BadRequestError
+				if errors.As(err, &serviceUnavailableErr) {
 					respondJsonError(ctx, w, err, http.StatusServiceUnavailable)
 					return
 				}
-
+				if errors.As(err, &badRequestErr) {
+					respondJsonError(ctx, w, err, http.StatusBadRequest)
+					return
+				}
 				respondJsonError(ctx, w, err, http.StatusInternalServerError)
 				return
 			}
@@ -314,9 +318,14 @@ func (ls *LivepeerServer) Upscale() http.Handler {
 		start := time.Now()
 		resp, err := processUpscale(ctx, params, req)
 		if err != nil {
-			var e *ServiceUnavailableError
-			if errors.As(err, &e) {
+			var serviceUnavailableErr *ServiceUnavailableError
+			var badRequestErr *BadRequestError
+			if errors.As(err, &serviceUnavailableErr) {
 				respondJsonError(ctx, w, err, http.StatusServiceUnavailable)
+				return
+			}
+			if errors.As(err, &badRequestErr) {
+				respondJsonError(ctx, w, err, http.StatusBadRequest)
 				return
 			}
 			respondJsonError(ctx, w, err, http.StatusInternalServerError)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -897,6 +897,10 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 		if errors.Is(err, common.ErrAudioDurationCalculation) {
 			return nil, &BadRequestError{err}
 		}
+
+		if strings.Contains(string(err.Error()), "Error loading LoRas") {
+			return nil, &BadRequestError{err}
+		}
 	}
 
 	if resp == nil {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
This change prints bad request errors from the t2i and i2i pipelines, specifically when LoRa parameters are incorrect or fail to load:

`2024/08/26 11:37:46 ERROR text-to-image container returned 400 err="{\"detail\":{\"msg\":\"Error loading LoRas: Error loading LoRas: Unable to load LoRas for adapter 'nerijs/pihxel-art-xl' (RepositoryNotFoundError)\"}}"`

`2024/08/26 11:35:52 ERROR image-to-image container returned 400 err="{\"detail\":{\"msg\":\"Error loading LoRas: Error loading LoRas: Unable to load LoRas for adapter 'nerijs/pihxel-art-xl' (RepositoryNotFoundError)\"}}"`

`2024/08/26 11:43:34 ERROR text-to-image container returned 400 err="{\"detail\":{\"msg\":\"Error loading LoRas: Error loading LoRas: Unable to parse '{ \\\"nerijs/pihxel-art-xl\\\" : f }' as JSON.\"}}"`

This PR is dependent on https://github.com/livepeer/ai-worker/pull/119

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates `ai_mediaserver.go` to log the error
- Updated `ai_process.go` prevent retries when LoRa error message returned


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Tested with invalid LoRa name in both t2i and i2i pipelines
- Tested with invalid LoRa weights in both t2i and i2i pipelines


**Does this pull request close any open issues?**
<!-- Fixes # -->
AI-501: add-lora-support-to-t2i-and-image-to-image-pipelines

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
