### PR TITLE
live-ai: Update to use FLV-enabled LPMS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,6 +68,4 @@ COPY --from=build	/usr/bin/grpc_health_probe	/usr/local/bin/grpc_health_probe
 COPY --from=build	/src/tasmodel.pb	/tasmodel.pb
 COPY --from=build	/usr/share/misc/pci.ids	/usr/share/misc/pci.ids
 
-RUN apt update && apt install -yqq ffmpeg
-
 ENTRYPOINT	["/usr/local/bin/livepeer"]

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/livepeer/ai-worker v0.12.6
 	github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b
 	github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18
-	github.com/livepeer/lpms v0.0.0-20241122145837-7b07ba3a2204
+	github.com/livepeer/lpms v0.0.0-20241203000512-b33cac634b43
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.14.18
 	github.com/oapi-codegen/nethttp-middleware v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/livepeer/ai-worker v0.12.6
 	github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b
 	github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18
-	github.com/livepeer/lpms v0.0.0-20241203000512-b33cac634b43
+	github.com/livepeer/lpms v0.0.0-20241203012405-fc96cadb6393
 	github.com/livepeer/m3u8 v0.11.1
 	github.com/mattn/go-sqlite3 v1.14.18
 	github.com/oapi-codegen/nethttp-middleware v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -613,8 +613,6 @@ github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cO
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18 h1:4oH3NqV0NvcdS44Ld3zK2tO8IUiNozIggm74yobQeZg=
 github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18/go.mod h1:Jpf4jHK+fbWioBHRDRM1WadNT1qmY27g2YicTdO0Rtc=
-github.com/livepeer/lpms v0.0.0-20241203000512-b33cac634b43 h1:kq0OtTiw15qSsbZTSCUCXtUdmOAZ94Ic8/wPqVLc0tY=
-github.com/livepeer/lpms v0.0.0-20241203000512-b33cac634b43/go.mod h1:z5ROP1l5OzAKSoqVRLc34MjUdueil6wHSecQYV7llIw=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/go.sum
+++ b/go.sum
@@ -613,8 +613,8 @@ github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cO
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18 h1:4oH3NqV0NvcdS44Ld3zK2tO8IUiNozIggm74yobQeZg=
 github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18/go.mod h1:Jpf4jHK+fbWioBHRDRM1WadNT1qmY27g2YicTdO0Rtc=
-github.com/livepeer/lpms v0.0.0-20241122145837-7b07ba3a2204 h1:YalnQu8BB9vRh+7gcEjfzfHNl9NEwagBTHQqnlUYDrA=
-github.com/livepeer/lpms v0.0.0-20241122145837-7b07ba3a2204/go.mod h1:z5ROP1l5OzAKSoqVRLc34MjUdueil6wHSecQYV7llIw=
+github.com/livepeer/lpms v0.0.0-20241203000512-b33cac634b43 h1:kq0OtTiw15qSsbZTSCUCXtUdmOAZ94Ic8/wPqVLc0tY=
+github.com/livepeer/lpms v0.0.0-20241203000512-b33cac634b43/go.mod h1:z5ROP1l5OzAKSoqVRLc34MjUdueil6wHSecQYV7llIw=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/go.sum
+++ b/go.sum
@@ -613,6 +613,8 @@ github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cO
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18 h1:4oH3NqV0NvcdS44Ld3zK2tO8IUiNozIggm74yobQeZg=
 github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18/go.mod h1:Jpf4jHK+fbWioBHRDRM1WadNT1qmY27g2YicTdO0Rtc=
+github.com/livepeer/lpms v0.0.0-20241203012405-fc96cadb6393 h1:aoDFI66Kj1pQueka93PLY59WlnI7jy4cJUfPxteIgCE=
+github.com/livepeer/lpms v0.0.0-20241203012405-fc96cadb6393/go.mod h1:z5ROP1l5OzAKSoqVRLc34MjUdueil6wHSecQYV7llIw=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo 'WARNING: downloading and executing lpms/install_ffmpeg.sh, use it directly in case of issues'
-curl https://raw.githubusercontent.com/livepeer/lpms/ffde2327537517b3345162e9544704571bc58a34/install_ffmpeg.sh | bash -s $1
+curl https://raw.githubusercontent.com/livepeer/lpms/b33cac634b43d2ecd160224417daf8e920b0f500/install_ffmpeg.sh | bash -s $1

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -9,13 +9,13 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"time"
 
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/media"
 	"github.com/livepeer/go-livepeer/trickle"
+	"github.com/livepeer/lpms/ffmpeg"
 )
 
 func startTricklePublish(url *url.URL, params aiRequestParams) {
@@ -69,23 +69,22 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 		}
 	}()
 
-	// TODO: Change this to LPMS
 	go func() {
 		defer r.Close()
 		retryCount := 0
+		// TODO check whether stream is actually terminated
+		//      so we aren't just looping unnecessarily
 		for retryCount < 10 {
-			cmd := exec.Command("ffmpeg",
-				"-i", "pipe:0",
-				"-c:a", "copy",
-				"-c:v", "copy",
-				"-f", "flv",
-				params.liveParams.outputRTMPURL,
-			)
-			cmd.Stdin = r
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-			if err := cmd.Run(); err != nil {
-				clog.Infof(ctx, "Error running trickle subscribe ffmpeg: %s", err)
+			_, err := ffmpeg.Transcode3(&ffmpeg.TranscodeOptionsIn{
+				Fname: fmt.Sprintf("pipe:%d", r.Fd()),
+			}, []ffmpeg.TranscodeOptions{{
+				Oname:        params.liveParams.outputRTMPURL,
+				AudioEncoder: ffmpeg.ComponentOptions{Name: "copy"},
+				VideoEncoder: ffmpeg.ComponentOptions{Name: "copy"},
+				Muxer:        ffmpeg.ComponentOptions{Name: "flv"},
+			}})
+			if err != nil {
+				clog.Infof(ctx, "Error sending RTMP out: %s", err)
 			}
 			retryCount++
 			time.Sleep(5 * time.Second)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Updates LPMS to use the FLV muxer introduced in https://github.com/livepeer/lpms/pull/428 which should resolve issues with getting RTMP output.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates LPMS to [b33cac634b43d2ecd160224417daf8e920b0f500](https://github.com/livepeer/lpms/commit/b33cac634b43d2ecd160224417daf8e920b0f500)
- Uses LPMS for ffmpeg output
- Remove ffmpeg from go-livepeer Dockerfile

**How did you test each of these updates (required)**

Manually tested a production LPMS build with and without the FLV muxer.