### PR TITLE
refactor: fix aiRunnerImage warning typo

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1225,7 +1225,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 		// Backwards compatibility for deprecated flags.
 		if *cfg.AIRunnerImage != "" {
-			glog.Warning("-aiRunnerImage flag is deprecated and will be removed in a future release. Please use -aiWorkerImageOverrides instead")
+			glog.Warning("-aiRunnerImage flag is deprecated and will be removed in a future release. Please use -aiRunnerImageOverrides instead")
 			if imageOverrides.Default == "" {
 				imageOverrides.Default = *cfg.AIRunnerImage
 			}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This commit fixes a typo in the aiRunnerImage deprecation command.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates the `aiRunnerImage` deprecation warning in starter.go.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment and the tests you ran to see how your change affects other areas of the code, etc. -->

It should not need testing, but just out of practice, I started an orchestrator.

**Does this pull request close any open issues?**
<!-- Fixes # -->

It fixes [a bug](https://discord.com/channels/423160867534929930/750796877762527262/1335594769073836174) report in the orchestrator channel.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- ~[x] README and other documentation updated~
- ~[x] [Pending changelog](./CHANGELOG_PENDING.md) updated~
