### PR TITLE
Improve to startup

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -644,6 +644,13 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		lpmon.InitCensus(nodeType, core.LivepeerVersion)
 	}
 
+	// Start Kafka producer
+	if *cfg.Monitor {
+		if err := startKafkaProducer(cfg); err != nil {
+			exit("Error while starting Kafka producer", err)
+		}
+	}
+
 	watcherErr := make(chan error)
 	serviceErr := make(chan error)
 	var timeWatcher *watchers.TimeWatcher
@@ -1687,13 +1694,6 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 		if n.NodeType == core.AIWorkerNode {
 			go server.RunAIWorker(n, orchURLs[0].Host, n.Capabilities.ToNetCapabilities())
-		}
-	}
-
-	// Start Kafka producer
-	if *cfg.Monitor {
-		if err := startKafkaProducer(cfg); err != nil {
-			exit("Error while starting Kafka producer", err)
 		}
 	}
 


### PR DESCRIPTION
1. Initialize `kafkaProducer` before Orchestrator Pool => That allows sending first Kafka event for `network_capabilities`
2. Do not delay the startup if the on-chain pool is not used => That will decrease the downtime when we deploy our Realtime AI Video Gateways