### PR TITLE
monitoring: add events trickle api

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -162,6 +162,7 @@ type LivepeerNode struct {
 type LivePipeline struct {
 	ControlPub  *trickle.TricklePublisher
 	StopControl func()
+	EventsPub   *trickle.TricklePublisher
 }
 
 // NewLivepeerNode creates a new Livepeer Node. Eth can be nil.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jaypipes/ghw v0.10.0
 	github.com/jaypipes/pcidb v1.0.0
-	github.com/livepeer/ai-worker v0.12.7-0.20241204213602-1021eaf4c373
+	github.com/livepeer/ai-worker v0.12.7-0.20241205213704-87d6efe82510
 	github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b
 	github.com/livepeer/livepeer-data v0.7.5-0.20231004073737-06f1f383fb18
 	github.com/livepeer/lpms v0.0.0-20241203012405-fc96cadb6393

--- a/go.sum
+++ b/go.sum
@@ -605,8 +605,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-netroute v0.2.0/go.mod h1:Vio7LTzZ+6hoT4CMZi5/6CpY3Snzh2vgZhWgxMNwlQI=
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
-github.com/livepeer/ai-worker v0.12.7-0.20241204213602-1021eaf4c373 h1:+IepZubsJ1NeYcgoa+7tk8ycOh5DaRZ14I+SxtAbsZ0=
-github.com/livepeer/ai-worker v0.12.7-0.20241204213602-1021eaf4c373/go.mod h1:ZibfmZQQh6jFvnPLHeIPInghfX5ln+JpN845nS3GuyM=
+github.com/livepeer/ai-worker v0.12.7-0.20241205213704-87d6efe82510 h1:rPMpkf43tOa8eixmQkBvYbgGleRWPEpKu3P7FKgtPnc=
+github.com/livepeer/ai-worker v0.12.7-0.20241205213704-87d6efe82510/go.mod h1:ZibfmZQQh6jFvnPLHeIPInghfX5ln+JpN845nS3GuyM=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b h1:VQcnrqtCA2UROp7q8ljkh2XA/u0KRgVv0S1xoUvOweE=
 github.com/livepeer/go-tools v0.3.6-0.20240130205227-92479de8531b/go.mod h1:hwJ5DKhl+pTanFWl+EUpw1H7ukPO/H+MFpgA7jjshzw=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded h1:ZQlvR5RB4nfT+cOQee+WqmaDOgGtP2oDMhcVvR4L0yA=

--- a/monitor/kafka.go
+++ b/monitor/kafka.go
@@ -149,23 +149,12 @@ func SendQueueEventAsync(eventType string, data interface{}) {
 	randomID := uuid.New().String()
 	timestampMs := time.Now().UnixMilli()
 
-	// Add debug logging
-	if status, ok := data.(PipelineStatus); ok {
-		glog.Infof("Pipeline Status before sending to Kafka - StreamID: %v, Pipeline: %s",
-			status.StreamID, status.Pipeline)
-	}
-
 	event := GatewayEvent{
 		ID:        stringPtr(randomID),
 		Gateway:   stringPtr(kafkaProducer.gatewayAddress),
 		Type:      &eventType,
 		Timestamp: stringPtr(fmt.Sprint(timestampMs)),
 		Data:      data,
-	}
-
-	// Add debug logging for the full event
-	if eventBytes, err := json.Marshal(event); err == nil {
-		glog.Infof("Full event being sent to Kafka: %s", string(eventBytes))
 	}
 
 	select {

--- a/monitor/kafka.go
+++ b/monitor/kafka.go
@@ -35,6 +35,20 @@ type GatewayEvent struct {
 	Data      interface{} `json:"data"`
 }
 
+type PipelineStatus struct {
+	Pipeline        string   `json:"pipeline"`
+	StartTime       float64  `json:"start_time"`
+	InputFPS        float64  `json:"input_fps"`
+	OutputFPS       float64  `json:"output_fps"`
+	LastInputTime   float64  `json:"last_input_time"`
+	LastOutputTime  float64  `json:"last_output_time"`
+	RestartCount    int      `json:"restart_count"`
+	LastRestartTime float64  `json:"last_restart_time"`
+	LastRestartLogs []string `json:"last_restart_logs"`
+	LastError       *string  `json:"last_error"`
+	StreamID        *string  `json:"stream_id"`
+}
+
 var kafkaProducer *KafkaProducer
 
 func InitKafkaProducer(bootstrapServers, user, password, topic, gatewayAddress string) error {

--- a/monitor/kafka.go
+++ b/monitor/kafka.go
@@ -149,12 +149,23 @@ func SendQueueEventAsync(eventType string, data interface{}) {
 	randomID := uuid.New().String()
 	timestampMs := time.Now().UnixMilli()
 
+	// Add debug logging
+	if status, ok := data.(PipelineStatus); ok {
+		glog.Infof("Pipeline Status before sending to Kafka - StreamID: %v, Pipeline: %s",
+			status.StreamID, status.Pipeline)
+	}
+
 	event := GatewayEvent{
 		ID:        stringPtr(randomID),
 		Gateway:   stringPtr(kafkaProducer.gatewayAddress),
 		Type:      &eventType,
 		Timestamp: stringPtr(fmt.Sprint(timestampMs)),
 		Data:      data,
+	}
+
+	// Add debug logging for the full event
+	if eventBytes, err := json.Marshal(event); err == nil {
+		glog.Infof("Full event being sent to Kafka: %s", string(eventBytes))
 	}
 
 	select {

--- a/monitor/kafka.go
+++ b/monitor/kafka.go
@@ -36,17 +36,20 @@ type GatewayEvent struct {
 }
 
 type PipelineStatus struct {
-	Pipeline        string   `json:"pipeline"`
-	StartTime       float64  `json:"start_time"`
-	InputFPS        float64  `json:"input_fps"`
-	OutputFPS       float64  `json:"output_fps"`
-	LastInputTime   float64  `json:"last_input_time"`
-	LastOutputTime  float64  `json:"last_output_time"`
-	RestartCount    int      `json:"restart_count"`
-	LastRestartTime float64  `json:"last_restart_time"`
-	LastRestartLogs []string `json:"last_restart_logs"`
-	LastError       *string  `json:"last_error"`
-	StreamID        *string  `json:"stream_id"`
+	Pipeline             string      `json:"pipeline"`
+	StartTime            float64     `json:"start_time"`
+	LastParamsUpdateTime float64     `json:"last_params_update_time"`
+	LastParams           interface{} `json:"last_params"`
+	LastParamsHash       string      `json:"last_params_hash"`
+	InputFPS             float64     `json:"input_fps"`
+	OutputFPS            float64     `json:"output_fps"`
+	LastInputTime        float64     `json:"last_input_time"`
+	LastOutputTime       float64     `json:"last_output_time"`
+	RestartCount         int         `json:"restart_count"`
+	LastRestartTime      float64     `json:"last_restart_time"`
+	LastRestartLogs      []string    `json:"last_restart_logs"`
+	LastError            *string     `json:"last_error"`
+	StreamID             *string     `json:"stream_id"`
 }
 
 var kafkaProducer *KafkaProducer

--- a/monitor/pipeline_status.go
+++ b/monitor/pipeline_status.go
@@ -1,0 +1,30 @@
+package monitor
+
+import (
+	"sync"
+)
+
+var (
+	// pipelineStatusMap stores the latest pipeline status for each stream
+	pipelineStatusMap = make(map[string]PipelineStatus)
+	pipelineStatusMu  sync.RWMutex
+)
+
+func UpdatePipelineStatus(stream string, status PipelineStatus) {
+	pipelineStatusMu.Lock()
+	defer pipelineStatusMu.Unlock()
+	pipelineStatusMap[stream] = status
+}
+
+func GetPipelineStatus(stream string) (PipelineStatus, bool) {
+	pipelineStatusMu.RLock()
+	defer pipelineStatusMu.RUnlock()
+	status, exists := pipelineStatusMap[stream]
+	return status, exists
+}
+
+func DeletePipelineStatus(stream string) {
+	pipelineStatusMu.Lock()
+	defer pipelineStatusMu.Unlock()
+	delete(pipelineStatusMap, stream)
+}

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -234,6 +234,7 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 			pubCh.Close()
 			subCh.Close()
 			controlPubCh.Close()
+			eventsCh.Close()
 			cancel()
 			respondWithError(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -215,10 +215,13 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 		// Prepare request to worker
 		controlUrlOverwrite := overwriteHost(h.node.LiveAITrickleHostForRunner, controlUrl)
 		eventsUrlOverwrite := overwriteHost(h.node.LiveAITrickleHostForRunner, eventsUrl)
+		subscribeUrlOverwrite := overwriteHost(h.node.LiveAITrickleHostForRunner, pubUrl)
+		publishUrlOverwrite := overwriteHost(h.node.LiveAITrickleHostForRunner, subUrl)
+
 		workerReq := worker.LiveVideoToVideoParams{
 			ModelId:      req.ModelId,
-			PublishUrl:   overwriteHost(h.node.LiveAITrickleHostForRunner, subUrl),
-			SubscribeUrl: overwriteHost(h.node.LiveAITrickleHostForRunner, pubUrl),
+			PublishUrl:   publishUrlOverwrite,
+			SubscribeUrl: subscribeUrlOverwrite,
 			EventsUrl:    &eventsUrlOverwrite,
 			ControlUrl:   &controlUrlOverwrite,
 			Params:       req.Params,

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -211,7 +211,13 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 				continue
 			}
 
+			// Add debug logging
+			clog.Infof(ctx, "Raw event body: %s", string(body))
+			clog.Infof(ctx, "Unmarshaled status before StreamID assignment: %+v", status)
+
 			status.StreamID = &stream
+
+			clog.Infof(ctx, "Status after StreamID assignment: %+v", status)
 
 			// update the in-memory pipeline status
 			monitor.UpdatePipelineStatus(stream, status)

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -174,7 +174,6 @@ func startControlPublish(control *url.URL, params aiRequestParams) {
 
 func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestParams) {
 	subscriber := trickle.NewTrickleSubscriber(url.String())
-	ctx = clog.AddVal(ctx, "url", url.Redacted())
 
 	go func() {
 		for {

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -211,13 +211,7 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 				continue
 			}
 
-			// Add debug logging
-			clog.Infof(ctx, "Raw event body: %s", string(body))
-			clog.Infof(ctx, "Unmarshaled status before StreamID assignment: %+v", status)
-
 			status.StreamID = &stream
-
-			clog.Infof(ctx, "Status after StreamID assignment: %+v", status)
 
 			// update the in-memory pipeline status
 			monitor.UpdatePipelineStatus(stream, status)

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -184,6 +184,7 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 			segment, err := subscriber.Read()
 			if err != nil {
 				clog.Infof(ctx, "Error reading events subscription: %s", err)
+				monitor.DeletePipelineStatus(params.liveParams.stream)
 				return
 			}
 
@@ -217,6 +218,9 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 			}
 
 			status.StreamID = &stream
+
+			// update the in-memory pipeline status
+			monitor.UpdatePipelineStatus(stream, status)
 
 			monitor.SendQueueEventAsync(
 				"stream_status",

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -182,12 +182,16 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 		}
 		defer segment.Body.Close()
 		if _, err = io.Copy(os.Stdout, segment.Body); err != nil {
-			// TODO: produce kafka
+			body, err := io.ReadAll(segment.Body)
+			if err != nil {
+				clog.Infof(ctx, "Error reading events subscription body: %s", err)
+				return
+			}
+			clog.Infof(ctx, "Received from events trickle: %s", string(body))
 			monitor.SendQueueEventAsync(
-				"event", // todo event type
-				"error", // todo event payload
+				"stream_status",
+				string(body), // todo event payload
 			)
-			clog.Infof(ctx, "Error copying to stdout: %s", err)
 			return
 		}
 	}

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -211,12 +211,6 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 				continue
 			}
 
-			pipelineStatus, err := json.Marshal(status)
-			if err != nil {
-				clog.Infof(ctx, "Failed to re-serialize pipeline status: %s", err)
-				continue
-			}
-
 			status.StreamID = &stream
 
 			// update the in-memory pipeline status
@@ -224,7 +218,7 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 
 			monitor.SendQueueEventAsync(
 				"stream_status",
-				pipelineStatus,
+				status,
 			)
 		}
 	}()

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -184,7 +184,8 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 			segment, err := subscriber.Read()
 			if err != nil {
 				clog.Infof(ctx, "Error reading events subscription: %s", err)
-				monitor.DeletePipelineStatus(params.liveParams.stream)
+				// TODO
+				// monitor.DeletePipelineStatus(params.liveParams.stream)
 				return
 			}
 
@@ -213,8 +214,10 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 
 			status.StreamID = &stream
 
-			// update the in-memory pipeline status
-			monitor.UpdatePipelineStatus(stream, status)
+			// TODO: update the in-memory pipeline status
+			// monitor.UpdatePipelineStatus(stream, status)
+
+			clog.Infof(ctx, "Received event for stream=%s status=%+v", stream, status)
 
 			monitor.SendQueueEventAsync(
 				"stream_status",

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1049,9 +1049,16 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 			return nil, fmt.Errorf("invalid control URL: %w", err)
 		}
 		// TODO any errors from these funcs should we kill the input stream?
+
+		events, err := common.AppendHostname(*resp.JSON200.EventsUrl, host)
+		if err != nil {
+			return nil, fmt.Errorf("invalid events URL: %w", err)
+		}
+		clog.V(common.VERBOSE).Infof(ctx, "pub %s sub %s control %s events %s", pub, sub, control, events)
 		startTricklePublish(ctx, pub, params, sess)
 		startTrickleSubscribe(ctx, sub, params)
 		startControlPublish(control, params)
+		startEventsSubscribe(ctx, events, params)
 	}
 	return resp, nil
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
A trickle api for worker related events on the live-video-to-video pipeline, to monitor errors and stream_status

**Specific updates (required)**
- Added events trickle api on O, with the G subscribing and the W publishing G -> O <- W 
- The G receives the status of the stream including errors and real time FPS for both input and output 
- Added a publish on Kafka of these events

**How did you test each of these updates (required)**
dev env


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
