### PR TITLE
Update retryable logic for Live Video to Video

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1545,14 +1545,8 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 			continue
 		}
 
-		// when the ticket nonce is invalid, swap to a different Orchestrator, do not suspend the Orchestrator,
-		// but also don't get it back into the pool until the next sessions refresh
-		if isInvalidTicketSenderNonce(err) {
-			continue
-		}
-
 		// when no capacity error is received, retry with another session, but do not suspend the session
-		if isNoCapacityError(err) {
+		if (isInvalidTicketSenderNonce(err) || isNoCapacityError(err)) && cap != core.Capability_LiveVideoToVideo {
 			retryableSessions = append(retryableSessions, sess)
 			continue
 		}

--- a/server/ai_session.go
+++ b/server/ai_session.go
@@ -193,6 +193,8 @@ func NewAISessionSelector(ctx context.Context, cap core.Capability, modelID stri
 		// We always select a fresh session which has the lowest initial latency
 		warmSel = NewSelector(stakeRdr, node.SelectionAlgorithm, node.OrchPerfScore, warmCaps)
 		coldSel = NewSelector(stakeRdr, node.SelectionAlgorithm, node.OrchPerfScore, coldCaps)
+		// we don't use penalties for not in Realtime Video AI
+		penalty = 0
 	} else {
 		// sort sessions based on current latency score
 		warmSel = NewSelectorOrderByLatencyScore(stakeRdr, node.SelectionAlgorithm, node.OrchPerfScore, warmCaps)


### PR DESCRIPTION
Another fix fo the Realtime Video AI selection logic. I realized that we cannot use `inUse` for Video to Video, because one O never serves more than 1 stream for now.

So, the problem it causes is that if we're out of Os replying in less < 500ms, then we keep selecting the same `inUse` Os, which results in the infinite loop.