### PR TITLE
Temporarily disable apple build requirement

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -256,7 +256,7 @@ jobs:
       id-token: "write"
     runs-on: ubuntu-20.04
     needs:
-      - macos-build
+#      - macos-build
       - linux-build
     steps:
       - name: Check out code


### PR DESCRIPTION
Disable this as macos builds are failing: https://github.com/livepeer/go-livepeer/actions/runs/12469650943/job/34803745848