### PR TITLE
broadcaster: Fix video compatibility check

### DIFF
--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -989,7 +989,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	cxn.mu.Lock()
 	if cxn.mediaFormat == (ffmpeg.MediaFormatInfo{}) {
 		cxn.mediaFormat = mediaFormat
-	} else if !videoCompatible(cxn.mediaFormat, mediaFormat) {
+	} else if !mediaCompatible(cxn.mediaFormat, mediaFormat) {
 		cxn.mediaFormat = mediaFormat
 		segPar.ForceSessionReinit = true
 	}
@@ -1650,8 +1650,9 @@ func getRemoteAddr(r *http.Request) string {
 	return strings.Split(addr, ":")[0]
 }
 
-func videoCompatible(a, b ffmpeg.MediaFormatInfo) bool {
-	return a.Vcodec == b.Vcodec &&
+func mediaCompatible(a, b ffmpeg.MediaFormatInfo) bool {
+	return a.Acodec == b.Acodec &&
+		a.Vcodec == b.Vcodec &&
 		a.PixFormat == b.PixFormat &&
 		a.Width == b.Width &&
 		a.Height == b.Height

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -989,7 +989,7 @@ func (s *LivepeerServer) HandlePush(w http.ResponseWriter, r *http.Request) {
 	cxn.mu.Lock()
 	if cxn.mediaFormat == (ffmpeg.MediaFormatInfo{}) {
 		cxn.mediaFormat = mediaFormat
-	} else if cxn.mediaFormat != mediaFormat {
+	} else if !videoCompatible(cxn.mediaFormat, mediaFormat) {
 		cxn.mediaFormat = mediaFormat
 		segPar.ForceSessionReinit = true
 	}
@@ -1648,4 +1648,15 @@ func getRemoteAddr(r *http.Request) string {
 		addr = strings.Split(proxiedAddr, ",")[0]
 	}
 	return strings.Split(addr, ":")[0]
+}
+
+func videoCompatible(a, b ffmpeg.MediaFormatInfo) bool {
+	return a.Vcodec == b.Vcodec &&
+		a.PixFormat == b.PixFormat &&
+		a.Width == b.Width &&
+		a.Height == b.Height
+
+	// NB: there is also a Format field but that does
+	// not need to match since transcoder will reopen
+	// a new demuxer each time
 }

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -1494,6 +1494,86 @@ func TestJsonProfileToVideoProfiles(t *testing.T) {
 	assert.Equal("unable to parse the H264 encoder profile: unknown VideoProfile profile name", err.Error())
 }
 
+func TestVideoCompatible(t *testing.T) {
+	empty := ffmpeg.MediaFormatInfo{}
+	normal := ffmpeg.MediaFormatInfo{
+		Acodec:    "aac",
+		Vcodec:    "h264",
+		PixFormat: ffmpeg.PixelFormat{RawValue: ffmpeg.PixelFormatNV12},
+		Format:    "mpegts",
+		Width:     100,
+		Height:    200,
+		DurSecs:   5,
+	}
+	tests := []struct {
+		name  string
+		a     ffmpeg.MediaFormatInfo
+		b     ffmpeg.MediaFormatInfo
+		match bool
+	}{{
+		name:  "empty",
+		a:     empty,
+		match: true,
+	}, {
+		name:  "normal",
+		match: true,
+		a:     normal,
+		b: ffmpeg.MediaFormatInfo{
+			Acodec:    "opus",
+			Format:    "mp4",
+			DurSecs:   10,
+			Vcodec:    normal.Vcodec,
+			PixFormat: normal.PixFormat,
+			Width:     normal.Width,
+			Height:    normal.Height,
+		},
+	}, {
+		name: "w",
+		a:    normal,
+		b: ffmpeg.MediaFormatInfo{
+			Width:     normal.Width + 1,
+			Vcodec:    normal.Vcodec,
+			PixFormat: normal.PixFormat,
+			Height:    normal.Height,
+		},
+	}, {
+		name: "h",
+		a:    normal,
+		b: ffmpeg.MediaFormatInfo{
+			Width:     normal.Width,
+			Vcodec:    normal.Vcodec,
+			PixFormat: normal.PixFormat,
+			Height:    normal.Height + 1,
+		},
+	}, {
+		name: "pixfmt",
+		a:    normal,
+		b: ffmpeg.MediaFormatInfo{
+			Width:     normal.Width,
+			Vcodec:    normal.Vcodec,
+			PixFormat: ffmpeg.PixelFormat{RawValue: ffmpeg.PixelFormatYUV420P},
+			Height:    normal.Height,
+		},
+	}, {
+		name: "codec",
+		a:    normal,
+		b: ffmpeg.MediaFormatInfo{
+			Width:     normal.Width,
+			Acodec:    normal.Acodec,
+			Format:    normal.Format,
+			DurSecs:   normal.DurSecs,
+			Vcodec:    "flv",
+			PixFormat: normal.PixFormat,
+			Height:    normal.Height,
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.match, videoCompatible(tt.a, tt.b))
+		})
+	}
+}
+
 func mustParseUrl(t *testing.T, str string) *url.URL {
 	url, err := url.Parse(str)
 	if err != nil {

--- a/server/mediaserver_test.go
+++ b/server/mediaserver_test.go
@@ -1494,16 +1494,17 @@ func TestJsonProfileToVideoProfiles(t *testing.T) {
 	assert.Equal("unable to parse the H264 encoder profile: unknown VideoProfile profile name", err.Error())
 }
 
-func TestVideoCompatible(t *testing.T) {
+func TestMediaCompatible(t *testing.T) {
 	empty := ffmpeg.MediaFormatInfo{}
 	normal := ffmpeg.MediaFormatInfo{
-		Acodec:    "aac",
-		Vcodec:    "h264",
-		PixFormat: ffmpeg.PixelFormat{RawValue: ffmpeg.PixelFormatNV12},
-		Format:    "mpegts",
-		Width:     100,
-		Height:    200,
-		DurSecs:   5,
+		Acodec:       "aac",
+		Vcodec:       "h264",
+		PixFormat:    ffmpeg.PixelFormat{RawValue: ffmpeg.PixelFormatNV12},
+		Format:       "mpegts",
+		Width:        100,
+		Height:       200,
+		AudioBitrate: 300,
+		DurSecs:      5,
 	}
 	tests := []struct {
 		name  string
@@ -1519,19 +1520,21 @@ func TestVideoCompatible(t *testing.T) {
 		match: true,
 		a:     normal,
 		b: ffmpeg.MediaFormatInfo{
-			Acodec:    "opus",
-			Format:    "mp4",
-			DurSecs:   10,
-			Vcodec:    normal.Vcodec,
-			PixFormat: normal.PixFormat,
-			Width:     normal.Width,
-			Height:    normal.Height,
+			Format:       "mp4",
+			DurSecs:      10,
+			AudioBitrate: 400,
+			Acodec:       normal.Acodec,
+			Vcodec:       normal.Vcodec,
+			PixFormat:    normal.PixFormat,
+			Width:        normal.Width,
+			Height:       normal.Height,
 		},
 	}, {
 		name: "w",
 		a:    normal,
 		b: ffmpeg.MediaFormatInfo{
 			Width:     normal.Width + 1,
+			Acodec:    normal.Acodec,
 			Vcodec:    normal.Vcodec,
 			PixFormat: normal.PixFormat,
 			Height:    normal.Height,
@@ -1540,36 +1543,48 @@ func TestVideoCompatible(t *testing.T) {
 		name: "h",
 		a:    normal,
 		b: ffmpeg.MediaFormatInfo{
-			Width:     normal.Width,
+			Height:    normal.Height + 1,
+			Acodec:    normal.Acodec,
 			Vcodec:    normal.Vcodec,
 			PixFormat: normal.PixFormat,
-			Height:    normal.Height + 1,
+			Width:     normal.Width,
 		},
 	}, {
 		name: "pixfmt",
 		a:    normal,
 		b: ffmpeg.MediaFormatInfo{
 			Width:     normal.Width,
+			Acodec:    normal.Acodec,
 			Vcodec:    normal.Vcodec,
 			PixFormat: ffmpeg.PixelFormat{RawValue: ffmpeg.PixelFormatYUV420P},
 			Height:    normal.Height,
 		},
 	}, {
-		name: "codec",
+		name: "video codec",
 		a:    normal,
 		b: ffmpeg.MediaFormatInfo{
-			Width:     normal.Width,
+			Vcodec:    "flv",
 			Acodec:    normal.Acodec,
 			Format:    normal.Format,
-			DurSecs:   normal.DurSecs,
-			Vcodec:    "flv",
 			PixFormat: normal.PixFormat,
+			Width:     normal.Width,
+			Height:    normal.Height,
+		},
+	}, {
+		name: "audio codec",
+		a:    normal,
+		b: ffmpeg.MediaFormatInfo{
+			Acodec:    "opus",
+			Vcodec:    normal.Vcodec,
+			Format:    normal.Format,
+			PixFormat: normal.PixFormat,
+			Width:     normal.Width,
 			Height:    normal.Height,
 		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.match, videoCompatible(tt.a, tt.b))
+			assert.Equal(t, tt.match, mediaCompatible(tt.a, tt.b))
 		})
 	}
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Fixes video compatibility check that led to excessive transcoder re-initialization.

Not all fields will be identical segment-to-segment, particularly DurationSecs.
This caused unnecessary transcoder re-initialization.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add a `videoCompatible` helper to check for video compatibility
- Add unit tests for the `videoCompatible` helper


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
1. Unit tests for the helper
2. Manual testing to ensure transcoding session gets reused

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
