### PR TITLE
Update ControlUrl to pointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jaypipes/ghw v0.10.0
 	github.com/jaypipes/pcidb v1.0.0
-	github.com/livepeer/ai-worker v0.12.6
+	github.com/livepeer/ai-worker v0.12.7-0.20241204213602-1021eaf4c373
 	github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b
 	github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18
 	github.com/livepeer/lpms v0.0.0-20241203012405-fc96cadb6393

--- a/go.sum
+++ b/go.sum
@@ -605,8 +605,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-netroute v0.2.0/go.mod h1:Vio7LTzZ+6hoT4CMZi5/6CpY3Snzh2vgZhWgxMNwlQI=
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
-github.com/livepeer/ai-worker v0.12.6 h1:1RN7eYy4C3D+iVaK5WuUu8Jgm7hTQ08J8EBeRekGJSo=
-github.com/livepeer/ai-worker v0.12.6/go.mod h1:ZibfmZQQh6jFvnPLHeIPInghfX5ln+JpN845nS3GuyM=
+github.com/livepeer/ai-worker v0.12.7-0.20241204213602-1021eaf4c373 h1:+IepZubsJ1NeYcgoa+7tk8ycOh5DaRZ14I+SxtAbsZ0=
+github.com/livepeer/ai-worker v0.12.7-0.20241204213602-1021eaf4c373/go.mod h1:ZibfmZQQh6jFvnPLHeIPInghfX5ln+JpN845nS3GuyM=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b h1:VQcnrqtCA2UROp7q8ljkh2XA/u0KRgVv0S1xoUvOweE=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b/go.mod h1:hwJ5DKhl+pTanFWl+EUpw1H7ukPO/H+MFpgA7jjshzw=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cOQee+WqmaDOgGtP2oDMhcVvR4L0yA=

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -184,7 +184,7 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 		jsonData, err := json.Marshal(&worker.LiveVideoToVideoResponse{
 			PublishUrl:   pubUrl,
 			SubscribeUrl: subUrl,
-			ControlUrl:   controlUrl,
+			ControlUrl:   &controlUrl,
 		})
 		if err != nil {
 			respondWithError(w, err.Error(), http.StatusInternalServerError)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1029,7 +1029,7 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 		if err != nil {
 			return nil, fmt.Errorf("invalid subscribe URL: %w", err)
 		}
-		control, err := common.AppendHostname(resp.JSON200.ControlUrl, host)
+		control, err := common.AppendHostname(*resp.JSON200.ControlUrl, host)
 		if err != nil {
 			return nil, fmt.Errorf("invalid control URL: %w", err)
 		}

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1020,6 +1020,10 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 	}
 
 	if resp.JSON200 != nil {
+		if resp.JSON200.ControlUrl == nil {
+			return nil, errors.New("control URL is missing")
+		}
+
 		host := sess.Transcoder()
 		pub, err := common.AppendHostname(resp.JSON200.PublishUrl, host)
 		if err != nil {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
This change fixes an invalid type reference to `ControlUrl` in [LiveVideoToVideoParams](https://github.com/livepeer/ai-worker/blob/1021eaf4c3734f33a55af949334c33359772aed8/worker/runner.gen.go#L280C1-L283C1) and [LiveVideoToVideoResponse](https://github.com/livepeer/ai-worker/blob/1021eaf4c3734f33a55af949334c33359772aed8/worker/runner.gen.go#L301-L303), which is currently nullable to allow for easier development.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updated `LiveVideoToVideoParams.ControlUrl` reference to use a pointer since it is nullable in ai-worker
- Updated reference to `*resp.JSON200.ControlUrl` in `ai_process.go` to nullable reference from `LiveVideoToVideoResponse`

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Tested end-to-end with gateway, orchestrator and ai-worker

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
