### PR TITLE
Gateway publish to orchestrator.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opencensus.io v0.24.0
 	go.uber.org/goleak v1.3.0
 	golang.org/x/net v0.28.0
+	golang.org/x/sys v0.26.0
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.1
 	pgregory.net/rapid v1.1.0
@@ -237,7 +238,6 @@ require (
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/oauth2 v0.20.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect
-	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect

--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -1,0 +1,269 @@
+package media
+
+import (
+	"bufio"
+	"encoding/base32"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/livepeer/lpms/ffmpeg"
+	"golang.org/x/sys/unix"
+)
+
+var waitTimeout = 20 * time.Second
+
+func RunSegmentation(in string, segmentHandler SegmentHandler) {
+
+	// TODO workdir stuff
+	outFilePattern := randomString() + "-%d.ts"
+	completionSignal := make(chan bool)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		processSegments(segmentHandler, outFilePattern, completionSignal)
+	}()
+	ffmpeg.FfmpegSetLogLevel(ffmpeg.FFLogWarning)
+	ffmpeg.Transcode3(&ffmpeg.TranscodeOptionsIn{
+		Fname: in,
+	}, []ffmpeg.TranscodeOptions{{
+		Oname:        outFilePattern,
+		AudioEncoder: ffmpeg.ComponentOptions{Name: "copy"},
+		VideoEncoder: ffmpeg.ComponentOptions{Name: "copy"},
+		Muxer:        ffmpeg.ComponentOptions{Name: "segment"},
+	}})
+	completionSignal <- true
+	slog.Info("sent completion signal, now waiting")
+	wg.Wait()
+}
+
+func createNamedPipe(pipeName string) {
+	err := syscall.Mkfifo(pipeName, 0666)
+	if err != nil && !os.IsExist(err) {
+		slog.Error("Failed to create named pipe", "pipeName", pipeName, "err", err)
+	}
+}
+
+func cleanUpPipe(pipeName string) {
+	err := os.Remove(pipeName)
+	if err != nil {
+		slog.Error("Failed to remove pipe", "pipeName", pipeName, "err", err)
+	}
+}
+
+func openNonBlockingWithRetry(name string, timeout time.Duration, completed <-chan bool) (*os.File, error) {
+	// Pipes block if there is no writer available
+
+	// Attempt to open the named pipe in non-blocking mode once
+	fd, err := syscall.Open(name, syscall.O_RDONLY|syscall.O_NONBLOCK, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("error opening file in non-blocking mode: %w", err)
+	}
+
+	deadline := time.Now().Add(timeout)
+
+	// setFd sets the given file descriptor in the fdSet
+	setFd := func(fd int, fdSet *syscall.FdSet) {
+		fdSet.Bits[fd/64] |= 1 << (uint(fd) % 64)
+	}
+
+	// isFdSet checks if the given file descriptor is set in the fdSet
+	isFdSet := func(fd int, fdSet *syscall.FdSet) bool {
+		return fdSet.Bits[fd/64]&(1<<(uint(fd)%64)) != 0
+	}
+
+	for {
+		// Check if completed
+		select {
+		case <-completed:
+			syscall.Close(fd)
+			return nil, fmt.Errorf("Completed")
+		default:
+			// continue
+		}
+		// Calculate the remaining time until the deadline
+		timeLeft := time.Until(deadline)
+		if timeLeft <= 0 {
+			syscall.Close(fd)
+			return nil, fmt.Errorf("timeout waiting for file to be ready: %s", name)
+		}
+
+		// Convert timeLeft to a syscall.Timeval for the select call
+		tv := syscall.NsecToTimeval(timeLeft.Nanoseconds())
+
+		// Set up the read file descriptor set for select
+		readFds := &syscall.FdSet{}
+		setFd(fd, readFds)
+
+		// Wait using select until the pipe is ready for reading
+		n, err := crossPlatformSelect(fd+1, readFds, nil, nil, &tv)
+		if err != nil {
+			if err == syscall.EINTR {
+				continue // Retry if interrupted by a signal
+			}
+			syscall.Close(fd)
+			return nil, fmt.Errorf("select error: %v", err)
+		}
+
+		// Check if the file descriptor is ready
+		if n > 0 && isFdSet(fd, readFds) {
+			// Modify the file descriptor to blocking mode using fcntl
+			flags, err := unix.FcntlInt(uintptr(fd), syscall.F_GETFL, 0)
+			if err != nil {
+				syscall.Close(fd)
+				return nil, fmt.Errorf("error getting file flags: %w", err)
+			}
+
+			// Clear the non-blocking flag
+			flags &^= syscall.O_NONBLOCK
+			if _, err := unix.FcntlInt(uintptr(fd), syscall.F_SETFL, flags); err != nil {
+				syscall.Close(fd)
+				return nil, fmt.Errorf("error setting file to blocking mode: %w", err)
+			}
+
+			// Convert the file descriptor to an *os.File to return
+			return os.NewFile(uintptr(fd), name), nil
+		}
+	}
+}
+
+func processSegments(segmentHandler SegmentHandler, outFilePattern string, completionSignal <-chan bool) {
+
+	// things protected by the mutex mu
+	mu := &sync.Mutex{}
+	isComplete := false
+	var currentSegment *os.File = nil
+
+	// Start a goroutine to wait for the completion signal
+	go func() {
+		<-completionSignal
+		mu.Lock()
+		defer mu.Unlock()
+		if currentSegment != nil {
+			// Trigger EOF on the current segment by closing the file
+			slog.Info("Completion signal received. Closing current segment to trigger EOF.")
+			currentSegment.Close()
+		}
+		isComplete = true
+		slog.Info("Got completion signal")
+	}()
+
+	pipeNum := 0
+	createNamedPipe(fmt.Sprintf(outFilePattern, pipeNum))
+
+	for {
+		pipeName := fmt.Sprintf(outFilePattern, pipeNum)
+		nextPipeName := fmt.Sprintf(outFilePattern, pipeNum+1)
+
+		// Create the next pipe ahead of time
+		createNamedPipe(nextPipeName)
+
+		// Open the current pipe for reading
+		// Blocks if no writer is available so do some tricks to it
+		file, err := openNonBlockingWithRetry(pipeName, waitTimeout, completionSignal)
+		if err != nil {
+			slog.Error("Error opening pipe", "pipeName", pipeName, "err", err)
+			cleanUpPipe(pipeName)
+			cleanUpPipe(nextPipeName)
+			break
+		}
+
+		mu.Lock()
+		currentSegment = file
+		mu.Unlock()
+
+		// Handle the reading process
+		readSegment(segmentHandler, file, pipeName)
+
+		// Increment to the next pipe
+		pipeNum++
+
+		// Clean up the current pipe after reading
+		cleanUpPipe(pipeName)
+
+		mu.Lock()
+		if isComplete {
+			cleanUpPipe(pipeName)
+			cleanUpPipe(nextPipeName)
+			mu.Unlock()
+			break
+		}
+		mu.Unlock()
+
+	}
+}
+
+func readSegment(segmentHandler SegmentHandler, file *os.File, pipeName string) {
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	firstByteRead := false
+	totalBytesRead := int64(0)
+
+	buf := make([]byte, 32*1024)
+
+	// TODO should be explicitly buffered for better management
+	interfaceReader, interfaceWriter := io.Pipe()
+	defer interfaceWriter.Close()
+	segmentHandler(interfaceReader)
+
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			if !firstByteRead {
+				slog.Info("First byte read", "pipeName", pipeName)
+				firstByteRead = true
+
+			}
+			totalBytesRead += int64(n)
+			if _, err := interfaceWriter.Write(buf[:n]); err != nil {
+				if err != io.EOF {
+					slog.Info("Error writing", "pipeName", pipeName, "err", err)
+				}
+			}
+		}
+		if n == len(buf) && n < 1024*1024 {
+			newLen := int(float64(len(buf)) * 1.5)
+			slog.Info("Max buf hit, increasing", "oldSize", humanBytes(int64(len(buf))), "newSize", humanBytes(int64(newLen)))
+			buf = make([]byte, newLen)
+		}
+
+		if err != nil {
+			if err.Error() == "EOF" {
+				slog.Info("Last byte read", "pipeName", pipeName, "totalRead", humanBytes(totalBytesRead))
+			} else {
+				slog.Error("Error reading", "pipeName", pipeName, "err", err)
+			}
+			break
+		}
+	}
+}
+
+func randomString() string {
+	// Create a random 4-byte string encoded as base32, trimming padding
+	b := make([]byte, 4)
+	for i := range b {
+		b[i] = byte(rand.Intn(256))
+	}
+	return strings.TrimRight(base32.StdEncoding.EncodeToString(b), "=")
+}
+
+func humanBytes(bytes int64) string {
+	var unit int64 = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := unit, 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -237,13 +237,13 @@ func readSegment(segmentHandler SegmentHandler, file *os.File, pipeName string) 
 		}
 		if n == len(buf) && n < 1024*1024 {
 			newLen := int(float64(len(buf)) * 1.5)
-			slog.Info("Max buf hit, increasing", "oldSize", humanBytes(int64(len(buf))), "newSize", HumanBytes(int64(newLen)))
+			slog.Info("Max buf hit, increasing", "oldSize", humanBytes(int64(len(buf))), "newSize", humanBytes(int64(newLen)))
 			buf = make([]byte, newLen)
 		}
 
 		if err != nil {
 			if err.Error() == "EOF" {
-				slog.Debug("Last byte read", "pipeName", pipeName, "totalRead", HumanBytes(totalBytesRead))
+				slog.Debug("Last byte read", "pipeName", pipeName, "totalRead", humanBytes(totalBytesRead))
 			} else {
 				slog.Error("Error reading", "pipeName", pipeName, "err", err)
 			}

--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -224,26 +224,26 @@ func readSegment(segmentHandler SegmentHandler, file *os.File, pipeName string) 
 		n, err := reader.Read(buf)
 		if n > 0 {
 			if !firstByteRead {
-				slog.Info("First byte read", "pipeName", pipeName)
+				slog.Debug("First byte read", "pipeName", pipeName)
 				firstByteRead = true
 
 			}
 			totalBytesRead += int64(n)
 			if _, err := interfaceWriter.Write(buf[:n]); err != nil {
 				if err != io.EOF {
-					slog.Info("Error writing", "pipeName", pipeName, "err", err)
+					slog.Error("Error writing", "pipeName", pipeName, "err", err)
 				}
 			}
 		}
 		if n == len(buf) && n < 1024*1024 {
 			newLen := int(float64(len(buf)) * 1.5)
-			slog.Info("Max buf hit, increasing", "oldSize", humanBytes(int64(len(buf))), "newSize", humanBytes(int64(newLen)))
+			slog.Info("Max buf hit, increasing", "oldSize", humanBytes(int64(len(buf))), "newSize", HumanBytes(int64(newLen)))
 			buf = make([]byte, newLen)
 		}
 
 		if err != nil {
 			if err.Error() == "EOF" {
-				slog.Info("Last byte read", "pipeName", pipeName, "totalRead", humanBytes(totalBytesRead))
+				slog.Debug("Last byte read", "pipeName", pipeName, "totalRead", HumanBytes(totalBytesRead))
 			} else {
 				slog.Error("Error reading", "pipeName", pipeName, "err", err)
 			}

--- a/media/segment_reader.go
+++ b/media/segment_reader.go
@@ -1,0 +1,37 @@
+package media
+
+import (
+	"io"
+	"sync"
+)
+
+type SegmentHandler func(reader io.Reader)
+
+func NoopReader(reader io.Reader) {
+	go func() {
+		io.Copy(io.Discard, reader)
+	}()
+}
+
+type SwitchableSegmentReader struct {
+	mu     sync.RWMutex
+	reader SegmentHandler
+}
+
+func NewSwitchableSegmentReader() *SwitchableSegmentReader {
+	return &SwitchableSegmentReader{
+		reader: NoopReader,
+	}
+}
+
+func (sr *SwitchableSegmentReader) SwitchReader(newReader SegmentHandler) {
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	sr.reader = newReader
+}
+
+func (sr *SwitchableSegmentReader) Read(reader io.Reader) {
+	sr.mu.RLock()
+	defer sr.mu.RUnlock()
+	sr.reader(reader)
+}

--- a/media/segment_reader.go
+++ b/media/segment_reader.go
@@ -13,6 +13,12 @@ func NoopReader(reader io.Reader) {
 	}()
 }
 
+type EOSReader struct{}
+
+func (r EOSReader) Read(p []byte) (n int, err error) {
+	return 0, io.EOF
+}
+
 type SwitchableSegmentReader struct {
 	mu     sync.RWMutex
 	reader SegmentHandler
@@ -34,4 +40,10 @@ func (sr *SwitchableSegmentReader) Read(reader io.Reader) {
 	sr.mu.RLock()
 	defer sr.mu.RUnlock()
 	sr.reader(reader)
+}
+
+func (sr *SwitchableSegmentReader) Close() {
+	sr.mu.RLock()
+	defer sr.mu.RUnlock()
+	sr.reader(&EOSReader{})
 }

--- a/media/select_darwin.go
+++ b/media/select_darwin.go
@@ -1,0 +1,42 @@
+//go:build darwin
+
+package media
+
+import "syscall"
+
+func crossPlatformSelect(nfd int, r, w, e *syscall.FdSet, timeout *syscall.Timeval) (int, error) {
+	// On macOS, syscall.Select only returns an error
+	err := syscall.Select(nfd, r, w, e, timeout)
+	if err != nil {
+		return -1, err // Return -1 in case of an error
+	}
+	// We need to manually count the number of ready descriptors in FdSets
+	n := 0
+	if r != nil {
+		n += countReadyDescriptors(r, nfd)
+	}
+	if w != nil {
+		n += countReadyDescriptors(w, nfd)
+	}
+	if e != nil {
+		n += countReadyDescriptors(e, nfd)
+	}
+	return n, nil
+
+}
+
+// countReadyDescriptors manually counts the number of ready file descriptors in an FdSet
+func countReadyDescriptors(set *syscall.FdSet, nfd int) int {
+	count := 0
+	for fd := 0; fd < nfd; fd++ {
+		if isSet(fd, set) {
+			count++
+		}
+	}
+	return count
+}
+
+// isSet checks if a file descriptor is set in an FdSet
+func isSet(fd int, set *syscall.FdSet) bool {
+	return set.Bits[fd/64]&(1<<(uint(fd)%64)) != 0
+}

--- a/media/select_linux.go
+++ b/media/select_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package media
+
+import "syscall"
+
+func crossPlatformSelect(nfd int, r, w, e *syscall.FdSet, timeout *syscall.Timeval) (int, error) {
+	return syscall.Select(nfd, r, w, e, timeout)
+}

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -25,6 +25,7 @@ import (
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/monitor"
+	"github.com/livepeer/go-livepeer/trickle"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
 )
 
@@ -50,6 +51,8 @@ func startAIServer(lp lphttp) error {
 
 	openapi3filter.RegisterBodyDecoder("image/png", openapi3filter.FileBodyDecoder)
 
+	trickle.ConfigureServerWithMux(lp.transRPC)
+
 	lp.transRPC.Handle("/text-to-image", oapiReqValidator(aiHttpHandle(&lp, jsonDecoder[worker.GenTextToImageJSONRequestBody])))
 	lp.transRPC.Handle("/image-to-image", oapiReqValidator(aiHttpHandle(&lp, multipartDecoder[worker.GenImageToImageMultipartRequestBody])))
 	lp.transRPC.Handle("/image-to-video", oapiReqValidator(aiHttpHandle(&lp, multipartDecoder[worker.GenImageToVideoMultipartRequestBody])))
@@ -58,8 +61,9 @@ func startAIServer(lp lphttp) error {
 	lp.transRPC.Handle("/llm", oapiReqValidator(aiHttpHandle(&lp, jsonDecoder[worker.GenLLMFormdataRequestBody])))
 	lp.transRPC.Handle("/segment-anything-2", oapiReqValidator(aiHttpHandle(&lp, multipartDecoder[worker.GenSegmentAnything2MultipartRequestBody])))
 	lp.transRPC.Handle("/image-to-text", oapiReqValidator(aiHttpHandle(&lp, multipartDecoder[worker.GenImageToTextMultipartRequestBody])))
-	lp.transRPC.Handle("/live-video-to-video", oapiReqValidator(lp.StartLiveVideoToVideo()))
 	lp.transRPC.Handle("/text-to-speech", oapiReqValidator(aiHttpHandle(&lp, multipartDecoder[worker.GenTextToSpeechJSONRequestBody])))
+
+	lp.transRPC.Handle("/live-video-to-video", oapiReqValidator(lp.StartLiveVideoToVideo()))
 	// Additionally, there is the '/aiResults' endpoint registered in server/rpc.go
 
 	return nil
@@ -89,24 +93,20 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 
 		var (
 			mid    = string(core.RandomManifestID())
-			pubUrl = "/ai/live-video/" + mid
-			subUrl = pubUrl + "/out"
+			pubUrl = trickle.BaseServerPath + mid
+			subUrl = pubUrl + "-out"
 		)
-		jsonData, err := json.Marshal(struct {
-			PublishUrl   string
-			SubscribeUrl string
-		}{
-			PublishUrl:   pubUrl,
-			SubscribeUrl: subUrl,
-		})
+		jsonData, err := json.Marshal(
+			&worker.LiveVideoToVideoResponse{
+				PublishUrl:   pubUrl,
+				SubscribeUrl: subUrl,
+			})
 		if err != nil {
 			respondWithError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		w.Write(jsonData)
+		respondJsonOk(w, jsonData)
 	})
 }
 

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -32,5 +32,5 @@ func startTricklePublish(url *url.URL, params aiRequestParams) {
 	slog.Info("trickle pub", "url", url)
 }
 
-func startTrickleSubscribe(url *url.URL) {
+func startTrickleSubscribe(url *url.URL, params aiRequestParams) {
 }

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"io"
+	"log/slog"
+	"net/url"
+
+	"github.com/livepeer/go-livepeer/trickle"
+)
+
+func startTricklePublish(url *url.URL, params aiRequestParams) {
+	publisher, err := trickle.NewTricklePublisher(url.String())
+	if err != nil {
+		slog.Info("error publishing trickle", "err", err)
+	}
+	params.segmentReader.SwitchReader(func(reader io.Reader) {
+		go func() {
+			// TODO this blocks! very bad!
+			publisher.Write(reader)
+		}()
+	})
+	// TODO close trickle publish on stream termination
+	slog.Info("trickle pub", "url", url)
+}
+
+func startTrickleSubscribe(url *url.URL) {
+}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -367,7 +367,8 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		// Kick off the RTMP pull and segmentation as soon as possible
 		ssr := media.NewSwitchableSegmentReader()
 		go func() {
-			media.RunSegmentation("rtmp://localhost/"+streamName, ssr.Read)
+			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir}
+			ms.RunSegmentation("rtmp://localhost/"+streamName, ssr.Read)
 			// TODO handle stream stops
 		}()
 

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/media"
 	"github.com/livepeer/go-tools/drivers"
 	middleware "github.com/oapi-codegen/nethttp-middleware"
 	"github.com/oapi-codegen/runtime"
@@ -360,15 +361,26 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			return
 		}
 		requestID := string(core.RandomManifestID())
