### PR TITLE
trickle-server: Don't auto-create channels on first publish.

### DIFF
--- a/trickle/local_publisher.go
+++ b/trickle/local_publisher.go
@@ -28,11 +28,11 @@ func NewLocalPublisher(sm *Server, channelName string, mimeType string) *Trickle
 }
 
 func (c *TrickleLocalPublisher) CreateChannel() {
-	c.server.getOrCreateStream(c.channelName, c.mimeType)
+	c.server.getOrCreateStream(c.channelName, c.mimeType, true)
 }
 
 func (c *TrickleLocalPublisher) Write(data io.Reader) error {
-	stream := c.server.getOrCreateStream(c.channelName, c.mimeType)
+	stream := c.server.getOrCreateStream(c.channelName, c.mimeType, true)
 	c.mu.Lock()
 	seq := c.seq
 	segment, exists := stream.getForWrite(seq)


### PR DESCRIPTION
Channels can still be created locally on the server.

This is needed in case a payment fails then we need to close the channel but we don't want the publisher to re-open them.

We introduce a flag instead of just hard-coding the behavior because we depend on auto-creating in some [other tools](https://github.com/j0sh/http-trickle/commit/1b5b9e42eeb4a66e1384c4a48f8ec9112c953237) including the server on the demo box.