### PR TITLE
Fix selection to work also for the transcoding

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -63,7 +63,6 @@ type BroadcastConfig struct {
 func newBroadcastConfig() *BroadcastConfig {
 	maxPrices := make(map[core.Capability]map[string]*core.AutoConvertedPrice)
 	models := make(map[string]*core.AutoConvertedPrice)
-	models["default"] = core.NewFixedPrice(big.NewRat(0, 1))
 	maxPrices[core.Capability_Unused] = models
 	return &BroadcastConfig{
 		maxPricePerCapability: maxPrices,

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -127,7 +127,7 @@ func (cfg *BroadcastConfig) getCapabilityMaxPrice(cap core.Capability, modelID s
 		// No price set for capability
 		return nil
 	}
-	if price, modelOk := models[modelID]; modelOk {
+	if price, modelOk := models[modelID]; modelOk && price != nil {
 		return price.Value()
 	}
 	if defaultPrice, hasDefault := models["default"]; hasDefault {

--- a/server/selection.go
+++ b/server/selection.go
@@ -137,23 +137,15 @@ func (s *MinLSSelector) Select(ctx context.Context) *BroadcastSession {
 		return s.selectUnknownSession(ctx)
 	}
 
-	minSess := sess.(*BroadcastSession)
-	if minSess.LatencyScore > s.minLS && len(s.unknownSessions) > 0 {
-		return s.selectUnknownSession(ctx)
+	lowestLatencyScoreKnownSession := heap.Pop(s.knownSessions).(*BroadcastSession)
+	if lowestLatencyScoreKnownSession.LatencyScore < s.minLS {
+		// known session has good enough latency score, use it
+		return lowestLatencyScoreKnownSession
 	}
 
-	return heap.Pop(s.knownSessions).(*BroadcastSession)
-
-	// TODO: Fix AI selection logic, remove above code and uncomment transcoding logic below.
-	// lowestLatencyScoreKnownSession := heap.Pop(s.knownSessions).(*BroadcastSession)
-	// if lowestLatencyScoreKnownSession.LatencyScore <= s.minLS {
-	// 	// known session has good enough latency score, use it
-	// 	return lowestLatencyScoreKnownSession
-	// }
-
-	// // known session does not have good enough latency score, clear the heap and use unknown session
-	// s.knownSessions = &sessHeap{}
-	// return s.selectUnknownSession(ctx)
+	// known session does not have good enough latency score, clear the heap and use unknown session
+	s.knownSessions = &sessHeap{}
+	return s.selectUnknownSession(ctx)
 }
 
 // Size returns the number of sessions stored by the selector

--- a/server/selection.go
+++ b/server/selection.go
@@ -137,15 +137,12 @@ func (s *MinLSSelector) Select(ctx context.Context) *BroadcastSession {
 		return s.selectUnknownSession(ctx)
 	}
 
-	lowestLatencyScoreKnownSession := heap.Pop(s.knownSessions).(*BroadcastSession)
-	if lowestLatencyScoreKnownSession.LatencyScore < s.minLS {
-		// known session has good enough latency score, use it
-		return lowestLatencyScoreKnownSession
+	minSess := sess.(*BroadcastSession)
+	if minSess.LatencyScore > s.minLS && len(s.unknownSessions) > 0 {
+		return s.selectUnknownSession(ctx)
 	}
 
-	// known session does not have good enough latency score, clear the heap and use unknown session
-	s.knownSessions = &sessHeap{}
-	return s.selectUnknownSession(ctx)
+	return heap.Pop(s.knownSessions).(*BroadcastSession)
 }
 
 // Size returns the number of sessions stored by the selector

--- a/server/stub.go
+++ b/server/stub.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"github.com/livepeer/go-livepeer/net"
+)
+
+type StubCapabilityComparator struct {
+	NetCaps  *net.Capabilities
+	IsLegacy bool
+}
+
+func (s *StubCapabilityComparator) ToNetCapabilities() *net.Capabilities {
+	return s.NetCaps
+}
+
+func (s *StubCapabilityComparator) CompatibleWith(other *net.Capabilities) bool {
+	// Implement the logic for compatibility check if needed
+	return true
+}
+
+func (s *StubCapabilityComparator) LegacyOnly() bool {
+	return s.IsLegacy
+}


### PR DESCRIPTION
Changes to make the selection logic in `ai-video` work for transcoding as well (make it compatible with the current `master`:
1. Remove setting `0` max price for unused capability:
   - go-livepeer always worked in a way that if you don't set max price (for transcoding), then it'll accept ANY price (not judging if it's good or bad)
    - This change is not strictly required for Studio, because we always set up max price anyway
    - I _believe_ that it's for AI, because for AI we anyway always set up max price per capability (please double check this statement @ad-astra-video @rickstaa )
2. Keep the selection logic from AI (effectively it will revert #3086 from `master`)
   - I believe the logic introduced in #3086 was wrong, we should never clean the knownSessions, but rather increase the   (session pool size (https://github.com/livepeer/go-livepeer/blob/aad1a230a3c1ff3ef722a96bd2093d985b517ce2/server/broadcast.go#L39)
