### PR TITLE
Multiple AI Runner Container per 1 GPU

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -452,6 +452,9 @@ func resolveGPU(gpu string) string {
 	if strings.HasPrefix(gpu, "stack-") {
 		return strings.Replace(gpu, "stack-", "", 1)
 	}
+	if strings.HasPrefix(gpu, "sstack-") {
+		return strings.Replace(gpu, "sstack-", "", 1)
+	}
 	return gpu
 }
 
@@ -701,7 +704,11 @@ func portOffset(gpu string) string {
 	}
 	if actualGpu != gpu {
 		// stacked
-		res = strings.Replace(res, "0", "1", 1)
+		if strings.HasPrefix(gpu, "sstack-") {
+			res = strings.Replace(res, "0", "2", 1)
+		} else {
+			res = strings.Replace(res, "0", "1", 1)
+		}
 	}
 	return res
 }

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -323,7 +323,6 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 		return nil, err
 	}
 
-	// NOTE: We currently allow only one container per GPU for each pipeline.
 	containerHostPort := containerHostPorts[pipeline][:2] + portOffset(gpu)
 	containerName := dockerContainerName(pipeline, modelID, containerHostPort)
 	containerImage, err := m.getContainerImageName(pipeline, modelID)

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -450,7 +450,7 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 }
 
 func hwGPU(gpu string) string {
-	if !strings.Contains(gpu, "colocated-") {
+	if !strings.HasPrefix(gpu, "colocated-") {
 		return gpu
 	}
 

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -1090,3 +1090,75 @@ func TestDockerWaitUntilRunning(t *testing.T) {
 		mockDockerClient.AssertExpectations(t)
 	})
 }
+
+func TestHwGPU(t *testing.T) {
+	tests := []struct {
+		name          string
+		gpu           string
+		expectedHwGPU string
+	}{
+		{
+			name:          "Standard GPU",
+			gpu:           "0",
+			expectedHwGPU: "0",
+		},
+		{
+			name:          "Emulated GPU",
+			gpu:           "emulated-0",
+			expectedHwGPU: "emulated-0",
+		},
+		{
+			name:          "Colocated GPU",
+			gpu:           "colocated-2-1",
+			expectedHwGPU: "1",
+		},
+		{
+			name:          "Colocated Emulated GPU",
+			gpu:           "colocated-1-emulated-0",
+			expectedHwGPU: "emulated-0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := hwGPU(tt.gpu)
+			require.Equal(t, tt.expectedHwGPU, res)
+		})
+	}
+}
+
+func TestPortOffset(t *testing.T) {
+	tests := []struct {
+		name               string
+		gpu                string
+		expectedPortOffset string
+	}{
+		{
+			name:               "Standard GPU",
+			gpu:                "0",
+			expectedPortOffset: "00",
+		},
+		{
+			name:               "Emulated GPU",
+			gpu:                "emulated-1",
+			expectedPortOffset: "01",
+		},
+		{
+			name:               "Colocated GPU",
+			gpu:                "colocated-2-1",
+			expectedPortOffset: "21",
+		},
+		{
+			name:               "Colocated Emulated GPU",
+			gpu:                "colocated-1-emulated-0",
+			expectedPortOffset: "10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := portOffset(tt.gpu)
+			require.Equal(t, tt.expectedPortOffset, res)
+		})
+	}
+}

--- a/box/aiModels.json
+++ b/box/aiModels.json
@@ -8,5 +8,10 @@
     "model_id": "noop",
     "pipeline": "live-video-to-video",
     "warm": true
+  },
+  {
+    "model_id": "noop",
+    "pipeline": "live-video-to-video",
+    "warm": true
   }
 ]

--- a/box/aiModels.json
+++ b/box/aiModels.json
@@ -3,15 +3,5 @@
     "model_id": "noop",
     "pipeline": "live-video-to-video",
     "warm": true
-  },
-  {
-    "model_id": "noop",
-    "pipeline": "live-video-to-video",
-    "warm": true
-  },
-  {
-    "model_id": "noop",
-    "pipeline": "live-video-to-video",
-    "warm": true
   }
 ]

--- a/box/aiModels.json
+++ b/box/aiModels.json
@@ -3,5 +3,10 @@
     "model_id": "noop",
     "pipeline": "live-video-to-video",
     "warm": true
+  },
+  {
+    "model_id": "noop",
+    "pipeline": "live-video-to-video",
+    "warm": true
   }
 ]

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -165,6 +165,7 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.AIVerboseLogs = flag.Bool("aiVerboseLogs", *cfg.AIVerboseLogs, "Set to true to enable verbose logs for the AI runner containers created by the worker")
 	cfg.AIRunnerImageOverrides = flag.String("aiRunnerImageOverrides", *cfg.AIRunnerImageOverrides, `Specify overrides for the Docker images used by the AI runner. Example: '{"default": "livepeer/ai-runner:v1.0", "batch": {"text-to-speech": "livepeer/ai-runner:text-to-speech-v1.0"}, "live": {"another-pipeline": "livepeer/ai-runner:another-pipeline-v1.0"}}'`)
 	cfg.AIProcessingRetryTimeout = flag.Duration("aiProcessingRetryTimeout", *cfg.AIProcessingRetryTimeout, "Timeout for retrying to initiate AI processing request")
+	cfg.AIRunnerContainersPerGPU = flag.Int("aiRunnerContainersPerGPU", *cfg.AIRunnerContainersPerGPU, "Number of AI runner containers to run per GPU; default to 1")
 
 	// Live AI:
 	cfg.MediaMTXApiPassword = flag.String("mediaMTXApiPassword", "", "HTTP basic auth password for MediaMTX API requests")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1212,6 +1212,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			// Create 2 fake GPU instances, intended for the local non-GPU setup
 			gpus = []string{"emulated-0"}
 		}
+		gpus = append(gpus, fmt.Sprintf("stack-%s", gpus[0]))
 
 		modelsDir := *cfg.AIModelsDir
 		if modelsDir == "" {

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1213,6 +1213,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			gpus = []string{"emulated-0"}
 		}
 		gpus = append(gpus, fmt.Sprintf("stack-%s", gpus[0]))
+		gpus = append(gpus, fmt.Sprintf("sstack-%s", gpus[0]))
 
 		modelsDir := *cfg.AIModelsDir
 		if modelsDir == "" {


### PR DESCRIPTION
Add `-aiRunnerContainersPerGPU` flag which allow to specify the number of AI Runner container run for a single GPU.