### PR TITLE
Better retry logic for mediaserver pull and small refactor

### DIFF
--- a/media/mediamtx.go
+++ b/media/mediamtx.go
@@ -1,4 +1,4 @@
-package mediaserver
+package media
 
 import (
 	"fmt"

--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -35,7 +35,7 @@ func (ms *MediaSegmenter) RunSegmentation(ctx context.Context, in string, segmen
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		processSegments(segmentHandler, outFilePattern, completionSignal)
+		processSegments(ctx, segmentHandler, outFilePattern, completionSignal)
 	}()
 
 	retryCount := 0
@@ -161,7 +161,7 @@ func openNonBlockingWithRetry(name string, timeout time.Duration, completed <-ch
 	}
 }
 
-func processSegments(segmentHandler SegmentHandler, outFilePattern string, completionSignal <-chan bool) {
+func processSegments(ctx context.Context, segmentHandler SegmentHandler, outFilePattern string, completionSignal <-chan bool) {
 
 	// things protected by the mutex mu
 	mu := &sync.Mutex{}
@@ -209,7 +209,7 @@ func processSegments(segmentHandler SegmentHandler, outFilePattern string, compl
 		mu.Unlock()
 
 		// Handle the reading process
-		readSegment(segmentHandler, file, pipeName)
+		readSegment(ctx, segmentHandler, file, pipeName)
 
 		// Increment to the next pipe
 		pipeNum++
@@ -229,7 +229,7 @@ func processSegments(segmentHandler SegmentHandler, outFilePattern string, compl
 	}
 }
 
-func readSegment(segmentHandler SegmentHandler, file *os.File, pipeName string) {
+func readSegment(ctx context.Context, segmentHandler SegmentHandler, file *os.File, pipeName string) {
 	defer file.Close()
 
 	reader := bufio.NewReader(file)
@@ -247,33 +247,33 @@ func readSegment(segmentHandler SegmentHandler, file *os.File, pipeName string) 
 		n, err := reader.Read(buf)
 		if n > 0 {
 			if !firstByteRead {
-				slog.Debug("First byte read", "pipeName", pipeName)
+				clog.V(7).Infof(ctx, "First byte read. pipeName=%s", pipeName)
 				firstByteRead = true
 
 			}
 			totalBytesRead += int64(n)
 			if _, err := interfaceWriter.Write(buf[:n]); err != nil {
 				if err != io.EOF {
-					slog.Error("Error writing", "pipeName", pipeName, "err", err)
+					clog.Errorf(ctx, "Error writing. pipeName=%s err=%s", pipeName, err)
 				}
 			}
 		}
 		if n == len(buf) && n < 1024*1024 {
 			newLen := int(float64(len(buf)) * 1.5)
-			slog.Debug("Max buf hit, increasing", "oldSize", humanBytes(int64(len(buf))), "newSize", humanBytes(int64(newLen)))
+			clog.V(7).Infof(ctx, "Max buf hit, increasing. oldSize=%s newSize=%s", humanBytes(int64(len(buf))), humanBytes(int64(newLen)))
 			buf = make([]byte, newLen)
 		}
 
 		if err != nil {
 			if err.Error() == "EOF" {
-				slog.Debug("Last byte read", "pipeName", pipeName, "totalRead", humanBytes(totalBytesRead))
+				clog.V(7).Infof(ctx, "Last byte read. pipeName=%s totalRead=%s", pipeName, humanBytes(totalBytesRead))
 			} else {
-				slog.Error("Error reading", "pipeName", pipeName, "err", err)
+				clog.Errorf(ctx, "Error reading. pipeName=%s err=%s", pipeName, err)
 			}
 			break
 		}
 	}
-	clog.V(8).Infof(context.Background(), "read segment. totalRead=%s", humanBytes(totalBytesRead))
+	clog.V(8).Infof(ctx, "read segment. totalRead=%s", humanBytes(totalBytesRead))
 
 }
 

--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/livepeer/go-livepeer/clog"
-	"github.com/livepeer/go-livepeer/mediaserver"
 	"github.com/livepeer/lpms/ffmpeg"
 	"golang.org/x/sys/unix"
 )
@@ -27,7 +26,7 @@ var waitTimeout = 20 * time.Second
 
 type MediaSegmenter struct {
 	Workdir        string
-	MediaMTXClient *mediaserver.MediaMTXClient
+	MediaMTXClient *MediaMTXClient
 	MediaMTXHost   string
 }
 
@@ -45,7 +44,7 @@ func (ms *MediaSegmenter) RunSegmentation(ctx context.Context, in string, segmen
 	for {
 		streamExists, err := ms.MediaMTXClient.StreamExists(ms.MediaMTXHost, id, sourceType)
 		if err != nil {
-			clog.Errorf(ctx, "Failed to check if input stream exists. err=%s", err)
+			clog.Errorf(ctx, "StreamExists check failed. err=%s", err)
 		}
 		if retryCount > 20 && !streamExists {
 			clog.Errorf(ctx, "Stopping segmentation, input stream does not exist. in=%s err=%s", in, err)

--- a/media/rtmp2segment_windows.go
+++ b/media/rtmp2segment_windows.go
@@ -2,8 +2,12 @@
 
 package media
 
+import "context"
+
 type MediaSegmenter struct {
-	Workdir string
+	Workdir        string
+	MediaMTXClient *MediaMTXClient
+	MediaMTXHost   string
 }
 
 func (ms *MediaSegmenter) RunSegmentation(ctx context.Context, in string, segmentHandler SegmentHandler, id, sourceType string) {

--- a/media/rtmp2segment_windows.go
+++ b/media/rtmp2segment_windows.go
@@ -6,6 +6,6 @@ type MediaSegmenter struct {
 	Workdir string
 }
 
-func (ms *MediaSegmenter) RunSegmentation(in string, segmentHandler SegmentHandler) {
+func (ms *MediaSegmenter) RunSegmentation(ctx context.Context, in string, segmentHandler SegmentHandler, id, sourceType string) {
 	// Not supported for Windows
 }

--- a/mediaserver/mediamtx.go
+++ b/mediaserver/mediamtx.go
@@ -21,7 +21,7 @@ const (
 	MediaMTXRtmpConn      = "rtmpConn"
 )
 
-func (ls *MediaMTXClient) KickInputConnection(mediaMTXHost, sourceID, sourceType string) error {
+func getApiPath(sourceType string) (string, error) {
 	var apiPath string
 	switch sourceType {
 	case MediaMTXWebrtcSession:
@@ -29,14 +29,22 @@ func (ls *MediaMTXClient) KickInputConnection(mediaMTXHost, sourceID, sourceType
 	case MediaMTXRtmpConn:
 		apiPath = "rtmpconns"
 	default:
-		return fmt.Errorf("invalid sourceType: %s", sourceType)
+		return "", fmt.Errorf("invalid sourceType: %s", sourceType)
+	}
+	return apiPath, nil
+}
+
+func (mc *MediaMTXClient) KickInputConnection(mediaMTXHost, sourceID, sourceType string) error {
+	apiPath, err := getApiPath(sourceType)
+	if err != nil {
+		return err
 	}
 
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s:%s/v3/%s/kick/%s", mediaMTXHost, mediaMTXControlPort, apiPath, sourceID), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create kick request: %w", err)
 	}
-	req.SetBasicAuth(mediaMTXControlUser, ls.apiPassword)
+	req.SetBasicAuth(mediaMTXControlUser, mc.apiPassword)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to kick connection: %w", err)
@@ -46,4 +54,25 @@ func (ls *MediaMTXClient) KickInputConnection(mediaMTXHost, sourceID, sourceType
 		return fmt.Errorf("kick connection failed with status code: %d body: %s", resp.StatusCode, body)
 	}
 	return nil
+}
+
+func (mc *MediaMTXClient) StreamExists(mediaMTXHost, sourceID, sourceType string) (bool, error) {
+	apiPath, err := getApiPath(sourceType)
+	if err != nil {
+		return false, err
+	}
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://%s:%s/v3/%s/get/%s", mediaMTXHost, mediaMTXControlPort, apiPath, sourceID), nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create get stream request: %w", err)
+	}
+	req.SetBasicAuth(mediaMTXControlUser, mc.apiPassword)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to get stream: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("get stream failed with status code: %d body: %s", resp.StatusCode, body)
+	}
+	return true, nil
 }

--- a/mediaserver/mediamtx.go
+++ b/mediaserver/mediamtx.go
@@ -1,0 +1,49 @@
+package mediaserver
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type MediaMTXClient struct {
+	apiPassword string
+}
+
+func NewMediaMTXClient(apiPassword string) *MediaMTXClient {
+	return &MediaMTXClient{apiPassword: apiPassword}
+}
+
+const (
+	mediaMTXControlPort   = "9997"
+	mediaMTXControlUser   = "admin"
+	MediaMTXWebrtcSession = "webrtcSession"
+	MediaMTXRtmpConn      = "rtmpConn"
+)
+
+func (ls *MediaMTXClient) KickInputConnection(mediaMTXHost, sourceID, sourceType string) error {
+	var apiPath string
+	switch sourceType {
+	case MediaMTXWebrtcSession:
+		apiPath = "webrtcsessions"
+	case MediaMTXRtmpConn:
+		apiPath = "rtmpconns"
+	default:
+		return fmt.Errorf("invalid sourceType: %s", sourceType)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s:%s/v3/%s/kick/%s", mediaMTXHost, mediaMTXControlPort, apiPath, sourceID), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create kick request: %w", err)
+	}
+	req.SetBasicAuth(mediaMTXControlUser, ls.apiPassword)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to kick connection: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("kick connection failed with status code: %d body: %s", resp.StatusCode, body)
+	}
+	return nil
+}

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -3,10 +3,8 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
-	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
@@ -15,31 +13,33 @@ import (
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/media"
+	"github.com/livepeer/go-livepeer/mediaserver"
 	"github.com/livepeer/go-livepeer/trickle"
 )
 
-func startTricklePublish(url *url.URL, params aiRequestParams) {
+func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestParams) {
+	ctx = clog.AddVal(ctx, "url", url.Redacted())
 	publisher, err := trickle.NewTricklePublisher(url.String())
 	if err != nil {
-		slog.Info("error publishing trickle", "err", err)
+		clog.Infof(ctx, "error publishing trickle. err=%s", err)
 	}
 	params.liveParams.segmentReader.SwitchReader(func(reader io.Reader) {
 		// check for end of stream
 		if _, eos := reader.(*media.EOSReader); eos {
 			if err := publisher.Close(); err != nil {
-				slog.Info("Error closing trickle publisher", "err", err)
+				clog.Infof(ctx, "Error closing trickle publisher. err=%s", err)
 			}
 			return
 		}
 		go func() {
-			clog.V(8).Infof(context.Background(), "publishing trickle. url=%s", url.Redacted())
+			clog.V(8).Infof(ctx, "trickle publish writing data")
 			// TODO this blocks! very bad!
 			if err := publisher.Write(reader); err != nil {
-				slog.Info("Error writing to trickle publisher", "err", err)
+				clog.Infof(ctx, "Error writing to trickle publisher. err=%s", err)
 			}
 		}()
 	})
-	slog.Info("trickle pub", "url", url)
+	clog.Infof(ctx, "trickle pub")
 }
 
 func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestParams) {
@@ -73,6 +73,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 	go func() {
 		defer r.Close()
 		retryCount := 0
+		// TODO better retry logic
 		for retryCount < 10 {
 			cmd := exec.Command("ffmpeg",
 				"-i", "pipe:0",
@@ -95,9 +96,9 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 
 func mediamtxSourceTypeToString(s string) (string, error) {
 	switch s {
-	case mediaMTXWebrtcSession:
+	case mediaserver.MediaMTXWebrtcSession:
 		return "whip", nil
-	case mediaMTXRtmpConn:
+	case mediaserver.MediaMTXRtmpConn:
 		return "rtmp", nil
 	default:
 		return "", errors.New("unknown media source")
@@ -114,38 +115,4 @@ func startControlPublish(control *url.URL, params aiRequestParams) {
 	params.node.LiveMu.Lock()
 	defer params.node.LiveMu.Unlock()
 	params.node.LivePipelines[stream] = &core.LivePipeline{ControlPub: controlPub}
-}
-
-const (
-	mediaMTXControlPort   = "9997"
-	mediaMTXControlUser   = "admin"
-	mediaMTXWebrtcSession = "webrtcSession"
-	mediaMTXRtmpConn      = "rtmpConn"
-)
-
-func (ls *LivepeerServer) kickInputConnection(mediaMTXHost, sourceID, sourceType string) error {
-	var apiPath string
-	switch sourceType {
-	case mediaMTXWebrtcSession:
-		apiPath = "webrtcsessions"
-	case mediaMTXRtmpConn:
-		apiPath = "rtmpconns"
-	default:
-		return fmt.Errorf("invalid sourceType: %s", sourceType)
-	}
-
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s:%s/v3/%s/kick/%s", mediaMTXHost, mediaMTXControlPort, apiPath, sourceID), nil)
-	if err != nil {
-		return fmt.Errorf("failed to create kick request: %w", err)
-	}
-	req.SetBasicAuth(mediaMTXControlUser, ls.mediaMTXApiPassword)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to kick connection: %w", err)
-	}
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("kick connection failed with status code: %d body: %s", resp.StatusCode, body)
-	}
-	return nil
 }

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -13,7 +13,6 @@ import (
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/media"
-	"github.com/livepeer/go-livepeer/mediaserver"
 	"github.com/livepeer/go-livepeer/trickle"
 	"github.com/livepeer/lpms/ffmpeg"
 )
@@ -95,9 +94,9 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 
 func mediamtxSourceTypeToString(s string) (string, error) {
 	switch s {
-	case mediaserver.MediaMTXWebrtcSession:
+	case media.MediaMTXWebrtcSession:
 		return "whip", nil
-	case mediaserver.MediaMTXRtmpConn:
+	case media.MediaMTXRtmpConn:
 		return "rtmp", nil
 	default:
 		return "", errors.New("unknown media source")

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -475,8 +475,8 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			if mediaMTXStreamPrefix != "" {
 				mediaMTXStreamPrefix = mediaMTXStreamPrefix + "/"
 			}
-			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir}
-			ms.RunSegmentation(ctx, fmt.Sprintf("rtmp://%s/%s%s", remoteHost, mediaMTXStreamPrefix, streamName), ssr.Read)
+			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir, MediaMTXClient: ls.mediaMTXClient, MediaMTXHost: remoteHost}
+			ms.RunSegmentation(ctx, fmt.Sprintf("rtmp://%s/%s%s", remoteHost, mediaMTXStreamPrefix, streamName), ssr.Read, sourceID, sourceType)
 			ssr.Close()
 			ls.cleanupLive(streamName)
 		}()

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -441,7 +441,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 				QueryParams: queryParams,
 			})
 			if err != nil {
-				kickErr := ls.kickInputConnection(remoteHost, sourceID, sourceType)
+				kickErr := ls.mediaMTXClient.KickInputConnection(remoteHost, sourceID, sourceType)
 				if kickErr != nil {
 					clog.Errorf(ctx, "failed to kick input connection: %s", kickErr.Error())
 				}
@@ -476,7 +476,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 				mediaMTXStreamPrefix = mediaMTXStreamPrefix + "/"
 			}
 			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir}
-			ms.RunSegmentation(fmt.Sprintf("rtmp://%s/%s%s", remoteHost, mediaMTXStreamPrefix, streamName), ssr.Read)
+			ms.RunSegmentation(ctx, fmt.Sprintf("rtmp://%s/%s%s", remoteHost, mediaMTXStreamPrefix, streamName), ssr.Read)
 			ssr.Close()
 			ls.cleanupLive(streamName)
 		}()

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1033,7 +1033,7 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 		if err != nil {
 			return nil, fmt.Errorf("invalid control URL: %w", err)
 		}
