### PR TITLE
ai/live: Fix early EOFs in media reader

### DIFF
--- a/media/rw.go
+++ b/media/rw.go
@@ -88,8 +88,11 @@ func (mw *MediaWriter) MakeReader() CloneableReader {
 func (mr *MediaReader) Read(p []byte) (int, error) {
 	data, eof := mr.source.readData(mr.readPos)
 	toRead := len(p)
-	if len(data) < toRead {
+	if len(data) <= toRead {
 		toRead = len(data)
+	} else {
+		// there is more data to read
+		eof = false
 	}
 
 	copy(p, data[:toRead])


### PR DESCRIPTION
Sometimes if the reader is slow to pull data (eg, during a retry) and the buffer grows larger than a read then closes, the reader may incorrectly signal EOF and return incomplete data. Don't do that.

The practical consequence here is we would sometime write truncated segments to the server, since the trickle publish is serviced by the segment reader which is being fixed here