### PR TITLE
fix: correct URL unmarshal error

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,8 @@
 
 #### CLI
 
+-   [#3364](https://github.com/livepeer/go-livepeer/pull/3364) fix orchestrator status json unmarshalling issue.
+
 #### General
 
 #### Broadcaster

--- a/common/types.go
+++ b/common/types.go
@@ -86,6 +86,7 @@ func FromRemoteInfos(infos []*net.OrchestratorInfo) OrchestratorDescriptors {
 	return ods
 }
 
+// MarshalJSON ensures that URL is marshaled as a string.
 func (u *OrchestratorLocalInfo) MarshalJSON() ([]byte, error) {
 	type Alias OrchestratorLocalInfo
 	return json.Marshal(&struct {
@@ -95,6 +96,26 @@ func (u *OrchestratorLocalInfo) MarshalJSON() ([]byte, error) {
 		URL:   u.URL.String(),
 		Alias: (*Alias)(u),
 	})
+}
+
+// UnmarshalJSON ensures that URL string is unmarshaled as a URL.
+func (o *OrchestratorLocalInfo) UnmarshalJSON(data []byte) error {
+	type Alias OrchestratorLocalInfo
+	aux := &struct {
+		URL string `json:"Url"`
+		*Alias
+	}{
+		Alias: (*Alias)(o),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	parsedURL, err := url.Parse(aux.URL)
+	if err != nil {
+		return err
+	}
+	o.URL = parsedURL
+	return nil
 }
 
 type ScorePred = func(float32) bool


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This pull request addresses an issue where the `URL` field in the `/status` response was not properly unmarshalled as a URL, resulting in a `cannot unmarshal string into Go struct field` error. The fix ensures correct unmarshalling for seamless handling of the response.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
-  Added custom unmarshall logic to the  `OrchestratorLocalInfo` type.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Test it on-chain.

**Does this pull request close any open issues?**
<!-- Fixes # -->

None.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
