### PR TITLE
ai/live: Use events as a heartbeat.

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -287,10 +287,25 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 	stream := params.liveParams.stream
 	streamId := params.liveParams.streamID
 
+	// vars to check events periodically to ensure liveness
+	var (
+		eventCheckInterval = 10 * time.Second
+		maxEventGap        = 30 * time.Second
+		eventTicker        = time.NewTicker(eventCheckInterval)
+		eventsDone         = make(chan bool)
+		// remaining vars in this block must be protected by mutex
+		lastEventMu = &sync.Mutex{}
+		lastEvent   = time.Now()
+	)
+
 	clog.Infof(ctx, "Starting event subscription for URL: %s", url.String())
 
 	go func() {
 		defer time.AfterFunc(clearStreamDelay, func() { StreamStatusStore.Clear(streamId) })
+		defer func() {
+			eventTicker.Stop()
+			eventsDone <- true
+		}()
 		const maxRetries = 5
 		const retryPause = 300 * time.Millisecond
 		retries := 0
@@ -348,6 +363,11 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 
 			clog.V(8).Infof(ctx, "Received event for stream=%s event=%+v", stream, event)
 
+			// record the event time
+			lastEventMu.Lock()
+			lastEvent = time.Now()
+			lastEventMu.Unlock()
+
 			eventType, ok := event["type"].(string)
 			if !ok {
 				eventType = "unknown"
@@ -382,6 +402,26 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 			}
 
 			monitor.SendQueueEventAsync(queueEventType, event)
+		}
+	}()
+
+	// Use events as a heartbeat of sorts:
+	// if no events arrive for too long, abort the job
+	go func() {
+		for {
+			select {
+			case <-eventTicker.C:
+				lastEventMu.Lock()
+				eventTime := lastEvent
+				lastEventMu.Unlock()
+				if time.Now().Sub(eventTime) > maxEventGap {
+					params.liveParams.stopPipeline(errors.New("timeout waiting for events"))
+					eventTicker.Stop()
+					return
+				}
+			case <-eventsDone:
+				return
+			}
 		}
 	}()
 }


### PR DESCRIPTION
If there are no incoming events for a period of time, terminate the stream. The timeout is currently set to 30 seconds, but that can be tuned if 30 seconds turns out to be too aggressive.

This allows the gateway to more quickly handle scenarios where the runner completely explodes without a tear-down or stops responding entirely. Otherwise the gateway would have to wait for the orchestrator to expire idle trickle channels after roughly 5 minutes before starting its own tear-down process.

Eventually this should be used as a signal to swap orchestrators instead of terminating the incoming stream.