### PR TITLE
feat(rewardService): add reward call retries

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,8 @@
 
 #### Orchestrator
 
+- [#3206](https://github.com/livepeer/go-livepeer/pull/3206) Added exponential backoff to RewardService retries and introduced the `rewardRetryTimes` CLI flag.
+
 #### Transcoder
 
 ### Bug Fixes 🐞

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -214,6 +214,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.RedeemerAddr = flag.String("redeemerAddr", *cfg.RedeemerAddr, "URL of the ticket redemption service to use")
 	// Reward service
 	cfg.Reward = flag.Bool("reward", false, "Set to true to run a reward service")
+	cfg.RewardRetryInterval = flag.Duration("rewardRetryInterval", *cfg.RewardRetryInterval, "Interval at which the reward call is retried in case of failure, set to 0 to disable retries")
 	// Metrics & logging:
 	cfg.Monitor = flag.Bool("monitor", *cfg.Monitor, "Set to true to send performance metrics")
 	cfg.MetricsPerStream = flag.Bool("metricsPerStream", *cfg.MetricsPerStream, "Set to true to group performance metrics per stream")

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -214,7 +214,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.RedeemerAddr = flag.String("redeemerAddr", *cfg.RedeemerAddr, "URL of the ticket redemption service to use")
 	// Reward service
 	cfg.Reward = flag.Bool("reward", false, "Set to true to run a reward service")
-	cfg.RewardRetryInterval = flag.Duration("rewardRetryInterval", *cfg.RewardRetryInterval, "Interval at which the reward call is retried in case of failure, set to 0 to disable retries")
+	cfg.RewardRetryTimes = flag.Int("rewardRetryTimes", *cfg.RewardRetryTimes, "Number of times to retry the reward call in case of failure, set to 0 to disable retries")
 	// Metrics & logging:
 	cfg.Monitor = flag.Bool("monitor", *cfg.Monitor, "Set to true to send performance metrics")
 	cfg.MetricsPerStream = flag.Bool("metricsPerStream", *cfg.MetricsPerStream, "Set to true to group performance metrics per stream")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -144,7 +144,7 @@ type LivepeerConfig struct {
 	Redeemer                   *bool
 	RedeemerAddr               *string
 	Reward                     *bool
-	RewardRetryInterval        *time.Duration
+	RewardRetryTimes           *int
 	Monitor                    *bool
 	MetricsPerStream           *bool
 	MetricsExposeClientIP      *bool
@@ -261,7 +261,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultBlockPollingInterval := 5
 	defaultRedeemer := false
 	defaultRedeemerAddr := ""
-	defaultRewardTryInterval := 0 * time.Minute // disabled by default
+	defaultRewardRetryTimes := 5
 	defaultMonitor := false
 	defaultMetricsPerStream := false
 	defaultMetricsExposeClientIP := false
@@ -377,7 +377,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		BlockPollingInterval:    &defaultBlockPollingInterval,
 		Redeemer:                &defaultRedeemer,
 		RedeemerAddr:            &defaultRedeemerAddr,
-		RewardRetryInterval:     &defaultRewardTryInterval,
+		RewardRetryTimes:        &defaultRewardRetryTimes,
 		Monitor:                 &defaultMonitor,
 		MetricsPerStream:        &defaultMetricsPerStream,
 		MetricsExposeClientIP:   &defaultMetricsExposeClientIP,
@@ -1155,7 +1155,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		if reward {
 			// Start reward service
 			// The node will only call reward if it is active in the current round
-			rs := eth.NewRewardService(n.Eth, timeWatcher, *cfg.RewardRetryInterval)
+			rs := eth.NewRewardService(n.Eth, timeWatcher, *cfg.RewardRetryTimes)
 			go func() {
 				if err := rs.Start(ctx); err != nil {
 					serviceErr <- err

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -144,6 +144,7 @@ type LivepeerConfig struct {
 	Redeemer                   *bool
 	RedeemerAddr               *string
 	Reward                     *bool
+	RewardRetryInterval        *time.Duration
 	Monitor                    *bool
 	MetricsPerStream           *bool
 	MetricsExposeClientIP      *bool
@@ -260,6 +261,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultBlockPollingInterval := 5
 	defaultRedeemer := false
 	defaultRedeemerAddr := ""
+	defaultRewardTryInterval := 0 * time.Minute // disabled by default
 	defaultMonitor := false
 	defaultMetricsPerStream := false
 	defaultMetricsExposeClientIP := false
@@ -375,6 +377,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		BlockPollingInterval:    &defaultBlockPollingInterval,
 		Redeemer:                &defaultRedeemer,
 		RedeemerAddr:            &defaultRedeemerAddr,
+		RewardRetryInterval:     &defaultRewardTryInterval,
 		Monitor:                 &defaultMonitor,
 		MetricsPerStream:        &defaultMetricsPerStream,
 		MetricsExposeClientIP:   &defaultMetricsExposeClientIP,
@@ -1152,7 +1155,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		if reward {
 			// Start reward service
 			// The node will only call reward if it is active in the current round
-			rs := eth.NewRewardService(n.Eth, timeWatcher)
+			rs := eth.NewRewardService(n.Eth, timeWatcher, *cfg.RewardRetryInterval)
 			go func() {
 				if err := rs.Start(ctx); err != nil {
 					serviceErr <- err

--- a/eth/rewardservice.go
+++ b/eth/rewardservice.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/monitor"
@@ -14,23 +15,31 @@ import (
 var (
 	ErrRewardServiceStarted = fmt.Errorf("reward service already started")
 	ErrRewardServiceStopped = fmt.Errorf("reward service already stopped")
+
+	DefaultRetryInterval  = 30 * time.Second // Avoid same-block retries
+	DefaultMaxElapsedTime = 20 * time.Hour   // Avoid retries outside round
 )
 
 type RewardService struct {
-	client              LivepeerEthClient
-	working             bool
-	cancelWorker        context.CancelFunc
-	tw                  timeWatcher
-	mu                  sync.Mutex
-	rewardRetryInterval time.Duration
-	cancelRetryWorker   context.CancelFunc
+	client            LivepeerEthClient
+	working           bool
+	cancelWorker      context.CancelFunc
+	tw                timeWatcher
+	mu                sync.Mutex
+	cancelRetryWorker context.CancelFunc
+	rewardRetryTimes  int
+	retryInterval     time.Duration
+	maxElapsedTime    time.Duration
+	wg                sync.WaitGroup
 }
 
-func NewRewardService(client LivepeerEthClient, tw timeWatcher, rewardRetryInterval time.Duration) *RewardService {
+func NewRewardService(client LivepeerEthClient, tw timeWatcher, rewardRetryTimes int) *RewardService {
 	return &RewardService{
-		client:              client,
-		tw:                  tw,
-		rewardRetryInterval: rewardRetryInterval,
+		client:           client,
+		tw:               tw,
+		rewardRetryTimes: rewardRetryTimes,
+		retryInterval:    DefaultRetryInterval,
+		maxElapsedTime:   DefaultMaxElapsedTime,
 	}
 }
 
@@ -58,12 +67,11 @@ func (s *RewardService) Start(ctx context.Context) error {
 				glog.Errorf("Round subscription error err=%q", err)
 			}
 		case <-roundSink:
-			s.cancelRetryWorker()
+			s.stopPreviousWorker()
 
-			retryCtx, cancelRetry := context.WithCancel(cancelCtx)
-			s.cancelRetryWorker = cancelRetry
-
-			go s.callRewardWithRetries(retryCtx)
+			// Start a new worker for the initialized round.
+			currentRound := s.tw.LastInitializedRound()
+			s.startNewWorker(cancelCtx, currentRound.Int64())
 		case <-cancelCtx.Done():
 			glog.V(5).Infof("Reward service done")
 			return nil
@@ -84,6 +92,25 @@ func (s *RewardService) Stop() error {
 
 func (s *RewardService) IsWorking() bool {
 	return s.working
+}
+
+func (s *RewardService) startNewWorker(ctx context.Context, round int64) {
+	retryCtx, cancelRetry := context.WithCancel(ctx)
+	s.cancelRetryWorker = cancelRetry
+
+	// Increment WaitGroup counter to track the retry worker.
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.callRewardWithRetries(retryCtx, round)
+	}()
+}
+
+func (s *RewardService) stopPreviousWorker() {
+	if s.cancelRetryWorker != nil {
+		s.cancelRetryWorker()
+		s.wg.Wait()
+	}
 }
 
 func (s *RewardService) tryReward() error {
@@ -115,35 +142,45 @@ func (s *RewardService) tryReward() error {
 	return nil
 }
 
-func (s *RewardService) callRewardWithRetries(ctx context.Context) {
-	if s.rewardRetryInterval == 0 {
-		err := s.tryReward()
-		if err != nil {
-			glog.Errorf("Error trying to call reward for round %v err=%q", s.tw.LastInitializedRound(), err)
-			if monitor.Enabled {
-				monitor.RewardCallError(err.Error())
-			}
+func (s *RewardService) callRewardWithRetries(ctx context.Context, round int64) {
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = s.retryInterval
+	expBackoff.MaxInterval = 1 * time.Hour // Cap maximum interval between retries.
+	expBackoff.MaxElapsedTime = s.maxElapsedTime
+
+	backoffCtx := backoff.WithContext(expBackoff, ctx)
+
+	retryCount := 0
+	err := backoff.Retry(func() error {
+		if retryCount >= s.rewardRetryTimes {
+			return backoff.Permanent(fmt.Errorf("max retry attempts reached"))
 		}
+
+		// Validate the round before retrying.
+		currentRound := s.tw.LastInitializedRound()
+		if currentRound.Int64() != round {
+			return backoff.Permanent(fmt.Errorf("round %v is no longer valid", round))
+		}
+
+		err := s.tryReward()
+		if err == nil {
+			return nil
+		}
+
+		retryCount++
+		glog.Errorf("Error trying to call reward (attempt %d): %v", retryCount, err)
+		return err // Retry on transient errors
+	}, backoffCtx)
+
+	if ctx.Err() != nil {
+		glog.Infof("Retry context canceled, stopping retries")
 		return
 	}
 
-	ticker := time.NewTicker(s.rewardRetryInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			err := s.tryReward()
-			if err == nil {
-				return
-			}
-
-			glog.Errorf("Error trying to call reward for round %v err=%q", s.tw.LastInitializedRound(), err)
-			if monitor.Enabled {
-				monitor.RewardCallError(err.Error())
-			}
-		case <-ctx.Done():
-			return
+	if err != nil {
+		glog.Errorf("Failed to call reward after %d retries for round %v: %v", retryCount, round, err)
+		if monitor.Enabled {
+			monitor.RewardCallError(err.Error())
 		}
 	}
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request refactors the RewardService to create a retry worker with exponential backoff for retrying Reward calls. Retries are limited to a specified number and only attempted for the intended round, ensuring efficiency and avoiding redundant calls.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Update the retry logic to retry failed rewards.
- Updates tests to check the new code.
- Add a new `RewardRetryTimes` parameter for people to set the number of retries.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I wrote tests. I still have to test them on a real orchestrator.

**Does this pull request close any open issues?**
<!-- Fixes # -->

No.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
