### PR TITLE
gateway: queue parameters casing

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -223,10 +223,10 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.TestOrchAvail = flag.Bool("startupAvailabilityCheck", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
 
 	// Gateway metrics
-	cfg.KafkaBootstrapServers = flag.String("kafka-bootstrap-servers", *cfg.KafkaBootstrapServers, "URL of Kafka Bootstrap Servers")
-	cfg.KafkaUsername = flag.String("kafka-user", *cfg.KafkaUsername, "Kafka Username")
-	cfg.KafkaPassword = flag.String("kafka-password", *cfg.KafkaPassword, "Kafka Password")
-	cfg.KafkaGatewayTopic = flag.String("kafka-gateway-topic", *cfg.KafkaGatewayTopic, "Kafka Topic used to send gateway logs")
+	cfg.KafkaBootstrapServers = flag.String("kafkaBootstrapServers", *cfg.KafkaBootstrapServers, "URL of Kafka Bootstrap Servers")
+	cfg.KafkaUsername = flag.String("kafkaUser", *cfg.KafkaUsername, "Kafka Username")
+	cfg.KafkaPassword = flag.String("kafkaPassword", *cfg.KafkaPassword, "Kafka Password")
+	cfg.KafkaGatewayTopic = flag.String("kafkaGatewayTopic", *cfg.KafkaGatewayTopic, "Kafka Topic used to send gateway logs")
 
 	return cfg
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fix queue params casing to be the same as other params
i.e. 
`kafkaBootstrapServers` instead of `kafka-bootstrap-servers`
**Specific updates (required)**
Params change

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
