### PR TITLE
ai/live: Prevent a race condition with control channels

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -165,6 +165,7 @@ type LivepeerNode struct {
 }
 
 type LivePipeline struct {
+	RequestID   string
 	ControlPub  *trickle.TricklePublisher
 	StopControl func()
 }

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -551,27 +551,6 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			monitor.AILiveVideoAttempt()
 		}
 
-		// Kick off the RTMP pull and segmentation as soon as possible
-		ssr := media.NewSwitchableSegmentReader()
-		go func() {
-			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir, MediaMTXClient: mediaMTXClient}
-			ms.RunSegmentation(ctx, mediaMTXInputURL, ssr.Read)
-			monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
-				"type":        "gateway_ingest_stream_closed",
-				"timestamp":   time.Now().UnixMilli(),
-				"stream_id":   streamID,
-				"pipeline_id": pipelineID,
-				"request_id":  requestID,
-				"orchestrator_info": map[string]interface{}{
-					"address": "",
-					"url":     "",
-				},
-			})
-			ssr.Close()
-			<-orchSelection // wait for selection to complete
-			cleanupLive(ctx, ls.LivepeerNode, streamName)
-		}()
-
 		sendErrorEvent := LiveErrorEventSender(ctx, streamID, map[string]string{
 			"type":        "error",
 			"request_id":  requestID,
@@ -596,6 +575,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			}
 		}
 
+		ssr := media.NewSwitchableSegmentReader()
 		params := aiRequestParams{
 			node:        ls.LivepeerNode,
 			os:          drivers.NodeStorage.NewSession(requestID),
@@ -614,6 +594,26 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 				sendErrorEvent:         sendErrorEvent,
 			},
 		}
+
+		// Kick off the RTMP pull and segmentation as soon as possible
+		go func() {
+			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir, MediaMTXClient: mediaMTXClient}
+			ms.RunSegmentation(ctx, mediaMTXInputURL, ssr.Read)
+			monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
+				"type":        "gateway_ingest_stream_closed",
+				"timestamp":   time.Now().UnixMilli(),
+				"stream_id":   streamID,
+				"pipeline_id": pipelineID,
+				"request_id":  requestID,
+				"orchestrator_info": map[string]interface{}{
+					"address": "",
+					"url":     "",
+				},
+			})
+			ssr.Close()
+			<-orchSelection // wait for selection to complete
+			cleanupControl(ctx, params)
+		}()
 
 		req := worker.GenLiveVideoToVideoJSONRequestBody{
 			ModelId:          &pipeline,
@@ -898,7 +898,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			}
 			whipConn.AwaitClose()
 			ssr.Close()
-			cleanupLive(ctx, ls.LivepeerNode, streamName)
+			cleanupControl(ctx, params)
 			clog.Info(ctx, "Live cleaned up")
 		}()
 
@@ -914,8 +914,10 @@ func (ls *LivepeerServer) WithCode(code int) http.Handler {
 	})
 }
 
-func cleanupLive(ctx context.Context, node *core.LivepeerNode, stream string) {
+func cleanupControl(ctx context.Context, params aiRequestParams) {
 	clog.Infof(ctx, "Live video pipeline finished")
+	stream := params.liveParams.stream
+	node := params.node
 	node.LiveMu.Lock()
 	pub, ok := node.LivePipelines[stream]
 	if !ok {
@@ -930,7 +932,7 @@ func cleanupLive(ctx context.Context, node *core.LivepeerNode, stream string) {
 	}
 	node.LiveMu.Unlock()
 
-	if pub != nil && pub.ControlPub != nil {
+	if pub != nil && pub.ControlPub != nil && pub.RequestID == params.liveParams.requestID {
 		if err := pub.ControlPub.Close(); err != nil {
 			slog.Info("Error closing trickle publisher", "err", err)
 		}

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -97,8 +97,8 @@ func (a aiRequestParams) inputStreamExists() bool {
 	}
 	a.node.LiveMu.RLock()
 	defer a.node.LiveMu.RUnlock()
-	_, ok := a.node.LivePipelines[a.liveParams.stream]
-	return ok
+	p, ok := a.node.LivePipelines[a.liveParams.stream]
+	return ok && p.RequestID == a.liveParams.requestID
 }
 
 // For live video pipelines


### PR DESCRIPTION
Depends on https://github.com/livepeer/go-livepeer/pull/3502 - without the "single cleanup point" the setup becomes more gnarly in the MediaMTX ingest handler.

Draft for now because I've had a really hard time testing this due to various issues with concurrent connections on a gateway.

---

It is possible for us to receive concurrent connections for the same stream key. For most things it is not an issue and we can let stale connections tear themselves down eventually, but the control API poses a special problem since it is indexed by stream key, not request ID.

This could result in a stale connection shutting down the control channel for an active connection, which would in turn terminate the stream on the runner.

To mitigate this, add a request ID to each control struct and check the ID wherever we use the control struct. If we try to overwrite an existing control struct, then shut the old one down.

Stomping over old control structs is not ideal and potentially problematic but OK for now.

Some alternatives to consider later include:

- Keeping a list of control structs under the same stream key. Any control API calls would have to go out to each of them.

- Updating the API to access active streams only, eg by including the request ID in the control call.