### PR TITLE
workflows: Rename package to `pkgconf` for macos/brew install

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -194,7 +194,11 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.target.GOOS }}-${{ matrix.target.GOARCH }}-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
 
       - name: Install dependencies
-        run: brew install coreutils pkg-config
+        run: |
+          brew update
+          brew upgrade
+          brew uninstall --ignore-dependencies --force pkg-config@0.29.2
+          brew install coreutils pkgconf
 
       - name: Install go modules
         # if: steps.go.outputs.cache-hit != 'true'


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10984

most likely to be resolved within a week, considering the scale of affected repos/workflows. but we still need a bypass/fix to unblock our build pipelines