### PR TITLE
Livepeer.Cloud SPE - Proposal #2 - Enable Single Orchestrator AI Job Testing Support for Gateway Nodes

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -139,7 +139,9 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.IgnoreMaxPriceIfNeeded = flag.Bool("ignoreMaxPriceIfNeeded", *cfg.IgnoreMaxPriceIfNeeded, "Set to true to allow exceeding max price condition if there is no O that meets this requirement")
 	cfg.MinPerfScore = flag.Float64("minPerfScore", *cfg.MinPerfScore, "The minimum orchestrator's performance score a broadcaster is willing to accept")
 	cfg.DiscoveryTimeout = flag.Duration("discoveryTimeout", *cfg.DiscoveryTimeout, "Time to wait for orchestrators to return info to be included in transcoding sessions for manifest (default = 500ms)")
-
+	cfg.AISessionTimeout = flag.Duration("aiSessionTimeout", *cfg.AISessionTimeout, "The length of time (in seconds) that an AI Session will be cached (default = 600s)")
+	cfg.WebhookRefreshInterval = flag.Duration("webhookRefreshInterval", *cfg.WebhookRefreshInterval, "The length of time (in seconds) that an Orchestrator Webhook Discovery Request will be cached (default = 60s)")
+	cfg.AITesterGateway = flag.Bool("aiTesterGateway", *cfg.AITesterGateway, "Set to true to allow the gateway to run in \"tester\" mode. This will bypass caching of AI session selectors.")
 	// Transcoding:
 	cfg.Orchestrator = flag.Bool("orchestrator", *cfg.Orchestrator, "Set to true to be an orchestrator")
 	cfg.Transcoder = flag.Bool("transcoder", *cfg.Transcoder, "Set to true to be a transcoder")

--- a/common/util.go
+++ b/common/util.go
@@ -44,9 +44,6 @@ var SegUploadTimeoutMultiplier = 0.5
 // MinSegmentUploadTimeout defines the minimum timeout enforced for uploading a segment to orchestrators
 var MinSegmentUploadTimeout = 2 * time.Second
 
