### PR TITLE
[ENG-2343] Stream attempts metric (AI Gateway side)

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -95,10 +95,6 @@ func aiHttpHandle[I any](h *lphttp, decoderFunc func(*I, *http.Request) error) h
 
 func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if monitor.Enabled {
-			monitor.AILiveVideoAttempt()
-		}
-
 		remoteAddr := getRemoteAddr(r)
 		ctx := clog.AddVal(r.Context(), clog.ClientIP, remoteAddr)
 		requestID := string(core.RandomManifestID())

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -439,6 +439,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 				return
 			}
 		}
+
 		mediaMTXClient := media.NewMediaMTXClient(remoteHost, ls.mediaMTXApiPassword, sourceID, sourceType)
 
 		if LiveAIAuthWebhookURL != nil {
@@ -487,6 +488,12 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		ctx = clog.AddVal(ctx, "request_id", requestID)
 		ctx = clog.AddVal(ctx, "stream_id", streamID)
 		clog.Infof(ctx, "Received live video AI request for %s. pipelineParams=%v", streamName, pipelineParams)
+
+		// Count `ai_live_attempts` after successful parameters validation
+		clog.V(common.VERBOSE).Infof(ctx, "AI Live video attempt")
+		if monitor.Enabled {
+			monitor.AILiveVideoAttempt()
+		}
 
 		// Kick off the RTMP pull and segmentation as soon as possible
 		ssr := media.NewSwitchableSegmentReader()


### PR DESCRIPTION
Moving `ai_live_attempts` on AI Gateway side where it should be in the first place