### PR TITLE
Restart warm container when it does not exist

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -163,7 +163,9 @@ func (m *DockerManager) Warm(ctx context.Context, pipeline string, modelID strin
 	go func() {
 		for {
 			// Watch with a background context since we're not borrowing the container.
-			m.watchContainer(rc, context.Background())
+			if rc != nil {
+				m.watchContainer(rc, context.Background())
+			}
 
 			m.mu.Lock()
 			rc, err = m.createContainer(ctx, pipeline, modelID, true, optimizationFlags)


### PR DESCRIPTION
In case of the warm container, go-livepeer should monitor if the container is running and recreate it if it's stopped.

The issue happened during our deployments, when we update runner image, we need to stop it and then go-livepeer should start it again.