### PR TITLE
fix(ai): allow workers to run without the transcoder flag

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,9 +9,12 @@
 #### General
 
 #### Broadcaster
-- [#3321](https://github.com/livepeer/go-livepeer/pull/3321) Add orchestrator info on live AI monitoring events
+
+-   [#3321](https://github.com/livepeer/go-livepeer/pull/3321) Add orchestrator info on live AI monitoring events
 
 #### Orchestrator
+
+-   [#3355](https://github.com/livepeer/go-livepeer/pull/3355) Allow AI orchs to run without `transcoder` flag.
 
 #### Transcoder
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,7 +14,7 @@
 
 #### Orchestrator
 
--   [#3355](https://github.com/livepeer/go-livepeer/pull/3355) Allow AI orchs to run without `transcoder` flag.
+-   [#3355](https://github.com/livepeer/go-livepeer/pull/3355) Allow O/T AI orchs to run without `transcoder` flag.
 
 #### Transcoder
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1534,10 +1534,11 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", TranscoderCliPort)
 	} else if n.NodeType == core.AIWorkerNode {
 		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", AIWorkerCliPort)
-		// Need to have default Capabilities if not running transcoder.
-		if !*cfg.Transcoder {
-			aiCaps = append(aiCaps, core.DefaultCapabilities()...)
-		}
+	}
+
+	// Apply default capabilities if not running as a transcoder.
+	if !*cfg.Transcoder && (n.NodeType == core.AIWorkerNode || n.NodeType == core.OrchestratorNode) {
+		aiCaps = append(aiCaps, core.DefaultCapabilities()...)
 	}
 
 	n.Capabilities = core.NewCapabilities(append(transcoderCaps, aiCaps...), nil)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request ensures that default capabilities are added automatically. As a result, AI orchestrators no longer need to explicitly set the transcoder flag, simplifying the configuration and eliminating potential confusion.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Default capabilities are added when `aiWorker` flag is set and `-transcoder` is not set. 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I tested the updates by spinning up an on-chain orch and gateway and seeing that now AI orchs can receive jobs from Gateways if the forget the `transcoder` flag.

**Does this pull request close any open issues?**
<!-- Fixes # -->

No issue but this has been a source of confusion in the last month.s

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
