### PR TITLE
ai/live: Report normal disconnects as errors.

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -840,8 +840,10 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 				}()
 				err := whipConn.AwaitClose()
 				if err != nil {
-					sendErrorEvent(err)
+					// For now, set a "whip disconnected" event"
+					err = errors.New("whip disconnected")
 				}
+				sendErrorEvent(err)
 				monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
 					"type":        "gateway_ingest_stream_closed",
 					"timestamp":   time.Now().UnixMilli(),


### PR DESCRIPTION
This may make it easier to identify disconnects as the root source of a failed stream, since teardowns make things bounce around a bit until we eventually hit a trickle subscribe end-of-stream "error" which may be misleading.

This change is separate from https://github.com/livepeer/go-livepeer/pull/3479 in case we would rather not report this as an error.

Requires https://github.com/livepeer/go-livepeer/pull/3479

<img width="530" alt="image" src="https://github.com/user-attachments/assets/6dcaa7fa-10f6-4422-a007-1f6eeedbc352" />