### PR TITLE
feat(ai): enable worker image pulling

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,8 @@
 
 ## v0.X.X
 
+- [#3279](https://github.com/livepeer/go-livepeer/pull/3279) - Enable automatic worker image pulling.
+
 ### Breaking Changes 🚨🚨
 
 ### Features ⚒

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1242,6 +1242,9 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 					modelConstraint.Capacity = config.Capacity
 				}
 
+				// Ensure the AI worker has the image needed to serve the job.
+				n.AIWorker.EnsureImageAvailable(ctx, config.Pipeline, config.ModelID)
+
 				if config.Warm || config.URL != "" {
 					// Register external container endpoint if URL is provided.
 					endpoint := worker.RunnerEndpoint{URL: config.URL, Token: config.Token}

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1243,7 +1243,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				}
 
 				// Ensure the AI worker has the image needed to serve the job.
-				n.AIWorker.EnsureImageAvailable(ctx, config.Pipeline, config.ModelID)
+				err := n.AIWorker.EnsureImageAvailable(ctx, config.Pipeline, config.ModelID)
+				if err != nil {
+					glog.Errorf("Error ensuring AI worker image available for %v: %v", config.Pipeline, err)
+				}
 
 				if config.Warm || config.URL != "" {
 					// Register external container endpoint if URL is provided.

--- a/core/ai.go
+++ b/core/ai.go
@@ -29,9 +29,9 @@ type AI interface {
 	TextToSpeech(context.Context, worker.GenTextToSpeechJSONRequestBody) (*worker.AudioResponse, error)
 	LiveVideoToVideo(context.Context, worker.GenLiveVideoToVideoJSONRequestBody) (*worker.LiveVideoToVideoResponse, error)
 	Warm(context.Context, string, string, worker.RunnerEndpoint, worker.OptimizationFlags) error
-	EnsureImageAvailable(context.Context, string, string) error
 	Stop(context.Context) error
-	HasCapacity(pipeline, modelID string) bool
+	HasCapacity(string, string) bool
+	EnsureImageAvailable(context.Context, string, string) error
 }
 
 // Custom type to parse a big.Rat from a JSON number.

--- a/core/ai.go
+++ b/core/ai.go
@@ -29,6 +29,7 @@ type AI interface {
 	TextToSpeech(context.Context, worker.GenTextToSpeechJSONRequestBody) (*worker.AudioResponse, error)
 	LiveVideoToVideo(context.Context, worker.GenLiveVideoToVideoJSONRequestBody) (*worker.LiveVideoToVideoResponse, error)
 	Warm(context.Context, string, string, worker.RunnerEndpoint, worker.OptimizationFlags) error
+	EnsureImageAvailable(context.Context, string, string) error
 	Stop(context.Context) error
 	HasCapacity(pipeline, modelID string) bool
 }

--- a/core/ai_test.go
+++ b/core/ai_test.go
@@ -679,6 +679,10 @@ func (a *stubAIWorker) HasCapacity(pipeline, modelID string) bool {
 	return true
 }
 
+func (a *stubAIWorker) EnsureImageAvailable(ctx context.Context, pipeline string, modelID string) error {
+	return nil
+}
+
 type StubAIWorkerServer struct {
 	manager      *RemoteAIWorkerManager
 	SendError    error

--- a/server/ai_worker_test.go
+++ b/server/ai_worker_test.go
@@ -649,3 +649,8 @@ func (a *stubAIWorker) HasCapacity(pipeline, modelID string) bool {
 	a.Called++
 	return true
 }
+
+func (a *stubAIWorker) EnsureImageAvailable(ctx context.Context, pipeline string, modelID string) error {
+	a.Called++
+	return nil
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This commit ensures that the docker containers the worker uses are
pulled during startup. They use the new changes implemented in
https://github.com/livepeer/ai-worker/pull/200.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Calls the new `EnsureImageAvailable` implemented in https://github.com/livepeer/ai-worker/pull/200 during orchestrator/worker startup. This will ensure that the worker has all the images it needs to serve the specifie requests.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- I ran offchain e2e tests to see if the requests were working.

**Does this pull request close any open issues?**
<!-- Fixes # -->

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
