### PR TITLE
Trickle subscribe on O and G

### DIFF
--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -77,7 +77,7 @@ func openNonBlockingWithRetry(name string, timeout time.Duration, completed <-ch
 
 	// setFd sets the given file descriptor in the fdSet
 	setFd := func(fd int, fdSet *syscall.FdSet) {
-		idx := fd/64
+		idx := fd / 64
 		if idx >= len(fdSet.Bits) {
 			// only happens under very weird conditions
 			return
@@ -87,7 +87,7 @@ func openNonBlockingWithRetry(name string, timeout time.Duration, completed <-ch
 
 	// isFdSet checks if the given file descriptor is set in the fdSet
 	isFdSet := func(fd int, fdSet *syscall.FdSet) bool {
-		idx := fd/64
+		idx := fd / 64
 		if idx >= len(fdSet.Bits) {
 			// only happens under very weird conditions
 			return false

--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -77,12 +77,22 @@ func openNonBlockingWithRetry(name string, timeout time.Duration, completed <-ch
 
 	// setFd sets the given file descriptor in the fdSet
 	setFd := func(fd int, fdSet *syscall.FdSet) {
-		fdSet.Bits[fd/64] |= 1 << (uint(fd) % 64)
+		idx := fd/64
+		if idx >= len(fdSet.Bits) {
+			// only happens under very weird conditions
+			return
+		}
+		fdSet.Bits[idx] |= 1 << (uint(fd) % 64)
 	}
 
 	// isFdSet checks if the given file descriptor is set in the fdSet
 	isFdSet := func(fd int, fdSet *syscall.FdSet) bool {
-		return fdSet.Bits[fd/64]&(1<<(uint(fd)%64)) != 0
+		idx := fd/64
+		if idx >= len(fdSet.Bits) {
+			// only happens under very weird conditions
+			return false
+		}
+		return fdSet.Bits[idx]&(1<<(uint(fd)%64)) != 0
 	}
 
 	for {

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -43,7 +43,7 @@ func startTrickleSubscribe(url *url.URL, params aiRequestParams) {
 		slog.Info("error getting pipe for trickle-ffmpeg", "url", url, "err", err)
 	}
 
-	// read segments from trickle subscrption
+	// read segments from trickle subscription
 	go func() {
 		defer w.Close()
 		for {

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -1,12 +1,15 @@
 package server
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"net/url"
+	"os"
 
 	"github.com/livepeer/go-livepeer/media"
 	"github.com/livepeer/go-livepeer/trickle"
+	"github.com/livepeer/lpms/ffmpeg"
 )
 
 func startTricklePublish(url *url.URL, params aiRequestParams) {
@@ -33,4 +36,39 @@ func startTricklePublish(url *url.URL, params aiRequestParams) {
 }
 
 func startTrickleSubscribe(url *url.URL, params aiRequestParams) {
+	// subscribe to the outputs and send them into LPMS
+	subscriber := trickle.NewTrickleSubscriber(url.String())
+	r, w, err := os.Pipe()
+	if err != nil {
+		slog.Info("error getting pipe for trickle-ffmpeg", "url", url, "err", err)
+	}
+
+	// read segments from trickle subscrption
+	go func() {
+		defer w.Close()
+		for {
+			segment, err := subscriber.Read()
+			if err != nil {
+				// TODO if not EOS then signal a new orchestrator is needed
+				slog.Info("Error reading trickle subscription", "url", url, "err", err)
+				return
+			}
+			defer segment.Body.Close()
+			// TODO send this into ffmpeg
+			io.Copy(w, segment.Body)
+		}
+	}()
+
+	// lpms
+	go func() {
+		ffmpeg.Transcode3(&ffmpeg.TranscodeOptionsIn{
+			Fname: fmt.Sprintf("pipe:%d", r.Fd()),
+		}, []ffmpeg.TranscodeOptions{{
+			// TODO take from params
+			Oname:        "rtmp://localhost/out-stream",
+			AudioEncoder: ffmpeg.ComponentOptions{Name: "copy"},
+			VideoEncoder: ffmpeg.ComponentOptions{Name: "copy"},
+			Muxer:        ffmpeg.ComponentOptions{Name: "flv"},
+		}})
+	}()
 }

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -360,6 +360,10 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			http.Error(w, "Missing stream name", http.StatusBadRequest)
 			return
 		}
+		if streamName == "out-stream" {
+			// skip for now; we don't want to re-publish our own outputs
+			return
+		}
 		requestID := string(core.RandomManifestID())
 		ctx := clog.AddVal(r.Context(), "request_id", requestID)
 		clog.Infof(ctx, "Received live video AI request for %s", streamName)

--- a/trickle/trickle_server.go
+++ b/trickle/trickle_server.go
@@ -198,13 +198,13 @@ type timeoutReader struct {
 	body          io.Reader
 	timeout       time.Duration
 	firstByteRead bool
-	readStarted  bool
-	doneCh chan int
-	errCh chan error
+	readStarted   bool
+	doneCh        chan int
+	errCh         chan error
 }
 
-func (tr *timeoutReader) startRead(p []byte){
-	go func(){
+func (tr *timeoutReader) startRead(p []byte) {
+	go func() {
 		n, err := tr.body.Read(p)
 		if err != nil {
 			tr.errCh <- err
@@ -223,15 +223,15 @@ func (tr *timeoutReader) Read(p []byte) (int, error) {
 	// we only want to start the reader once
 	if !tr.readStarted {
 		tr.errCh = make(chan error, 1)
-		tr.doneCh = make (chan int, 1)
+		tr.doneCh = make(chan int, 1)
 		tr.readStarted = true
 		go tr.startRead(p)
 	}
 
 	select {
-	case err := <- tr.errCh:
+	case err := <-tr.errCh:
 		return 0, err
-	case n := <- tr.doneCh:
+	case n := <-tr.doneCh:
 		if n > 0 {
 			tr.firstByteRead = true
 		}

--- a/trickle/trickle_subscriber.go
+++ b/trickle/trickle_subscriber.go
@@ -149,6 +149,7 @@ func (c *TrickleSubscriber) Read() (*http.Response, error) {
 		// reset preconnect error
 		c.preconnectErrorCount = 0
 	}
+	c.pendingGet = nil
 
 	if IsEOS(conn) {
 		return nil, EOS
@@ -156,7 +157,7 @@ func (c *TrickleSubscriber) Read() (*http.Response, error) {
 
 	// Set to use the next index for the next (pre-)connection
 	idx := GetSeq(conn)
-	if idx != -1 {
+	if idx >= 0 {
 		c.idx = idx + 1
 	}
 
@@ -172,10 +173,7 @@ func (c *TrickleSubscriber) Read() (*http.Response, error) {
 		}
 
 		c.pendingGet = nextConn
-		idx := GetSeq(nextConn)
-		if idx != -1 {
-			c.idx = idx + 1
-		}
+
 		// reset preconnect error
 		c.preconnectErrorCount = 0
 	}()


### PR DESCRIPTION
* Orchestrator monitors incoming stream
* Gateway subscribes to outgoing stream

Orchestrator also pre-creates the incoming and outgoing streams in order to avoid race conditions.

There is currently no content for the outgoing stream unless something actually creates it, eg by manually starting an inference process. Because of that, the HTTP subscriber on the gateway side will eventually time out. 

Depends on #3211 