### PR TITLE
mediamtx: Publish deployed version if runtime args are present

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,12 +23,12 @@ end_of_line = unset
 insert_final_newline = unset
 
 # Makefiles/Dockerfile/golang files
-[{Makefile,Dockerfile{,.debian},*.go}]
+[{Makefile,Dockerfile{,.cuda-base,.mediamtx},*.go}]
 indent_style = tab
 indent_size = 8
 
-# YAML/JSON Files
-[{.ecrc,*.{yml,yaml,sh,json}}]
+# YAML/JSON/sh Files
+[{.ecrc,*.{yml,yaml,sh,json,bash}}]
 indent_size = 2
 
 [{server/handlers_test,eth/accountmanager_test}.go]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,11 @@ docker:
     - any-glob-to-any-file:
       - "docker/**"
 
+docs:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "doc/**"
+
 github_actions:
   - changed-files:
     - any-glob-to-any-file:

--- a/.github/workflows/docker-mediamtx.yaml
+++ b/.github/workflows/docker-mediamtx.yaml
@@ -2,12 +2,15 @@ name: MediaMTX Docker build
 
 on:
   pull_request:
+    branches:
+      - master
+    paths:
+      - 'docker/*mediamtx*'
   push:
     branches:
       - master
     paths:
-      - 'docker/Dockerfile.mediamtx'
-      - 'docker/mediamtx.yml'
+      - 'docker/*mediamtx*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -20,7 +23,7 @@ jobs:
     permissions:
       packages: write
       contents: read
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v4.1.7

--- a/docker/Dockerfile.mediamtx
+++ b/docker/Dockerfile.mediamtx
@@ -1,9 +1,5 @@
 FROM	ubuntu:24.04
 
-ENV	MEDIAMTX_VERSION="1.9.3"
-
-ADD	"https://github.com/bluenviron/mediamtx/releases/download/v${MEDIAMTX_VERSION}/mediamtx_v${MEDIAMTX_VERSION}_linux_amd64.tar.gz"	/opt/mediamtx.tar.gz
-
 # we need curl in the image as it's later used in the runOnReady command
 RUN	apt-get update \
 	&& apt-get install -y \
@@ -11,6 +7,10 @@ RUN	apt-get update \
 		curl \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
+
+ENV	MEDIAMTX_VERSION="1.9.3"
+
+ADD	"https://github.com/bluenviron/mediamtx/releases/download/v${MEDIAMTX_VERSION}/mediamtx_v${MEDIAMTX_VERSION}_linux_amd64.tar.gz"	/opt/mediamtx.tar.gz
 
 RUN	tar xzf /opt/mediamtx.tar.gz -C /opt/ \
 	&& mkdir -p /usr/local/bin /etc/mediamtx/ \

--- a/docker/Dockerfile.mediamtx
+++ b/docker/Dockerfile.mediamtx
@@ -1,17 +1,23 @@
-FROM ubuntu:24.04
+FROM	ubuntu:24.04
 
-ENV MEDIAMTX_VERSION="v1.9.3"
+ENV	MEDIAMTX_VERSION="1.9.3"
+
+ADD	"https://github.com/bluenviron/mediamtx/releases/download/v${MEDIAMTX_VERSION}/mediamtx_v${MEDIAMTX_VERSION}_linux_amd64.tar.gz"	/opt/mediamtx.tar.gz
 
 # we need curl in the image as it's later used in the runOnReady command
-RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        curl \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN	apt-get update \
+	&& apt-get install -y \
+		ca-certificates \
+		curl \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
 
-RUN curl -L https://github.com/bluenviron/mediamtx/releases/download/${MEDIAMTX_VERSION}/mediamtx_${MEDIAMTX_VERSION}_linux_amd64.tar.gz -o /mediamtx.tar.gz \
-    && tar xzvf /mediamtx.tar.gz \
-    && rm /mediamtx.tar.gz
+RUN	tar xzf /opt/mediamtx.tar.gz -C /opt/ \
+	&& mkdir -p /usr/local/bin /etc/mediamtx/ \
+	&& mv /opt/mediamtx /usr/local/bin/mediamtx \
+	&& mv /opt/mediamtx.yml /etc/mediamtx/mediamtx.yml \
+	&& rm -rf /opt/
 
-ENTRYPOINT ["/mediamtx"]
+COPY	mediamtx-entry.bash	/
+
+ENTRYPOINT	["/mediamtx-entry.bash"]

--- a/docker/mediamtx-entry.bash
+++ b/docker/mediamtx-entry.bash
@@ -16,4 +16,4 @@ EOF
     curl -X POST --data-binary @- "$LP_PUBLISH_MEDIAMTX_METRICS_ENDPOINT"
 fi
 
-/usr/local/bin/mediamtx
+exec "${@:-/usr/local/bin/mediamtx}"

--- a/docker/mediamtx-entry.bash
+++ b/docker/mediamtx-entry.bash
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+[ -v DEBUG ] && set -x
+
+set -euo pipefail
+
+if [ -v LP_PUBLISH_MEDIAMTX_METRICS ]; then
+  if [ -z "$LP_PUBLISH_MEDIAMTX_METRICS_ENDPOINT" ]; then
+    echo >&2 "No endpoint specified for publishing mediamtx metrics."
+  fi
+  echo <<EOF |
+# HELP version Current software version as a tag, always 1
+# TYPE version gauge
+version{app="MediaMTX",version="$MEDIAMTX_VERSION"} 1
+EOF
+    curl -X POST --data-binary @- "$LP_PUBLISH_MEDIAMTX_METRICS_ENDPOINT"
+fi
+
+/usr/local/bin/mediamtx


### PR DESCRIPTION
preparing the image so that container can optionally inject version metrics to prometheus/victoriametrics at runtime.