### PR TITLE
server/ai: Add event when the ingest stream ends

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -554,7 +554,6 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		go func() {
 			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir, MediaMTXClient: mediaMTXClient}
 			ms.RunSegmentation(ctx, mediaMTXInputURL, ssr.Read)
-			ssr.Close()
 			monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
 				"type":        "gateway_ingest_stream_closed",
 				"timestamp":   time.Now().UnixMilli(),
@@ -566,6 +565,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 					"url":     "",
 				},
 			})
+			ssr.Close()
 			ls.cleanupLive(ctx, streamName)
 		}()
 

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -826,6 +826,25 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 					"url":     "",
 				},
 			})
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						clog.Errorf(ctx, "Panic in stream close event routine: %s", r)
+					}
+				}()
+				whipConn.AwaitClose()
+				monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
+					"type":        "gateway_ingest_stream_closed",
+					"timestamp":   time.Now().UnixMilli(),
+					"stream_id":   streamID,
+					"pipeline_id": pipelineID,
+					"request_id":  requestID,
+					"orchestrator_info": map[string]interface{}{
+						"address": "",
+						"url":     "",
+					},
+				})
+			}()
 
 			if monitor.Enabled {
 				monitor.AILiveVideoAttempt()

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -555,6 +555,17 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir, MediaMTXClient: mediaMTXClient}
 			ms.RunSegmentation(ctx, mediaMTXInputURL, ssr.Read)
 			ssr.Close()
+			monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
+				"type":        "gateway_ingest_stream_closed",
+				"timestamp":   time.Now().UnixMilli(),
+				"stream_id":   streamID,
+				"pipeline_id": pipelineID,
+				"request_id":  requestID,
+				"orchestrator_info": map[string]interface{}{
+					"address": "",
+					"url":     "",
+				},
+			})
 			ls.cleanupLive(ctx, streamName)
 		}()
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This adds a new kafka event when the input stream from the user is closed on the AI flow.

This will allow us to differentiate errors from cases where the user bounced before ever sending any data.

I looked around in the code for the ideal place for this event. Even though we don't have orchestrator
information on the place where I put it, it seemed like the most natural choice since it's the place where
we run the segmentation from the mediamtx input stream. On the place that we send the `gateway_send_first_ingest_segment`
 event ([`ai_live_video.go#104`](https://github.com/livepeer/go-livepeer/blob/b9cf0ea61f4332ec82d25a09cc3afcf9e2e77ae2/server/ai_live_video.go#L104)) it seemed trickier as we have less control over the execution flow (even
tho we'd have O info). Let me know on review if that or another place would be preferred instead.

**Specific updates (required)**
- Add new event when segmentation ends

**How did you test each of these updates (required)**
Builds, tests pass

**Does this pull request close any open issues?**
[Source](https://discord.com/channels/423160867534929930/1352038030814347335/1352386567142113281)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
