### PR TITLE
ai/live: Use clog consistently for payments

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -216,7 +216,7 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 				}
 				reader := segment.Reader
 				if paymentProcessor != nil {
-					reader = paymentProcessor.process(segment.Reader)
+					reader = paymentProcessor.process(ctx, segment.Reader)
 				}
 				io.Copy(io.Discard, reader)
 			}

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -78,7 +78,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 			defer slowOrchChecker.EndSegment()
 			var r io.Reader = reader
 			if paymentProcessor != nil {
-				r = paymentProcessor.process(reader)
+				r = paymentProcessor.process(ctx, reader)
 			}
 
 			clog.V(8).Infof(ctx, "trickle publish writing data seq=%d", seq)


### PR DESCRIPTION
Makes payment info easier to find in the logs while debugging, including the probed codec info