### PR TITLE
Fix startup nil pointer introduced in 9127ccee42ebb4f2f7dd09c707583c53464f134c

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -611,7 +611,12 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		case core.BroadcasterNode:
 			nodeType = lpmon.Broadcaster
 			if *cfg.KafkaBootstrapServers != "" && *cfg.KafkaUsername != "" && *cfg.KafkaPassword != "" && *cfg.KafkaGatewayTopic != "" {
-				err := lpmon.InitKafkaProducer(*cfg.KafkaBootstrapServers, *cfg.KafkaUsername, *cfg.KafkaPassword, *cfg.KafkaGatewayTopic, n.Eth.Account().Address.Hex())
+				var broadcasterEthAddress = ""
+				if cfg.EthAcctAddr != nil {
+					broadcasterEthAddress = *cfg.EthAcctAddr
+				}
+
+				err := lpmon.InitKafkaProducer(*cfg.KafkaBootstrapServers, *cfg.KafkaUsername, *cfg.KafkaPassword, *cfg.KafkaGatewayTopic, broadcasterEthAddress)
 				if err != nil {
 					glog.Warning("error while initializing Kafka producer: %w", err)
 				}


### PR DESCRIPTION
The value I was using isn't populated yet, so I switched to grabbing it from the config instead