### PR TITLE
For Development Use Only - Do Not Merge!

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1195,7 +1195,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 
 			for _, config := range configs {
-				modelConstraint := &core.ModelConstraint{Warm: config.Warm}
+				modelConstraint := &core.ModelConstraint{Warm: false} //override to always false to be cold for base capacity
 
 				var autoPrice *core.AutoConvertedPrice
 				if *cfg.Network != "offchain" {


### PR DESCRIPTION
# DO NOT MERGE!!

Updates `starter.go` to force models to report as cold in capabilities. Used to ensure that AI SPE base capacity is selected after the regular orchestrators.

> [!CAUTION]
> Do not merge! This will severely disrupt the Livepeer network, and trust us, you don’t want to face the wrath of Mike Zoop—who will hunt you down. Proceed with caution!