### PR TITLE
ai/live: Set the default model on the request if needed

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1425,6 +1425,9 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 		modelID = defaultLiveVideoToVideoModelID
 		if v.ModelId != nil && *v.ModelId != "" {
 			modelID = *v.ModelId
+		} else {
+			// set default model
+			v.ModelId = &modelID
 		}
 		submitFn = func(ctx context.Context, params aiRequestParams, sess *AISession) (interface{}, error) {
 			return submitLiveVideoToVideo(ctx, params, sess, v)


### PR DESCRIPTION
Without it, the O does not have a model ID to initialize the job