-		params := aiRequestParams{
-			node:        ls.LivepeerNode,
-			os:          drivers.NodeStorage.NewSession(requestID),
-			sessManager: ls.AISessionManager,
-		}
 		ctx := clog.AddVal(r.Context(), "request_id", requestID)
-		// TODO set model and initial parameters here if necessary (eg, prompt)
-		req := struct{}{}
-		resp, err := processAIRequest(ctx, params, req)
-		clog.Infof(ctx, "Received live video AI request stream=%s resp=%v err=%v", streamName, resp, err)
+		clog.Infof(ctx, "Received live video AI request for %s", streamName)
+
+		// Kick off the RTMP pull and segmentation as soon as possible
+		ssr := media.NewSwitchableSegmentReader()
+		go func() {
+			media.RunSegmentation("rtmp://localhost/"+streamName, ssr.Read)
+			// TODO handle stream stops
+		}()
+
+		params := aiRequestParams{
+			node:          ls.LivepeerNode,
+			os:            drivers.NodeStorage.NewSession(requestID),
+			sessManager:   ls.AISessionManager,
+			segmentReader: ssr,
+		}
+
+		req := worker.GenLiveVideoToVideoJSONRequestBody{
+			// TODO set model and initial parameters here if necessary (eg, prompt)
+		}
+		processAIRequest(ctx, params, req)
 	})
 }

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -369,7 +369,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		go func() {
 			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir}
 			ms.RunSegmentation("rtmp://localhost/"+streamName, ssr.Read)
