### PR TITLE
fix(ai): delete I2V temp file on combined Orch/worker

### DIFF
--- a/core/ai_worker.go
+++ b/core/ai_worker.go
@@ -439,6 +439,8 @@ func (n *LivepeerNode) saveLocalAIWorkerResults(ctx context.Context, results int
 				if err != nil {
 					return nil, err
 				}
+				defer os.Remove(image.Url)
+
 				buf = *bytes.NewBuffer(f)
 			}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Delete temp file when using combined orchestrator/ai-worker.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- add defer `os.Remove(image.Url)` to `saveLocalAIWorkerResults` function when reading local file.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Ran ai tests and tested locally

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [x ] `make` runs successfully
- [x ] All tests in `./test.sh` pass     `ai tests pass`
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
