### PR TITLE
[ENG-2342] ai_first_segment_delay metric added

### DIFF
--- a/monitor/census.go
+++ b/monitor/census.go
@@ -205,6 +205,7 @@ type (
 		mAIResultUploadTime     *stats.Float64Measure
 		mAIResultSaveFailed     *stats.Int64Measure
 		mAICurrentLivePipelines *stats.Int64Measure
+		mAIFirstSegmentDelay    *stats.Int64Measure
 
 		lock        sync.Mutex
 		emergeTimes map[uint64]map[uint64]time.Time // nonce:seqNo
@@ -375,6 +376,7 @@ func InitCensus(nodeType NodeType, version string) {
 	census.mAIResultUploadTime = stats.Float64("ai_result_upload_time_seconds", "Upload (to Orchestrator) time", "sec")
 	census.mAIResultSaveFailed = stats.Int64("ai_result_upload_failed_total", "AIResultUploadFailed", "tot")
 	census.mAICurrentLivePipelines = stats.Int64("ai_current_live_pipelines", "Number of live AI pipelines currently running", "tot")
+	census.mAIFirstSegmentDelay = stats.Int64("ai_first_segment_delay", "Delay of the first live AI segment being processed", "ms")
 
 	glog.Infof("Compiler: %s Arch %s OS %s Go version %s", runtime.Compiler, runtime.GOARCH, runtime.GOOS, runtime.Version())
 	glog.Infof("Livepeer version: %s", version)
@@ -981,6 +983,13 @@ func InitCensus(nodeType NodeType, version string) {
 			Description: "Number of live AI pipelines currently running",
 			TagKeys:     append([]tag.Key{census.kOrchestratorURI, census.kPipeline, census.kModelName}, baseTags...),
 			Aggregation: view.LastValue(),
+		},
+		{
+			Name:        "ai_first_segment_delay",
+			Measure:     census.mAIFirstSegmentDelay,
+			Description: "Delay of the first live AI segment being processed",
+			TagKeys:     baseTags,
+			Aggregation: view.Distribution(0, .10, .20, .50, .100, .150, .200, .500, .1000, .5000, 10.000),
 		},
 	}
 
@@ -1985,6 +1994,10 @@ func AIResultDownloaded(ctx context.Context, pipeline string, model string, down
 		census.mAIResultDownloadTime.M(downloadDur.Seconds())); err != nil {
 		clog.Errorf(ctx, "Error recording metrics err=%q", err)
 	}
+}
+
+func AIFirstSegmentDelay(delay int64) {
+	stats.Record(census.ctx, census.mAIFirstSegmentDelay.M(delay))
 }
 
 // Convert wei to gwei

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -19,7 +19,9 @@ import (
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/media"
 	"github.com/livepeer/go-livepeer/monitor"
+	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/trickle"
+
 	"github.com/livepeer/lpms/ffmpeg"
 
 	"github.com/dustin/go-humanize"
@@ -123,7 +125,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 	clog.Infof(ctx, "trickle pub")
 }
 
-func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestParams, startTime time.Time) {
+func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestParams, startTime time.Time, orchInfo *net.OrchestratorInfo) {
 	// subscribe to the outputs and send them into LPMS
 	subscriber := trickle.NewTrickleSubscriber(url.String())
 	r, w, err := os.Pipe()
@@ -137,7 +139,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 	// read segments from trickle subscription
 	go func() {
 		var err error
-		firstSegment := false
+		firstSegment := true
 
 		defer w.Close()
 		retries := 0
@@ -185,7 +187,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 			}
 			if monitor.Enabled && firstSegment {
 				firstSegment = false
-				monitor.AIFirstSegmentDelay(time.Since(startTime).Milliseconds())
+				monitor.AIFirstSegmentDelay(time.Since(startTime).Milliseconds(), orchInfo)
 			}
 			clog.V(8).Infof(ctx, "trickle subscribe read data completed seq=%d bytes=%s", seq, humanize.Bytes(uint64(n)))
 		}

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -19,7 +19,6 @@ import (
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/media"
 	"github.com/livepeer/go-livepeer/monitor"
-	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-livepeer/trickle"
 
 	"github.com/livepeer/lpms/ffmpeg"
@@ -125,7 +124,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 	clog.Infof(ctx, "trickle pub")
 }
 
-func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestParams, startTime time.Time, orchInfo *net.OrchestratorInfo) {
+func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestParams, onFistSegment func()) {
 	// subscribe to the outputs and send them into LPMS
 	subscriber := trickle.NewTrickleSubscriber(url.String())
 	r, w, err := os.Pipe()
@@ -185,9 +184,9 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 				params.liveParams.stopPipeline(fmt.Errorf("trickle subscribe error copying: %w", err))
 				return
 			}
-			if monitor.Enabled && firstSegment {
+			if firstSegment {
 				firstSegment = false
-				monitor.AIFirstSegmentDelay(time.Since(startTime).Milliseconds(), orchInfo)
+				onFistSegment()
 			}
 			clog.V(8).Infof(ctx, "trickle subscribe read data completed seq=%d bytes=%s", seq, humanize.Bytes(uint64(n)))
 		}

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1078,7 +1078,11 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 
 	startControlPublish(control, params)
 	startTricklePublish(ctx, pub, params, sess)
-	startTrickleSubscribe(ctx, sub, params, startTime, sess.OrchestratorInfo)
+	startTrickleSubscribe(ctx, sub, params, func() {
+		if monitor.Enabled {
+			monitor.AIFirstSegmentDelay(time.Since(startTime).Milliseconds(), sess.OrchestratorInfo)
+		}
+	})
 	startEventsSubscribe(ctx, events, params, sess)
 	return resp, nil
 }

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1026,6 +1026,7 @@ func submitAudioToText(ctx context.Context, params aiRequestParams, sess *AISess
 const initPixelsToPay = 30 * 30 * 3200 * 1800 // 30 seconds, 30fps, 1800p
 
 func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *AISession, req worker.GenLiveVideoToVideoJSONRequestBody) (any, error) {
+	startTime := time.Now()
 	// Live Video should not reuse the existing session balance, because it could lead to not sending the init
 	// payment, which in turns may cause "Insufficient Balance" on the Orchestrator's side.
 	// It works differently than other AI Jobs, because Live Video is accounted by mid on the Orchestrator's side.
@@ -1077,7 +1078,7 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 
 	startControlPublish(control, params)
 	startTricklePublish(ctx, pub, params, sess)
-	startTrickleSubscribe(ctx, sub, params)
+	startTrickleSubscribe(ctx, sub, params, startTime)
 	startEventsSubscribe(ctx, events, params, sess)
 	return resp, nil
 }

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1078,7 +1078,7 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 
 	startControlPublish(control, params)
 	startTricklePublish(ctx, pub, params, sess)
-	startTrickleSubscribe(ctx, sub, params, startTime)
+	startTrickleSubscribe(ctx, sub, params, startTime, sess.OrchestratorInfo)
 	startEventsSubscribe(ctx, events, params, sess)
 	return resp, nil
 }


### PR DESCRIPTION
Adding `ai_first_segment_delay` prometheus metric.
It measures the time between AI Gateway receiving a GenLiveVideoToVideo request and successfully receiving the first processed segment from O.

