### PR TITLE
ai/worker: Avoid idle container spam with always-on healthcheck

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -528,9 +528,9 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer) {
 
 		// The BorrowCtx is set when the container has been borrowed for a request/stream. If it is not set (nil) it means
 		// that it's not currently borrowed, so we don't need to wait for it to be done (hence using the background context).
-		borrowDone := borrowCtx.Done()
-		if borrowDone == nil {
-			borrowDone = context.Background().Done()
+		borrowDone := context.Background().Done()
+		if borrowCtx != nil {
+			borrowDone = borrowCtx.Done()
 		}
 		select {
 		case <-borrowDone:

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -928,6 +928,7 @@ func TestDockerManager_watchContainer(t *testing.T) {
 				time.Sleep(dur)
 			}
 		}
+		rc.BorrowCtx = context.Background() // Simulate a borrow of the container
 		go dockerManager.watchContainer(rc)
 		sleepUntil(30 * time.Millisecond) // Almost the entire grace period
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This fixes the log on the ai-worker when the container is idle. Since we run the healthcheck
all the time now, we would keep logging "container is idle returning to pool" even though the
container was already in the pool.

This fixes it by only doing the return logic when the container is actually borrowed. We do so
by checking the BorrowCtx in the runnercontainer struct.

**Specific updates (required)**
- Check borrowCtx before returning container to pool 

**How did you test each of these updates (required)**
Run O and make sure it doesn't spam idle container logs when the container goes idle

**Does this pull request close any open issues?**
No just a logging issue


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