-// WebhookDiscoveryRefreshInterval defines for long the Webhook Discovery values should be cached
-var WebhookDiscoveryRefreshInterval = 1 * time.Minute
-
 // Max Segment Duration
 var MaxDuration = (5 * time.Minute)
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -120,6 +120,8 @@ type LivepeerNode struct {
 	// AI worker public fields
 	AIWorker        AI
 	AIWorkerManager *RemoteAIWorkerManager
+	AISessionTimeout time.Duration
+	AITesterGateway  bool
 
 	// Transcoder public fields
 	SegmentChans       map[ManifestID]SegmentChan

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1120,7 +1120,7 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 
 	// assert created webhook pool is correct length
 	whURL, _ := url.ParseRequestURI("https://livepeer.live/api/orchestrator")
-	whpool := NewWebhookPool(nil, whURL, 500*time.Millisecond)
+	whpool := NewWebhookPool(nil, whURL, 500*time.Millisecond, 1*time.Minute)
 	assert.Equal(3, whpool.Size())
 
 	// assert that list is not refreshed if lastRequest is less than 1 min ago and hash is the same

--- a/server/ai_session.go
+++ b/server/ai_session.go
@@ -341,18 +341,20 @@ func (sel *AISessionSelector) getSessions(ctx context.Context) ([]*BroadcastSess
 }
 
 type AISessionManager struct {
-	node      *core.LivepeerNode
-	selectors map[string]*AISessionSelector
-	mu        sync.Mutex
-	ttl       time.Duration
+	node                 *core.LivepeerNode
+	selectors            map[string]*AISessionSelector
+	mu                   sync.Mutex
+	ttl                  time.Duration
+	testerGatewayEnabled bool
 }
 
-func NewAISessionManager(node *core.LivepeerNode, ttl time.Duration) *AISessionManager {
+func NewAISessionManager(node *core.LivepeerNode, ttl time.Duration, testerGatewayEnabled bool) *AISessionManager {
 	return &AISessionManager{
-		node:      node,
-		selectors: make(map[string]*AISessionSelector),
-		mu:        sync.Mutex{},
-		ttl:       ttl,
+		node:                 node,
+		selectors:            make(map[string]*AISessionSelector),
+		mu:                   sync.Mutex{},
+		ttl:                  ttl,
+		testerGatewayEnabled: testerGatewayEnabled,
 	}
 }
 
@@ -400,18 +402,27 @@ func (c *AISessionManager) getSelector(ctx context.Context, cap core.Capability,
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	cacheKey := strconv.Itoa(int(cap)) + "_" + modelID
-	sel, ok := c.selectors[cacheKey]
-	if !ok {
-		// Create the selector
-		var err error
-		sel, err = NewAISessionSelector(cap, modelID, c.node, c.ttl)
+	if c.testerGatewayEnabled {
+		sel, err := NewAISessionSelector(cap, modelID, c.node, c.ttl)
 		if err != nil {
 			return nil, err
 		}
+		return sel, nil
+	} else {
+		cacheKey := strconv.Itoa(int(cap)) + "_" + modelID
+		sel, ok := c.selectors[cacheKey]
+		if !ok {
+			// Create the selector
+			var err error
+			sel, err = NewAISessionSelector(cap, modelID, c.node, c.ttl)
+			if err != nil {
+				return nil, err
+			}
 
-		c.selectors[cacheKey] = sel
+			c.selectors[cacheKey] = sel
+		}
+
+		return sel, nil
+
 	}
-
-	return sel, nil
 }

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -62,8 +62,6 @@ const StreamKeyBytes = 6
 const SegLen = 2 * time.Second
 const BroadcastRetry = 15 * time.Second
 
-const AISessionManagerTTL = 10 * time.Minute
-
 var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmpeg.P360p30fps16x9}
 
 var AuthWebhookURL *url.URL
@@ -188,7 +186,7 @@ func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bo
 		rtmpConnections:         make(map[core.ManifestID]*rtmpConnection),
 		internalManifests:       make(map[core.ManifestID]core.ManifestID),
 		recordingsAuthResponses: cache.New(time.Hour, 2*time.Hour),
-		AISessionManager:        NewAISessionManager(lpNode, AISessionManagerTTL),
+		AISessionManager:        NewAISessionManager(lpNode, lpNode.AISessionTimeout, lpNode.AITesterGateway),
 	}
 	if lpNode.NodeType == core.BroadcasterNode && httpIngest {
 		opts.HttpMux.HandleFunc("/live/", ls.HandlePush)

--- a/server/orchestrator_ai_capabilities_manager.go
+++ b/server/orchestrator_ai_capabilities_manager.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/core"
+)
+
+// ModelStatus represents the status information for each model under an orchestrator.
+type ModelStatus struct {
+	Cold int `json:"Cold"`
+	Warm int `json:"Warm"`
+}
+
+// ModelInfo represents information about a model in a pipeline.
+type ModelInfo struct {
+	Name   string      `json:"name"`
+	Status ModelStatus `json:"status"`
+}
+
+// PipelineInfo represents information about a pipeline.
+type PipelineInfo struct {
+	Type   string      `json:"type"`
+	Models []ModelInfo `json:"models"`
+}
+
+// OrchestratorInfo represents the information for each orchestrator.
+type OrchestratorInfo struct {
+	Address   string         `json:"address"`
+	Pipelines []PipelineInfo `json:"pipelines"`
+}
+
+// OrchestratorAICapabilitiesManager represents the full structure with better type safety.
+type OrchestratorAICapabilitiesManager struct {
+	Orchestrators []OrchestratorInfo `json:"orchestrators"`
+}
+
+// NewOrchestratorAICapabilitiesManager creates and initializes a new OrchestratorAICapabilitiesManager structure.
+func NewOrchestratorAICapabilitiesManager() *OrchestratorAICapabilitiesManager {
+	return &OrchestratorAICapabilitiesManager{
+		Orchestrators: []OrchestratorInfo{},
+	}
+}
+
+// AddOrchestrator adds a new orchestrator if it doesn't exist.
+func (ncm *OrchestratorAICapabilitiesManager) AddOrchestrator(orchAddress string) {
+	if ncm.getOrchestrator(orchAddress) == nil {
+		ncm.Orchestrators = append(ncm.Orchestrators, OrchestratorInfo{
+			Address:   orchAddress,
+			Pipelines: []PipelineInfo{},
+		})
+	}
+}
+
+// getOrchestrator retrieves an orchestrator by address.
+func (ncm *OrchestratorAICapabilitiesManager) getOrchestrator(orchAddress string) *OrchestratorInfo {
+	for i := range ncm.Orchestrators {
+		if ncm.Orchestrators[i].Address == orchAddress {
+			return &ncm.Orchestrators[i]
+		}
+	}
+	return nil
+}
+
+// AddOrchestratorPipeline adds or updates a pipeline entry for an orchestrator.
+func (ncm *OrchestratorAICapabilitiesManager) AddOrchestratorPipeline(orchAddress string, pipelineType string) {
+	orch := ncm.getOrchestrator(orchAddress)
+	if orch == nil {
+		ncm.AddOrchestrator(orchAddress)
+		orch = ncm.getOrchestrator(orchAddress)
+	}
+
+	if orch.getPipeline(pipelineType) == nil {
+		orch.Pipelines = append(orch.Pipelines, PipelineInfo{
+			Type:   pipelineType,
+			Models: []ModelInfo{},
+		})
+	}
+}
+
+// getPipeline retrieves a pipeline by type.
+func (orch *OrchestratorInfo) getPipeline(pipelineType string) *PipelineInfo {
+	for i := range orch.Pipelines {
+		if orch.Pipelines[i].Type == pipelineType {
+			return &orch.Pipelines[i]
+		}
+	}
+	return nil
+}
+
+// AddOrchestratorPipelineModel adds or updates a model in an orchestrator's pipeline.
+func (ncm *OrchestratorAICapabilitiesManager) AddOrchestratorPipelineModel(orchAddress, pipelineType, modelName string, warm bool) error {
+	orch := ncm.getOrchestrator(orchAddress)
+	if orch == nil {
+		return errors.New("orchestrator not found")
+	}
+	pipeline := orch.getPipeline(pipelineType)
+	if pipeline == nil {
+		orch.Pipelines = append(orch.Pipelines, PipelineInfo{
+			Type:   pipelineType,
+			Models: []ModelInfo{},
+		})
+		pipeline = orch.getPipeline(pipelineType)
+	}
+
+	model := pipeline.getModel(modelName)
+	if model == nil {
+		pipeline.Models = append(pipeline.Models, ModelInfo{
+			Name:   modelName,
+			Status: ModelStatus{},
+		})
+		model = pipeline.getModel(modelName)
+	}
+
+	if warm {
+		model.Status.Warm++
+	} else {
+		model.Status.Cold++
+	}
+	return nil
+}
+
+// getModel retrieves a model by name.
+func (pipeline *PipelineInfo) getModel(modelName string) *ModelInfo {
+	for i := range pipeline.Models {
+		if pipeline.Models[i].Name == modelName {
+			return &pipeline.Models[i]
+		}
+	}
+	return nil
+}
+
+// PrintJSONData is a utility function to print the current JSONData.
+func (ncm *OrchestratorAICapabilitiesManager) PrintJSONData() {
+	fmt.Printf("Orchestrators: %+v\n", ncm.Orchestrators)
+}
+
+func buildOrchestratorAICapabilitiesManager(livepeerNode *core.LivepeerNode) (*OrchestratorAICapabilitiesManager, error) {
+	caps := core.NewCapabilities(core.DefaultCapabilities(), nil)
+	caps.SetPerCapabilityConstraints(nil)
+	ods, err := livepeerNode.OrchestratorPool.GetOrchestrators(context.Background(), 100, newSuspender(), caps, common.ScoreAtLeast(0))
+	caps.SetMinVersionConstraint(livepeerNode.Capabilities.MinVersionConstraint())
+	if err != nil {
+		return nil, err
+	}
+
+	networkCapsMgr := NewOrchestratorAICapabilitiesManager()
+	remoteInfos := ods.GetRemoteInfos()
+
+	glog.V(common.SHORT).Infof("getting network capabilities for %d orchestrators", len(remoteInfos))
+
+	for idx, orch_info := range remoteInfos {
+		glog.V(common.DEBUG).Infof("getting capabilities for orchestrator %d %v", idx, orch_info.Transcoder)
+
+		// Ensure the orch has the proper on-chain TicketParams to ensure ethAddress was configured.
+		tp := orch_info.TicketParams
+		var orchAddr string
+		if tp != nil {
+			ethAddress := tp.Recipient
+			orchAddr = hexutil.Encode(ethAddress)
+		} else {
+			orchAddr = "0x0000000000000000000000000000000000000000"
+		}
+
+		// Parse the capabilities and capacities.
+		if orch_info.GetCapabilities() != nil {
+			for capability, constraints := range orch_info.Capabilities.Constraints.PerCapability {
+				capName, err := core.CapabilityToName(core.Capability(int(capability)))
+				if err != nil {
+					continue
+				}
+				networkCapsMgr.AddOrchestratorPipeline(orchAddr, capName)
+
+				models := constraints.GetModels()
+				for model, constraint := range models {
+					err := networkCapsMgr.AddOrchestratorPipelineModel(orchAddr, capName, model, constraint.GetWarm())
+					if err != nil {
+						glog.V(common.DEBUG).Infof("  error adding model to orch %v", err)
+					}
+				}
+			}
+		}
+	}
+	return networkCapsMgr, nil
+}

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -114,5 +114,7 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 		mux.Handle("/metrics", monitor.Exporter)
 	}
 
