### PR TITLE
[ENG-2343] Stream attempts metric

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -95,6 +95,9 @@ func aiHttpHandle[I any](h *lphttp, decoderFunc func(*I, *http.Request) error) h
 
 func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if monitor.Enabled {
+			monitor.AILiveVideoAttempt()
+		}
 
 		remoteAddr := getRemoteAddr(r)
 		ctx := clog.AddVal(r.Context(), clog.ClientIP, remoteAddr)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1079,9 +1079,12 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 	startControlPublish(control, params)
 	startTricklePublish(ctx, pub, params, sess)
 	startTrickleSubscribe(ctx, sub, params, func() {
+		delayMs := time.Since(startTime).Milliseconds()
 		if monitor.Enabled {
-			monitor.AIFirstSegmentDelay(time.Since(startTime).Milliseconds(), sess.OrchestratorInfo)
+			monitor.AIFirstSegmentDelay(delayMs, sess.OrchestratorInfo)
 		}
+		clog.V(common.VERBOSE).Infof(ctx, "First Segment delay=%dms streamID=%s", delayMs, params.liveParams.streamID)
+
 	})
 	startEventsSubscribe(ctx, events, params, sess)
 	return resp, nil


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
A new prometheus counter added - `ai_live_attempt`. The metric counts the number of AI live stream start attempts. The metric is generated early, before any connection to Os.



We could additionally add a runOnConnect [mediamtx hook](https://github.com/bluenviron/mediamtx?tab=readme-ov-file#hooks) sth like:
```yaml
MTX_PATHDEFAULTS_RUNONCONNECT: curl "..../live/video-to-video/$MTX_PATH/connect"
```
receive it on the AI Gateway and log to prometheus from there