### PR TITLE
Swap Orchestrator if no first segment recevied before timeout

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -165,6 +165,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.AIVerboseLogs = flag.Bool("aiVerboseLogs", *cfg.AIVerboseLogs, "Set to true to enable verbose logs for the AI runner containers created by the worker")
 	cfg.AIRunnerImageOverrides = flag.String("aiRunnerImageOverrides", *cfg.AIRunnerImageOverrides, `Specify overrides for the Docker images used by the AI runner. Example: '{"default": "livepeer/ai-runner:v1.0", "batch": {"text-to-speech": "livepeer/ai-runner:text-to-speech-v1.0"}, "live": {"another-pipeline": "livepeer/ai-runner:another-pipeline-v1.0"}}'`)
 	cfg.AIProcessingRetryTimeout = flag.Duration("aiProcessingRetryTimeout", *cfg.AIProcessingRetryTimeout, "Timeout for retrying to initiate AI processing request")
+	cfg.AIStartupOrchSwapTimeout = flag.Duration("aiStartupOrchSwapTimeout", *cfg.AIStartupOrchSwapTimeout, "Timeout to wait for Orchestrator return first output segment")
 	cfg.AIRunnerContainersPerGPU = flag.Int("aiRunnerContainersPerGPU", *cfg.AIRunnerContainersPerGPU, "Number of AI runner containers to run per GPU; default to 1")
 
 	// Live AI:

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -167,6 +167,7 @@ type LivepeerConfig struct {
 	AIRunnerImageOverrides     *string
 	AIVerboseLogs              *bool
 	AIProcessingRetryTimeout   *time.Duration
+	AIStartupOrchSwapTimeout   *time.Duration
 	AIRunnerContainersPerGPU   *int
 	KafkaBootstrapServers      *string
 	KafkaUsername              *string
@@ -220,6 +221,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultAIRunnerImage := "livepeer/ai-runner:latest"
 	defaultAIVerboseLogs := false
 	defaultAIProcessingRetryTimeout := 2 * time.Second
+	defaultAIStartupOrchSwapTimeout := 15 * time.Second
 	defaultAIRunnerContainersPerGPU := 1
 	defaultAIRunnerImageOverrides := ""
 	defaultLiveAIAuthWebhookURL := ""
@@ -333,6 +335,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		AIRunnerImage:            &defaultAIRunnerImage,
 		AIVerboseLogs:            &defaultAIVerboseLogs,
 		AIProcessingRetryTimeout: &defaultAIProcessingRetryTimeout,
+		AIStartupOrchSwapTimeout: &defaultAIStartupOrchSwapTimeout,
 		AIRunnerContainersPerGPU: &defaultAIRunnerContainersPerGPU,
 		AIRunnerImageOverrides:   &defaultAIRunnerImageOverrides,
 		LiveAIAuthWebhookURL:     &defaultLiveAIAuthWebhookURL,
@@ -523,6 +526,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		glog.Errorf("Error creating livepeer node: %v", err)
 	}
 	n.AIProcesssingRetryTimeout = *cfg.AIProcessingRetryTimeout
+	n.AIStartupOrchSwapTimeout = *cfg.AIStartupOrchSwapTimeout
 
 	if *cfg.OrchSecret != "" {
 		n.OrchSecret, _ = common.ReadFromFile(*cfg.OrchSecret)

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -122,6 +122,7 @@ type LivepeerNode struct {
 	AIWorker                  AI
 	AIWorkerManager           *RemoteAIWorkerManager
 	AIProcesssingRetryTimeout time.Duration
+	AIStartupOrchSwapTimeout  time.Duration
 
 	// Transcoder public fields
 	SegmentChans       map[ManifestID]SegmentChan

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -294,7 +294,7 @@ func ffmpegOutput(ctx context.Context, outputUrl string, r io.ReadCloser, params
 			break
 		}
 
-		cmd := exec.Command("ffmpeg",
+		cmd := exec.CommandContext(ctx, "ffmpeg",
 			"-analyzeduration", "2500000", // 2.5 seconds
 			"-i", "pipe:0",
 			"-c:a", "copy",

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -591,7 +591,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 				streamID:               streamID,
 				pipelineID:             pipelineID,
 				stopPipeline:           stopPipeline,
-				initCompleted:          make(chan struct{}, 1),
+				initCompleted:          make(chan struct{}),
 				sendErrorEvent:         sendErrorEvent,
 			},
 		}
@@ -884,7 +884,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 					streamID:               streamID,
 					pipelineID:             pipelineID,
 					stopPipeline:           stopPipeline,
-					initCompleted:          make(chan struct{}, 1),
+					initCompleted:          make(chan struct{}),
 					sendErrorEvent:         sendErrorEvent,
 					orchestrator:           orchestrator,
 				},

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -591,6 +591,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 				streamID:               streamID,
 				pipelineID:             pipelineID,
 				stopPipeline:           stopPipeline,
+				initCompleted:          make(chan struct{}, 1),
 				sendErrorEvent:         sendErrorEvent,
 			},
 		}
@@ -883,6 +884,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 					streamID:               streamID,
 					pipelineID:             pipelineID,
 					stopPipeline:           stopPipeline,
+					initCompleted:          make(chan struct{}, 1),
 					sendErrorEvent:         sendErrorEvent,
 					orchestrator:           orchestrator,
 				},

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1088,7 +1088,7 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 		return nil, fmt.Errorf("invalid events URL: %w", err)
 	}
 	clog.V(common.VERBOSE).Infof(ctx, "pub %s sub %s control %s events %s", pub, sub, control, events)
-	firstSegmentReceived := make(chan struct{})
+	firstSegmentReceived := make(chan struct{}, 1)
 	ctx, cancelCtx := context.WithCancel(ctx)
 
 	startControlPublish(ctx, control, params)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1110,7 +1110,10 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 			})
 		}
 		clog.V(common.VERBOSE).Infof(ctx, "First Segment delay=%dms streamID=%s", delayMs, params.liveParams.streamID)
-		firstSegmentReceived <- struct{}{}
+		select {
+		case firstSegmentReceived <- struct{}{}:
+		default:
+		}
 
 	})
 	startEventsSubscribe(ctx, events, params, sess)


### PR DESCRIPTION
Introduce Orchestrator's Swapping during the startup. If Orchestrator does not return the output segment within the value specified with the `aiStartupOrchSwapTimeout` flag (15s by default), then it's swapped to another Orchestrator.

The tricky part in the implementation is that we need to wait until the request is done with the `stopPipeline`. Please check if it's ok in your opinion @j0sh 