### PR TITLE
ai/live: Handle more special cases in trickle.

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -89,6 +89,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 				if seq != currentSeq {
 					clog.Infof(ctx, "Next segment has already started; skipping this one seq=%d currentSeq=%d", seq, currentSeq)
 					params.liveParams.sendErrorEvent(fmt.Errorf("Next segment has started"))
+					segment.Close()
 					return
 				}
 				n, err := segment.Write(r)
@@ -107,6 +108,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 				if n > 0 {
 					clog.Infof(ctx, "Error publishing segment; dropping remainder wrote=%d err=%v", n, err)
 					params.liveParams.sendErrorEvent(fmt.Errorf("Error publishing, wrote %d dropping %v", n, err))
+					segment.Close()
 					return
 				}
 				clog.Infof(ctx, "Error publishing segment before writing; retrying err=%v", err)


### PR DESCRIPTION
[ai/live: More error handling for gotrickle clients.](https://github.com/livepeer/go-livepeer/commit/8b685298691518f350b72f09294a810320d2a1cc) 
- Handles additional stopping conditions in publisher such as 404
- Handles "stream exists but segment doesn't" condition in subscriber

These lead to 1) more timely shutdowns when necessary, and 2) faster recovery if a subscription falls behind


[ai/live: Close a segment if it will be dropped.](https://github.com/livepeer/go-livepeer/commit/d4743e7ee471ba66fdbb989943584d63db01bbca)

This is being polite to notify any subscribers that might be
waiting for the segment that the segment will not be around.

Not required if the segment is written normally, and subscribers
will still work fine without; it would just take longer to happen
when the segment drops out of the window of active segments.
