### PR TITLE
ai/live: Disable golang client keepalives.

### DIFF
--- a/trickle/trickle_publisher.go
+++ b/trickle/trickle_publisher.go
@@ -78,6 +78,7 @@ func (c *TricklePublisher) preconnect() (*pendingPost, error) {
 	go func() {
 		// Createa new client to prevent connection reuse
 		client := http.Client{Transport: &http.Transport{
+			DisableKeepAlives: true,
 			// ignore orch certs for now
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}}
@@ -126,6 +127,7 @@ func (c *TricklePublisher) Close() error {
 		return err
 	}
 	resp, err := (&http.Client{Transport: &http.Transport{
+		DisableKeepAlives: true,
 		// ignore orch certs for now
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}).Do(req)
@@ -260,6 +262,7 @@ func (p *pendingPost) Close() error {
 		return err
 	}
 	resp, err := (&http.Client{Transport: &http.Transport{
+		DisableKeepAlives: true,
 		// ignore orch certs for now
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}).Do(req)

--- a/trickle/trickle_subscriber.go
+++ b/trickle/trickle_subscriber.go
@@ -94,7 +94,8 @@ func (c *TrickleSubscriber) connect(ctx context.Context) (*http.Response, error)
 
 	// Execute the GET request
 	resp, err := (&http.Client{Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		DisableKeepAlives: true,
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true},
 	}}).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to complete GET for next segment: %w", err)


### PR DESCRIPTION
This prevents dangling connections after each trickle segment.