### PR TITLE
ai/live: Configure parameters from auth callback

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -86,7 +86,11 @@ type aiRequestParams struct {
 	os          drivers.OSSession
 	sessManager *AISessionManager
 
-	// For live video pipelines
+	liveParams liveRequestParams
+}
+
+// For live video pipelines
+type liveRequestParams struct {
 	segmentReader *media.SwitchableSegmentReader
 	outputRTMPURL string
 	stream        string
@@ -1402,7 +1406,7 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 	case worker.GenLiveVideoToVideoJSONRequestBody:
 		cap = core.Capability_LiveVideoToVideo
 		modelID = defaultLiveVideoToVideoModelID
-		if v.ModelId != nil {
+		if v.ModelId != nil && *v.ModelId != "" {
 			modelID = *v.ModelId
 		}
 		submitFn = func(ctx context.Context, params aiRequestParams, sess *AISession) (interface{}, error) {

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -72,10 +72,11 @@ func TestAILiveAuthSucceeds(t *testing.T) {
 	s, serverURL := stubAuthServer(t, http.StatusOK, `{}`)
 	defer s.Close()
 
-	err := authenticateAIStream(serverURL, AIAuthRequest{
+	resp, err := authenticateAIStream(serverURL, AIAuthRequest{
 		Stream: "stream",
 	})
 	require.NoError(t, err)
+	require.Equal(t, AIAuthResponse{}, *resp)
 }
 
 func TestNoErrorWhenTranscodeAuthHeaderNotPassed(t *testing.T) {


### PR DESCRIPTION
Adds a JSON schema for the auth callback, wires it up to the rest of the inference params and incorporates a couple more of the query strings. Take note of the field naming - `pipeline` and `pipeline_params` , happy to adjust those if preferred - eg, to match the existing `model_id` fields

Also some minor refactor to move the AI fields for `aiRequestParams` into its own struct to keep things tidy since I think we will be adding a bunch more things there later. 