### PR TITLE
Set ID params in new whip server request

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -879,8 +879,10 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			}
 
 			req := worker.GenLiveVideoToVideoJSONRequestBody{
-				ModelId: &pipeline,
-				Params:  &pipelineParams,
+				ModelId:          &pipeline,
+				Params:           &pipelineParams,
+				GatewayRequestId: &requestID,
+				StreamId:         &streamID,
 			}
 			_, err := processAIRequest(ctx, params, req)
 			if err != nil {


### PR DESCRIPTION
Forgot about new whip server in https://github.com/livepeer/go-livepeer/pull/3475. This fixes that.