### PR TITLE
ai/live: Sent events for any WHIP connection errors.

### DIFF
--- a/media/whip_connection.go
+++ b/media/whip_connection.go
@@ -46,12 +46,12 @@ func (w *WHIPConnection) getWHIPConnection() *MediaState {
 	return w.peer
 }
 
-func (w *WHIPConnection) AwaitClose() {
+func (w *WHIPConnection) AwaitClose() error {
 	p := w.getWHIPConnection()
 	if p == nil {
-		return
+		return nil
 	}
-	p.AwaitClose()
+	return p.AwaitClose()
 }
 
 func (w *WHIPConnection) Close() {
@@ -74,30 +74,55 @@ type WHIPPeerConnection interface {
 
 // MediaState manages the lifecycle of a media connection
 type MediaState struct {
-	pc      WHIPPeerConnection
-	closeCh chan bool
-	once    sync.Once
+	pc     WHIPPeerConnection
+	mu     *sync.Mutex
+	cond   *sync.Cond
+	closed bool
+	err    error
 }
 
 // NewMediaState creates a new MediaState with the given peerconnection
 func NewMediaState(pc WHIPPeerConnection) *MediaState {
+	mu := &sync.Mutex{}
 	return &MediaState{
-		pc:      pc,
-		closeCh: make(chan bool),
+		pc:   pc,
+		mu:   mu,
+		cond: sync.NewCond(mu),
 	}
+}
+
+// Returns a mediastate that is already closed with an error
+func NewMediaStateError(err error) *MediaState {
+	m := NewMediaState(nil)
+	m.CloseError(err)
+	return m
 }
 
 // Close closes the underlying connection and signals any waiters
 func (m *MediaState) Close() {
-	m.once.Do(func() {
-		if m.pc != nil {
-			m.pc.Close()
-		}
-		close(m.closeCh)
-	})
+	m.CloseError(nil)
+}
+
+func (m *MediaState) CloseError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return
+	}
+	if m.pc != nil {
+		m.pc.Close()
+	}
+	m.closed = true
+	m.err = err
+	m.cond.Broadcast()
 }
 
 // AwaitClose blocks until the connection is closed
-func (m *MediaState) AwaitClose() {
-	<-m.closeCh
+func (m *MediaState) AwaitClose() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for !m.closed {
+		m.cond.Wait()
+	}
+	return m.err
 }

--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -75,14 +75,14 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 	// Must have Content-Type: application/sdp (the spec strongly recommends it)
 	if r.Header.Get("Content-Type") != "application/sdp" {
 		http.Error(w, "Unsupported Media Type, expected application/sdp", http.StatusUnsupportedMediaType)
-		return nil
+		return NewMediaStateError(errors.New("unsupported media type"))
 	}
 
 	// Read the SDP offer
 	offerBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Error reading offer", http.StatusBadRequest)
-		return nil
+		return NewMediaStateError(errors.New("error reading offer"))
 	}
 	defer r.Body.Close()
 
@@ -91,7 +91,7 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 	if err != nil {
 		clog.InfofErr(ctx, "Failed to create peerconnection", err)
 		http.Error(w, "Failed to create PeerConnection", http.StatusInternalServerError)
-		return nil
+		return NewMediaStateError(errors.New("failed to create peerconnection"))
 	}
 	mediaState := NewMediaState(peerConnection)
 
@@ -106,7 +106,7 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
 		clog.Info(ctx, "ice connection state changed", "state", connectionState)
 		if connectionState == webrtc.ICEConnectionStateFailed {
-			peerConnection.Close()
+			mediaState.CloseError(errors.New("ICE connection state failed"))
 		} else if connectionState == webrtc.ICEConnectionStateClosed {
 			// Business logic when PeerConnection done
 		}
@@ -118,24 +118,27 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 		SDP:  string(offerBytes),
 	}
 	if err := peerConnection.SetRemoteDescription(sdpOffer); err != nil {
-		http.Error(w, fmt.Sprintf("SetRemoteDescription failed: %v", err), http.StatusInternalServerError)
-		mediaState.Close()
+		e := fmt.Sprintf("SetRemoteDescription failed: %v", err)
+		http.Error(w, e, http.StatusInternalServerError)
+		mediaState.CloseError(errors.New(e))
 		return mediaState
 	}
 
 	// Create the answer
 	answer, err := peerConnection.CreateAnswer(nil)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("CreateAnswer failed: %v", err), http.StatusInternalServerError)
-		mediaState.Close()
+		e := fmt.Sprintf("CreateAnswer failed: %v", err)
+		http.Error(w, e, http.StatusInternalServerError)
+		mediaState.CloseError(errors.New(e))
 		return mediaState
 	}
 
 	// Gather ICE candidates and set local description
 	gatherComplete := webrtc.GatheringCompletePromise(peerConnection)
 	if err = peerConnection.SetLocalDescription(answer); err != nil {
-		http.Error(w, fmt.Sprintf("SetLocalDescription failed: %v", err), http.StatusInternalServerError)
-		mediaState.Close()
+		e := fmt.Sprintf("SetLocalDescription failed: %v", err)
+		http.Error(w, e, http.StatusInternalServerError)
+		mediaState.CloseError(errors.New(e))
 		return mediaState
 	}
 	// Wait for ICE gathering if you want the full candidate set in the SDP
@@ -165,18 +168,20 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 
 	// wait for audio or video
 	go func() {
-		defer mediaState.Close()
 		audioTrack, videoTrack, err := gatherIncomingTracks(ctx, peerConnection, trackCh)
 		if err != nil {
 			clog.Info(ctx, "error gathering tracks", "took", time.Since(gatherStartTime), "err", err)
+			mediaState.CloseError(fmt.Errorf("error gathering tracks: %w", err))
 			return
 		}
 		if videoTrack == nil {
 			clog.Info(ctx, "no video! disconnecting", "took", time.Since(gatherStartTime))
+			mediaState.CloseError(errors.New("missing video"))
 			return
 		}
 		if videoTrack.Codec().MimeType != webrtc.MimeTypeH264 {
 			clog.Info(ctx, "Expected H.264 video", "mime", videoTrack.Codec().MimeType)
+			mediaState.CloseError(errors.New("non-h264 video"))
 			return
 		}
 		tracks := []RTPTrack{videoTrack}
@@ -206,6 +211,7 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 		clog.Infof(ctx, "Gathered %d tracks (%s) took=%v", len(trackCodecs), strings.Join(trackCodecs, ", "), gatherDuration)
 		wg.Wait()
 		segmenter.CloseSegment()
+		mediaState.Close()
 	}()
 	return mediaState
 }

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -837,7 +837,10 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 						clog.Errorf(ctx, "Panic in stream close event routine: %s", r)
 					}
 				}()
-				whipConn.AwaitClose()
+				err := whipConn.AwaitClose()
+				if err != nil {
+					sendErrorEvent(err)
+				}
 				monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
 					"type":        "gateway_ingest_stream_closed",
 					"timestamp":   time.Now().UnixMilli(),


### PR DESCRIPTION
This gives us more visibility into any connectivity errors related to the new WHIP server.

Note that no error is generated or sent on a "normal" disconnect (ICE state == closed)