### PR TITLE
clog: fix Info printing of file and line numbers

### DIFF
--- a/clog/clog.go
+++ b/clog/clog.go
@@ -225,7 +225,7 @@ func Info(ctx context.Context, msg string, keyvals ...interface{}) {
 		}
 	}
 
-	Infof(ctx, "%s", sb.String())
+	infof(ctx, false, false, sb.String())
 }
 
 // V returns a Verbose instance for conditional logging at the specified level


### PR DESCRIPTION
Print the actual filename and line number instead of clog.go:228