### PR TITLE
Enable parallel MediaMTX playback

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -131,8 +131,16 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 		params.liveParams.stopPipeline(fmt.Errorf("error getting pipe for trickle-ffmpeg. url=%s %w", url, err))
 		return
 	}
+	rMediaMTX, wMediaMTX, err := os.Pipe()
+	if err != nil {
+		params.liveParams.stopPipeline(fmt.Errorf("error getting pipe for MediaMTX trickle-ffmpeg. url=%s %w", url, err))
+		return
+	}
 	ctx = clog.AddVal(ctx, "url", url.Redacted())
 	ctx = clog.AddVal(ctx, "outputRTMPURL", params.liveParams.outputRTMPURL)
+	ctx = clog.AddVal(ctx, "mediaMTXOutputRTMPURL", params.liveParams.mediaMTXOutputRTMPURL)
+
+	multiWriter := io.MultiWriter(w, wMediaMTX)
 
 	// read segments from trickle subscription
 	go func() {
@@ -140,6 +148,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 		firstSegment := true
 
 		defer w.Close()
+		defer wMediaMTX.Close()
 		retries := 0
 		// we're trying to keep (retryPause x maxRetries) duration to fall within one output GOP length
 		const retryPause = 300 * time.Millisecond
@@ -178,7 +187,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 			seq := trickle.GetSeq(segment)
 			clog.V(8).Infof(ctx, "trickle subscribe read data received seq=%d", seq)
 
-			n, err := copySegment(segment, w)
+			n, err := copySegment(segment, multiWriter)
 			if err != nil {
 				params.liveParams.stopPipeline(fmt.Errorf("trickle subscribe error copying: %w", err))
 				return
@@ -191,6 +200,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 		}
 	}()
 
+	// Studio Output ffmpeg process
 	go func() {
 		defer func() {
 			r.Close()
@@ -225,6 +235,45 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 				clog.Infof(ctx, "Process output: %s", output)
 				return
 			}
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
+	// MediaMTX Output ffmpeg process
+	go func() {
+		defer func() {
+			rMediaMTX.Close()
+			if rec := recover(); rec != nil {
+				// panicked, so shut down the stream and handle it
+				err, ok := rec.(error)
+				if !ok {
+					err = errors.New("unknown error")
+				}
+				clog.Errorf(ctx, "LPMS panic err=%v", err)
+				params.liveParams.stopPipeline(fmt.Errorf("LPMS panic %w", err))
+			}
+		}()
+		for {
+			clog.V(6).Infof(ctx, "Starting MediaMTX output rtmp")
+			if !params.inputStreamExists() {
+				clog.Errorf(ctx, "Stopping MediaMTX output rtmp stream, input stream does not exist.")
+				break
+			}
+
+			cmd := exec.Command("ffmpeg",
+				"-i", "pipe:0",
+				"-c:a", "copy",
+				"-c:v", "copy",
+				"-f", "flv",
+				params.liveParams.mediaMTXOutputRTMPURL,
+			)
+			cmd.Stdin = rMediaMTX
+			output, err := cmd.CombinedOutput()
+			if err != nil {
+				clog.Errorf(ctx, "Error sending MediaMTX RTMP out: %v", err)
+				// return
+			}
+			clog.Infof(ctx, "Process output: %s", output)
 			time.Sleep(5 * time.Second)
 		}
 	}()

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -428,10 +428,12 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		}
 		// If auth webhook is set and returns an output URL, this will be replaced
 		outputURL := qp.Get("rtmpOutput")
+
+		mediaMTXOutputURL := fmt.Sprintf("rtmp://%s/aiWebrtc/%s-out", remoteHost, streamName)
 		if outputURL == "" {
 			// re-publish to ourselves for now
 			// Not sure if we want this to be permanent
-			outputURL = fmt.Sprintf("rtmp://%s/%s-out", remoteHost, streamName)
+			outputURL = mediaMTXOutputURL
 		}
 
 		// convention to avoid re-subscribing to our own streams
@@ -556,6 +558,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			liveParams: liveRequestParams{
 				segmentReader:          ssr,
 				outputRTMPURL:          outputURL,
+				mediaMTXOutputRTMPURL:  mediaMTXOutputURL,
 				stream:                 streamName,
 				paymentProcessInterval: ls.livePaymentInterval,
 				requestID:              requestID,

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -97,13 +97,13 @@ func (a aiRequestParams) inputStreamExists() bool {
 
 // For live video pipelines
 type liveRequestParams struct {
-	segmentReader *media.SwitchableSegmentReader
-	outputRTMPURL string
+	segmentReader         *media.SwitchableSegmentReader
+	outputRTMPURL         string
 	mediaMTXOutputRTMPURL string
-	stream        string
-	requestID     string
-	streamID      string
-	pipelineID    string
+	stream                string
+	requestID             string
+	streamID              string
+	pipelineID            string
 
 	paymentProcessInterval time.Duration
 

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -99,6 +99,7 @@ func (a aiRequestParams) inputStreamExists() bool {
 type liveRequestParams struct {
 	segmentReader *media.SwitchableSegmentReader
 	outputRTMPURL string
+	mediaMTXOutputRTMPURL string
 	stream        string
 	requestID     string
 	streamID      string

--- a/server/auth.go
+++ b/server/auth.go
@@ -109,8 +109,6 @@ type AIAuthRequest struct {
 
 	// Gateway host
 	GatewayHost string `json:"gateway_host"`
-
-	// TODO not sure what params we need yet
 }
 
 // Contains the configuration parameters for this AI job


### PR DESCRIPTION
We want to try direct playback from MediaMTX to see how much startup time is saved from avoiding studio stream startup.