### PR TITLE
Don't try to publish to the same rtmp url twice

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -433,7 +433,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		if outputURL == "" {
 			// re-publish to ourselves for now
 			// Not sure if we want this to be permanent
-			outputURL = mediaMTXOutputURL
+			outputURL = fmt.Sprintf("rtmp://%s/%s-out", remoteHost, streamName)
 		}
 
 		// convention to avoid re-subscribing to our own streams


### PR DESCRIPTION
We were accidentally publishing to the same url twice with the previous change to stream to mediamtx, this fixes that to allow local development.