-		startTricklePublish(pub, params)
+		startTricklePublish(ctx, pub, params)
 		startTrickleSubscribe(ctx, sub, params)
 		startControlPublish(control, params)
 	}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/livepeer/go-livepeer/clog"
+	"github.com/livepeer/go-livepeer/mediaserver"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/go-tools/drivers"
@@ -126,8 +127,8 @@ type LivepeerServer struct {
 	connectionLock    *sync.RWMutex
 	serverLock        *sync.RWMutex
 
-	mediaMTXApiPassword string
-	liveAIAuthApiKey    string
+	mediaMTXClient   *mediaserver.MediaMTXClient
+	liveAIAuthApiKey string
 }
 
 func (s *LivepeerServer) SetContextFromUnitTest(c context.Context) {
@@ -193,7 +194,7 @@ func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bo
 		internalManifests:       make(map[core.ManifestID]core.ManifestID),
 		recordingsAuthResponses: cache.New(time.Hour, 2*time.Hour),
 		AISessionManager:        NewAISessionManager(lpNode, AISessionManagerTTL),
-		mediaMTXApiPassword:     lpNode.MediaMTXApiPassword,
+		mediaMTXClient:          mediaserver.NewMediaMTXClient(lpNode.MediaMTXApiPassword),
 		liveAIAuthApiKey:        lpNode.LiveAIAuthApiKey,
 	}
 	if lpNode.NodeType == core.BroadcasterNode && httpIngest {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/livepeer/go-livepeer/clog"
-	"github.com/livepeer/go-livepeer/mediaserver"
+	"github.com/livepeer/go-livepeer/media"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/go-tools/drivers"
@@ -127,7 +127,7 @@ type LivepeerServer struct {
 	connectionLock    *sync.RWMutex
 	serverLock        *sync.RWMutex
 
-	mediaMTXClient   *mediaserver.MediaMTXClient
+	mediaMTXClient   *media.MediaMTXClient
 	liveAIAuthApiKey string
 }
 
@@ -194,7 +194,7 @@ func NewLivepeerServer(rtmpAddr string, lpNode *core.LivepeerNode, httpIngest bo
 		internalManifests:       make(map[core.ManifestID]core.ManifestID),
 		recordingsAuthResponses: cache.New(time.Hour, 2*time.Hour),
 		AISessionManager:        NewAISessionManager(lpNode, AISessionManagerTTL),
-		mediaMTXClient:          mediaserver.NewMediaMTXClient(lpNode.MediaMTXApiPassword),
+		mediaMTXClient:          media.NewMediaMTXClient(lpNode.MediaMTXApiPassword),
 		liveAIAuthApiKey:        lpNode.LiveAIAuthApiKey,
 	}
 	if lpNode.NodeType == core.BroadcasterNode && httpIngest {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
In order to have better retry logic we need to check if the stream still exists, if the input stream is still coming in then we should continue retrying on errors, if the user stops streaming in then we can bail out. At the moment I've implemented this for the segmentation call, we can implement it in other places where we need retries like the output stream once we're happy with it.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Refactor mediamtx api calls into separate package
- Stop retrying segmentation if stream does not exist

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
