### PR TITLE
ai/live: Take RTMP output URL from stream query parameters 

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -64,8 +64,7 @@ func startTrickleSubscribe(url *url.URL, params aiRequestParams) {
 		ffmpeg.Transcode3(&ffmpeg.TranscodeOptionsIn{
 			Fname: fmt.Sprintf("pipe:%d", r.Fd()),
 		}, []ffmpeg.TranscodeOptions{{
-			// TODO take from params
-			Oname:        "rtmp://localhost/out-stream",
+			Oname:        params.outputRTMPURL,
 			AudioEncoder: ffmpeg.ComponentOptions{Name: "copy"},
 			VideoEncoder: ffmpeg.ComponentOptions{Name: "copy"},
 			Muxer:        ffmpeg.ComponentOptions{Name: "flv"},

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -70,4 +71,15 @@ func startTrickleSubscribe(url *url.URL, params aiRequestParams) {
 			Muxer:        ffmpeg.ComponentOptions{Name: "flv"},
 		}})
 	}()
+}
+
+func mediamtxSourceTypeToString(s string) (string, error) {
+	switch s {
+	case "webrtcSession":
+		return "whip", nil
+	case "rtmpConn":
+		return "rtmp", nil
+	default:
+		return "", errors.New("unknown media source")
+	}
 }

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -358,26 +358,34 @@ func (ls *LivepeerServer) ImageToVideoResult() http.Handler {
 
 func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
 		streamName := r.FormValue("stream")
 		if streamName == "" {
+			clog.Errorf(ctx, "Missing stream name")
 			http.Error(w, "Missing stream name", http.StatusBadRequest)
 			return
 		}
+		ctx = clog.AddVal(ctx, "stream", streamName)
 		sourceID := r.FormValue("source_id")
 		if sourceID == "" {
+			clog.Errorf(ctx, "Missing source_id")
 			http.Error(w, "Missing source_id", http.StatusBadRequest)
 			return
 		}
+		ctx = clog.AddVal(ctx, "source_id", sourceID)
 		sourceType := r.FormValue("source_type")
 		if sourceType == "" {
+			clog.Errorf(ctx, "Missing source_type")
 			http.Error(w, "Missing source_type", http.StatusBadRequest)
 			return
 		}
 		sourceTypeStr, err := mediamtxSourceTypeToString(sourceType)
 		if err != nil {
+			clog.Errorf(ctx, "Invalid source type %s", sourceType)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		ctx = clog.AddVal(ctx, "source_type", sourceType)
 
 		queryParams := r.FormValue("query")
 		qp, err := url.ParseQuery(queryParams)
@@ -401,9 +409,6 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			// skip for now; we don't want to re-publish our own outputs
 			return
 		}
-		ctx := clog.AddVal(r.Context(), "stream", streamName)
-		ctx = clog.AddVal(ctx, "source_id", sourceID)
-		ctx = clog.AddVal(ctx, "source_type", sourceType)
 
 		err = authenticateAIStream(AuthWebhookURL, AIAuthRequest{
 			Stream:      streamName,

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -373,6 +373,11 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			http.Error(w, "Missing source_type", http.StatusBadRequest)
 			return
 		}
+		sourceTypeStr, err := mediamtxSourceTypeToString(sourceType)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 
 		queryParams := r.FormValue("query")
 		qp, err := url.ParseQuery(queryParams)
@@ -400,8 +405,10 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		ctx = clog.AddVal(ctx, "source_id", sourceID)
 		ctx = clog.AddVal(ctx, "source_type", sourceType)
 
-		err := authenticateAIStream(AuthWebhookURL, AIAuthRequest{
-			Stream: streamName,
+		err = authenticateAIStream(AuthWebhookURL, AIAuthRequest{
+			Stream:      streamName,
+			Type:        sourceTypeStr,
+			QueryParams: queryParams,
 		})
 		if err != nil {
 			kickErr := kickInputConnection(sourceID, sourceType)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -88,6 +88,7 @@ type aiRequestParams struct {
 
 	// For live video pipelines
 	segmentReader *media.SwitchableSegmentReader
+	outputRTMPURL string
 }
 
 // CalculateTextToImageLatencyScore computes the time taken per pixel for an text-to-image request.

--- a/server/auth.go
+++ b/server/auth.go
@@ -97,7 +97,15 @@ func (a authWebhookResponse) areProfilesEqual(b authWebhookResponse) bool {
 }
 
 type AIAuthRequest struct {
+	// Stream name or stream key
 	Stream string `json:"stream"`
+
+	// Stream type, eg RTMP or WHIP
+	Type string `json:"type"`
+
+	// Query parameters that came with the stream, if any
+	QueryParams string `json:"query_params,omitempty"`
+
 	// TODO not sure what params we need yet
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

- [ai/live: Take RTMP output URL from stream query params](https://github.com/livepeer/go-livepeer/commit/2aca7296c20ede4764548c48b25433c7bf3bdfc2)
- [Add stream type and query params to auth request](https://github.com/livepeer/go-livepeer/commit/e622f8db8a230b2d287ae5440168dca812def336)
- [Logging updates for MediaMTX errors](https://github.com/livepeer/go-livepeer/commit/1c741e9177d7bef1258c71e59f374be6a0bb0f4e)


**Specific updates (required)**
<!--- List out all significant updates your code introduces -->


Takes the RTMP output URL from stream query parameters using a `rtmpOutput` field. If there is no output supplied, it'll send to `rtmp://localhost/<streamname>-out` by default for ease of local development / testing (local mediamtx instance). Tested with Livepeer Studio (staging) and it seems to work.

Once we have a working auth backend, any output URL that is returned from the auth webhook should have priority over any URL that is supplied here.  

### Testing

This can be tested via MediaMTX WHIP ingest with something like this

```
http://localhost:8889/streamname/publish?video-codec=h264%2F90000&rtmpOutput=rtmp://rtmp-host/stream-key
``` 

RTMP ingest works the same way: add `?rtmpOutput=...` to the end of the rtmp path or stream key.

### MediaMTX Config Updates

This requires adding `-F query=$MTX_QUERY` to the mediamtx.yml runOnReady config, eg

```yaml
  runOnReady: curl http://localhost:5936/live/video-to-video/start -F stream=$MTX_PATH -F source_id=$MTX_SOURCE_ID -F source_type=$MTX_SOURCE_TYPE -F query=$MTX_QUERY
```

### Other Updates: Auth Webhook and Logging

Also send in the stream type (rtmp/whip) and any query params to the auth webhook. This is useful in case the auth / config needs to check something there, eg JWT

Introduced a bit of error logging to the MediaMTX handler since I hadn't updated my MediaMTX config to take the stream id / type and things were silently failing, so hopefully this helps someone figure things out sooner.


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Manual testing

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
