### PR TITLE
Skip rtmp2segment logic for Windows.

### DIFF
--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package media
 
 import (

--- a/media/rtmp2segment_windows.go
+++ b/media/rtmp2segment_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package media
+
+type MediaSegmenter struct {
+	Workdir string
+}
+
+func (ms *MediaSegmenter) RunSegmentation(in string, segmentHandler SegmentHandler) {
+	// Not supported for Windows
+}


### PR DESCRIPTION
It broke the Windows builds and is not used anywhere other than Realtime Video AI.

CC: @j0sh I think you'll need to implement that part for Windows too at some point.
