### PR TITLE
Send duration in a2t inference requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -255,5 +255,3 @@ require (
 	lukechampine.com/blake3 v1.2.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-replace github.com/livepeer/ai-worker => /home/ricks/development/livepeer/ai/ai-worker

--- a/go.mod
+++ b/go.mod
@@ -255,3 +255,5 @@ require (
 	lukechampine.com/blake3 v1.2.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/livepeer/ai-worker => /home/ricks/development/livepeer/ai/ai-worker

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/jaypipes/ghw v0.10.0
 	github.com/jaypipes/pcidb v1.0.0
-	github.com/livepeer/ai-worker v0.11.0
+	github.com/livepeer/ai-worker v0.12.0
 	github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b
 	github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18
 	github.com/livepeer/lpms v0.0.0-20240909171057-fe5aff1fa6a2

--- a/go.sum
+++ b/go.sum
@@ -604,8 +604,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-netroute v0.2.0/go.mod h1:Vio7LTzZ+6hoT4CMZi5/6CpY3Snzh2vgZhWgxMNwlQI=
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
-github.com/livepeer/ai-worker v0.11.0 h1:prbRRBgCIrECUuZFWuyN6z3QZLfygYqBKYMleT+I7o4=
-github.com/livepeer/ai-worker v0.11.0/go.mod h1:GjQuPmz69UO53WVtqzB9Ygok5MmKCGNuobbfMXH7zgw=
+github.com/livepeer/ai-worker v0.12.0 h1:t+/f1jjOtciWvs6Azgq1hCT4SJB9aFuowtQnxGbh9nY=
+github.com/livepeer/ai-worker v0.12.0/go.mod h1:/Deme7XXRP4BiYXt/j694Ygw+dh8rWJdikJsKY64sjE=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b h1:VQcnrqtCA2UROp7q8ljkh2XA/u0KRgVv0S1xoUvOweE=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b/go.mod h1:hwJ5DKhl+pTanFWl+EUpw1H7ukPO/H+MFpgA7jjshzw=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cOQee+WqmaDOgGtP2oDMhcVvR4L0yA=

--- a/go.sum
+++ b/go.sum
@@ -604,6 +604,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-netroute v0.2.0/go.mod h1:Vio7LTzZ+6hoT4CMZi5/6CpY3Snzh2vgZhWgxMNwlQI=
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
+github.com/livepeer/ai-worker v0.11.0 h1:prbRRBgCIrECUuZFWuyN6z3QZLfygYqBKYMleT+I7o4=
+github.com/livepeer/ai-worker v0.11.0/go.mod h1:GjQuPmz69UO53WVtqzB9Ygok5MmKCGNuobbfMXH7zgw=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b h1:VQcnrqtCA2UROp7q8ljkh2XA/u0KRgVv0S1xoUvOweE=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b/go.mod h1:hwJ5DKhl+pTanFWl+EUpw1H7ukPO/H+MFpgA7jjshzw=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cOQee+WqmaDOgGtP2oDMhcVvR4L0yA=

--- a/go.sum
+++ b/go.sum
@@ -604,8 +604,6 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-netroute v0.2.0/go.mod h1:Vio7LTzZ+6hoT4CMZi5/6CpY3Snzh2vgZhWgxMNwlQI=
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
-github.com/livepeer/ai-worker v0.11.0 h1:prbRRBgCIrECUuZFWuyN6z3QZLfygYqBKYMleT+I7o4=
-github.com/livepeer/ai-worker v0.11.0/go.mod h1:GjQuPmz69UO53WVtqzB9Ygok5MmKCGNuobbfMXH7zgw=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b h1:VQcnrqtCA2UROp7q8ljkh2XA/u0KRgVv0S1xoUvOweE=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b/go.mod h1:hwJ5DKhl+pTanFWl+EUpw1H7ukPO/H+MFpgA7jjshzw=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cOQee+WqmaDOgGtP2oDMhcVvR4L0yA=

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -913,13 +913,7 @@ func submitAudioToText(ctx context.Context, params aiRequestParams, sess *AISess
 	metadata := map[string]string{
 		"duration": strconv.Itoa(int(durationSeconds)),
 	}
-	metadataStr, err := encodeReqMetadata(metadata)
-	if err != nil {
-		if monitor.Enabled {
-			monitor.AIRequestError(err.Error(), "audio-to-text", *req.ModelId, sess.OrchestratorInfo)
-		}
-		return nil, err
-	}
+	metadataStr := encodeReqMetadata(metadata)
 	req.Metadata = &metadataStr
 
 	var buf bytes.Buffer
@@ -1504,12 +1498,7 @@ func estimateAIFee(outPixels int64, priceInfo *big.Rat) (*big.Rat, error) {
 }
 
 // encodeReqMetadata encodes a map of metadata into a JSON string.
-func encodeReqMetadata(metadata map[string]string) (string, error) {
-	metadataBytes, err := json.Marshal(metadata)
-	if err != nil {
-		return "", err
-	}
-
-	metadataStr := string(metadataBytes)
-	return metadataStr, nil
+func encodeReqMetadata(metadata map[string]string) string {
+	metadataBytes, _ := json.Marshal(metadata)
+	return string(metadataBytes)
 }

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -910,10 +910,10 @@ func submitAudioToText(ctx context.Context, params aiRequestParams, sess *AISess
 	}
 
 	//Add the duration to the request via 'job_info' field
-	job_info_str, err := encodeJobParams(map[string]string{
+	job_metadata_str, err := encodeJobMetadata(map[string]string{
 		"duration": strconv.Itoa(int(durationSeconds)),
     })
-	req.JobInfo = &job_info_str
+	req.JobMetadata = &job_metadata_str
 
 	var buf bytes.Buffer
 	mw, err := worker.NewAudioToTextMultipartWriter(&buf, req)
@@ -1496,7 +1496,7 @@ func estimateAIFee(outPixels int64, priceInfo *big.Rat) (*big.Rat, error) {
 	return fee, nil
 }
 
-func encodeJobParams(info map[string]string) (string, error) {
+func encodeJobMetadata(info map[string]string) (string, error) {
 	jobParamBytes, err := json.Marshal(info)
 	if err != nil {
 		return "", err

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -909,11 +909,11 @@ func submitAudioToText(ctx context.Context, params aiRequestParams, sess *AISess
 		return nil, err
 	}
 
-	//Add the duration to the request via 'job_info' field
-	job_metadata_str, err := encodeJobMetadata(map[string]string{
+	//Add the duration to the request via 'metadata' field
+	metadata_str, err := encodeReqMetadata(map[string]string{
 		"duration": strconv.Itoa(int(durationSeconds)),
     })
-	req.JobMetadata = &job_metadata_str
+	req.Metadata = &metadata_str
 
 	var buf bytes.Buffer
 	mw, err := worker.NewAudioToTextMultipartWriter(&buf, req)
@@ -1496,7 +1496,7 @@ func estimateAIFee(outPixels int64, priceInfo *big.Rat) (*big.Rat, error) {
 	return fee, nil
 }
 
-func encodeJobMetadata(info map[string]string) (string, error) {
+func encodeReqMetadata(info map[string]string) (string, error) {
 	jobParamBytes, err := json.Marshal(info)
 	if err != nil {
 		return "", err

--- a/server/ai_process_test.go
+++ b/server/ai_process_test.go
@@ -30,65 +30,8 @@ func Test_submitLLM(t *testing.T) {
 				t.Errorf("submitLLM() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("submitAudioToText() error = %v, wantErr %v", err, tt.wantErr)
-				}
-				return
-			}
-			if reflect.TypeOf(got) != reflect.TypeOf(tt.want) {
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("submitLLM() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_submitAudioToText(t *testing.T) {
-	type args struct {
-		ctx    context.Context
-		params aiRequestParams
-		sess   *AISession
-		req    worker.GenAudioToTextMultipartRequestBody
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    interface{}
-		wantErr bool
-	}{
-		{
-			name: "invalid request (no file)",
-			args: args{
-				ctx:    context.Background(),
-				params: aiRequestParams{},
-				sess:   &AISession{/* populate with valid session */},
-				req:    worker.GenAudioToTextMultipartRequestBody{},
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "nil session",
-			args: args{
-				ctx:    context.Background(),
-				params: aiRequestParams{/* populate with valid params */},
-				sess:   nil,
-				req:    worker.GenAudioToTextMultipartRequestBody{/* populate with valid request body */},
-			},
-			want:    nil,
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := submitAudioToText(tt.args.ctx, tt.args.params, tt.args.sess, tt.args.req)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("submitAudioToText() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("submitAudioToText() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/server/ai_process_test.go
+++ b/server/ai_process_test.go
@@ -37,6 +37,57 @@ func Test_submitLLM(t *testing.T) {
 	}
 }
 
+func Test_submitAudioToText(t *testing.T) {
+	type args struct {
+		ctx    context.Context
+		params aiRequestParams
+		sess   *AISession
+		req    worker.GenAudioToTextMultipartRequestBody
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "invalid request (no file)",
+			args: args{
+				ctx:    context.Background(),
+				params: aiRequestParams{},
+				sess:   &AISession{/* populate with valid session */},
+				req:    worker.GenAudioToTextMultipartRequestBody{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "nil session",
+			args: args{
+				ctx:    context.Background(),
+				params: aiRequestParams{/* populate with valid params */},
+				sess:   nil,
+				req:    worker.GenAudioToTextMultipartRequestBody{/* populate with valid request body */},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := submitAudioToText(tt.args.ctx, tt.args.params, tt.args.sess, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("submitAudioToText() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("submitAudioToText() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEncodeReqMetadata(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/server/ai_process_test.go
+++ b/server/ai_process_test.go
@@ -36,3 +36,39 @@ func Test_submitLLM(t *testing.T) {
 		})
 	}
 }
+
+func TestEncodeReqMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]string
+		want     string
+	}{
+		{
+			name: "valid metadata",
+			metadata: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			want: `{"key1":"value1","key2":"value2"}`,
+		},
+		{
+			name:     "empty metadata",
+			metadata: map[string]string{},
+			want:     `{}`,
+		},
+		{
+			name:     "nil metadata",
+			metadata: nil,
+			want:     `null`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := encodeReqMetadata(tt.metadata)
+			if got != tt.want {
+				t.Errorf("encodeReqMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/ai_process_test.go
+++ b/server/ai_process_test.go
@@ -30,8 +30,65 @@ func Test_submitLLM(t *testing.T) {
 				t.Errorf("submitLLM() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("submitAudioToText() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			if reflect.TypeOf(got) != reflect.TypeOf(tt.want) {
 				t.Errorf("submitLLM() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_submitAudioToText(t *testing.T) {
+	type args struct {
+		ctx    context.Context
+		params aiRequestParams
+		sess   *AISession
+		req    worker.GenAudioToTextMultipartRequestBody
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "invalid request (no file)",
+			args: args{
+				ctx:    context.Background(),
+				params: aiRequestParams{},
+				sess:   &AISession{/* populate with valid session */},
+				req:    worker.GenAudioToTextMultipartRequestBody{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "nil session",
+			args: args{
+				ctx:    context.Background(),
+				params: aiRequestParams{/* populate with valid params */},
+				sess:   nil,
+				req:    worker.GenAudioToTextMultipartRequestBody{/* populate with valid request body */},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := submitAudioToText(tt.args.ctx, tt.args.params, tt.args.sess, tt.args.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("submitAudioToText() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("submitAudioToText() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/server/ai_process_test.go
+++ b/server/ai_process_test.go
@@ -55,7 +55,7 @@ func Test_submitAudioToText(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				params: aiRequestParams{},
-				sess:   &AISession{/* populate with valid session */},
+				sess:   &AISession{},
 				req:    worker.GenAudioToTextMultipartRequestBody{},
 			},
 			want:    nil,
@@ -65,9 +65,9 @@ func Test_submitAudioToText(t *testing.T) {
 			name: "nil session",
 			args: args{
 				ctx:    context.Background(),
-				params: aiRequestParams{/* populate with valid params */},
+				params: aiRequestParams{},
 				sess:   nil,
-				req:    worker.GenAudioToTextMultipartRequestBody{/* populate with valid request body */},
+				req:    worker.GenAudioToTextMultipartRequestBody{},
 			},
 			want:    nil,
 			wantErr: true,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
This change introduces a new `job_info` field that is a key/value dictionary for passing data between gateway and worker. It is read on the ai-runner in https://github.com/livepeer/ai-worker/pull/163

This field is not exported to the openapi spec and isn't parsed from requests to the gateway.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds a utility method `encodeReqMetadata` to ai_process.go for encoding the job parameters to new request field `metadata`
- Implements `duration` as a key/value in `metadata` for `audio-to-text` pipeline 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Tested performance of model with and without return_timestamps
- Verified backward compatibility in ai-runner when metadata field not provided

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
