### PR TITLE
Switch kafka producer to use gatewayHost config

### DIFF
--- a/cmd/livepeer/starter/kafka.go
+++ b/cmd/livepeer/starter/kafka.go
@@ -11,9 +11,9 @@ func startKafkaProducer(cfg LivepeerConfig) error {
 		return nil
 	}
 
-	var broadcasterEthAddress = ""
-	if cfg.EthAcctAddr != nil {
-		broadcasterEthAddress = *cfg.EthAcctAddr
+	var gatewayHost = ""
+	if cfg.GatewayHost != nil {
+		gatewayHost = *cfg.GatewayHost
 	}
 
 	return lpmon.InitKafkaProducer(
@@ -21,6 +21,6 @@ func startKafkaProducer(cfg LivepeerConfig) error {
 		*cfg.KafkaUsername,
 		*cfg.KafkaPassword,
 		*cfg.KafkaGatewayTopic,
-		broadcasterEthAddress,
+		gatewayHost,
 	)
 }


### PR DESCRIPTION
The host field was empty in our network events, since `EthAcctAddr` is not set, switch to gatewayHost that we're using elsewhere too.