### PR TITLE
Livepeer.Cloud SPE - add windows build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,9 @@ docker:
 docker_mtx:
 	docker buildx build -f docker/Dockerfile.mediamtx docker/
 
+docker-windows:
+	docker buildx build --build-arg='BUILD_TAGS=mainnet,experimental' -f docker/Dockerfile.windows .
+
 swagger:
 	swag init --generalInfo server/ai_mediaserver.go --outputTypes yaml --output . && mv swagger.yaml liveai.openapi.yaml
 

--- a/docker/Dockerfile.windows
+++ b/docker/Dockerfile.windows
@@ -1,0 +1,26 @@
+FROM ubuntu:22.04 as builder
+WORKDIR /root/
+ENV GOOS=windows
+ENV GOARCH=amd64
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH=$PATH:/usr/local/go/bin
+ENV GO111MODULE=on
+ENV CGO_ENABLED=1
+ENV CGO_LDFLAGS="-L/usr/x86_64-w64-mingw32/lib -lz"
+ENV PKG_CONFIG_PATH=~/compiled/lib/pkgconfig
+ENV BUILD_TAGS=mainnet,experimental
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y zip curl binutils build-essential pkg-config nasm clang git make autoconf automake patch libtool texinfo zip wget mingw-w64 protobuf-compiler-grpc golang-goprotobuf-dev yasm mockgen zlib1g-dev
+
+RUN wget https://zlib.net/fossils/zlib-1.2.11.tar.gz
+RUN tar -xvf zlib-1.2.11.tar.gz && \
+    cd zlib-1.2.11 && \
+    CC=x86_64-w64-mingw32-gcc ./configure --prefix=/usr/x86_64-w64-mingw32 --static && \
+    make && \
+    make install
+
+RUN wget https://go.dev/dl/go1.21.6.linux-amd64.tar.gz
+RUN rm -rf /usr/local/go && tar -C /usr/local -xzf go1.21.6.linux-amd64.tar.gz
+COPY . .
+RUN ./install_ffmpeg.sh
+RUN PKG_CONFIG_PATH=~/compiled/lib/pkgconfig make livepeer livepeer_bench livepeer_cli livepeer_router


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This provides a docker build for Windows binaries. This was in response to the Bounty published by @rickstaa 
https://github.com/livepeer/bounties/issues/62

**Specific updates (required)**
- added a Makefile entry for **docker-windows**
- added a Dockerfile.windows file

**How did you test each of these updates (required)**
The build ran successfully on Livepeer.Cloud's CI/CD environment. The windows binary was deployed to a windows server and properly started. (testing on the actual transcoding was NOT done)

**Does this pull request close any open issues?**
No


**Checklist:**
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
