### PR TITLE
Only send gateway_ingest_stream_closed on client disconnects

### DIFF
--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -39,6 +39,8 @@ var (
 	allowedCodecs func(*webrtc.API)
 	interceptors  func(*webrtc.API)
 	settings      func(*webrtc.API)
+
+	ICEDisconnect = errors.New("ICE connection state closed")
 )
 
 // Generate a random ID for new resources
@@ -108,7 +110,7 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 		if connectionState == webrtc.ICEConnectionStateFailed {
 			mediaState.CloseError(errors.New("ICE connection state failed"))
 		} else if connectionState == webrtc.ICEConnectionStateClosed {
-			// Business logic when PeerConnection done
+			mediaState.CloseError(ICEDisconnect)
 		}
 	})
 


### PR DESCRIPTION
Instead of firing `gateway_ingest_stream_closed` event on every type of shutdown we can detect the ICE connection `closed` state (which happens on client disconnects) and only fire it in those cases as I believe was the intent, right @victorges ?
(I saw an example from prod where we had the ICE connection `failed` state and we still fired `gateway_ingest_stream_closed`)