### PR TITLE
ai/live: Send WHEP playback URL in WHIP answer.

### DIFF
--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -69,7 +69,7 @@ type WHIPServer struct {
 }
 
 // handleCreate implements the POST that creates a new resource.
-func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReader, w http.ResponseWriter, r *http.Request) *MediaState {
+func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReader, whepURL string, w http.ResponseWriter, r *http.Request) *MediaState {
 	clog.Infof(ctx, "creating whip")
 
 	// Must have Content-Type: application/sdp (the spec strongly recommends it)
@@ -156,6 +156,7 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 	w.Header().Set("Location", resourceURL)
 	w.Header().Set("ETag", etag)
 	w.Header()["Link"] = GenICELinkHeaders(WebrtcConfig.ICEServers)
+	w.Header().Set("Livepeer-Playback-URL", whepURL)
 	w.WriteHeader(http.StatusCreated)
 
 	// Write the full SDP answer

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -745,6 +745,12 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 
 		whipConn := media.NewWHIPConnection()
 
+		whepURL := os.Getenv("LIVE_AI_WHEP_URL")
+		if whepURL == "" {
+			whepURL = "http://localhost:8889/" // default mediamtx output
+		}
+		whepURL = whepURL + streamName + "-out/whep"
+
 		go func() {
 			internalOutputHost := os.Getenv("LIVE_AI_PLAYBACK_HOST") // TODO proper cli arg
 			if internalOutputHost == "" {
@@ -896,7 +902,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			clog.Info(ctx, "Live cleaned up")
 		}()
 
-		conn := server.CreateWHIP(ctx, ssr, w, r)
+		conn := server.CreateWHIP(ctx, ssr, whepURL, w, r)
 		whipConn.SetWHIPConnection(conn) // might be nil if theres an error and thats okay
 	})
 }


### PR DESCRIPTION
Players can use the `Livepeer-Playback-URL`  header to extract the WHEP playback URL from the WHIP answer, which avoids the roll of the DNS dice between ingest and playback.