### PR TITLE
docs(ai): add missing aiServiceRegistry flag

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -33,9 +33,10 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "request": "launch",
       "mode": "debug",
       "program": "cmd/livepeer_cli",
+      "console": "integratedTerminal",
       "buildFlags": "-ldflags=-extldflags=-lm", // Fix missing symbol error.
       "args": [
-        // "--http=8935", // Uncomment for Orch CLI.
+        // "--http=7935", // Uncomment for Orch CLI.
         "--http=5935" // Uncomment for Gateway CLI.
       ]
     },
@@ -208,9 +209,10 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "request": "launch",
       "mode": "debug",
       "program": "cmd/livepeer_cli",
+      "console": "integratedTerminal",
       "buildFlags": "-ldflags=-extldflags=-lm", // Fix missing symbol error.
       "args": [
-        // "--http=8935", // Uncomment for Orch CLI.
+        // "--http=7935", // Uncomment for Orch CLI.
         "--http=5935" // Uncomment for Gateway CLI.
       ]
     },
@@ -271,6 +273,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "buildFlags": "-ldflags=-extldflags=-lm", // Fix missing symbol error.
       "args": [
         "-gateway",
+        "-datadir=${env:HOME}/.lpData2",
         "-orchAddr=0.0.0.0:8935",
         "-httpAddr=0.0.0.0:9935",
         "-v",
@@ -288,6 +291,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-orchestrator",
         "-aiWorker",
+        "-aiServiceRegistry",
         "-serviceAddr=0.0.0.0:8935",
         "-v=6",
         "-nvidia=all",
@@ -310,6 +314,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-orchestrator",
         "-orchSecret=orchSecret",
+        "-aiServiceRegistry",
         "-serviceAddr=0.0.0.0:8935",
         "-v=6",
         "-network=arbitrum-one-mainnet",
@@ -346,7 +351,8 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "buildFlags": "-tags=mainnet,experimental -ldflags=-extldflags=-lm", // Fix missing symbol error and enable mainnet.
       "args": [
         "-gateway",
-        "-transcodingOptions=${env:HOME}/.lpData/offchain/transcodingOptions.json",
+        "-aiServiceRegistry",
+        "-datadir=${env:HOME}/.lpData2",
         "-orchAddr=0.0.0.0:8935",
         "-httpAddr=0.0.0.0:9935",
         "-v",


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request ensures the `aiServiceRegistry` flag is added to the example JSON, which is required to connect to the AI network. It also improves the AI VSCode `launch.json` example by using a separate data directory for the gateway and removes the unused `transcodingOptions` flag, resulting in a cleaner and more organized configuration.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updated `doc/development.md`.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**
<!-- Fixes # -->

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- ~[ ] `make` runs successfully~
- ~[ ] All tests in `./test.sh` pass~
- ~[ ] README and other documentation updated~
- ~[ ] [Pending changelog](./CHANGELOG_PENDING.md) updated~
