### PR TITLE
Auto clear existing sessions if they are not returned from the discovery

### DIFF
--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -259,7 +259,7 @@ func (s *stubSelector) Complete(sess *BroadcastSession)          {}
 func (s *stubSelector) Select(context.Context) *BroadcastSession { return s.sess }
 func (s *stubSelector) Size() int                                { return s.size }
 func (s *stubSelector) Clear()                                   {}
-func (s *stubSelector) Remove(session *BroadcastSession) bool    { return false }
+func (s *stubSelector) Remove(session *BroadcastSession)         {}
 
 func TestStopSessionErrors(t *testing.T) {
 

--- a/server/selection_test.go
+++ b/server/selection_test.go
@@ -233,6 +233,8 @@ func TestSelector_Size(t *testing.T) {
 	sel.Complete(sess3)
 	sel.Complete(sess2)
 	assert.Equal(3, sel.Size())
+	sel.Remove(sess2)
+	assert.Equal(2, sel.Size())
 	sel.Clear()
 	assert.Equal(0, sel.Size())
 	assert.Nil(sel.Select(context.Background()))
@@ -275,9 +277,10 @@ func TestMinLSSelector(t *testing.T) {
 	sel := NewMinLSSelector(nil, 1.0, stubSelectionAlgorithm{}, nil, nil)
 	assert.Zero(sel.Size())
 
+	oneSess := &BroadcastSession{}
 	sessions := []*BroadcastSession{
 		{},
-		{},
+		oneSess,
 		{},
 	}
 
@@ -289,6 +292,11 @@ func TestMinLSSelector(t *testing.T) {
 	for _, sess := range sessions {
 		assert.Contains(sel.sessions, sess)
 	}
+
+	// Remove session
+	sel.Remove(oneSess)
+	assert.Equal(2, sel.Size())
+	sel.Add([]*BroadcastSession{oneSess})
 
 	// Select from sessions
 	sess1 := sel.Select(context.TODO())


### PR DESCRIPTION
Every time we do the discovery process (every 6 min for Realtime Video), it will remove the existing sessions that were not returned from the discovery.

Why?
- If we store the stale sessions in the pool, then it's hard to take O out of rotation, because the session can be reused for a long time (until it fails for the first time) in the pool;
- This can improve performance for Realtime Video, because we will have more "fresh state" in the pool; currently we may cache O's session that are busy at the moment

fix https://linear.app/livepeer/issue/PS-1051/take-orchestrator-out-of-rotation