### PR TITLE
github workflow - use go.mod for go version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
         id: go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version-file: './go.mod'
           cache: true
           cache-dependency-path: go.sum
 
@@ -174,7 +174,7 @@ jobs:
         id: go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version-file: './go.mod'
           cache: true
           cache-dependency-path: go.sum
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
         id: go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.23.2
+          go-version-file: './go.mod'
           cache: true
           cache-dependency-path: go.sum
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Making sure we use the same go version on github workflows and `go.mod`

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
