### PR TITLE
Send requestID and streamID through to the runner for logging

### DIFF
--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -604,14 +604,19 @@ func (w *Worker) TextToSpeech(ctx context.Context, req GenTextToSpeechJSONReques
 	return resp.JSON200, nil
 }
 
-func (w *Worker) LiveVideoToVideo(ctx context.Context, req GenLiveVideoToVideoJSONRequestBody) (*LiveVideoToVideoResponse, error) {
+func (w *Worker) LiveVideoToVideo(ctx context.Context, requestID, streamID string, req GenLiveVideoToVideoJSONRequestBody) (*LiveVideoToVideoResponse, error) {
 	// Live video containers keep running after the initial request, so we use a background context to borrow the container.
 	c, err := w.borrowContainer(context.Background(), "live-video-to-video", *req.ModelId)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.Client.GenLiveVideoToVideoWithResponse(ctx, req)
+	setHeaders := func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("requestID", requestID)
+		req.Header.Set("streamID", streamID)
+		return nil
+	}
+	resp, err := c.Client.GenLiveVideoToVideoWithResponse(ctx, req, setHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/core/ai.go
+++ b/core/ai.go
@@ -27,7 +27,7 @@ type AI interface {
 	SegmentAnything2(context.Context, worker.GenSegmentAnything2MultipartRequestBody) (*worker.MasksResponse, error)
 	ImageToText(context.Context, worker.GenImageToTextMultipartRequestBody) (*worker.ImageToTextResponse, error)
 	TextToSpeech(context.Context, worker.GenTextToSpeechJSONRequestBody) (*worker.AudioResponse, error)
-	LiveVideoToVideo(context.Context, worker.GenLiveVideoToVideoJSONRequestBody) (*worker.LiveVideoToVideoResponse, error)
+	LiveVideoToVideo(context.Context, string, string, worker.GenLiveVideoToVideoJSONRequestBody) (*worker.LiveVideoToVideoResponse, error)
 	Warm(context.Context, string, string, worker.RunnerEndpoint, worker.OptimizationFlags) error
 	Stop(context.Context) error
 	HasCapacity(string, string) bool

--- a/core/ai_orchestrator.go
+++ b/core/ai_orchestrator.go
@@ -551,10 +551,10 @@ func (orch *orchestrator) TextToImage(ctx context.Context, requestID string, req
 	return res.Results, nil
 }
 
-func (orch *orchestrator) LiveVideoToVideo(ctx context.Context, requestID string, req worker.GenLiveVideoToVideoJSONRequestBody) (interface{}, error) {
+func (orch *orchestrator) LiveVideoToVideo(ctx context.Context, requestID, streamID string, req worker.GenLiveVideoToVideoJSONRequestBody) (interface{}, error) {
 	// local AIWorker processes job if combined orchestrator/ai worker
 	if orch.node.AIWorker != nil {
-		workerResp, err := orch.node.LiveVideoToVideo(ctx, req)
+		workerResp, err := orch.node.LiveVideoToVideo(ctx, requestID, streamID, req)
 		if err == nil {
 			return orch.node.saveLocalAIWorkerResults(ctx, *workerResp, requestID, "application/json")
 		} else {
@@ -1060,8 +1060,8 @@ func (n *LivepeerNode) TextToSpeech(ctx context.Context, req worker.GenTextToSpe
 	return n.AIWorker.TextToSpeech(ctx, req)
 }
 
-func (n *LivepeerNode) LiveVideoToVideo(ctx context.Context, req worker.GenLiveVideoToVideoJSONRequestBody) (*worker.LiveVideoToVideoResponse, error) {
-	return n.AIWorker.LiveVideoToVideo(ctx, req)
+func (n *LivepeerNode) LiveVideoToVideo(ctx context.Context, requestID, streamID string, req worker.GenLiveVideoToVideoJSONRequestBody) (*worker.LiveVideoToVideoResponse, error) {
+	return n.AIWorker.LiveVideoToVideo(ctx, requestID, streamID, req)
 }
 
 // transcodeFrames converts a series of image URLs into a video segment for the image-to-video pipeline.

--- a/core/ai_test.go
+++ b/core/ai_test.go
@@ -666,7 +666,7 @@ func (a *stubAIWorker) TextToSpeech(ctx context.Context, req worker.GenTextToSpe
 	return &worker.AudioResponse{Audio: worker.MediaURL{Url: "http://example.com/audio.wav"}}, nil
 }
 
-func (a *stubAIWorker) LiveVideoToVideo(ctx context.Context, req worker.GenLiveVideoToVideoJSONRequestBody) (*worker.LiveVideoToVideoResponse, error) {
+func (a *stubAIWorker) LiveVideoToVideo(ctx context.Context, requestID, streamID string, req worker.GenLiveVideoToVideoJSONRequestBody) (*worker.LiveVideoToVideoResponse, error) {
 	return &worker.LiveVideoToVideoResponse{}, nil
 }
 

--- a/server/ai_worker_test.go
+++ b/server/ai_worker_test.go
@@ -609,7 +609,7 @@ func (a *stubAIWorker) TextToSpeech(ctx context.Context, req worker.GenTextToSpe
 	}
 }
 
-func (a *stubAIWorker) LiveVideoToVideo(ctx context.Context, req worker.GenLiveVideoToVideoJSONRequestBody) (*worker.LiveVideoToVideoResponse, error) {
+func (a *stubAIWorker) LiveVideoToVideo(ctx context.Context, requestID, streamID string, req worker.GenLiveVideoToVideoJSONRequestBody) (*worker.LiveVideoToVideoResponse, error) {
 	a.Called++
 	if a.Err != nil {
 		return nil, a.Err

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -78,7 +78,7 @@ type Orchestrator interface {
 	SegmentAnything2(ctx context.Context, requestID string, req worker.GenSegmentAnything2MultipartRequestBody) (interface{}, error)
 	ImageToText(ctx context.Context, requestID string, req worker.GenImageToTextMultipartRequestBody) (interface{}, error)
 	TextToSpeech(ctx context.Context, requestID string, req worker.GenTextToSpeechJSONRequestBody) (interface{}, error)
-	LiveVideoToVideo(ctx context.Context, requestID string, req worker.GenLiveVideoToVideoJSONRequestBody) (interface{}, error)
+	LiveVideoToVideo(ctx context.Context, requestID, streamID string, req worker.GenLiveVideoToVideoJSONRequestBody) (interface{}, error)
 }
 
 // Balance describes methods for a session's balance maintenance

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -223,7 +223,7 @@ func (r *stubOrchestrator) TextToSpeech(ctx context.Context, requestID string, r
 	return nil, nil
 }
 
-func (r *stubOrchestrator) LiveVideoToVideo(ctx context.Context, requestID string, req worker.GenLiveVideoToVideoJSONRequestBody) (interface{}, error) {
+func (r *stubOrchestrator) LiveVideoToVideo(ctx context.Context, requestID, streamID string, req worker.GenLiveVideoToVideoJSONRequestBody) (interface{}, error) {
 	return nil, nil
 }
 
@@ -1429,7 +1429,7 @@ func (r *mockOrchestrator) ImageToText(ctx context.Context, requestID string, re
 func (r *mockOrchestrator) TextToSpeech(ctx context.Context, requestID string, req worker.GenTextToSpeechJSONRequestBody) (interface{}, error) {
 	return nil, nil
 }
-func (r *mockOrchestrator) LiveVideoToVideo(ctx context.Context, requestID string, req worker.GenLiveVideoToVideoJSONRequestBody) (interface{}, error) {
+func (r *mockOrchestrator) LiveVideoToVideo(ctx context.Context, requestID, streamID string, req worker.GenLiveVideoToVideoJSONRequestBody) (interface{}, error) {
 	return nil, nil
 }
 func (r *mockOrchestrator) CheckAICapacity(pipeline, modelID string) bool {


### PR DESCRIPTION
Sending the requestID and streamID through from the gateway to orchestrator and from O to the runner to allow us to do contextual logging there and make debugging much easier.
Related runner PR: https://github.com/livepeer/ai-runner/pull/413