### PR TITLE
ai/live: Add buffered segment read/writes for RTMP / publish

### DIFF
--- a/media/rw.go
+++ b/media/rw.go
@@ -1,0 +1,110 @@
+package media
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"sync"
+)
+
+type CloneableReader interface {
+	io.Reader
+	Clone() CloneableReader
+}
+
+type MediaWriter struct {
+	mu     *sync.Mutex
+	cond   *sync.Cond
+	buffer *bytes.Buffer
+	closed bool
+}
+
+type MediaReader struct {
+	source  *MediaWriter
+	readPos int
+}
+
+func NewMediaWriter() *MediaWriter {
+	mu := &sync.Mutex{}
+	return &MediaWriter{
+		buffer: new(bytes.Buffer),
+		cond:   sync.NewCond(mu),
+		mu:     mu,
+	}
+}
+
+func (mw *MediaWriter) Write(data []byte) (int, error) {
+	mw.mu.Lock()
+	defer mw.mu.Unlock()
+
+	// Write to buffer
+	n, err := mw.buffer.Write(data)
+
+	// Signal waiting readers
+	mw.cond.Broadcast()
+
+	return n, err
+}
+
+func (mw *MediaWriter) readData(startPos int) ([]byte, bool) {
+	mw.mu.Lock()
+	defer mw.mu.Unlock()
+	for {
+		totalLen := mw.buffer.Len()
+		if startPos < totalLen {
+			data := mw.buffer.Bytes()[startPos:totalLen]
+			return data, mw.closed
+		}
+		if startPos > totalLen {
+			slog.Info("Invalid start pos, invoking eof")
+			return nil, true
+		}
+		if mw.closed {
+			return nil, true
+		}
+		// Wait for new data
+		mw.cond.Wait()
+	}
+}
+
+func (mw *MediaWriter) Close() {
+	if mw == nil {
+		return // sometimes happens, weird
+	}
+	mw.mu.Lock()
+	defer mw.mu.Unlock()
+	if !mw.closed {
+		mw.closed = true
+		mw.cond.Broadcast()
+	}
+}
+
+func (mw *MediaWriter) MakeReader() CloneableReader {
+	return &MediaReader{
+		source: mw,
+	}
+}
+
+func (mr *MediaReader) Read(p []byte) (int, error) {
+	data, eof := mr.source.readData(mr.readPos)
+	toRead := len(p)
+	if len(data) < toRead {
+		toRead = len(data)
+	}
+
+	copy(p, data[:toRead])
+	mr.readPos += toRead
+
+	var err error = nil
+	if eof {
+		err = io.EOF
+	}
+
+	return toRead, err
+}
+
+func (mr *MediaReader) Clone() CloneableReader {
+	return &MediaReader{
+		source: mr.source,
+	}
+}

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -44,7 +44,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 		clog.Warningf(ctx, "No price info found from Orchestrator, Gateway will not send payments for the video processing")
 	}
 
-	params.liveParams.segmentReader.SwitchReader(func(reader io.Reader) {
+	params.liveParams.segmentReader.SwitchReader(func(reader media.CloneableReader) {
 		// check for end of stream
 		if _, eos := reader.(*media.EOSReader); eos {
 			if err := publisher.Close(); err != nil {
@@ -54,7 +54,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 			return
 		}
 		go func() {
-			r := reader
+			var r io.Reader = reader
 			if paymentProcessor != nil {
 				r = paymentProcessor.process(reader)
 			}


### PR DESCRIPTION
Replaces most of the old pipe logic in the RTMP segmenter which didn't really do anything except some logging.

This change allows for segment writes to an `io.Writer` (from RTMP) to proceed without being blocked by reads (from trickle publish). This avoids some potential back-pressure with MediaMTX in case publishes are slow in going out for whatever reason.

This will also allow us to 1) have concurrent segments in-flight, and 2) track _how many_ segments are in-flight as a proxy for "is this orchestrator slow" so we can switch orchestrators if necessary, since we should not have more than 1 segment in-flight (sometimes 2 for a very brief overlap). This logic will be added in a follow-up PR.

The reader interface here also has a `Clone` method (also non-blocking) which has the potential to simplify some of the reader handling around payments, but that is not changed right now.

Most of the code here was borrowed from the [trickle server](https://github.com/livepeer/go-livepeer/blob/master/trickle/trickle_server.go#L497-L561) but generalized into a proper reader/writer interface. Eventually we'll back-port this code into the trickle server but it's not needed there right now.