### PR TITLE
Push Kafka initialisation to later in startup

### DIFF
--- a/cmd/livepeer/starter/kafka.go
+++ b/cmd/livepeer/starter/kafka.go
@@ -8,6 +8,7 @@ import (
 func startKafkaProducer(cfg LivepeerConfig) error {
 	if *cfg.KafkaBootstrapServers == "" || *cfg.KafkaUsername == "" || *cfg.KafkaPassword == "" || *cfg.KafkaGatewayTopic == "" {
 		glog.Warning("not starting Kafka producer as producer config values aren't present")
+		return nil
 	}
 
 	var broadcasterEthAddress = ""

--- a/cmd/livepeer/starter/kafka.go
+++ b/cmd/livepeer/starter/kafka.go
@@ -1,0 +1,25 @@
+package starter
+
+import (
+	"github.com/golang/glog"
+	lpmon "github.com/livepeer/go-livepeer/monitor"
+)
+
+func startKafkaProducer(cfg LivepeerConfig) error {
+	if *cfg.KafkaBootstrapServers == "" || *cfg.KafkaUsername == "" || *cfg.KafkaPassword == "" || *cfg.KafkaGatewayTopic == "" {
+		glog.Warning("not starting Kafka producer as producer config values aren't present")
+	}
+
+	var broadcasterEthAddress = ""
+	if cfg.EthAcctAddr != nil {
+		broadcasterEthAddress = *cfg.EthAcctAddr
+	}
+
+	return lpmon.InitKafkaProducer(
+		*cfg.KafkaBootstrapServers,
+		*cfg.KafkaUsername,
+		*cfg.KafkaPassword,
+		*cfg.KafkaGatewayTopic,
+		broadcasterEthAddress,
+	)
+}

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -611,17 +611,6 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		switch n.NodeType {
 		case core.BroadcasterNode:
 			nodeType = lpmon.Broadcaster
-			if *cfg.KafkaBootstrapServers != "" && *cfg.KafkaUsername != "" && *cfg.KafkaPassword != "" && *cfg.KafkaGatewayTopic != "" {
-				var broadcasterEthAddress = ""
-				if cfg.EthAcctAddr != nil {
-					broadcasterEthAddress = *cfg.EthAcctAddr
-				}
-
-				err := lpmon.InitKafkaProducer(*cfg.KafkaBootstrapServers, *cfg.KafkaUsername, *cfg.KafkaPassword, *cfg.KafkaGatewayTopic, broadcasterEthAddress)
-				if err != nil {
-					glog.Warning("error while initializing Kafka producer: %w", err)
-				}
-			}
 		case core.OrchestratorNode:
 			nodeType = lpmon.Orchestrator
 		case core.TranscoderNode:
@@ -1626,6 +1615,13 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 		if n.NodeType == core.AIWorkerNode {
 			go server.RunAIWorker(n, orchURLs[0].Host, n.Capabilities.ToNetCapabilities())
+		}
+	}
+
+	// Start Kafka producer
+	if *cfg.Monitor {
+		if err := startKafkaProducer(cfg); err != nil {
+			exit("Error while starting Kafka producer", err)
 		}
 	}
 


### PR DESCRIPTION
We were doing it before all the config was set up, which meant that the Gateway value wasn't populated. Took the opportunity to split out the code too, to try and reduce the craziness of starter.go