### PR TITLE
ai/live: Error handling and retries for event subscriptions.

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -264,12 +264,35 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 
 	go func() {
 		defer StreamStatusStore.Clear(streamId)
+		const maxRetries = 5
+		const retryPause = 300 * time.Millisecond
+		retries := 0
 		for {
 			clog.Infof(ctx, "Reading from event subscription for URL: %s", url.String())
 			segment, err := subscriber.Read()
-			if err != nil {
-				clog.Infof(ctx, "Error reading events subscription: %s", err)
-				return
+			if err == nil {
+				retries = 0
+			} else {
+				// handle errors from event read
+				if errors.Is(err, trickle.EOS) || errors.Is(err, trickle.StreamNotFoundErr) {
+					clog.Infof(ctx, "Stopping subscription due to %s", err)
+					return
+				}
+				var seqErr *trickle.SequenceNonexistent
+				if errors.As(err, &seqErr) {
+					// stream exists but segment doesn't, so skip to leading edge
+					subscriber.SetSeq(seqErr.Latest)
+				}
+				if retries > maxRetries {
+					clog.Infof(ctx, "Too many errors reading events; stopping subscription err=%v", err)
+					err = fmt.Errorf("Error reading subscription: %w", err)
+					params.liveParams.stopPipeline(err)
+					return
+				}
+				clog.Infof(ctx, "Error reading events subscription: err=%v retry=%d", err, retries)
+				retries++
+				time.Sleep(retryPause)
+				continue
 			}
 
 			body, err := io.ReadAll(segment.Body)

--- a/trickle/trickle_server.go
+++ b/trickle/trickle_server.go
@@ -523,8 +523,9 @@ func (s *Stream) handleGet(w http.ResponseWriter, r *http.Request, idx int) {
 					if closed {
 						w.Header().Set("Lp-Trickle-Closed", "terminated")
 					} else {
-						// if the segment was dropped, its probably slow
-						// send over latest seq so the client can grab leading edge
+						// usually happens if a publisher cancels a pending segment right before closing the channel
+						// other times, the subscriber is slow and the segment falls out of the live window
+						// send over latest seq so slow clients can grab leading edge
 						w.Header().Set("Lp-Trickle-Latest", strconv.Itoa(latestSeq))
 						w.WriteHeader(470)
 					}


### PR DESCRIPTION
Added this after noticing a number of errors in the prod logs for the event subscriber along the lines of

```
Channel exists but sequence does not: requested 71 latest 71
``` 

This is harmless and usually happens at the very end of the stream when a publisher cancels a segment just before closing the entire channel, but I thought it would be best to make the overall behavior a little more robust.

Specifically:

* Exits immediately on EOS / StreamNotFound
* Retries 5 times max
* Retry counter resets to zero after each successful read
* 300ms sleep in between each retry
* Stops the pipeline if max retries hit