### PR TITLE
Revert "Set ID params in the body rather than headers (#3475)"

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -617,10 +617,8 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		}
 
 		req := worker.GenLiveVideoToVideoJSONRequestBody{
-			ModelId:          &pipeline,
-			Params:           &pipelineParams,
-			GatewayRequestId: &requestID,
-			StreamId:         &streamID,
+			ModelId: &pipeline,
+			Params:  &pipelineParams,
 		}
 		_, err = processAIRequest(ctx, params, req)
 		if err != nil {

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1054,8 +1054,17 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 	}
 	defer completeBalanceUpdate(sess.BroadcastSession, balUpdate)
 
+	setHeaders := func(ctx context.Context, req *http.Request) error {
+		if err := paymentHeaders(ctx, req); err != nil {
+			return err
+		}
+		req.Header.Set("requestID", params.liveParams.requestID)
+		req.Header.Set("streamID", params.liveParams.streamID)
+		return nil
+	}
+
 	// Send request to orchestrator
-	resp, err := client.GenLiveVideoToVideoWithResponse(ctx, nil, req, paymentHeaders)
+	resp, err := client.GenLiveVideoToVideoWithResponse(ctx, nil, req, setHeaders)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This reverts commit 7fa2d4e3cace96bdc8e1dd0e347c420ce03fb236.

This doesn't seem to be working in our environment so revert for now.
