### PR TITLE
Improve live pipeline cleanup

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -133,7 +133,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 					return
 				}
 				clog.Infof(ctx, "Error publishing segment before writing; retrying err=%v", err)
-				// Clone in case read head was incremented somewhere, which cloning ressets
+				// Clone in case read head was incremented somewhere, which cloning resets
 				r = reader.Clone()
 				time.Sleep(250 * time.Millisecond)
 			}
@@ -317,7 +317,7 @@ func copySegment(segment *http.Response, w io.Writer) (int64, error) {
 	return io.Copy(w, segment.Body)
 }
 
-func startControlPublish(control *url.URL, params aiRequestParams) {
+func startControlPublish(ctx context.Context, control *url.URL, params aiRequestParams) {
 	stream := params.liveParams.stream
 	controlPub, err := trickle.NewTricklePublisher(control.String())
 	if err != nil {
@@ -357,6 +357,7 @@ func startControlPublish(control *url.URL, params aiRequestParams) {
 				}
 				// if there was another type of error, we'll just retry anyway
 			case <-done:
+				cleanupLive(ctx, params.node, stream)
 				return
 			}
 		}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -908,6 +908,11 @@ func cleanupLive(ctx context.Context, node *core.LivepeerNode, stream string) {
 	clog.Infof(ctx, "Live video pipeline finished")
 	node.LiveMu.Lock()
 	pub, ok := node.LivePipelines[stream]
+	if !ok {
+	    // already cleaned up
+	    node.LiveMy.Unlock()
+	    return
+	}
 	delete(node.LivePipelines, stream)
 	if monitor.Enabled {
 		monitor.AICurrentLiveSessions(len(node.LivePipelines))

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -909,9 +909,9 @@ func cleanupLive(ctx context.Context, node *core.LivepeerNode, stream string) {
 	node.LiveMu.Lock()
 	pub, ok := node.LivePipelines[stream]
 	if !ok {
-	    // already cleaned up
-	    node.LiveMy.Unlock()
-	    return
+		// already cleaned up
+		node.LiveMu.Unlock()
+		return
 	}
 	delete(node.LivePipelines, stream)
 	if monitor.Enabled {
@@ -920,7 +920,7 @@ func cleanupLive(ctx context.Context, node *core.LivepeerNode, stream string) {
 	}
 	node.LiveMu.Unlock()
 
-	if ok && pub != nil && pub.ControlPub != nil {
+	if pub != nil && pub.ControlPub != nil {
 		if err := pub.ControlPub.Close(); err != nil {
 			slog.Info("Error closing trickle publisher", "err", err)
 		}

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1088,7 +1088,7 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 	}
 	clog.V(common.VERBOSE).Infof(ctx, "pub %s sub %s control %s events %s", pub, sub, control, events)
 
-	startControlPublish(control, params)
+	startControlPublish(ctx, control, params)
 	startTricklePublish(ctx, pub, params, sess)
 	startTrickleSubscribe(ctx, sub, params, sess, func() {
 		delayMs := time.Since(startTime).Milliseconds()


### PR DESCRIPTION
It fixes the race condition that happened when segmented failed before creating control trickle channel. Then, livePipelines was never cleaned up which results in the excessive live pipeline metric.

Effectively this fixes this broken metric (plus avoid some mem leaks in gateway).

<img width="727" alt="image" src="https://github.com/user-attachments/assets/1612df9b-3bba-4bc1-9e50-5d4df69ec76a" />
