### PR TITLE
Don't suspend sessions in case of the InssufficientCapacity Error

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1545,8 +1545,8 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 			continue
 		}
 
-		//for batch AI add session to be used on next request, for live-video-to-video suspend the session until next refresh
-		if isNoCapacityError(err) && cap != core.Capability_LiveVideoToVideo {
+		// when no capacity error is received, retry with another session, but do not suspend the session
+		if isNoCapacityError(err) {
 			retryableSessions = append(retryableSessions, sess)
 			continue
 		}


### PR DESCRIPTION
I think we should not suspend sessions for Realtime Video AI if the Orchestrator returns "Insufficient Capacity".

Currently, the suspend/penalization affects the G<>O latency selection, because it works as follows:
1. G starts using O, but the O is already in use
2. It suspends O with penalty 3 which effectively means it's suspended for the next 18 min
3. During that 18 min we select O with worse latency

It's especially bad connecting with our load tests, because they basically drain out our G from the best Os.