### PR TITLE
Clean up inactive sessions

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -922,7 +922,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			glog.Info("Broadcaster Deposit: ", eth.FormatUnits(info.Deposit, "ETH"))
 			glog.Info("Broadcaster Reserve: ", eth.FormatUnits(info.Reserve.FundsRemaining, "ETH"))
 
-			n.Sender = pm.NewSender(n.Eth, timeWatcher, senderWatcher, maxEV, maxTotalEV, *cfg.DepositMultiplier)
+			n.Sender = pm.NewSender(ctx, n.Eth, timeWatcher, senderWatcher, maxEV, maxTotalEV, *cfg.DepositMultiplier)
 
 			pixelsPerUnit, ok := new(big.Rat).SetString(*cfg.PixelsPerUnit)
 			if !ok || !pixelsPerUnit.IsInt() {


### PR DESCRIPTION
Not cleaning up the sessions causes quite a big memory leak which in effect causes OOMKilled

fix https://linear.app/livepeer/issue/PS-726/5xx-broadcasters-alerts-prod-livepeer-broadcaster-08gow