### PR TITLE
Disable payment check on the O's side

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -181,12 +181,16 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 					sessionID: mid,
 				})
 				if err != nil {
-					slog.Warn("Error accounting payment, stopping stream processing", "err", err)
-					pubCh.Close()
-					subCh.Close()
-					eventsCh.Close()
-					controlPubCh.Close()
-					cancel()
+					slog.Warn("Error accounting payment", "err", err)
+					// We encounter "insufficient balance" error from time to time on prod.
+					// This needs investigation, but since we're not using public Os,
+					// let's temporarily not stop steams even if not enough payment
+					//slog.Warn("Error accounting payment, stopping stream processing", "err", err)
+					//pubCh.Close()
+					//subCh.Close()
+					//eventsCh.Close()
+					//controlPubCh.Close()
+					//cancel()
 				}
 				return err
 			}

--- a/server/live_payment_processor.go
+++ b/server/live_payment_processor.go
@@ -94,7 +94,8 @@ func (p *LivePaymentProcessor) processOne(timestamp time.Time) {
 	err := p.processSegmentFunc(int64(pixelsSinceLastProcessed))
 	if err != nil {
 		slog.Error("Error processing payment", "err", err)
-		return
+		// Temporarily ignore failing payments, because they are not critical while we're using our own Os
+		// return
 	}
 
 	p.lastProcessedMu.Lock()


### PR DESCRIPTION
We encounter "insufficient balance" error from time to time on prod. This needs investigation, but since we're not using public Os, let's temporarily not stop steams even if not enough payment