### PR TITLE
Add Orchestrator-side metrics to track the number of streams currently being processed

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -681,7 +681,7 @@ tickerLoop:
 
 func (m *DockerManager) monitorInUse() {
 	if monitor.Enabled {
-		monitor.AIContainersInUse(len(m.containers))
+		monitor.AIContainersInUse(len(m.gpuContainers) - len(m.containers))
 	}
 }
 


### PR DESCRIPTION
It should give the same results as the Gateway-side ai_current_live_pipelines