### PR TITLE
Corrected typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,7 +353,7 @@ None
 
 #### Broadcaster
 
-- [#2666](https://github.com/livepeer/go-livepeer/pull/2666) Re-use a session as long as it passes the latency score threshold check (@yondonfu)
+- [#2666](https://github.com/livepeer/go-livepeer/pull/2666) Reuse a session as long as it passes the latency score threshold check (@yondonfu)
 
 #### Orchestrator
 - [#2639](https://github.com/livepeer/go-livepeer/pull/2639) Increase IdleTimeout for HTTP connections (@leszko)
@@ -963,7 +963,7 @@ Thanks to everyone that submitted bug reports and assisted in testing!
 
 - [#1845](https://github.com/livepeer/go-livepeer/pull/1845) Staking actions with hints (@kyriediculous)
 - [#1873](https://github.com/livepeer/go-livepeer/pull/1873) Increase TicketParams expiration to 10 blocks (@kyriediculous)
-- [#1849](https://github.com/livepeer/go-livepeer/pull/1849) Re-use remote transcoders for a stream sessions (@reubenr0d)
+- [#1849](https://github.com/livepeer/go-livepeer/pull/1849) Reuse remote transcoders for a stream sessions (@reubenr0d)
 
 #### Transcoder
 

--- a/cmd/livepeer_cli/wizard_token.go
+++ b/cmd/livepeer_cli/wizard_token.go
@@ -9,7 +9,7 @@ import (
 func (w *wizard) transferTokens() {
 	fmt.Printf("Current LPT balance: %v\n", w.getTokenBalance())
 
-	fmt.Printf("Enter receipient address (in hex i.e. 0xfoo) - ")
+	fmt.Printf("Enter recipient address (in hex i.e. 0xfoo) - ")
 	to := w.readString()
 
 	amount := w.readBigInt("Enter amount")

--- a/core/ai_orchestrator.go
+++ b/core/ai_orchestrator.go
@@ -533,7 +533,7 @@ func (orch *orchestrator) TextToImage(ctx context.Context, requestID string, req
 		}
 	}
 
-	// remote ai worker proceses job
+	// remote ai worker processes job
 	res, err := orch.node.AIWorkerManager.Process(ctx, requestID, "text-to-image", *req.ModelId, "", AIJobRequestData{Request: req})
 	if err != nil {
 		return nil, err
@@ -599,7 +599,7 @@ func (orch *orchestrator) ImageToImage(ctx context.Context, requestID string, re
 		}
 	}
 
-	// remote ai worker proceses job
+	// remote ai worker processes job
 	imgBytes, err := req.Image.Bytes()
 	if err != nil {
 		return nil, err
@@ -643,7 +643,7 @@ func (orch *orchestrator) ImageToVideo(ctx context.Context, requestID string, re
 		}
 	}
 
-	// remote ai worker proceses job
+	// remote ai worker processes job
 	imgBytes, err := req.Image.Bytes()
 	if err != nil {
 		return nil, err
@@ -687,7 +687,7 @@ func (orch *orchestrator) Upscale(ctx context.Context, requestID string, req wor
 		}
 	}
 
-	// remote ai worker proceses job
+	// remote ai worker processes job
 	imgBytes, err := req.Image.Bytes()
 	if err != nil {
 		return nil, err
@@ -723,7 +723,7 @@ func (orch *orchestrator) AudioToText(ctx context.Context, requestID string, req
 		return orch.node.AudioToText(ctx, req)
 	}
 
-	// remote ai worker proceses job
+	// remote ai worker processes job
 	audioBytes, err := req.Audio.Bytes()
 	if err != nil {
 		return nil, err
@@ -759,7 +759,7 @@ func (orch *orchestrator) SegmentAnything2(ctx context.Context, requestID string
 		return orch.node.SegmentAnything2(ctx, req)
 	}
 
-	// remote ai worker proceses job
+	// remote ai worker processes job
 	imgBytes, err := req.Image.Bytes()
 	if err != nil {
 		return nil, err
@@ -824,7 +824,7 @@ func (orch *orchestrator) ImageToText(ctx context.Context, requestID string, req
 		return orch.node.ImageToText(ctx, req)
 	}
 
-	// remote ai worker proceses job
+	// remote ai worker processes job
 	imageBytes, err := req.Image.Bytes()
 	if err != nil {
 		return nil, err
@@ -868,7 +868,7 @@ func (orch *orchestrator) TextToSpeech(ctx context.Context, requestID string, re
 		}
 	}
 
-	// remote ai worker proceses job
+	// remote ai worker processes job
 	res, err := orch.node.AIWorkerManager.Process(ctx, requestID, "text-to-speech", *req.ModelId, "", AIJobRequestData{Request: req})
 	if err != nil {
 		return nil, err

--- a/core/autoconvertedprice_test.go
+++ b/core/autoconvertedprice_test.go
@@ -109,7 +109,7 @@ func TestAutoConvertedPrice_Update(t *testing.T) {
 	select {
 	case updatedPrice := <-priceUpdatedChan:
 		require.Equal(big.NewRat(5e16, 6), updatedPrice)  // 50 USD * 1/6000 USD/ETH
-		require.Equal(big.NewRat(5e16, 6), price.Value()) // must also udpate current value
+		require.Equal(big.NewRat(5e16, 6), price.Value()) // must also update current value
 	case <-time.After(time.Second):
 		t.Fatal("Expected price update not received")
 	}

--- a/core/capabilities.go
+++ b/core/capabilities.go
@@ -98,7 +98,7 @@ var CapabilityNameLookup = map[Capability]string{
 	Capability_ProfileH264Baseline:        "H264 Baseline profile",
 	Capability_ProfileH264Main:            "H264 Main profile",
 	Capability_ProfileH264High:            "H264 High profile",
-	Capability_ProfileH264ConstrainedHigh: "H264 Constained High profile",
+	Capability_ProfileH264ConstrainedHigh: "H264 Constrained, Contained High profile",
 	Capability_GOP:                        "GOP",
 	Capability_AuthToken:                  "Auth token",
 	Capability_MPEG7VideoSignature:        "MPEG7 signature",

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -400,7 +400,7 @@ func TestRemoveFromRemoteTranscoders(t *testing.T) {
 	remoteTranscoderList = append(remoteTranscoderList, tr...)
 	assert.Len(remoteTranscoderList, 5)
 
-	// Remove transcoder froms head of the list
+	// Remove transcoder forms head of the list
 	remoteTranscoderList = removeFromRemoteTranscoders(tr[0], remoteTranscoderList)
 	assert.Equal(remoteTranscoderList[0], tr[1])
 	assert.Equal(remoteTranscoderList[1], tr[2])

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -1087,7 +1087,7 @@ func (rtm *RemoteTranscoderManager) selectTranscoder(sessionId string, caps *Cap
 				return nil, ErrNoTranscodersAvailable
 			}
 
-			// Assinging transcoder to session for future use
+			// Assigning transcoder to session for future use
 			rtm.streamSessions[sessionId] = currentTranscoder
 			currentTranscoder.load++
 			sort.Sort(byLoadFactor(rtm.remoteTranscoders))

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -97,7 +97,7 @@ func TestResToTranscodeData(t *testing.T) {
 	_, err = resToTranscodeData(context.TODO(), res, opts)
 	assert.EqualError(err, "open badfile: no such file or directory")
 
-	// Test error after a successful read
+	// Test error after a successsful read
 	res = &ffmpeg.TranscodeResults{Encoded: make([]ffmpeg.MediaInfo, 3)}
 	tempDir := t.TempDir()
 
@@ -116,7 +116,7 @@ func TestResToTranscodeData(t *testing.T) {
 	assert.True(fileDNE(file1.Name()))
 	assert.False(fileDNE(file2.Name()))
 
-	// Test success for 1 output file
+	// Test successs for 1 output file
 	res = &ffmpeg.TranscodeResults{Encoded: make([]ffmpeg.MediaInfo, 1)}
 	res.Encoded[0].Pixels = 100
 
@@ -127,7 +127,7 @@ func TestResToTranscodeData(t *testing.T) {
 	assert.Equal(int64(100), tData.Segments[0].Pixels)
 	assert.True(fileDNE(file2.Name()))
 
-	// Test succes for 2 output files
+	// Test success for 2 output files
 	res = &ffmpeg.TranscodeResults{Encoded: make([]ffmpeg.MediaInfo, 2)}
 	res.Encoded[0].Pixels = 200
 	res.Encoded[1].Pixels = 300


### PR DESCRIPTION
Changes made in:

- /CHANGELOG.md ("Re-use" → "Reuse")

- /CHANGELOG.md ("Re-use" → "Reuse")

- /cmd/livepeer_cli/wizard_token.go ("receipient" → "recipient")

- /core/transcoder_test.go ("succes" → "success")

- /core/autoconvertedprice_test.go ("udpate" → "update")

- /core/orch_test.go ("froms" → "forms")

- /core/orchestrator.go ("Assinging" → "Assigning")

- /core/capabilities.go ("Constained" → "Constrained, Contained")

- /core/ai_orchestrator.go ("proceses" → "processes")

- /core/ai_orchestrator.go ("proceses" → "processes")
