### PR TITLE
Add Gateway ETH Address to Kafka events

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -611,7 +611,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		case core.BroadcasterNode:
 			nodeType = lpmon.Broadcaster
 			if *cfg.KafkaBootstrapServers != "" && *cfg.KafkaUsername != "" && *cfg.KafkaPassword != "" && *cfg.KafkaGatewayTopic != "" {
-				lpmon.InitKafkaProducer(*cfg.KafkaBootstrapServers, *cfg.KafkaUsername, *cfg.KafkaPassword, *cfg.KafkaGatewayTopic, n.Eth.Account().Address.Hex())
+				err := lpmon.InitKafkaProducer(*cfg.KafkaBootstrapServers, *cfg.KafkaUsername, *cfg.KafkaPassword, *cfg.KafkaGatewayTopic, n.Eth.Account().Address.Hex())
+				if err != nil {
+					glog.Warning("error while intializing Kafka producer: %w", err)
+				}
 			}
 		case core.OrchestratorNode:
 			nodeType = lpmon.Orchestrator

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -613,7 +613,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			if *cfg.KafkaBootstrapServers != "" && *cfg.KafkaUsername != "" && *cfg.KafkaPassword != "" && *cfg.KafkaGatewayTopic != "" {
 				err := lpmon.InitKafkaProducer(*cfg.KafkaBootstrapServers, *cfg.KafkaUsername, *cfg.KafkaPassword, *cfg.KafkaGatewayTopic, n.Eth.Account().Address.Hex())
 				if err != nil {
-					glog.Warning("error while intializing Kafka producer: %w", err)
+					glog.Warning("error while initializing Kafka producer: %w", err)
 				}
 			}
 		case core.OrchestratorNode:

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -611,7 +611,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		case core.BroadcasterNode:
 			nodeType = lpmon.Broadcaster
 			if *cfg.KafkaBootstrapServers != "" && *cfg.KafkaUsername != "" && *cfg.KafkaPassword != "" && *cfg.KafkaGatewayTopic != "" {
-				lpmon.InitKafkaProducer(*cfg.KafkaBootstrapServers, *cfg.KafkaUsername, *cfg.KafkaPassword, *cfg.KafkaGatewayTopic)
+				lpmon.InitKafkaProducer(*cfg.KafkaBootstrapServers, *cfg.KafkaUsername, *cfg.KafkaPassword, *cfg.KafkaGatewayTopic, n.Eth.Account().Address.Hex())
 			}
 		case core.OrchestratorNode:
 			nodeType = lpmon.Orchestrator


### PR DESCRIPTION
This field had been hardcoded to the empty string and is now being populated for all events that the Gateway emits