### PR TITLE
refactor: remove unused selection factory

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -453,7 +453,7 @@ func (bsm *BroadcastSessionsManager) shouldSkipVerification(sessions []*Broadcas
 	return common.RandomUintUnder(bsm.VerificationFreq) != 0
 }
 
-func NewSessionManager(ctx context.Context, node *core.LivepeerNode, params *core.StreamParameters, sel BroadcastSessionsSelectorFactory) *BroadcastSessionsManager {
+func NewSessionManager(ctx context.Context, node *core.LivepeerNode, params *core.StreamParameters) *BroadcastSessionsManager {
 	if node.Capabilities != nil {
 		params.Capabilities.SetMinVersionConstraint(node.Capabilities.MinVersionConstraint())
 	}

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -65,10 +65,6 @@ func StubBroadcastSession(transcoder string) *BroadcastSession {
 	}
 }
 
-func selFactoryEmpty() BroadcastSessionsSelector {
-	return &LIFOSelector{}
-}
-
 func bsmWithSessList(sessList []*BroadcastSession) *BroadcastSessionsManager {
 	return bsmWithSessListExt(sessList, nil, false)
 }
@@ -299,7 +295,7 @@ func TestNewSessionManager(t *testing.T) {
 
 	// Check empty pool produces expected numOrchs
 
-	sess := NewSessionManager(context.TODO(), n, params, selFactoryEmpty)
+	sess := NewSessionManager(context.TODO(), n, params)
 	assert.Equal(0, sess.trustedPool.numOrchs)
 	assert.Equal(0, sess.untrustedPool.numOrchs)
 
@@ -308,7 +304,7 @@ func TestNewSessionManager(t *testing.T) {
 	n.OrchestratorPool = sd
 	max := int(common.HTTPTimeout.Seconds()/SegLen.Seconds()) * 2
 	for i := 0; i < 10; i++ {
-		sess = NewSessionManager(context.TODO(), n, params, selFactoryEmpty)
+		sess = NewSessionManager(context.TODO(), n, params)
 		if i < max {
 			assert.Equal(i, sess.trustedPool.numOrchs)
 		} else {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -524,17 +524,8 @@ func (s *LivepeerServer) registerConnection(ctx context.Context, rtmpStrm stream
 	// do not obtain this lock again while initializing channel is open, it will cause deadlock if other goroutine already obtained the lock and called getActiveRtmpConnectionUnsafe()
 	s.connectionLock.Unlock()
 
-	// initialize session manager
-	var stakeRdr stakeReader
-	if s.LivepeerNode.Eth != nil {
-		stakeRdr = &storeStakeReader{store: s.LivepeerNode.Database}
-	}
-	selFactory := func() BroadcastSessionsSelector {
-		return NewMinLSSelector(stakeRdr, SELECTOR_LATENCY_SCORE_THRESHOLD, s.LivepeerNode.SelectionAlgorithm, s.LivepeerNode.OrchPerfScore)
-	}
-
 	// safe, because other goroutines should be waiting on initializing channel
-	cxn.sessManager = NewSessionManager(ctx, s.LivepeerNode, params, selFactory)
+	cxn.sessManager = NewSessionManager(ctx, s.LivepeerNode, params)
 
 	// populate fields and signal initializing channel
 	s.serverLock.Lock()


### PR DESCRIPTION


**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This commit cleansup the broadcaster and NewSessionManager code by
removing the selection factory that has been unused since
https://github.com/livepeer/go-livepeer/commit/fea5673d253dd9ba44e0ac01a752e9aa94319be7.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Removed the `selFactory` argument in the `NewSessionManager` function.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- I still need to test this with a on-chain gateway. I now only reviewd the changes ran `make` and ran the tests.

**Does this pull request close any open issues?**
<!-- Fixes # -->

No fixes, just cleanup.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated - @leszko do we need such a small change in the changelog?
