### PR TITLE
Fix parsing "warm" field in ParseAIModelConfigs

### DIFF
--- a/core/ai.go
+++ b/core/ai.go
@@ -106,7 +106,7 @@ func ParseAIModelConfigs(config string) ([]AIModelConfig, error) {
 
 		pipeline := parts[0]
 		modelID := parts[1]
-		warm, err := strconv.ParseBool(parts[3])
+		warm, err := strconv.ParseBool(parts[2])
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Fixes an off-by-one error when parsing the "warm" field when manually configuring AI pipelines via CLI flags.  Also adds unit tests for this function.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Fix parsing
- Add tests

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Unit tests, manual testing

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
