### PR TITLE
ai/live: Signal "stream exists but segment doesn't" with status 470

### DIFF
--- a/trickle/local_subscriber.go
+++ b/trickle/local_subscriber.go
@@ -39,7 +39,7 @@ func (c *TrickleLocalSubscriber) Read() (*TrickleData, error) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	segment, exists := stream.getForRead(c.seq)
+	segment, latestSeq, exists := stream.getForRead(c.seq)
 	if !exists {
 		return nil, errors.New("seq not found")
 	}
@@ -70,8 +70,9 @@ func (c *TrickleLocalSubscriber) Read() (*TrickleData, error) {
 	return &TrickleData{
 		Reader: r,
 		Metadata: map[string]string{
-			"Lp-Trickle-Seq": strconv.Itoa(segment.idx),
-			"Content-Type":   stream.mimeType,
+			"Lp-Trickle-Latest": strconv.Itoa(latestSeq),
+			"Lp-Trickle-Seq":    strconv.Itoa(segment.idx),
+			"Content-Type":      stream.mimeType,
 		}, // TODO take more metadata from http headers
 	}, nil
 }


### PR DESCRIPTION
Clients can use this information to jump to the leading edge if there are gaps in the sequence or they have fallen behind the window of available segments.

This is to distinguish from a 404 returned for "channel does not exist" which makes the client stop immediately.

Used in pytrickle - https://github.com/livepeer/ai-worker/pull/376. Golang subscriber implementation coming soon.