### PR TITLE
fix(ai): complete retryable sessions after current request

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1522,7 +1522,7 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 		}
 
 		// Don't suspend the session if the error is a transient error.
-		if isRetryableError(err) || (isNoCapacityErr(err) && cap != core.Capability_LiveVideoToVideo) {
+		if isRetryableError(err) || (isNoCapacityError(err) && cap != core.Capability_LiveVideoToVideo) {
 			retryableSessions = append(retryableSessions, sess)
 			continue
 		}
@@ -1570,7 +1570,7 @@ func isRetryableError(err error) bool {
 	return false
 }
 
-func isNoCapacityErr(err error) bool {
+func isNoCapacityError(err error) bool {
 	transientErrorMessages := []string{
 		"insufficient capacity", // Caused by limitation in our current implementation.
 	}

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1534,14 +1534,8 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 
 		// Don't suspend the session if the error is a transient error.
 		if isRetryableError(err) {
-			if cap == core.Capability_LiveVideoToVideo {
-				params.sessManager.Complete(ctx, sess)
-				continue
-			} else {
-				//keep session out of selection on this request for batch AI jobs
-				retryableSessions = append(retryableSessions, sess)
-				continue
-			}
+			params.sessManager.Complete(ctx, sess)
+			continue
 		}
 
 		//for batch AI add session to be used on next request, for live-video-to-video suspend the session until next refresh

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1569,35 +1569,22 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 
 // isRetryableError checks if the error is a transient error that can be retried.
 func isRetryableError(err error) bool {
-	transientErrorMessages := []string{
-		"invalid ticket sendernonce", // Caused by gateway nonce mismatch.
-		"ticketparams expired",       // Caused by ticket expiration.
-	}
-
-	errMsg := strings.ToLower(err.Error())
-	for _, msg := range transientErrorMessages {
-		if strings.Contains(errMsg, msg) {
-			return true
-		}
-	}
-	return false
+	return errContainsMsg(err, "invalid ticket sendernonce", "ticketparams expired")
 }
 
 func isNoCapacityError(err error) bool {
-	transientErrorMessages := []string{
-		"insufficient capacity", // Caused by limitation in our current implementation.
-	}
+	return errContainsMsg(err, "insufficient capacity")
+}
 
+func errContainsMsg(err error, msgs ...string) bool {
 	errMsg := strings.ToLower(err.Error())
-	for _, msg := range transientErrorMessages {
+	for _, msg := range msgs {
 		if strings.Contains(errMsg, msg) {
 			return true
 		}
 	}
-
 	return false
 }
-
 func prepareAIPayment(ctx context.Context, sess *AISession, outPixels int64) (worker.RequestEditorFn, *BalanceUpdate, error) {
 	// genSegCreds expects a stream.HLSSegment so in order to reuse it here we pass a dummy object
 	segCreds, err := genSegCreds(sess.BroadcastSession, &stream.HLSSegment{}, nil, false)

--- a/server/ai_process_test.go
+++ b/server/ai_process_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -119,6 +120,70 @@ func TestEncodeReqMetadata(t *testing.T) {
 			got := encodeReqMetadata(tt.metadata)
 			if got != tt.want {
 				t.Errorf("encodeReqMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isNoCapacityError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "insufficient capacity error",
+			err:  errors.New("Insufficient capacity"),
+			want: true,
+		},
+		{
+			name: "INSUFFICIENT capacity ERROR",
+			err:  errors.New("Insufficient capacity"),
+			want: true,
+		},
+		{
+			name: "non-insufficient capacity error",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNoCapacityError(tt.err); got != tt.want {
+				t.Errorf("isNoCapacityError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isRetryableError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "invalid ticket sendernonce",
+			err:  errors.New("invalid ticket sendernonce"),
+			want: true,
+		},
+		{
+			name: "INVALID ticket sendernonce",
+			err:  errors.New("Invalid ticket sendernonce"),
+			want: true,
+		},
+		{
+			name: "non-retryable error",
+			err:  errors.New("some other error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableError(tt.err); got != tt.want {
+				t.Errorf("isRetryableError() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Update `processAIRequest` to add sessions back to selector after the current request if errors are retryable.

Replaces #3400 and includes update for LiveVideoToVideo in #3407.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Adds sessions that have retryable errors to list to call `Complete` on when the request ends.  LiveVideoToVideo will add insufficient capacity errors back to selector on next refresh

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Built docker image and sent batch AI request until 503 unavailable error returned. Pulled /getAISessionPoolsInfo to confirm 1 orchestrator not suspended

**Does this pull request close any open issues?**
<!-- Fixes # -->
No

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
