### PR TITLE
Temporary hack to fix comfyui prompt

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -468,7 +468,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 
 			if len(authResp.paramsMap) > 0 {
 				if _, ok := authResp.paramsMap["prompt"]; !ok && pipeline == "comfyui" {
-					pipelineParams["prompt"] = authResp.paramsMap
+					pipelineParams = map[string]interface{}{"prompt": authResp.paramsMap}
 				} else {
 					pipelineParams = authResp.paramsMap
 				}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -467,7 +467,11 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			}
 
 			if len(authResp.paramsMap) > 0 {
-				pipelineParams = authResp.paramsMap
+				if _, ok := authResp.paramsMap["prompt"]; !ok && pipeline == "comfyui" {
+					pipelineParams["prompt"] = authResp.paramsMap
+				} else {
+					pipelineParams = authResp.paramsMap
+				}
 			}
 
 			if authResp.StreamID != "" {


### PR DESCRIPTION
For stream manager streams the pipelines app is not currently wrapping the comfyui json in a 'prompt' field so we need to handle this for now
