### PR TITLE
ai/worker: Fix VERBOSE_LOGGING flag again...

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -334,7 +334,7 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 		envVars = append(envVars, key+"="+value.String())
 	}
 	if m.verboseLogs {
-		envVars = append(envVars, "VERBOSE_LOGGING=true")
+		envVars = append(envVars, "VERBOSE_LOGGING=1")
 	}
 
 	containerConfig := &container.Config{


### PR DESCRIPTION
[The code](https://github.com/livepeer/ai-worker/blob/c2067ef5abe2624c38f95f42db6948823d44e457/runner/app/live/infer.py#L165) explicitly checks if it's equal to `1`, can't just be true-ish...