-			// TODO handle stream stops
+			ssr.Close()
 		}()
 
 		params := aiRequestParams{

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1039,13 +1039,7 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 		}
 		clog.V(common.VERBOSE).Infof(ctx, "pub %s sub %s", pub, sub)
 		startTricklePublish(pub, params)
-		startTrickleSubscribe(sub)
-	}
-	if resp.JSON400 != nil {
-		fmt.Println("json400", resp.JSON400)
-	}
-	if resp.JSON500 != nil {
-		fmt.Println("json500", resp.JSON500)
+		startTrickleSubscribe(sub, params)
 	}
 	return resp, nil
 }

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"math/big"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -21,6 +22,7 @@ import (
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/media"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-tools/drivers"
 	"github.com/livepeer/lpms/stream"
@@ -83,6 +85,9 @@ type aiRequestParams struct {
 	node        *core.LivepeerNode
 	os          drivers.OSSession
 	sessManager *AISessionManager
+
+	// For live video pipelines
+	segmentReader *media.SwitchableSegmentReader
 }
 
 // CalculateTextToImageLatencyScore computes the time taken per pixel for an text-to-image request.
@@ -994,17 +999,55 @@ func submitAudioToText(ctx context.Context, params aiRequestParams, sess *AISess
 	return &res, nil
 }
 
-func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *AISession, req struct{ ModelId *string }) (any, error) {
-	//client, err := worker.NewClientWithResponses(sess.Transcoder(), worker.WithHTTPClient(httpClient))
-	var err error
+func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *AISession, req worker.GenLiveVideoToVideoJSONRequestBody) (any, error) {
+	client, err := worker.NewClientWithResponses(sess.Transcoder(), worker.WithHTTPClient(httpClient))
 	if err != nil {
 		if monitor.Enabled {
 			monitor.AIRequestError(err.Error(), "LiveVideoToVideo", *req.ModelId, sess.OrchestratorInfo)
 		}
 		return nil, err
 	}
-	// TODO check urls and add sess.Transcoder to the host if necessary
-	return nil, nil
+	resp, err := client.GenLiveVideoToVideoWithResponse(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.JSON200 != nil {
+		// append orch hostname to the given url if necessary
+		appendHostname := func(urlPath string) (*url.URL, error) {
+			if urlPath == "" {
+				return nil, fmt.Errorf("invalid url from orch")
+			}
+			pu, err := url.Parse(urlPath)
+			if err != nil {
+				return nil, err
+			}
+			if pu.Hostname() != "" {
+				// url has a hostname already so use it
+				return pu, nil
+			}
+			// no hostname, so append one
+			u := sess.Transcoder() + urlPath
+			return url.Parse(u)
+		}
+		pub, err := appendHostname(resp.JSON200.PublishUrl)
+		if err != nil {
+			return nil, fmt.Errorf("pub url - %w", err)
+		}
+		sub, err := appendHostname(resp.JSON200.SubscribeUrl)
+		if err != nil {
+			return nil, fmt.Errorf("sub url %w", err)
+		}
+		clog.V(common.VERBOSE).Infof(ctx, "pub %s sub %s", pub, sub)
+		startTricklePublish(pub, params)
+		startTrickleSubscribe(sub)
+	}
+	if resp.JSON400 != nil {
+		fmt.Println("json400", resp.JSON400)
+	}
+	if resp.JSON500 != nil {
+		fmt.Println("json500", resp.JSON500)
+	}
+	return resp, nil
 }
 
 func CalculateLLMLatencyScore(took time.Duration, tokensUsed int) float64 {
@@ -1355,17 +1398,15 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 		submitFn = func(ctx context.Context, params aiRequestParams, sess *AISession) (interface{}, error) {
 			return submitTextToSpeech(ctx, params, sess, v)
 		}
-		/*
-			case worker.StartLiveVideoToVideoFormdataRequestBody:
-				cap = core.Capability_LiveVideoToVideo
-				modelID = defaultLiveVideoToVideoModelID
-				if v.ModelId != nil {
-					modelID = *v.ModelId
-				}
-				submitFn = func(ctx context.Context, params aiRequestParams, sess *AISession) (interface{}, error) {
-					return submitLiveVideoToVideo(ctx, params, sess, v)
-				}
-		*/
+	case worker.GenLiveVideoToVideoJSONRequestBody:
+		cap = core.Capability_LiveVideoToVideo
+		modelID = defaultLiveVideoToVideoModelID
+		if v.ModelId != nil {
+			modelID = *v.ModelId
+		}
+		submitFn = func(ctx context.Context, params aiRequestParams, sess *AISession) (interface{}, error) {
+			return submitLiveVideoToVideo(ctx, params, sess, v)
+		}
 	default:
 		return nil, fmt.Errorf("unsupported request type %T", req)
 	}

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -22,6 +22,7 @@ import (
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/pm"
+	"github.com/livepeer/go-livepeer/trickle"
 	"github.com/livepeer/go-tools/drivers"
 	ffmpeg "github.com/livepeer/lpms/ffmpeg"
 	"github.com/livepeer/lpms/stream"
@@ -174,6 +175,7 @@ type lphttp struct {
 	orchestrator Orchestrator
 	orchRPC      *grpc.Server
 	transRPC     *http.ServeMux
+	trickleSrv   *trickle.Server
 	node         *core.LivepeerNode
 	net.UnimplementedOrchestratorServer
 	net.UnimplementedTranscoderServer

--- a/trickle/README.md
+++ b/trickle/README.md
@@ -55,3 +55,5 @@ Subscribers can retrieve the current `seq` with the `Lp-Trickle-Seq` metadata (H
 Subscribers can initiate a subscribe with a `seq` of -N to get the Nth-from-last segment. (TODO)
 
 The server should send subscribers `Lp-Trickle-Size` metadata to indicate the size of the content up until now. This allows clients to know where the live edge is, eg video implementations can decode-and-discard frames up until the edge to achieve immediate playback without waiting for the next segment. (TODO)
+
+The server currently has a special changefeed channel named `_changes` which will send subscribers updates on streams that are added and removed. The changefeed is disabled by default.

--- a/trickle/README.md
+++ b/trickle/README.md
@@ -1,0 +1,57 @@
+# Trickle Protocol
+
+Trickle is a segmented publish-subscribe protocol that streams data in realtime, mainly over HTTP.
+
+Breaking this down:
+
+1. Data streams are called *channels*. Channels are content agonstic - the data can be video, audio, JSON, logs, a custom format, etc.
+
+2. Segmented: Data for each channel is sent as discrete *segments*. For example, a video may use a segment for each GOP, or an API may use a segment for each JSON message, or a logging application may split segments on time intervals. The boundaries of each segment are application defined, but segments are preferably standalone such that a request for a single segment should return usable content on its own.
+
+3. Publish-subscribe: Publishers push segments, and subscribers pull them.
+
+4. Streaming: Content can be sent by publishers and received by subscribers in real-time as it is generated - data is *trickled* out.
+
+5. HTTP: Trickle is tied to HTTP with GET / POST semantics, status codes, path based routing, metadata in headers, etc. However, other implementations are possible, such as a local, in-memory trickle client.
+
+### Protocol Specification
+
+TODO: more details
+
+Publishers POST to /channel-name/seq
+
+Subscribers GET to /channel-name/seq
+
+The `channel-name` is any valid HTTP path part.
+
+The `seq` is an integer sequence number indicating the segment, and must increase sequentially without gaps.
+
+As data is published to `channel-name/seq`,the server will relay the data to all subscribers for `channel-name/seq`.
+
+Clients are responsible for maintaining their own position in the sequence.
+
+Servers may opt to keep the last N segments for subscribers to catch up on.
+
+Servers will 404 if a `channel-name` or a `seq` does not exist.
+
+Clients may pre-connect the next segment in order to set up the resource and minimize connection set-up time.
+
+Publishers should only actively send data to one `seq` at a time, although they may still pre-connect to `seq + 1`
+
+Publishers do not have to push content immeditely after preconnecting, however the server should have some reasonable timeout to avoid excessive idle connections.
+
+If a subscriber retrieves a segment mid-publish, the server should return all the content it has up until that point, and trickle down the rest as it receives it.
+
+If a timeout has been hit without sending (or receiving) content, the publisher (or subscriber) can re-connect to the same `seq`. (TODO; also indicate timeout via signaling)
+
+Servers may offer some grace with leading sequence numbers to avoid data races, eg allowing a GET for `seq+1` if a publisher hasn't yet preconnected that number.
+
+Publishers are responsible for segmenting content (if necessary) and subscribers are responsible for re-assembling content (if necessary)
+
+Subscribers can initiate a subscribe with a `seq` of -1 to retrieve the most recent publish. With preconnects, the subscriber may be waiting for the *next* publish. For video this allows clients to eg, start streaming at the live edge of the next GOP.
+
+Subscribers can retrieve the current `seq` with the `Lp-Trickle-Seq` metadata (HTTP header). This is useful in case `-1` was used to initiate the subscription; the subscribing client can then pre-connect to `Lp-Trickle-Seq + 1`
+
+Subscribers can initiate a subscribe with a `seq` of -N to get the Nth-from-last segment. (TODO)
+
+The server should send subscribers `Lp-Trickle-Size` metadata to indicate the size of the content up until now. This allows clients to know where the live edge is, eg video implementations can decode-and-discard frames up until the edge to achieve immediate playback without waiting for the next segment. (TODO)

--- a/trickle/README.md
+++ b/trickle/README.md
@@ -4,7 +4,7 @@ Trickle is a segmented publish-subscribe protocol that streams data in realtime,
 
 Breaking this down:
 
-1. Data streams are called *channels*. Channels are content agonstic - the data can be video, audio, JSON, logs, a custom format, etc.
+1. Data streams are called *channels* , Channels are content agnostic - the data can be video, audio, JSON, logs, a custom format, etc.
 
 2. Segmented: Data for each channel is sent as discrete *segments*. For example, a video may use a segment for each GOP, or an API may use a segment for each JSON message, or a logging application may split segments on time intervals. The boundaries of each segment are application defined, but segments are preferably standalone such that a request for a single segment should return usable content on its own.
 

--- a/trickle/local_publisher.go
+++ b/trickle/local_publisher.go
@@ -1,0 +1,75 @@
+package trickle
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+)
+
+// local (in-memory) publisher for trickle protocol
+
+type TrickleLocalPublisher struct {
+	channelName string
+	mimeType    string
+	server      *Server
+
+	mu  *sync.Mutex
+	seq int
+}
+
+func NewLocalPublisher(sm *Server, channelName string, mimeType string) *TrickleLocalPublisher {
+	return &TrickleLocalPublisher{
+		channelName: channelName,
+		server:      sm,
+		mu:          &sync.Mutex{},
+		mimeType:    mimeType,
+	}
+}
+
+func (c *TrickleLocalPublisher) CreateChannel() {
+	c.server.getOrCreateStream(c.channelName, c.mimeType)
+}
+
+func (c *TrickleLocalPublisher) Write(data io.Reader) error {
+	stream := c.server.getOrCreateStream(c.channelName, c.mimeType)
+	c.mu.Lock()
+	seq := c.seq
+	segment, exists := stream.getForWrite(seq)
+	if exists {
+		c.mu.Unlock()
+		return errors.New("Entry already exists for this sequence")
+	}
+
+	// before we begin - let's pre-create the next segment
+	nextSeq := c.seq + 1
+	if _, exists = stream.getForWrite(nextSeq); exists {
+		c.mu.Unlock()
+		return errors.New("Next entry alredy exists in this sequence")
+	}
+	c.seq = nextSeq
+	c.mu.Unlock()
+
+	// now continue with the show
+	buf := make([]byte, 1024*32) // 32kb to begin with
+	totalRead := 0
+	for {
+		n, err := data.Read(buf)
+		if n > 0 {
+			segment.writeData(buf[:n])
+			totalRead += n
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			slog.Info("Error reading published data", "channel", c.channelName, "seq", seq, "bytes written", totalRead, "err", err)
+		}
+	}
+	segment.close()
+	return nil
+}
+
+func (c *TrickleLocalPublisher) Close() error {
+	return c.server.closeStream(c.channelName)
+}

--- a/trickle/local_subscriber.go
+++ b/trickle/local_subscriber.go
@@ -1,0 +1,77 @@
+package trickle
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"strconv"
+	"sync"
+)
+
+// local (in-memory) subscriber for trickle protocol
+
+type TrickleData struct {
+	Reader   io.Reader
+	Metadata map[string]string
+}
+
+type TrickleLocalSubscriber struct {
+	channelName string
+	server      *Server
+
+	mu  *sync.Mutex
+	seq int
+}
+
+func NewLocalSubscriber(sm *Server, channelName string) *TrickleLocalSubscriber {
+	return &TrickleLocalSubscriber{
+		channelName: channelName,
+		server:      sm,
+		mu:          &sync.Mutex{},
+		seq:         -1,
+	}
+}
+
+func (c *TrickleLocalSubscriber) Read() (*TrickleData, error) {
+	stream, exists := c.server.getStream(c.channelName)
+	if !exists {
+		return nil, errors.New("stream not found")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	segment, exists := stream.getForRead(c.seq)
+	if !exists {
+		return nil, errors.New("seq not found")
+	}
+	c.seq++
+	r, w := io.Pipe()
+	go func() {
+		subscriber := &SegmentSubscriber{
+			segment: segment,
+		}
+		for {
+			data, eof := subscriber.readData()
+			n, err := w.Write(data)
+			if err != nil {
+				slog.Info("Error writing", "channel", c.channelName, "seq", segment.idx, "err", err)
+				return
+			}
+			if n != len(data) {
+				slog.Info("Did not write enough data to local subscriber", "channel", c.channelName, "seq", segment.idx)
+				return
+			}
+			if eof {
+				// trigger eof on the reader
+				w.Close()
+				return
+			}
+		}
+	}()
+	return &TrickleData{
+		Reader: r,
+		Metadata: map[string]string{
+			"Lp-Trickle-Seq": strconv.Itoa(segment.idx),
+			"Content-Type":   stream.mimeType,
+		}, // TODO take more metadata from http headers
+	}, nil
+}

--- a/trickle/trickle_publisher.go
+++ b/trickle/trickle_publisher.go
@@ -51,7 +51,7 @@ func (c *TricklePublisher) preconnect() (*pendingPost, error) {
 	pr, pw := io.Pipe()
 	req, err := http.NewRequest("POST", url, pr)
 	if err != nil {
-		slog.Error("Failed to create request for segment", "idx", index, "err", err)
+		slog.Error("Failed to create request for segment", "url", url, "err", err)
 		return nil, err
 	}
 	req.Header.Set("Content-Type", c.contentType)
@@ -67,19 +67,19 @@ func (c *TricklePublisher) preconnect() (*pendingPost, error) {
 		}}
 		resp, err := client.Do(req)
 		if err != nil {
-			slog.Info("Failed to complete POST for segment", "index", index, "err", err)
+			slog.Info("Failed to complete POST for segment", "url", url, "err", err)
 			return
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			slog.Info("Error reading body", "index", index, "err", err)
+			slog.Info("Error reading body", "url", url, "err", err)
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			slog.Info("Failed POST segment", "index", index, "status_code", resp.StatusCode, "msg", string(body))
+			slog.Info("Failed POST segment", "url", url, "status_code", resp.StatusCode, "msg", string(body))
 		} else {
-			slog.Info("Uploaded segment", "index", index)
+			slog.Info("Uploaded segment", "url", url)
 		}
 	}()
 

--- a/trickle/trickle_publisher.go
+++ b/trickle/trickle_publisher.go
@@ -95,7 +95,10 @@ func (c *TricklePublisher) Close() error {
 	if err != nil {
 		return err
 	}
-	resp, err := (&http.Client{}).Do(req)
+	resp, err := (&http.Client{Transport: &http.Transport{
+		// ignore orch certs for now
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}).Do(req)
 	if err != nil {
 		return err
 	}

--- a/trickle/trickle_publisher.go
+++ b/trickle/trickle_publisher.go
@@ -1,0 +1,167 @@
+package trickle
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+)
+
+// TricklePublisher represents a trickle streaming client
+type TricklePublisher struct {
+	baseURL     string
+	index       int          // Current index for segments
+	writeLock   sync.Mutex   // Mutex to manage concurrent access
+	pendingPost *pendingPost // Pre-initialized POST request
+	contentType string
+}
+
+// pendingPost represents a pre-initialized POST request waiting for data
+type pendingPost struct {
+	index  int
+	writer *io.PipeWriter
+}
+
+// NewTricklePublisher creates a new trickle stream client
+func NewTricklePublisher(url string) (*TricklePublisher, error) {
+	c := &TricklePublisher{
+		baseURL:     url,
+		contentType: "video/MP2T",
+	}
+	p, err := c.preconnect()
+	if err != nil {
+		return nil, err
+	}
+	c.pendingPost = p
+
+	return c, nil
+}
+
+// Acquire lock to manage access to pendingPost and index
+// NB expects to have the lock already since we mutate the index
+func (c *TricklePublisher) preconnect() (*pendingPost, error) {
+
+	index := c.index
+	url := fmt.Sprintf("%s/%d", c.baseURL, index)
+
+	slog.Info("Preconnecting", "url", url)
+
+	pr, pw := io.Pipe()
+	req, err := http.NewRequest("POST", url, pr)
+	if err != nil {
+		slog.Error("Failed to create request for segment", "idx", index, "err", err)
+		return nil, err
+	}
+	req.Header.Set("Content-Type", c.contentType)
+
+	// Start the POST request in a background goroutine
+	// TODO error handling for these
+	go func() {
+		slog.Info("Initiailzing http client", "idx", index)
+		// Createa new client to prevent connection reuse
+		client := http.Client{Transport: &http.Transport{
+			// ignore orch certs for now
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}}
+		resp, err := client.Do(req)
+		if err != nil {
+			slog.Info("Failed to complete POST for segment", "index", index, "err", err)
+			return
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			slog.Info("Error reading body", "index", index, "err", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			slog.Info("Failed POST segment", "index", index, "status_code", resp.StatusCode, "msg", string(body))
+		} else {
+			slog.Info("Uploaded segment", "index", index)
+		}
+	}()
+
+	c.index += 1
+	return &pendingPost{
+		writer: pw,
+		index:  index,
+	}, nil
+}
+
+func (c *TricklePublisher) Close() error {
+	req, err := http.NewRequest("DELETE", c.baseURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("Failed to delete stream: %v - %s", resp.Status, string(body))
+	}
+	return nil
+}
+
+// Write sends data to the current segment, sets up the next segment concurrently, and blocks until completion
+func (c *TricklePublisher) Write(data io.Reader) error {
+
+	// Acquire lock to manage access to pendingPost and index
+	c.writeLock.Lock()
+
+	// Get the writer to use
+	pp := c.pendingPost
+	if pp == nil {
+		p, err := c.preconnect()
+		if err != nil {
+			c.writeLock.Unlock()
+			return err
+		}
+		pp = p
+	}
+	writer := pp.writer
+	index := pp.index
+
+	// Set up the next connection
+	nextPost, err := c.preconnect()
+	if err != nil {
+		c.writeLock.Unlock()
+		return err
+	}
+	c.pendingPost = nextPost
+
+	// Now unlock so the copy does not block
+	c.writeLock.Unlock()
+
+	// Start streaming data to the current POST request
+	n, err := io.Copy(writer, data)
+	if err != nil {
+		return fmt.Errorf("error streaming data to segment %d: %w", index, err)
+	}
+
+	slog.Info("Completed writing", "idx", index, "totalBytes", humanBytes(n))
+
+	// Close the pipe writer to signal end of data for the current POST request
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("error closing writer for segment %d: %w", index, err)
+	}
+
+	return nil
+}
+
+func humanBytes(bytes int64) string {
+	var unit int64 = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := unit, 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/trickle/trickle_server.go
+++ b/trickle/trickle_server.go
@@ -282,8 +282,6 @@ func (s *Stream) getForWrite(idx int) (*Segment, bool) {
 	defer s.mutex.Unlock()
 	if idx == -1 {
 		idx = s.latestWrite
-		// TODO figure out how to better handle restarts while maintaining ordering
-		/* } else if idx > s.latestWrite { */
 	} else {
 		s.latestWrite = idx
 	}
@@ -380,6 +378,10 @@ func (s *Stream) handleGet(w http.ResponseWriter, r *http.Request, idx int) {
 				flusher.Flush()
 			}
 			if eof {
+				if totalWrites <= 0 {
+					w.Header().Set("Lp-Trickle-Seq", strconv.Itoa(segment.idx))
+					w.Header().Set("Lp-Trickle-Closed", "terminated")
+				}
 				return totalWrites, nil
 			}
 		}

--- a/trickle/trickle_server.go
+++ b/trickle/trickle_server.go
@@ -1,0 +1,423 @@
+package trickle
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// TODO sweep idle streams connections
+
+type StreamManager struct {
+	mutex   sync.RWMutex
+	streams map[string]*Stream
+}
+
+type Stream struct {
+	mutex       sync.RWMutex
+	segments    []*Segment
+	latestWrite int
+}
+
+type Segment struct {
+	idx    int
+	mutex  *sync.Mutex
+	cond   *sync.Cond
+	buffer *bytes.Buffer
+	closed bool
+}
+
+type SegmentSubscriber struct {
+	segment *Segment
+	readPos int
+}
+
+const maxSegmentsPerStream = 5
+
+const BaseServerPath = "/ai/live-video/"
+
+var FirstByteTimeout = errors.New("pending read timeout")
+
+func ConfigureServerWithMux(mux *http.ServeMux) {
+	/* TODO we probably want to configure the below
+	srv := &http.Server{
+		// say max segment size is 20 secs
+		// we can allow 2 * 20 secs given preconnects
+		ReadTimeout:  40 * time.Second,
+		WriteTimeout: 45 * time.Second,
+	}
+	*/
+
+	streamManager := &StreamManager{
+		streams: make(map[string]*Stream),
+	}
+	mux.HandleFunc("GET "+BaseServerPath+"{streamName}/{idx}", streamManager.handleGet)
+	mux.HandleFunc("POST "+BaseServerPath+"{streamName}/{idx}", streamManager.handlePost)
+	mux.HandleFunc("DELETE "+BaseServerPath+"{streamName}", streamManager.handleDelete)
+}
+
+func (sm *StreamManager) getStream(streamName string) (*Stream, bool) {
+	sm.mutex.RLock()
+	defer sm.mutex.RUnlock()
+	stream, exists := sm.streams[streamName]
+	return stream, exists
+}
+
+func (sm *StreamManager) getOrCreateStream(streamName string) *Stream {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	stream, exists := sm.streams[streamName]
+	if !exists {
+		stream = &Stream{
+			segments: make([]*Segment, 5),
+		}
+		sm.streams[streamName] = stream
+		slog.Info("Creating stream", "stream", streamName)
+	}
+	return stream
+}
+
+func (sm *StreamManager) clearAllStreams() {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+
+	for _, stream := range sm.streams {
+		stream.clear()
+	}
+	sm.streams = make(map[string]*Stream)
+}
+
+func (s *Stream) clear() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	for _, segment := range s.segments {
+		segment.close()
+	}
+	s.segments = make([]*Segment, maxSegmentsPerStream)
+}
+
+func (sm *StreamManager) handleDelete(w http.ResponseWriter, r *http.Request) {
+	streamName := r.PathValue("streamName")
+	stream, exists := sm.getStream(streamName)
+	if !exists {
+		http.Error(w, "Invalid stream name", http.StatusBadRequest)
+		return
+	}
+
+	// TODO properly clear sessions once we have a good solution
+	//      for session reuse
+	return
+
+	stream.clear()
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	delete(sm.streams, streamName)
+	slog.Info("Deleted stream", "streamName", streamName)
+}
+
+func (sm *StreamManager) handlePost(w http.ResponseWriter, r *http.Request) {
+	stream := sm.getOrCreateStream(r.PathValue("streamName"))
+	idx, err := strconv.Atoi(r.PathValue("idx"))
+	if err != nil {
+		http.Error(w, "Invalid idx", http.StatusBadRequest)
+		return
+	}
+	stream.handlePost(w, r, idx)
+}
+
+type timeoutReader struct {
+	body          io.Reader
+	timeout       time.Duration
+	firstByteRead bool
+}
+
+func (tr *timeoutReader) Read(p []byte) (int, error) {
+	if tr.firstByteRead {
+		// After the first byte is read, proceed normally
+		return tr.body.Read(p)
+	}
+
+	done := make(chan struct{})
+	var n int
+	var err error
+
+	go func() {
+		n, err = tr.body.Read(p)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if n > 0 {
+			tr.firstByteRead = true
+		}
+		return n, err
+	case <-time.After(tr.timeout):
+		return 0, FirstByteTimeout
+	}
+}
+
+// TODO retry handling.
+//
+// What can happen is roughly the following:
+// client abruptly stops sending a segment X
+// client needs to continue at segment Y (Y > X, usually Y = X + 2)
+//
+// What needs to happen:
+//  server needs to keep track of bytes received at X
+//  For Y, client sends *full* segment (overlapping X)
+//  Server *discards* overlap bytes between X and Y
+//
+// client sends a POST for segment Y with a retry indication
+// Segment X can only be the last segment that the client sent content for.
+// Server should close segment X
+// (the server can continue transmitting what it has so far for Segment X to,
+// clients that are still downloading it, but should not add any more to X's buffer)
+// Also the server should close any pending POST and GET requests for X < segment < Y
+// even if these segment have NO data. This would mean marking any pending POST
+// segments as 'closed' and returning empty data (but still a 200 OK) to any
+// clients that GET these segments.
+// (in practice this would just be a single pre-connection for X + 1)
+// Server discards bytes for Segment Y up to its last read byte of Segment X
+// After reaching the last read byte, start buffering up the bytes of Segment Y
+// as they come in. Process requests normally.
+
+// Handle post requests for a given index
+func (s *Stream) handlePost(w http.ResponseWriter, r *http.Request, idx int) {
+	segment, exists := s.getForWrite(idx)
+	if exists {
+		slog.Warn("Overwriting existing entry", "idx", idx)
+		/*
+			// Overwrite anything that exists now. TODO figure out a safer behavior?
+				http.Error(w, "Entry already exists for this index", http.StatusBadRequest)
+				return
+		*/
+	}
+
+	// Wrap the request body with the custom timeoutReader
+	reader := &timeoutReader{
+		body: r.Body,
+		// This can't be too short for now but ideally it'd be like 1 second
+		// https://github.com/golang/go/issues/65035
+		timeout: 10 * time.Second,
+	}
+	defer r.Body.Close()
+
+	buf := make([]byte, 1024*32) // 32kb to begin with
+	totalRead := 0
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			segment.writeData(buf[:n])
+			if n == len(buf) && n < 1024*1024 { // 1 MB max
+				// filled the buffer, so double it for efficiency
+				buf = make([]byte, len(buf)*2)
+			}
+			totalRead += n
+		}
+		if err != nil {
+			if err == FirstByteTimeout {
+				// Keepalive via provisional headers
+				slog.Info("Sending provisional headers for", "idx", idx)
+				w.WriteHeader(http.StatusContinue)
+				continue
+			} else if err == io.EOF {
+				break
+			}
+			slog.Info("Error reading POST body", "idx", idx, "bytes written", totalRead, "err", err)
+			http.Error(w, "Server error", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Mark segment as closed
+	segment.close()
+}
+
+func (s *Stream) getForWrite(idx int) (*Segment, bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if idx == -1 {
+		idx = s.latestWrite
+		// TODO figure out how to better handle restarts while maintaining ordering
+		/* } else if idx > s.latestWrite { */
+	} else {
+		s.latestWrite = idx
+	}
+	slog.Info("POST segment", "idx", idx, "latest", s.latestWrite)
+	segmentPos := idx % maxSegmentsPerStream
+	if segment := s.segments[segmentPos]; segment != nil {
+		if idx == segment.idx {
+			return segment, !segment.isFresh()
+		}
+		// something exists here but its not the expected segment
+		// probably an old segment so overwrite it
+		segment.close()
+	}
+	segment := newSegment(idx)
+	s.segments[segmentPos] = segment
+	return segment, false
+}
+
+func (s *Stream) getForRead(idx int) (*Segment, bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	exists := func(seg *Segment, i int) bool {
+		return seg != nil && seg.idx == i
+	}
+	if idx == -1 {
+		idx = s.latestWrite
+	}
+	segmentPos := idx % maxSegmentsPerStream
+	segment := s.segments[segmentPos]
+	if !exists(segment, idx) && idx == s.latestWrite+1 {
+		// read request is just a little bit ahead of write head
+		segment = newSegment(idx)
+		s.segments[segmentPos] = segment
+		slog.Info("GET precreating", "idx", idx, "latest", s.latestWrite)
+	}
+	slog.Info("GET segment", "idx", idx, "latest", s.latestWrite, "exists?", exists(segment, idx))
+	return segment, exists(segment, idx)
+}
+
+func (sm *StreamManager) handleGet(w http.ResponseWriter, r *http.Request) {
+	stream, exists := sm.getStream(r.PathValue("streamName"))
+	if !exists {
+		http.Error(w, "Stream not found", http.StatusNotFound)
+		return
+	}
+	idx, err := strconv.Atoi(r.PathValue("idx"))
+	if err != nil {
+		http.Error(w, "Invalid idx", http.StatusBadRequest)
+		return
+	}
+	stream.handleGet(w, r, idx)
+}
+
+func (s *Stream) handleGet(w http.ResponseWriter, r *http.Request, idx int) {
+	segment, exists := s.getForRead(idx)
+	if !exists {
+		http.Error(w, "Entry not found", http.StatusNotFound)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	subscriber := &SegmentSubscriber{
+		segment: segment,
+	}
+
+	// Function to write data to the client
+	sendData := func() (int, error) {
+		totalWrites := 0
+		for {
+			// Check if client disconnected
+			select {
+			case <-r.Context().Done():
+				return totalWrites, fmt.Errorf("client disconnected")
+			default:
+			}
+
+			data, eof := subscriber.readData()
+			if len(data) > 0 {
+				if totalWrites <= 0 {
+					w.Header().Set("Lp-Trickle-Idx", strconv.Itoa(segment.idx))
+					w.Header().Set("Content-Type", "video/MP2T") // TODO take from post
+				}
+				n, err := w.Write(data)
+				totalWrites += n
+				if err != nil {
+					return totalWrites, err
+				}
+				// TODO error if bytes written != len(data) ?
+				flusher.Flush()
+			}
+			if eof {
+				return totalWrites, nil
+			}
+		}
+	}
+
+	if n, err := sendData(); err != nil {
+		// Handle write error or client disconnect
+		slog.Error("Error sending data to client", "idx", segment.idx, "sentBytes", n, "err", err)
+		return
+	}
+}
+
+func newSegment(idx int) *Segment {
+	mu := &sync.Mutex{}
+	return &Segment{
+		idx:    idx,
+		buffer: new(bytes.Buffer),
+		cond:   sync.NewCond(mu),
+		mutex:  mu,
+	}
+}
+
+func (segment *Segment) writeData(data []byte) {
+	segment.mutex.Lock()
+	defer segment.mutex.Unlock()
+
+	// Write to buffer
+	segment.buffer.Write(data)
+
+	// Signal waiting readers
+	segment.cond.Broadcast()
+}
+
+func (s *Segment) readData(startPos int) ([]byte, bool) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	for {
+		totalLen := s.buffer.Len()
+		if startPos < totalLen {
+			data := s.buffer.Bytes()[startPos:totalLen]
+			return data, s.closed
+		}
+		if startPos > totalLen {
+			slog.Info("Invalid start pos, invoking eof")
+			return nil, true
+		}
+		if s.closed {
+			return nil, true
+		}
+		// Wait for new data
+		s.cond.Wait()
+	}
+}
+
+func (s *Segment) close() {
+	if s == nil {
+		return // sometimes happens, weird
+	}
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if !s.closed {
+		s.closed = true
+		s.cond.Broadcast()
+	}
+}
+func (s *Segment) isFresh() bool {
+	// fresh segments have not been written to yet
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return !s.closed && s.buffer.Len() == 0
+}
+
+func (ss *SegmentSubscriber) readData() ([]byte, bool) {
+	data, eof := ss.segment.readData(ss.readPos)
+	ss.readPos += len(data)
+	return data, eof
+}

--- a/trickle/trickle_subscriber.go
+++ b/trickle/trickle_subscriber.go
@@ -1,0 +1,137 @@
+package trickle
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"sync"
+)
+
+// TrickleSubscriber represents a trickle streaming reader that always fetches from index -1
+type TrickleSubscriber struct {
+	url        string
+	mu         sync.Mutex     // Mutex to manage concurrent access
+	pendingGet *http.Response // Pre-initialized GET request
+	idx        int            // Segment index to request
+
+	// Number of errors from preconnect
+	preconnectErrorCount int
+}
+
+// NewTrickleSubscriber creates a new trickle stream reader for GET requests
+func NewTrickleSubscriber(url string) *TrickleSubscriber {
+	// No preconnect needed here; it will be handled by the first Read call.
+	return &TrickleSubscriber{
+		url: url,
+		idx: -1, // shortcut for 'latest'
+	}
+}
+
+func GetIndex(resp *http.Response) int {
+	if resp == nil {
+		return -1 // TODO hmm
+	}
+	v := resp.Header.Get("Lp-Trickle-Seq")
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		// Fetch the latest index
+		// TODO think through whether this is desirable
+		return -1
+	}
+	return i
+}
+
+// preconnect pre-initializes the next GET request for fetching the next segment (always index -1)
+func (c *TrickleSubscriber) preconnect() (*http.Response, error) {
+	url := fmt.Sprintf("%s/%d", c.url, c.idx)
+	slog.Info("preconnecting", "url", url)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		fmt.Printf("Failed to create request for segment: %v\n", err)
+		return nil, err
+	}
+
+	// Execute the GET request
+	resp, err := (&http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}).Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to complete GET for next segment: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close() // Ensure we close the body to avoid leaking connections
+		return nil, fmt.Errorf("failed GET segment, status code: %d, msg: %s", resp.StatusCode, string(body))
+	}
+
+	// Return the pre-initialized GET request
+	return resp, nil
+}
+
+// Read retrieves data from the current segment and sets up the next segment concurrently.
+// It returns the reader for the current segment's data.
+func (c *TrickleSubscriber) Read() (*http.Response, error) {
+	// Acquire lock to manage access to pendingGet
+	c.mu.Lock()
+
+	// TODO clean up this preconnect error handling!
+	hitMaxPreconnects := c.preconnectErrorCount > 5
+	if hitMaxPreconnects {
+		slog.Error("Hit max preconnect error", "url", c.url, "idx", c.idx)
+		c.mu.Unlock()
+		return nil, fmt.Errorf("Hit max preconnects")
+	}
+
+	// Get the reader to use for the current segment
+	conn := c.pendingGet
+	if conn == nil {
+		// Preconnect if we don't have a pending GET
+		slog.Info("No preconnect, connecting", "url", c.url, "idx", c.idx)
+		p, err := c.preconnect()
+		if err != nil {
+			c.preconnectErrorCount++
+			c.mu.Unlock()
+			return nil, err
+		}
+		conn = p
+		// reset preconnect error
+		c.preconnectErrorCount = 0
+	}
+
+	// Set to use the next index for the next (pre-)connection
+	idx := GetIndex(conn)
+	if idx != -1 {
+		c.idx = idx + 1
+	}
+
+	// Set up the next connection
+	go func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		nextConn, err := c.preconnect()
+		if err != nil {
+			slog.Error("failed to preconnect next segment", "idx", c.idx, "err", err)
+			c.preconnectErrorCount++
+			return
+		}
+
+		c.pendingGet = nextConn
+		idx := GetIndex(conn)
+		if idx != -1 {
+			c.idx = idx + 1
+		}
+		// reset preconnect error
+		c.preconnectErrorCount = 0
+	}()
+
+	// Now unlock since the next segment is set up and we have the reader for the current one
+	c.mu.Unlock()
+
+	// Return the reader for the current segment
+	return conn, nil
+}


### PR DESCRIPTION
- Requires #3210 
- Set up a trickle HTTP endpoints on the orchestrator (requires golang 1.22 for the new routes; will send a separate patch to bump the go.mod and do any CI adjustments)
- Pulls a RTMP stream from MediaMTX on the gateway when a new stream comes in 
- Converts the RTMP into mpegts segments
- Publishes segments to the orchestrator via trickle HTTP