### PR TITLE
Add Min Initial Latency Selector

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -934,6 +934,7 @@ func selectOrchestrator(ctx context.Context, n *core.LivepeerNode, params *core.
 			lock:              &sync.RWMutex{},
 			OrchestratorScore: oScore,
 			InitialPrice:      od.RemoteInfo.PriceInfo,
+			InitialLatency:    *od.LocalInfo.Latency,
 		}
 
 		sessions = append(sessions, session)

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -920,6 +920,10 @@ func selectOrchestrator(ctx context.Context, n *core.LivepeerNode, params *core.
 		if od.LocalInfo != nil {
 			oScore = od.LocalInfo.Score
 		}
+		var initialLatency time.Duration
+		if od.LocalInfo != nil && od.LocalInfo.Latency != nil {
+			initialLatency = *od.LocalInfo.Latency
+		}
 		session := &BroadcastSession{
 			Broadcaster:       core.NewBroadcaster(n),
 			Params:            params,
@@ -934,7 +938,7 @@ func selectOrchestrator(ctx context.Context, n *core.LivepeerNode, params *core.
 			lock:              &sync.RWMutex{},
 			OrchestratorScore: oScore,
 			InitialPrice:      od.RemoteInfo.PriceInfo,
-			InitialLatency:    *od.LocalInfo.Latency,
+			InitialLatency:    initialLatency,
 		}
 
 		sessions = append(sessions, session)

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -139,6 +139,8 @@ type BroadcastSession struct {
 	CleanupSession   sessionsCleanup
 	Balance          Balance
 	InitialPrice     *net.PriceInfo
+
+	InitialLatency time.Duration
 }
 
 func (bs *BroadcastSession) Transcoder() string {

--- a/server/selection.go
+++ b/server/selection.go
@@ -125,18 +125,14 @@ func (s *Selector) sortByInitialLatency() {
 	})
 }
 
-// Select returns the session with the lowest latency score if it is good enough.
-// Otherwise, a session without a latency score yet is returned
 func (s *Selector) Select(ctx context.Context) *BroadcastSession {
 	return s.selectUnknownSession(ctx)
 }
 
-// Size returns the number of sessions stored by the selector
 func (s *Selector) Size() int {
 	return len(s.unknownSessions)
 }
 
-// Clear resets the selector's state
 func (s *Selector) Clear() {
 	s.unknownSessions = nil
 	s.stakeRdr = nil

--- a/server/selection.go
+++ b/server/selection.go
@@ -126,7 +126,9 @@ func (s *Selector) sortByInitialLatency() {
 }
 
 func (s *Selector) Select(ctx context.Context) *BroadcastSession {
-	return s.selectUnknownSession(ctx)
+	sess := s.selectUnknownSession(ctx)
+	s.sortByInitialLatency()
+	return sess
 }
 
 func (s *Selector) Size() int {
@@ -267,9 +269,7 @@ func (s *Selector) selectUnknownSession(ctx context.Context) *BroadcastSession {
 }
 
 func (s *Selector) removeUnknownSession(i int) {
-	n := len(s.sessions)
-	s.sessions[n-1], s.sessions[i] = s.sessions[i], s.sessions[n-1]
-	s.sessions = s.sessions[:n-1]
+	s.sessions = append(s.sessions[:i], s.sessions[i+1:]...)
 }
 
 // LIFOSelector selects the next BroadcastSession in LIFO order

--- a/server/selection_test.go
+++ b/server/selection_test.go
@@ -336,8 +336,8 @@ func TestMinLSSelector_RemoveUnknownSession(t *testing.T) {
 	resetsessions()
 	sel.removeUnknownSession(0)
 	assert.Len(sel.sessions, 2)
-	assert.Equal("baz", string(sel.sessions[0].Params.ManifestID))
-	assert.Equal("bar", string(sel.sessions[1].Params.ManifestID))
+	assert.Equal("bar", string(sel.sessions[0].Params.ManifestID))
+	assert.Equal("baz", string(sel.sessions[1].Params.ManifestID))
 
 	// Test remove from middle of list
 	resetsessions()


### PR DESCRIPTION
Currently, the selection logic (both for Transcoding and AI) uses the following logic:
1. Select best O
2. Use it for the work
3. When done, cache it as `knownSessions`
4. When a new request is sent, re-use the O in `knownSessions`

For the Live video, it can be suboptimal, because the cached `knownSession` is not always the best Orchestrator to use. For example:
- There is a peak time and not many O are available so G select O with suboptimal latency
- After a few hours, there is no much traffic, so most Os are available
- However, G still uses the previously selected O

This PR introduces a new Selector which is way simpler than the currently used `MinLSSelector`. The new Selector doesn't cache anything and does not favor known sessions. It always selects an O with the lowest InitialLatency.

fix https://linear.app/livepeer/issue/ENG-2454/startup-time-suboptimal-g-o-selection