### PR TITLE
ai/live: Don't overwrite WHIP errors

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -839,7 +839,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 					}
 				}()
 				err := whipConn.AwaitClose()
-				if err != nil {
+				if err == nil {
 					// For now, set a "whip disconnected" event"
 					err = errors.New("whip disconnected")
 				}


### PR DESCRIPTION
Fixes an oops introduced in https://github.com/livepeer/go-livepeer/pull/3479 and partially exacerbated by https://github.com/livepeer/go-livepeer/pull/3480

This bug actually triggers a panic but we explicitly catch those so it was missed in the flurry of logs. I think this also made us send `gateway_ingest_stream_closed` events _only_ if we had an error disconnecting which is ... not correct, we should always be sending those events.