### PR TITLE
server/ai: Fix memory leak on trickle subscribe

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -87,8 +87,9 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 				clog.Infof(ctx, "Error reading trickle subscription: %s", err)
 				return
 			}
-			defer segment.Body.Close()
-			if _, err = io.Copy(w, segment.Body); err != nil {
+			_, err = io.Copy(w, segment.Body)
+			segment.Body.Close()
+			if err != nil {
 				clog.Infof(ctx, "Error copying to ffmpeg stdin: %s", err)
 				return
 			}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fix the closing of each segment body on the trickle subscribe function.

We used a defer which would keep the body open until the end of the whole stream.
This makes sure that doesn't happen.

**Specific updates (required)**
- Remove the defer and close segment body explicitly

**How did you test each of these updates (required)**
Run a stream and make sure it still works. Didn't check change in memory but it's a pretty simple scenario.

**Does this pull request close any open issues?**
N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
