### PR TITLE
Add gateway errors to the status API response

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -523,7 +523,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			ls.cleanupLive(streamName)
 		}()
 
-		sendErrorEvent := LiveErrorEventSender(ctx, map[string]string{
+		sendErrorEvent := LiveErrorEventSender(ctx, streamID, map[string]string{
 			"type":        "error",
 			"request_id":  requestID,
 			"stream_id":   streamID,
@@ -648,6 +648,12 @@ func (ls *LivepeerServer) GetLiveVideoToVideoStatus() http.Handler {
 		if !exists {
 			http.Error(w, "Stream not found", http.StatusNotFound)
 			return
+		}
+		gatewayStatus, exists := GatewayStatus.Get(streamId)
+		if exists {
+			for k, v := range gatewayStatus {
+				status["gateway_"+k] = v
+			}
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/server/ai_pipeline_status.go
+++ b/server/ai_pipeline_status.go
@@ -10,6 +10,7 @@ type streamStatusStore struct {
 }
 
 var StreamStatusStore = streamStatusStore{store: make(map[string]map[string]interface{})}
+var GatewayStatus = streamStatusStore{store: make(map[string]map[string]interface{})}
 
 // StoreStreamStatus updates the status for a stream
 func (s *streamStatusStore) Store(streamID string, status map[string]interface{}) {


### PR DESCRIPTION
This is to enable us to expose gateway errors to the UI via the status API. Fairly crude but might be ok for now, sounds like we probably want to subscribe the UI to the `ai_stream_events` anyway as Evan was saying.