### PR TITLE
Clear previous gateway status on new requests

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -520,7 +520,10 @@ func (s *SlowOrchChecker) GetCount() int {
 
 func LiveErrorEventSender(ctx context.Context, streamID string, event map[string]string) func(err error) {
 	return func(err error) {
-		GatewayStatus.Store(streamID, map[string]interface{}{"last_error": err.Error()})
+		GatewayStatus.Store(streamID, map[string]interface{}{
+			"last_error":      err.Error(),
+			"last_error_time": time.Now().UnixMilli(),
+		})
 
 		ev := maps.Clone(event)
 		ev["capability"] = clog.GetVal(ctx, "capability")


### PR DESCRIPTION
Clear any previous gateway status and allow the stream status API to return the gateway status if no stream status from the runner has been received. This is to allow the front end to properly detect things like capacity errors