### PR TITLE
Better messages for objectStore errors

### DIFF
--- a/core/capabilities.go
+++ b/core/capabilities.go
@@ -623,6 +623,14 @@ func CapabilityToName(capability Capability) (string, error) {
 	return capName, nil
 }
 
+func (c Capability) String() string {
+	name, err := CapabilityToName(c)
+	if err != nil {
+		return fmt.Sprintf("%d", int(c))
+	}
+	return name
+}
+
 func HasCapability(caps []Capability, capability Capability) bool {
 	for _, c := range caps {
 		if capability == c {

--- a/core/capabilities_test.go
+++ b/core/capabilities_test.go
@@ -714,3 +714,28 @@ func TestLiveeerVersionCompatibleWith(t *testing.T) {
 		})
 	}
 }
+
+func TestCapability_String(t *testing.T) {
+	var unknownCap Capability = -100
+	tests := []struct {
+		name string
+		c    Capability
+		want string
+	}{
+		{
+			name: "Capability_TextToImage",
+			c:    Capability_TextToImage,
+			want: "Text to image",
+		},
+		{
+			name: "Unknown",
+			c:    unknownCap,
+			want: "-100",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.c.String())
+		})
+	}
+}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -87,7 +87,7 @@ func (ls *LivepeerServer) TextToImage() http.Handler {
 			return
 		}
 
-		clog.V(common.VERBOSE).Infof(r.Context(), "Received TextToImage request prompt=%v model_id=%v", req.Prompt, *req.ModelId)
+		clog.V(common.VERBOSE).Infof(ctx, "Received TextToImage request prompt=%v model_id=%v", req.Prompt, *req.ModelId)
 
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

In the case of objectStore errors it wasn't clear before this was the reason, so I've added context to the error message by wrapping the `err` objects. I also improved the logging a bit by adding capability to the logging context and added a `String` function to make it easier.

Error message now looks like:
<img width="1200" alt="Screenshot 2024-09-25 at 17 43 14" src="https://github.com/user-attachments/assets/f534fd47-299c-4649-b782-2437c93eeeba">


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested locally simulating a broken objectStore

**Does this pull request close any open issues?**
<!-- Fixes # -->
https://linear.app/livepeer/issue/ENG-2318/dont-throw-500s-if-objectstore-stops-working

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
