### PR TITLE
darwin-amd64 build issue - disable brew upgrade temporarily

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -196,7 +196,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew upgrade
+          # brew upgrade  # temporarily disabled because of the issues it's causing
           brew uninstall --ignore-dependencies --force pkg-config@0.29.2
           brew install coreutils pkgconf
 


### PR DESCRIPTION
Example failing build -> https://github.com/livepeer/go-livepeer/actions/runs/12200154233/job/34036964958