### PR TITLE
docs: replace temporary Discord invite URL with permanent URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 [![Go Report Card](https://goreportcard.com/badge/github.com/livepeer/go-livepeer)](https://goreportcard.com/report/github.com/livepeer/go-livepeer)
-[![Discord](https://img.shields.io/discord/423160867534929930.svg?style=flat-square)](https://discord.gg/7wRSUGX)
+[![Discord](https://img.shields.io/discord/423160867534929930.svg?style=flat-square)](https://discord.gg/livepeer)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange.svg?style=flat-square)](CONTRIBUTING.md)
 
@@ -21,10 +21,10 @@ serve as the live media layer in the decentralized development (Web3) stack.
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Requirements](#requirements)
 - [Getting Started](#getting-started)
 - [Contributing](#contributing)
-- [Other Documentation](https://docs.livepeer.org/developers/introduction)
 - [Resources](#resources)
 
 <!-- hide-on-docup-stop -->
@@ -63,5 +63,5 @@ other resources:
 - 📖 [The Livepeer Docs](https://livepeer.org/docs)
 - 🔭 [The 10-Minute Primer](https://livepeer.org/primer/)
 - ✍ [The Livepeer Blog](https://medium.com/livepeer-blog)
-- 💬 [The Livepeer Chat](https://discord.gg/uaPhtyrWsF)
+- 💬 [The Livepeer Chat](https://discord.gg/livepeer)
 - ❓ [The Livepeer Forum](https://forum.livepeer.org/)


### PR DESCRIPTION
This commit updates the Discord invite URL from a temporary (expiring)
link to a fixed (permanent) one to ensure long-term accessibility.