### PR TITLE
validate `-serviceAddr` on startup and cli handler

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1200,8 +1200,8 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			glog.Exit("Error getting service URI: ", err)
 		}
 
-		if *cfg.Network == "arbitrum-one-mainnet" && strings.Contains(suri.Host, "0.0.0.0") {
-			glog.Exit("Service address must be a public IP address or hostname when operating on mainnet")
+		if *cfg.Network != "offchain" && common.ValidateServiceURI(suri) {
+			glog.Warning("Service address is a private IP address; this is not recommended for onchain networks")
 		}
 
 		n.SetServiceURI(suri)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1199,6 +1199,11 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		if err != nil {
 			glog.Exit("Error getting service URI: ", err)
 		}
+
+		if *cfg.Network == "arbitrum-one-mainnet" && strings.Contains(suri.Host, "0.0.0.0") {
+			glog.Exit("Service address must be a public IP address or hostname when operating on mainnet")
+		}
+
 		n.SetServiceURI(suri)
 		// if http addr is not provided, listen to all ifaces
 		// take the port to listen to from the service URI

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1200,8 +1200,8 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			glog.Exit("Error getting service URI: ", err)
 		}
 
-		if *cfg.Network != "offchain" && common.ValidateServiceURI(suri) {
-			glog.Warning("Service address is a private IP address; this is not recommended for onchain networks")
+		if *cfg.Network != "offchain" && !common.ValidateServiceURI(suri) {
+			glog.Warning("**Warning -serviceAddr is a not a public address or hostname; this is not recommended for onchain networks**")
 		}
 
 		n.SetServiceURI(suri)

--- a/common/util.go
+++ b/common/util.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"math/rand"
 	"mime"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -529,4 +530,12 @@ func ParseEthAddr(strJsonKey string) (string, error) {
 		}
 	}
 	return "", errors.New("Error parsing address from keyfile")
+}
+
+func ValidateServiceURI(serviceURI *url.URL) bool {
+	if strings.Contains(serviceURI.Host, "0.0.0.0") {
+		return false
+	} else {
+		return true
+	}
 }

--- a/common/util.go
+++ b/common/util.go
@@ -533,9 +533,5 @@ func ParseEthAddr(strJsonKey string) (string, error) {
 }
 
 func ValidateServiceURI(serviceURI *url.URL) bool {
-	if strings.Contains(serviceURI.Host, "0.0.0.0") {
-		return false
-	} else {
-		return true
-	}
+	return !strings.Contains(serviceURI.Host, "0.0.0.0")
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -482,4 +483,39 @@ func TestParseAccelDevices_CustomSelection(t *testing.T) {
 	assert.Equal(ids[0], "0")
 	assert.Equal(ids[1], "3")
 	assert.Equal(ids[2], "1")
+}
+func TestValidateServiceURI(t *testing.T) {
+	// Valid service URIs
+	validURIs := []string{
+		"https://8.8.8.8:8935",
+		"https://127.0.0.1:8935",
+	}
+
+	for _, uri := range validURIs {
+		serviceURI, err := url.Parse(uri)
+		if err != nil {
+			t.Errorf("Failed to parse valid service URI: %v", err)
+		}
+
+		if !ValidateServiceURI(serviceURI) {
+			t.Errorf("Expected service URI to be valid, but got invalid: %v", uri)
+		}
+	}
+
+	// Invalid service URIs
+	invalidURIs := []string{
+		"http://0.0.0.0",
+		"https://0.0.0.0",
+	}
+
+	for _, uri := range invalidURIs {
+		serviceURI, err := url.Parse(uri)
+		if err != nil {
+			t.Errorf("Failed to parse invalid service URI: %v", err)
+		}
+
+		if ValidateServiceURI(serviceURI) {
+			t.Errorf("Expected service URI to be invalid, but got valid: %v", uri)
+		}
+	}
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -526,6 +526,12 @@ func (s *LivepeerServer) setServiceURI(client eth.LivepeerEthClient, serviceURI 
 		return err
 	}
 
+	if strings.Contains(parsedURI.Host, "0.0.0.0") {
+		err = errors.New("service address must be a public IP address or hostname")
+		glog.Error(err)
+		return err
+	}
+
 	glog.Infof("Storing service URI %v in service registry...", serviceURI)
 
 	tx, err := client.SetServiceURI(serviceURI)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -526,7 +526,7 @@ func (s *LivepeerServer) setServiceURI(client eth.LivepeerEthClient, serviceURI 
 		return err
 	}
 
-	if strings.Contains(parsedURI.Host, "0.0.0.0") {
+	if !common.ValidateServiceURI(parsedURI) {
 		err = errors.New("service address must be a public IP address or hostname")
 		glog.Error(err)
 		return err

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/eth/types"
@@ -1570,7 +1571,29 @@ func TestMustHaveDb_Success(t *testing.T) {
 	assert.Equal(http.StatusOK, status)
 	assert.Equal("success", body)
 }
+func TestSetServiceURI(t *testing.T) {
+	s := stubServer()
+	client := &eth.MockClient{}
+	serviceURI := "https://8.8.8.8:8935"
 
+	t.Run("Valid Service URI", func(t *testing.T) {
+		client.On("SetServiceURI", serviceURI).Return(&ethtypes.Transaction{}, nil)
+		client.On("CheckTx", mock.Anything).Return(nil)
+
+		err := s.setServiceURI(client, serviceURI)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("Invalid Service URI", func(t *testing.T) {
+		invalidServiceURI := "https://0.0.0.0:8935"
+
+		err := s.setServiceURI(client, invalidServiceURI)
+
+		assert.Error(t, err)
+	})
+
+}
 func dummyHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
This change aims to bring awareness to orchestrators that setting `0.0.0.0` or any other non-public IP as the `-serviceAddr` flag will cause issues with receiving and processing work. This will also help improve network quality.


**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Logs a warning on startup if `-serviceAddr` contains `0.0.0.0`
- Returns a validation error in `livepeer_cli` option 13: Set orchestrator config

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Tested orchestrator on chain with https://0.0.0.0:8935 as `-serviceAddr`, confirm warning shows on startup
```
W0828 19:31:05.124127  733748 starter.go:1204] **Warning -serviceAddr is a not a public address or hostname; this is not recommended for onchain networks**
```

- Tested setting orchestrator config with livepeer_cli, option 13, confirm validation error is returned:
```
Enter the public host:port of node (default: https://127.0.0.1:8935)> http://0.0.0.0:8935
Error applying configuration: service address must be a public IP address or hostname
```

**Does this pull request close any open issues?**
<!-- Fixes # -->
AI-586

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
