### PR TITLE
Latency and misc fixes

### DIFF
--- a/media/mediamtx.go
+++ b/media/mediamtx.go
@@ -77,6 +77,7 @@ func (mc *MediaMTXClient) KickInputConnection(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to kick connection: %w", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("kick connection failed with status code: %d body: %s", resp.StatusCode, body)
@@ -100,6 +101,7 @@ func (mc *MediaMTXClient) StreamExists() (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("failed to get stream: %w", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
 		body, _ := io.ReadAll(resp.Body)
 		return false, fmt.Errorf("get stream failed with status code: %d body: %s", resp.StatusCode, body)

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -257,6 +257,7 @@ func ffmpegOutput(ctx context.Context, outputUrl string, r io.ReadCloser, params
 		}
 
 		cmd := exec.Command("ffmpeg",
+			"-analyzeduration", "2500000", // 2.5 seconds
 			"-i", "pipe:0",
 			"-c:a", "copy",
 			"-c:v", "copy",


### PR DESCRIPTION
* Reduce segmenter ffmpeg's analyzeduration to 2s. This avoids waiting for audio during RTMP pull at the risk of missing late tracks, especially video with a long GOP.

* Send current segment immediately when the publisher is ready to receive data, rather than waiting for the next segment. This reduces time-to-first-frame at the risk of higher *perceived* latency if playback happens to start at the current segment (which we are effectively buffering, instead of staying on the leading edge by waiting for the next segment)

* Rearrange retry sleeps in the segmenter: if ffmpeg needs to retry, it will immediately check for stream existence and exit if necessary. If the stream still exists, only then will it sleep for 5 seconds. This avoids a 5 second delay in signaling EOF.

* Add some comments around how retries are still kinda broken anyway

* Fix a couple of missing body closes in mediamtx HTTP request handling

* Log ffmpeg output on rtmp pull errors