+	//AI Handlers
+	mux.Handle("/getOrchestratorAICapabilities", s.getOrchestratorAICapabilitiesHandler())
 	return mux
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Provide features that enables AI Job Testing through gateway nodes. The gateway node has several hard-coded timeouts/cache values that need to be configurable to allow the a gateway to send an AI job to a specific orchestrator for  testing.  

**Specific updates (required)**
- Introduce several new startup flags to enable a gateway node to support AI Job testing. 
  - **aiTesterGateway** - a boolean that enables the gateway node to bypass AI Session caching. Defaults to **false** to prevent any behavior changes to the default gateway node.
  - **aiSessionTimeout** - a duration value that allows the AI session timeouts to be configured to a desired value. The default is **600s** to match the existing hard-coded value.
  - **webhookRefreshInterval** - a duration value that allows the orchWebhookUrl cached responses to be configured to a desired value. The default is **60s** to match the existing hard-coded value.
  - **LIVEPEER_OS_HTTP_TIMEOUT** - This is an environment variable (ENV Var). The code is standalone and cannot use common livepeer flags. The variable is a duration value that allows the AI assets (_.mp4_ files, etc...) download timeout  to be configured to a desired value. The default is **4s** to match the existing hard-coded value.
- A new HTTP endpoint was added to fetch all AI capabilities of each orchestrator (_/getOrchestratorAICapabilities_). This endpoint provides the AI Job Tester with information on all AI models available for the all orchestrators.

**How did you test each of these updates (required)**
Each of the new flags and timeout values were manually tested in our development environments. They are also deployed to the testing and production Livepeer.Cloud SPE AI Gateway nodes.

**Does this pull request close any open issues?**
No

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] Read the [contribution guide](./CONTRIBUTING.md)
- [ X] `make` runs successfully
- [ X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
