### PR TITLE
Fix RTMP pull

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -205,6 +205,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 			}
 		}()
 		for {
+			clog.V(6).Infof(ctx, "Starting output rtmp")
 			if !params.inputStreamExists() {
 				clog.Errorf(ctx, "Stopping output rtmp stream, input stream does not exist.")
 				break


### PR DESCRIPTION
We don't want to retry if the connection no longer exists in mediamtx, this was causing duplicate segmentation processes if a client started a new ingest into the same stream key. The `StreamExists` function would return false but we would retry anyway and would successfully be able to pull rtmp for the stream key since there is a new connection pushing into the same stream key. The new connection would separately follow the usual process of starting up a new stream on the gateway (along with duplicate rtmp pull).

https://discord.com/channels/423160867534929930/1324549995440902144/1334569265663180883