### PR TITLE
ai/live: Log input segments to disk

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -115,6 +115,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 							},
 						})
 					}
+					clog.Info(ctx, "trickle publish complete", "wrote", humanize.Bytes(uint64(n)), "seq", seq)
 					return
 				}
 				if errors.Is(err, trickle.StreamNotFoundErr) {


### PR DESCRIPTION
Stores the first 10 segments. They are [swept periodically](https://github.com/livepeer/go-livepeer/blob/92e87139006a67ca5599c20323429ca610d92c84/media/rtmp2segment.go#L293-L332) by the segmenter so we don't run out of disk space.