### PR TITLE
Fix race condition with stream existence check

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/livepeer/go-livepeer/clog"
+	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/media"
 	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-livepeer/trickle"
@@ -147,13 +148,10 @@ func startControlPublish(control *url.URL, params aiRequestParams) {
 		done <- true
 	}
 
-	p, ok := params.node.LivePipelines[stream]
-	if !ok {
-		slog.Info("error starting control publisher, stream not found", "stream", stream)
-		return
+	params.node.LivePipelines[stream] = &core.LivePipeline{
+		ControlPub:  controlPub,
+		StopControl: stop,
 	}
-	p.ControlPub = controlPub
-	p.StopControl = stop
 
 	// send a keepalive periodically to keep both ends of the connection alive
 	go func() {

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1048,7 +1048,9 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 		if err != nil {
 			return nil, fmt.Errorf("invalid control URL: %w", err)
 		}
-		// TODO any errors from these funcs should we kill the input stream?
+
+		params.node.LivePipelines[params.liveParams.stream] = &core.LivePipeline{}
+
 		startTricklePublish(ctx, pub, params, sess)
 		startTrickleSubscribe(ctx, sub, params)
 		startControlPublish(control, params)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1054,11 +1054,9 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 		}
 		clog.V(common.VERBOSE).Infof(ctx, "pub %s sub %s control %s events %s", pub, sub, control, events)
 
-		params.node.LivePipelines[params.liveParams.stream] = &core.LivePipeline{}
-
+		startControlPublish(control, params)
 		startTricklePublish(ctx, pub, params, sess)
 		startTrickleSubscribe(ctx, sub, params)
-		startControlPublish(control, params)
 		startEventsSubscribe(ctx, events, params)
 	}
 	return resp, nil


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

In `startTrickleSubscribe()` we check the stream exists in `LivePipelines` but this is only set up inside `startControlPublish()` so I'm moving the initialise step above both these functions so there's no longer a race condition.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
