### PR TITLE
ai/live: Emit events for trickle errors

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -27,6 +28,8 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 	publisher, err := trickle.NewTricklePublisher(url.String())
 	if err != nil {
 		clog.Infof(ctx, "error publishing trickle. err=%s", err)
+		params.liveParams.stopPipeline(fmt.Errorf("Error publishing trickle %w", err))
+		return
 	}
 
 	// Start payments which probes a segment every "paymentProcessInterval" and sends a payment
@@ -62,9 +65,9 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 		thisSeq, atMax := slowOrchChecker.BeginSegment()
 		if atMax {
 			clog.Infof(ctx, "Orchestrator is slow - terminating")
+			params.liveParams.stopPipeline(fmt.Errorf("slow orchestrator"))
 			cancel()
 			return
-			// TODO kill the rest of the processing, including ingest
 			// TODO switch orchestrators
 		}
 		go func(seq int) {
@@ -78,12 +81,14 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 			segment, err := publisher.Next()
 			if err != nil {
 				clog.Infof(ctx, "error getting next publish handle; dropping segment err=%v", err)
+				params.liveParams.sendErrorEvent(fmt.Errorf("Missing next handle %v", err))
 				return
 			}
 			for {
 				currentSeq := slowOrchChecker.GetCount()
 				if seq != currentSeq {
 					clog.Infof(ctx, "Next segment has already started; skipping this one seq=%d currentSeq=%d", seq, currentSeq)
+					params.liveParams.sendErrorEvent(fmt.Errorf("Next segment has started"))
 					return
 				}
 				n, err := segment.Write(r)
@@ -96,6 +101,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 				// otherwise drop
 				if n > 0 {
 					clog.Infof(ctx, "Error publishing segment; dropping remainder wrote=%d err=%v", n, err)
+					params.liveParams.sendErrorEvent(fmt.Errorf("Error publishing, wrote %d dropping %v", n, err))
 					return
 				}
 				clog.Infof(ctx, "Error publishing segment before writing; retrying err=%v", err)
@@ -147,6 +153,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 					return
 				}
 				retries++
+				params.liveParams.sendErrorEvent(err)
 				time.Sleep(retryPause)
 				continue
 			}
@@ -358,4 +365,13 @@ func (s *SlowOrchChecker) GetCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.segmentCount
+}
+
+func LiveErrorEventSender(ctx context.Context, event map[string]string) func(err error) {
+	return func(err error) {
+		ev := maps.Clone(event)
+		ev["capability"] = clog.GetVal(ctx, "capability")
+		ev["message"] = err.Error()
+		monitor.SendQueueEventAsync("ai_stream_events", ev)
+	}
 }

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -106,7 +106,12 @@ type liveRequestParams struct {
 	pipelineID    string
 
 	paymentProcessInterval time.Duration
-	stopPipeline           func(error)
+
+	// Stops the pipeline with an error. Also kicks the input
+	stopPipeline func(error)
+
+	// Report an error event
+	sendErrorEvent func(error)
 }
 
 // CalculateTextToImageLatencyScore computes the time taken per pixel for an text-to-image request.


### PR DESCRIPTION
Also clean up the stream properly on a couple of publish errors.