### PR TITLE
Livepeer.Cloud SPE - Fix the text-to-speech capability to use correct Content-Type

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -66,7 +66,7 @@ func startAIServer(lp lphttp) error {
 	lp.transRPC.Handle("/llm", oapiReqValidator(aiHttpHandle(&lp, jsonDecoder[worker.GenLLMFormdataRequestBody])))
 	lp.transRPC.Handle("/segment-anything-2", oapiReqValidator(aiHttpHandle(&lp, multipartDecoder[worker.GenSegmentAnything2MultipartRequestBody])))
 	lp.transRPC.Handle("/image-to-text", oapiReqValidator(aiHttpHandle(&lp, multipartDecoder[worker.GenImageToTextMultipartRequestBody])))
-	lp.transRPC.Handle("/text-to-speech", oapiReqValidator(aiHttpHandle(&lp, multipartDecoder[worker.GenTextToSpeechJSONRequestBody])))
+	lp.transRPC.Handle("/text-to-speech", oapiReqValidator(aiHttpHandle(&lp, jsonDecoder[worker.GenTextToSpeechJSONRequestBody])))
 
 	lp.transRPC.Handle("/live-video-to-video", oapiReqValidator(lp.StartLiveVideoToVideo()))
 	// Additionally, there is the '/aiResults' endpoint registered in server/rpc.go


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fix [issue 3242](https://github.com/livepeer/go-livepeer/issues/3242) 

When submitting a proper JSON request to the text-to-speech endpoint, the Gateway and Orchestrator Nodes receive the following error:

```E1108 13:37:12.202590       1 handlers.go:1596] HTTP Response Error statusCode=400 err=request Content-Type isn't multipart/form-data```

**How did you test each of these updates (required)**
* local validation
* deployment to the Livepeer.Cloud SPE' Testing and Production gateways
* deploy to the Xodeapp production Orchestrator

**Does this pull request close any open issues?**
<!-- Fixes # -->
https://github.com/livepeer/go-livepeer/issues/3242

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
