### PR TITLE
Fix context for logging

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -30,7 +30,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 	}
 
 	// Start payments which probes a segment every "paymentProcessInterval" and sends a payment
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	priceInfo := sess.OrchestratorInfo.PriceInfo
 	var paymentProcessor *LivePaymentProcessor
 	if priceInfo != nil && priceInfo.PricePerUnit != 0 {

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -481,7 +481,8 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 
 		requestID := string(core.RandomManifestID())
 		ctx = clog.AddVal(ctx, "request_id", requestID)
-		clog.Infof(ctx, "Received live video AI request for %s. pipelineParams=%v streamID=%s", streamName, pipelineParams, streamID)
+		ctx = clog.AddVal(ctx, "stream_id", streamID)
+		clog.Infof(ctx, "Received live video AI request for %s. pipelineParams=%v", streamName, pipelineParams)
 
 		// Kick off the RTMP pull and segmentation as soon as possible
 		ssr := media.NewSwitchableSegmentReader()


### PR DESCRIPTION
Use the `ctx` passed in so that we can keep the logging context for further log lines. Add stream_id to the logging context to allow us to search logs based on that rather than stream key.