### PR TITLE
Publish pipeline stream events on errors

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -503,6 +503,17 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 				return
 			}
 			clog.Errorf(ctx, "Live video pipeline stopping: %s", err)
+
+			capability := clog.GetVal(ctx, "capability")
+			monitor.SendQueueEventAsync("ai_stream_events", map[string]string{
+				"request_id":  requestID,
+				"capability":  capability,
+				"error":       err.Error(),
+				"stream_id":   streamID,
+				"pipeline_id": pipelineID,
+				"pipeline":    pipeline,
+			})
+
 			err = mediaMTXClient.KickInputConnection(ctx)
 			if err != nil {
 				clog.Errorf(ctx, "Failed to kick input connection: %s", err)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -506,9 +506,10 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 
 			capability := clog.GetVal(ctx, "capability")
 			monitor.SendQueueEventAsync("ai_stream_events", map[string]string{
+				"type":        "error",
 				"request_id":  requestID,
 				"capability":  capability,
-				"error":       err.Error(),
+				"message":     err.Error(),
 				"stream_id":   streamID,
 				"pipeline_id": pipelineID,
 				"pipeline":    pipeline,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Emit a pipeline stream event for any final errors that occur in the gateway. I'm doing this in a similar way to the events surfaced from the worker [here](https://github.com/livepeer/go-livepeer/blob/ee8c7097513323ef2c9e2a10e0aca07d3e75a5c9/server/ai_live_video.go#L260).

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
