### PR TITLE
Complete live session when stream is completed

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -566,6 +566,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 				pipelineID:             pipelineID,
 				stopPipeline:           stopPipeline,
 				sendErrorEvent:         sendErrorEvent,
+				aiSessionByStream:      ls.AISessionByStream,
 			},
 		}
 
@@ -683,6 +684,13 @@ func (ls *LivepeerServer) cleanupLive(stream string) {
 			slog.Info("Error closing trickle publisher", "err", err)
 		}
 		pub.StopControl()
+	}
+	ls.LivepeerNode.LiveMu.Lock()
+	sess, ok := ls.AISessionByStream[stream]
+	delete(ls.AISessionByStream, stream)
+	ls.LivepeerNode.LiveMu.Unlock()
+	if ok && sess != nil {
+		ls.AISessionManager.Complete(context.Background(), sess)
 	}
 }
 

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -114,7 +114,8 @@ type LivepeerServer struct {
 	ExposeCurrentManifest   bool
 	recordingsAuthResponses *cache.Cache
 
-	AISessionManager *AISessionManager
+	AISessionManager  *AISessionManager
+	AISessionByStream map[string]*AISession
 
 	// Thread sensitive fields. All accesses to the
 	// following fields should be protected by `connectionLock`

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -195,6 +195,7 @@ func NewLivepeerServer(ctx context.Context, rtmpAddr string, lpNode *core.Livepe
 		internalManifests:       make(map[core.ManifestID]core.ManifestID),
 		recordingsAuthResponses: cache.New(time.Hour, 2*time.Hour),
 		AISessionManager:        NewAISessionManager(lpNode, AISessionManagerTTL),
+		AISessionByStream:       make(map[string]*AISession),
 		mediaMTXApiPassword:     lpNode.MediaMTXApiPassword,
 		liveAIAuthApiKey:        lpNode.LiveAIAuthApiKey,
 		livePaymentInterval:     lpNode.LivePaymentInterval,


### PR DESCRIPTION
Currently, Live AI Streams are treated the same as AI Jobs, so the session is marked "completed" and returns to the session pool as soon as the sync AI request is returned from O. This is a not true for Live AI Video to Video, because in that case, the request is only the start of the processing.

**Why is it a problem?**
1. Person 1 starts streaming in EU
2. Gateway selects the best latency O, `TLL-2`
3. Just after the initial request `TLL-2` returns back to the pool
4. Person 2 starts streaming in EU
5. Gateway selects the best latency O `TLL-2`
6. Gateway realizes that `TLL-2` is busy (returns `insufficient capacity` error), so it removes it from the pool and suspends it
7. Gateway selects the second best O, `EU-STAGING-0`
8. Just after the initial request `EU-STAGING-0` returns to the pool
9. Person 1 stops streaming
10. Person 3 starts streaming in EU
11. Gateway realized that `EU-STAGING-0` is busy (returns `insufficient capacity` error), so it removes it from the pool and suspends it
12. Gateway selects the second best O currently in the pool `US-STAGING-0` (which is not the best choice, because `TLL-2` is free)

After point Point 11 we ended up with only US Orchestrators in the pool while the EU are still available. And it won't change until the next session refresh.

Related to https://linear.app/livepeer/issue/ENG-2454/startup-time-suboptimal-g-o-selection