### PR TITLE
Increase the initial fee

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1023,7 +1023,7 @@ func submitAudioToText(ctx context.Context, params aiRequestParams, sess *AISess
 	return &res, nil
 }
 
-const initPixelsToPay = 45 * 30 * 1280 * 720 // 45 seconds, 30fps, 720p
+const initPixelsToPay = 30 * 30 * 3200 * 1800 // 30 seconds, 30fps, 1800p
 
 func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *AISession, req worker.GenLiveVideoToVideoJSONRequestBody) (any, error) {
 	// Live Video should not reuse the existing session balance, because it could lead to not sending the init


### PR DESCRIPTION
We've seen a few "insufficient balance" in staging caused by high-resolution streams, so better to increase the initial fee which acts as payment buffer