### PR TITLE
fix: Add image-to-text pipeline to remote worker

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -786,7 +786,7 @@ func parseMultiPartResult(body io.Reader, boundary string, pipeline string) core
 					break
 				}
 				results = parsedResp
-			case "audio-to-text", "segment-anything-2", "llm":
+			case "audio-to-text", "segment-anything-2", "llm", "image-to-text":
 				err := json.Unmarshal(body, &results)
 				if err != nil {
 					glog.Error("Error getting results json:", err)

--- a/server/ai_worker.go
+++ b/server/ai_worker.go
@@ -285,6 +285,23 @@ func runAIJob(n *core.LivepeerNode, orchAddr string, httpc *http.Client, notify 
 			return n.LLM(ctx, req)
 		}
 		reqOk = true
+	case "image-to-text":
+		var req worker.GenImageToTextMultipartRequestBody
+		err = json.Unmarshal(reqData.Request, &req)
+		if err != nil || req.ModelId == nil {
+			break
+		}
+		input, err = core.DownloadData(ctx, reqData.InputUrl)
+		if err != nil {
+			break
+		}
+		modelID = *req.ModelId
+		resultType = "application/json"
+		req.Image.InitFromBytes(input, "image")
+		processFn = func(ctx context.Context) (interface{}, error) {
+			return n.ImageToText(ctx, req)
+		}
+		reqOk = true
 	case "text-to-speech":
 		var req worker.GenTextToSpeechJSONRequestBody
 		err = json.Unmarshal(reqData.Request, &req)

--- a/server/ai_worker_test.go
+++ b/server/ai_worker_test.go
@@ -205,6 +205,13 @@ func TestRunAIJob(t *testing.T) {
 			expectedOutputs: 1,
 		},
 		{
+			name:            "ImageToText_Success",
+			notify:          createAIJob(8, "image-to-text", modelId, parsedURL.String()+"/image.png"),
+			pipeline:        "image-to-text",
+			expectedErr:     "",
+			expectedOutputs: 1,
+		},
+		{
 			name:            "TextToSpeech_Success",
 			notify:          createAIJob(9, "text-to-speech", modelId, ""),
 			pipeline:        "text-to-speech",
@@ -319,6 +326,15 @@ func TestRunAIJob(t *testing.T) {
 					assert.Equal(len(results.Files), 0)
 					expectedResp, _ := wkr.LLM(context.Background(), worker.GenLLMFormdataRequestBody{})
 					assert.Equal(expectedResp, &jsonRes)
+				case "image-to-text":
+					res, _ := json.Marshal(results.Results)
+					var jsonRes worker.ImageToTextResponse
+					json.Unmarshal(res, &jsonRes)
+
+					assert.Equal("8", headers.Get("TaskId"))
+					assert.Equal(len(results.Files), 0)
+					expectedResp, _ := wkr.ImageToText(context.Background(), worker.GenImageToTextMultipartRequestBody{})
+					assert.Equal(expectedResp, &jsonRes)
 				case "text-to-speech":
 					audResp, ok := results.Results.(worker.AudioResponse)
 					assert.True(ok)
@@ -357,6 +373,9 @@ func createAIJob(taskId int64, pipeline, modelId, inputUrl string) *net.NotifyAI
 		req = worker.GenSegmentAnything2MultipartRequestBody{ModelId: &modelId, Image: inputFile}
 	case "llm":
 		req = worker.GenLLMFormdataRequestBody{Prompt: "tell me a story", ModelId: &modelId}
+	case "image-to-text":
+		inputFile.InitFromBytes(nil, inputUrl)
+		req = worker.GenImageToImageMultipartRequestBody{Prompt: "test prompt", ModelId: &modelId, Image: inputFile}
 	case "text-to-speech":
 		desc := "a young adult"
 		text := "let me tell you a story"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds remote worker parts to `server` package so image-to-text pipeline can be processed by remote working.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- add image to text to `runAIJob`
- update to add pipeline to `parseMultipartResult`
- Add test in `server/ai_worker_test.go`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Ran tests and built docker container to test combined and split Orchestrator and AI Worker

**Does this pull request close any open issues?**
<!-- Fixes # -->
No

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [x ] `make` runs successfully
- [x ] All tests in `./test.sh` pass  `AI tests pass`
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
