### PR TITLE
server: Add orch info on AI events

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,7 @@
 #### General
 
 #### Broadcaster
+- [#3321](https://github.com/livepeer/go-livepeer/pull/3321) Add orchestrator info on live AI monitoring events
 
 #### Orchestrator
 

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -199,7 +199,7 @@ func startControlPublish(control *url.URL, params aiRequestParams) {
 	}()
 }
 
-func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestParams) {
+func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestParams, sess *AISession) {
 	subscriber := trickle.NewTrickleSubscriber(url.String())
 	stream := params.liveParams.stream
 	streamId := params.liveParams.streamID
@@ -233,6 +233,12 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 			event["stream_id"] = streamId
 			event["request_id"] = params.liveParams.requestID
 			event["pipeline_id"] = params.liveParams.pipelineID
+			if sess != nil {
+				event["orchestrator_info"] = map[string]interface{}{
+					"address": sess.Address(),
+					"url":     sess.Transcoder(),
+				}
+			}
 
 			clog.Infof(ctx, "Received event for stream=%s event=%+v", stream, event)
 

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1073,7 +1073,7 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 	startControlPublish(control, params)
 	startTricklePublish(ctx, pub, params, sess)
 	startTrickleSubscribe(ctx, sub, params)
-	startEventsSubscribe(ctx, events, params)
+	startEventsSubscribe(ctx, events, params, sess)
 	return resp, nil
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds orchestrator information to the events reported by the AI live pipeline.

**Specific updates (required)**
- Pass the session to the event subscriber on gateway
- Add the orch info fields on the events

**How did you test each of these updates (required)**
YOLO

**Does this pull request close any open issues?**
https://discord.com/channels/423160867534929930/1316106387666894888/1318230613391839294

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
