### PR TITLE
AI: Put sessions with retryable errors in temporary hold

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -111,6 +111,7 @@ func aiMediaServerHandle[I, O any](ls *LivepeerServer, decoderFunc func(*I, *htt
 			node:        ls.LivepeerNode,
 			os:          drivers.NodeStorage.NewSession(requestID),
 			sessManager: ls.AISessionManager,
+			requestID:   requestID,
 		}
 
 		var req I
@@ -172,6 +173,7 @@ func (ls *LivepeerServer) ImageToVideo() http.Handler {
 			node:        ls.LivepeerNode,
 			os:          drivers.NodeStorage.NewSession(requestID),
 			sessManager: ls.AISessionManager,
+			requestID:   requestID,
 		}
 
 		if !async {
@@ -280,6 +282,7 @@ func (ls *LivepeerServer) LLM() http.Handler {
 			node:        ls.LivepeerNode,
 			os:          drivers.NodeStorage.NewSession(requestID),
 			sessManager: ls.AISessionManager,
+			requestID:   requestID,
 		}
 
 		start := time.Now()
@@ -554,6 +557,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			node:        ls.LivepeerNode,
 			os:          drivers.NodeStorage.NewSession(requestID),
 			sessManager: ls.AISessionManager,
+			requestID:   requestID,
 
 			liveParams: liveRequestParams{
 				segmentReader:          ssr,

--- a/server/ai_process_test.go
+++ b/server/ai_process_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -119,6 +120,38 @@ func TestEncodeReqMetadata(t *testing.T) {
 			got := encodeReqMetadata(tt.metadata)
 			if got != tt.want {
 				t.Errorf("encodeReqMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isRetryableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "insufficient capacity error",
+			err:  errors.New("Insufficient capacity"),
+			want: true,
+		},
+		{
+			name: "INSUFFICIENT capacity ERROR",
+			err:  errors.New("Insufficient capacity"),
+			want: true,
+		},
+		{
+			name: "non-retryable error",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableError(tt.err); got != tt.want {
+				t.Errorf("isRetryableError() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/server/ai_session_test.go
+++ b/server/ai_session_test.go
@@ -1,0 +1,310 @@
+package server
+
+import (
+	"container/heap"
+	"context"
+	"math/rand"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/livepeer/go-livepeer/ai/worker"
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/net"
+	"github.com/livepeer/go-tools/drivers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessAIRequest_RetryableError(t *testing.T) {
+	n, _ := core.NewLivepeerNode(nil, "", nil)
+	n.AIProcesssingRetryTimeout = 1 * time.Millisecond //allows processAIRequest to run one time
+	s := LivepeerServer{LivepeerNode: n}
+	penalty := 3
+	cap := core.Capability_AudioToText
+	modelID := "audio-model/1"
+
+	orchSess1 := StubBroadcastSession("http://local.host/1")
+	orchSess2 := StubBroadcastSession("http://local.host/2")
+	orchSess3 := StubBroadcastSession("http://local.host/3")
+	orchSess4 := StubBroadcastSession("http://local.host/4")
+	orchSessions := []*BroadcastSession{orchSess1, orchSess2, orchSess3, orchSess4}
+
+	n.OrchestratorPool = createOrchestratorPool(orchSessions)
+
+	//warmCaps := newAICapabilities(cap, modelID, true, "")
+	//coldCaps := newAICapabilities(cap, modelID, true, "")
+	warmSelector := newStubMinLSSelector()
+	coldSelector := newStubMinLSSelector()
+	suspender := newSuspender()
+
+	warmPool := AISessionPool{
+		selector:       warmSelector,
+		sessMap:        make(map[string]*BroadcastSession),
+		sessionsOnHold: make(map[string][]*BroadcastSession),
+		penalty:        penalty,
+		suspender:      suspender,
+	}
+
+	coldPool := AISessionPool{
+		selector:       coldSelector,
+		sessMap:        make(map[string]*BroadcastSession),
+		sessionsOnHold: make(map[string][]*BroadcastSession),
+		penalty:        penalty,
+		suspender:      suspender,
+	}
+	//add sessions to pool
+	warmPool.Add(orchSessions)
+
+	selector := &AISessionSelector{
+		cap:             cap,
+		modelID:         modelID,
+		node:            n,
+		warmPool:        &warmPool,
+		coldPool:        &coldPool,
+		ttl:             10 * time.Second,
+		lastRefreshTime: time.Now(),
+		initialPoolSize: 4,
+		suspender:       suspender,
+		penalty:         penalty,
+		os:              &stubOSSession{},
+	}
+
+	s.AISessionManager = NewAISessionManager(n, 10*time.Second)
+	selectorKey := strconv.Itoa(int(cap)) + "_" + modelID
+	s.AISessionManager.selectors[selectorKey] = selector
+
+	reqID := string(core.RandomManifestID())
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
+	params := aiRequestParams{
+		node:        n,
+		os:          drivers.NodeStorage.NewSession(reqID),
+		sessManager: s.AISessionManager,
+		requestID:   reqID,
+	}
+
+	testReq := worker.GenAudioToTextMultipartRequestBody{
+		ModelId: &modelID,
+	}
+
+	// Mock isRetryableError to return true
+	originalIsRetryableError := isRetryableError
+	defer func() { isRetryableError = originalIsRetryableError }()
+	isRetryableError = mockRetryableErrorTrue
+
+	//select one session
+	_, err := processAIRequest(context.TODO(), params, testReq)
+	if err != nil {
+		t.Logf("Unexpected error: %v", err)
+	}
+	assert := assert.New(t)
+	assert.Less(len(warmSelector.unknownSessions), 4)
+	assert.Equal(len(warmPool.sessionsOnHold[reqID]), 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(2 * time.Second)
+	}()
+	wg.Wait()
+	_, sessionStillOnHold := warmPool.sessionsOnHold[reqID]
+	assert.False(sessionStillOnHold)
+
+	// now test another error to confirm session is suspended
+	isRetryableError = mockRetryableErrorTrue
+	_, err = processAIRequest(context.TODO(), params, testReq)
+	if err != nil {
+		t.Logf("non retryable error: %v", err)
+	}
+	assert.Greater(len(warmPool.suspender.list), 0)
+	assert.Less(len(warmSelector.unknownSessions), 4)
+	assert.Equal(0, warmSelector.knownSessions.Len())
+}
+
+func TestPutSessionOnHold(t *testing.T) {
+	n, _ := core.NewLivepeerNode(nil, "", nil)
+	n.AIProcesssingRetryTimeout = 1 * time.Millisecond //allows processAIRequest to run one time
+	s := LivepeerServer{LivepeerNode: n}
+	penalty := 3
+	cap := core.Capability_AudioToText
+	modelID := "audio-model/1"
+
+	orchSess1 := StubBroadcastSession("http://local.host/1")
+	orchSessions := []*BroadcastSession{orchSess1}
+
+	n.OrchestratorPool = createOrchestratorPool(orchSessions)
+
+	warmSelector := newStubMinLSSelector()
+	coldSelector := newStubMinLSSelector()
+	suspender := newSuspender()
+
+	warmPool := AISessionPool{
+		selector:       warmSelector,
+		sessMap:        make(map[string]*BroadcastSession),
+		sessionsOnHold: make(map[string][]*BroadcastSession),
+		penalty:        penalty,
+		suspender:      suspender,
+	}
+
+	coldPool := AISessionPool{
+		selector:       coldSelector,
+		sessMap:        make(map[string]*BroadcastSession),
+		sessionsOnHold: make(map[string][]*BroadcastSession),
+		penalty:        penalty,
+		suspender:      suspender,
+	}
+	//add sessions to pool
+	warmPool.Add(orchSessions)
+
+	selector := &AISessionSelector{
+		cap:             cap,
+		modelID:         modelID,
+		node:            n,
+		warmPool:        &warmPool,
+		coldPool:        &coldPool,
+		ttl:             10 * time.Second,
+		lastRefreshTime: time.Now(),
+		initialPoolSize: 4,
+		suspender:       suspender,
+		penalty:         penalty,
+		os:              &stubOSSession{},
+	}
+
+	s.AISessionManager = NewAISessionManager(n, 10*time.Second)
+	selectorKey := strconv.Itoa(int(cap)) + "_" + modelID
+	s.AISessionManager.selectors[selectorKey] = selector
+
+	reqID := string(core.RandomManifestID())
+	//select one session and put it on hold
+	sess := selector.Select(context.TODO())
+	s.AISessionManager.PutSessionOnHold(context.TODO(), reqID, sess)
+
+	assert := assert.New(t)
+	assert.Equal(1, len(warmPool.sessionsOnHold[reqID]))
+	assert.Equal(0, warmPool.selector.Size())
+
+	//sessions should release in 1 millisecond
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+	}()
+	wg.Wait()
+	assert.Equal(0, len(warmPool.sessionsOnHold))
+	assert.Equal(1, warmPool.selector.Size())
+	assert.Equal(sess.Transcoder(), warmSelector.unknownSessions[0].Transcoder())
+
+	//select 2 sessions and put on hold for same reqID
+	orchSess2 := StubBroadcastSession("http://local.host/2")
+	orchSessions = []*BroadcastSession{orchSess2}
+	warmPool.Add(orchSessions)
+	selector.lastRefreshTime = time.Now()
+
+	sess1 := selector.Select(context.TODO())
+	sess2 := selector.Select(context.TODO())
+	s.AISessionManager.PutSessionOnHold(context.TODO(), reqID, sess1)
+	s.AISessionManager.PutSessionOnHold(context.TODO(), reqID, sess2)
+	assert.Equal(2, len(warmPool.sessionsOnHold[reqID]))
+	assert.Equal(1, len(warmPool.sessionsOnHold))
+	assert.Equal(0, warmPool.selector.Size())
+
+	// sessions should release after 1 millisecond
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(10 * time.Millisecond)
+	}()
+	wg.Wait()
+	assert.Equal(0, len(warmPool.sessionsOnHold))
+	assert.Equal(2, warmPool.selector.Size())
+}
+
+func createOrchestratorPool(sessions []*BroadcastSession) *stubDiscovery {
+	sd := &stubDiscovery{}
+
+	// populate stub discovery
+	for idx, sess := range sessions {
+		authToken := &net.AuthToken{Token: stubAuthToken.Token, SessionId: string(core.RandomManifestID()), Expiration: stubAuthToken.Expiration}
+		sess.OrchestratorInfo = &net.OrchestratorInfo{
+			PriceInfo:    &net.PriceInfo{PricePerUnit: int64(idx), PixelsPerUnit: 1},
+			TicketParams: &net.TicketParams{},
+			AuthToken:    authToken,
+			Transcoder:   sess.Transcoder(),
+		}
+
+		sd.infos = append(sd.infos, sess.OrchestratorInfo)
+	}
+
+	return sd
+}
+
+// selector to test behavior of AI session selection that is re-used and moves
+// sessions from unknownSessions to knownSessions at completion
+type stubMinLSSelector struct {
+	knownSessions   *sessHeap
+	unknownSessions []*BroadcastSession
+}
+
+func newStubMinLSSelector() *stubMinLSSelector {
+	knownSessions := &sessHeap{}
+	heap.Init(knownSessions)
+
+	return &stubMinLSSelector{
+		knownSessions: knownSessions,
+	}
+}
+
+var tries int
+
+func mockRetryableErrorTrue(err error) bool {
+	if tries < 1 {
+		tries++
+		return true
+	} else {
+		return false
+	}
+}
+
+func mockRetryableErrorFalse(err error) bool {
+	return false
+}
+
+func (s *stubMinLSSelector) Add(sessions []*BroadcastSession) {
+	s.unknownSessions = append(s.unknownSessions, sessions...)
+}
+
+func (s *stubMinLSSelector) Complete(sess *BroadcastSession) {
+	heap.Push(s.knownSessions, sess)
+}
+
+func (s *stubMinLSSelector) Select(ctx context.Context) *BroadcastSession {
+	sess := s.knownSessions.Peek()
+	if sess == nil {
+		randSelected := rand.Intn(len(s.unknownSessions))
+		sess := s.unknownSessions[randSelected]
+		s.removeUnknownSession(randSelected)
+		return sess
+	}
+
+	//return the known session selected
+	return heap.Pop(s.knownSessions).(*BroadcastSession)
+}
+
+// Size returns the number of sessions stored by the selector
+func (s *stubMinLSSelector) Size() int {
+	return len(s.unknownSessions) + s.knownSessions.Len()
+}
+
+// Clear resets the selector's state
+func (s *stubMinLSSelector) Clear() {
+	s.unknownSessions = nil
+	s.knownSessions = &sessHeap{}
+	//s.stakeRdr = nil //not used in this test
+}
+
+func (s *stubMinLSSelector) removeUnknownSession(i int) {
+	n := len(s.unknownSessions)
+	s.unknownSessions[n-1], s.unknownSessions[i] = s.unknownSessions[i], s.unknownSessions[n-1]
+	s.unknownSessions = s.unknownSessions[:n-1]
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Add temporary hold for Orchestrator sessions that return retryable errors to keep the Orchestrator from being selected in the current request and other concurrently running requests of the same capability/model id.  The Orchestrator is not suspended and is added back to `unknownSessions` after the timeout.

_Background_
- When the selector chooses a session it removes the session from the `knownSessions` if available and, if not, selects and removes a session from `unknownSessions`.  
- `AISessionManager` re-uses selectors for each capability/model id pair between requests.  The Suspender is also re-used between requests.
- Orchestrators that return retryable errors (e.g. insufficient capacity, too many nonces, ticket params expired) could be suspended for up to 30 minutes if the Gateway is not saturating the Orchestrators serving the model.
- The Orchestrator pools refresh every 10 minutes and it takes 3 refreshes to remove an Orchestrator from suspension.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Add new function `PutSessionOnHold` that does not suspend the Orchestrator but does keep the Orchestrator out of selection for the `AIProcesssingRetryTimeout` while the request is running. `ReleaseSessionsOnHold` runs after the timeout used for a request to try to complete to keep the session from being selected again in the very short term.
- Added `requestID` to `aiRequestParams` to use as the key to remove session from temporary hold

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

- Tested locally and wrote tests to cover the additional hold mechanism

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
