### PR TITLE
ai/worker: Restart warm containers when they crash

### DIFF
--- a/ai/worker/container.go
+++ b/ai/worker/container.go
@@ -36,10 +36,11 @@ type RunnerContainerConfig struct {
 	ContainerImageID string
 
 	// For managed containers only
-	ID               string
-	GPU              string
-	KeepWarm         bool
-	containerTimeout time.Duration
+	ID                string
+	GPU               string
+	KeepWarm          bool
+	OptimizationFlags OptimizationFlags
+	containerTimeout  time.Duration
 }
 
 // Create global references to functions to allow for mocking in tests.

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -405,10 +405,11 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 		Endpoint: RunnerEndpoint{
 			URL: "http://localhost:" + containerHostPort,
 		},
-		ID:               resp.ID,
-		GPU:              gpu,
-		KeepWarm:         keepWarm,
-		containerTimeout: runnerContainerTimeout,
+		ID:                resp.ID,
+		GPU:               gpu,
+		KeepWarm:          keepWarm,
+		OptimizationFlags: optimizationFlags,
+		containerTimeout:  runnerContainerTimeout,
 	}
 
 	rc, err := NewRunnerContainer(ctx, cfg, containerName)
@@ -498,6 +499,13 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer, borrowCtx context.Co
 		if failures >= maxHealthCheckFailures && time.Since(startTime) > pipelineStartGracePeriod {
 			slog.Error("Container health check failed too many times", slog.String("container", rc.Name))
 			m.destroyContainer(rc, false)
+			if rc.KeepWarm {
+				slog.Info("Container was kept warm, restarting", slog.String("container", rc.Name))
+				err := m.Warm(context.Background(), rc.Pipeline, rc.ModelID, rc.OptimizationFlags)
+				if err != nil {
+					slog.Error("Error restarting warm container", slog.String("container", rc.Name), slog.String("error", err.Error()))
+				}
+			}
 			return
 		}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This makes sure that we keep the warm containers running even when they crash due to
failed healthcheck.

**Specific updates (required)**
- Save optimization flags on `RunnerContainer` so we can repeat the same warm call
- Restart kept-warm containers when they crash healthcheck

**How did you test each of these updates (required)**
TODO

**Does this pull request close any open issues?**
Fixes https://linear.app/livepeer/issue/ENG-2443/startup-time-warm-containers-can-go-cold

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
