### PR TITLE
build.yaml: Skip upload step raising an error for PR from forks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -242,6 +242,7 @@ jobs:
 
   upload:
     name: Upload artifacts to google bucket
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: "read"
       id-token: "write"


### PR DESCRIPTION
We don't want our gcp buckets to get overfilled with builds from external devs.