### PR TITLE
feat(ai): add AI gateway OpenAPI overlay

### DIFF
--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,0 +1,7 @@
+# Gateway OpenAPI Specification
+
+This document contains the [OpenAPI overlay](https://github.com/OAI/Overlay-Specification) for the Gateway AI API. It extends the [AI runner OpenAPI specification](https://github.com/livepeer/ai-worker/blob/main/runner/openapi.yaml) from the [livepeer/ai-worker](https://github.com/livepeer/ai-worker) package. This overlay can be used to generate client libraries and API documentation, providing a comprehensive and up-to-date interface for interacting with the Gateway AI services.
+
+## Usage
+
+The Livepeer AI SDKs are generated using the [SpeakEasy](https://www.speakeasy.com/docs) SDK generator. For more information on generating SDKs with this overlay, please refer to the [SpeakEasy overlay documentation](https://www.speakeasy.com/docs/overlays). The SpeakEasy suite, through GitHub Actions, also ensures that the [API documentation](https://github.com/livepeer/docs) is up-to-date and synchronized with the API implementation.

--- a/openapi/ai-gateway-overlay.yaml
+++ b/openapi/ai-gateway-overlay.yaml
@@ -1,0 +1,72 @@
+overlay: 1.0.0
+info:
+  title: Overlay for translating AI runner OpenAPI spec to AI Gateway spec.
+  version: 1.0.0
+extends: https://github.com/livepeer/ai-worker/blob/main/runner/openapi.yaml
+
+actions:
+  # Remove health path and schema.
+  - target: "$.paths['/health']"
+    description: Remove the health path.
+    remove: true
+  - target: "$.components.schemas['HealthCheck']"
+    description: Remove the HealthCheck schema.
+    remove: true
+
+  # Ensure model_id is required for all routes.
+  - target: "$.components.schemas.Body_audio_to_text_audio_to_text_post"
+    description: Ensure model_id is required for Text to Audio route.
+    update:
+      required:
+        - model_id
+  - target: "$.components.schemas.Body_audio_to_text_audio_to_text_post.properties.model_id.default"
+    description: Remove default value for model_id in Text to Audio route.
+    remove: true
+
+  - target: "$.components.schemas.Body_image_to_image_image_to_image_post"
+    description: Ensure model_id is required for Image to Image route.
+    update:
+      required:
+        - model_id
+  - target: "$.components.schemas.Body_image_to_image_image_to_image_post.properties.model_id.default"
+    description: Remove default value for model_id in Image to Image route.
+    remove: true
+
+  - target: "$.components.schemas.Body_image_to_video_image_to_video_post"
+    description: Ensure model_id is required for Image to Video route.
+    update:
+      required:
+        - model_id
+  - target: "$.components.schemas.Body_image_to_video_image_to_video_post.properties.model_id.default"
+    description: Remove default value for model_id in Image to Video route.
+    remove: true
+
+  - target: "$.components.schemas.Body_upscale_upscale_post"
+    description: Ensure model_id is required for Upscale route.
+    update:
+      required:
+        - model_id
+  - target: "$.components.schemas.Body_upscale_upscale_post.properties.model_id.default"
+    description: Remove default value for model_id in Upscale route.
+    remove: true
+
+  - target: "$.components.schemas.TextToImageParams"
+    description: Ensure model_id is required for Text to Image route.
+    update:
+      required:
+        - model_id
+  - target: "$.components.schemas.TextToImageParams.properties.model_id.default"
+    description: Remove default value for model_id in Text to Image route.
+    remove: true
+
+  # Replace VideoResponse schema with ImageResponse schema.
+  - target: "$.components.schemas['VideoResponse']"
+    description: Remove the VideoResponse schema.
+    remove: true
+  - target: "$.components.schemas"
+    description: Create a new VideoResponse schema that extends ImageResponse.
+    update:
+      VideoResponse:
+        allOf:
+          - $ref: "#/components/schemas/ImageResponse"
+        title: VideoResponse


### PR DESCRIPTION
This commit adds the AI Gateway OpenAPI overlay to the codebase. Thiswas done to place the OpenAPI spec near the actual Gateway implementation. This pull request was quickly created to discuss where we should generate the Gateway OpenAPI spec.
