### PR TITLE
fix(transcoder): add input duration validation to prevent large output files

### DIFF
--- a/core/ai_orchestrator.go
+++ b/core/ai_orchestrator.go
@@ -1127,6 +1127,7 @@ func (n *LivepeerNode) transcodeFrames(ctx context.Context, sessionID string, ur
 			outProfile,
 		},
 		AuthToken: &net.AuthToken{SessionId: sessionID},
+		Duration:  1,
 	}
 
 	los := drivers.NodeStorage.NewSession(sessionID)

--- a/core/ai_orchestrator.go
+++ b/core/ai_orchestrator.go
@@ -1127,7 +1127,6 @@ func (n *LivepeerNode) transcodeFrames(ctx context.Context, sessionID string, ur
 			outProfile,
 		},
 		AuthToken: &net.AuthToken{SessionId: sessionID},
-		Duration:  1,
 	}
 
 	los := drivers.NodeStorage.NewSession(sessionID)

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -53,7 +53,7 @@ func TestTranscode(t *testing.T) {
 	ffmpeg.InitFFmpeg()
 
 	ss := StubSegment()
-	md := &SegTranscodingMetadata{Profiles: videoProfiles, AuthToken: stubAuthToken()}
+	md := &SegTranscodingMetadata{Profiles: videoProfiles, AuthToken: stubAuthToken(), Duration: 1}
 
 	// Check nil transcoder.
 	tr, err := n.sendToTranscodeLoop(context.TODO(), md, ss)
@@ -135,7 +135,7 @@ func TestTranscodeLoop_GivenNoSegmentsPastTimeout_CleansSegmentChan(t *testing.T
 	n, _ := NewLivepeerNode(seth, tmp, nil)
 	ffmpeg.InitFFmpeg()
 	ss := StubSegment()
-	md := &SegTranscodingMetadata{Profiles: videoProfiles, AuthToken: stubAuthToken()}
+	md := &SegTranscodingMetadata{Profiles: videoProfiles, AuthToken: stubAuthToken(), Duration: 1}
 	n.Transcoder = NewLocalTranscoder(tmp)
 
 	transcodeLoopTimeout = 100 * time.Millisecond
@@ -170,7 +170,7 @@ func TestTranscodeLoop_CleanupForBroadcasterEndTranscodingSession(t *testing.T) 
 	n, _ := NewLivepeerNode(&eth.StubClient{}, tmp, nil)
 	n.Transcoder = NewLocalTranscoder(tmp)
 
-	md := &SegTranscodingMetadata{Profiles: videoProfiles, AuthToken: stubAuthToken()}
+	md := &SegTranscodingMetadata{Profiles: videoProfiles, AuthToken: stubAuthToken(), Duration: 1}
 	mid := ManifestID(md.AuthToken.SessionId)
 
 	ss := StubSegment()

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -45,6 +45,12 @@ func (lt *LocalTranscoder) Transcode(ctx context.Context, md *SegTranscodingMeta
 	// Returns UnrecoverableError instead of panicking to gracefully notify orchestrator about transcoder's failure
 	defer recoverFromPanic(&retErr)
 
+	// Validate input duration
+	maxAllowedDuration := 30 * time.Second
+	if md.Duration.Seconds() > maxAllowedDuration.Seconds() || md.Duration.Seconds() <= 0 {
+		return nil, fmt.Errorf("invalid segment duration: %v seconds", md.Duration)
+	}
+
 	// Set up in / out config
 	in := &ffmpeg.TranscodeOptionsIn{
 		Fname:   md.Fname,

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -48,7 +48,7 @@ func (lt *LocalTranscoder) Transcode(ctx context.Context, md *SegTranscodingMeta
 	defer recoverFromPanic(&retErr)
 
 	// Validate input duration
-	if md.Duration.Seconds() > maxAllowedSegmentDuration.Seconds() || md.Duration.Seconds() <= 0 {
+	if md.Duration.Seconds() > maxAllowedSegmentDuration.Seconds() || md.Duration.Seconds() < 0 {
 		return nil, fmt.Errorf("invalid segment duration: %v seconds", md.Duration)
 	}
 

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -48,6 +48,7 @@ func (lt *LocalTranscoder) Transcode(ctx context.Context, md *SegTranscodingMeta
 	defer recoverFromPanic(&retErr)
 
 	// Validate input duration
+	// TODO: Allow 0 duration for backward compatibility; validate in the future.
 	if md.Duration.Seconds() > maxAllowedSegmentDuration.Seconds() || md.Duration.Seconds() < 0 {
 		return nil, fmt.Errorf("invalid segment duration: %v seconds", md.Duration)
 	}

--- a/core/transcoder.go
+++ b/core/transcoder.go
@@ -22,6 +22,8 @@ import (
 	"github.com/livepeer/lpms/ffmpeg"
 )
 
+const maxAllowedSegmentDuration = 30 * time.Second
+
 type Transcoder interface {
 	Transcode(ctx context.Context, md *SegTranscodingMetadata) (*TranscodeData, error)
 	EndTranscodingSession(sessionId string)
@@ -46,8 +48,7 @@ func (lt *LocalTranscoder) Transcode(ctx context.Context, md *SegTranscodingMeta
 	defer recoverFromPanic(&retErr)
 
 	// Validate input duration
-	maxAllowedDuration := 30 * time.Second
-	if md.Duration.Seconds() > maxAllowedDuration.Seconds() || md.Duration.Seconds() <= 0 {
+	if md.Duration.Seconds() > maxAllowedSegmentDuration.Seconds() || md.Duration.Seconds() <= 0 {
 		return nil, fmt.Errorf("invalid segment duration: %v seconds", md.Duration)
 	}
 

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func stubMetadata(sess string, profile ...ffmpeg.VideoProfile) *SegTranscodingMetadata {
-	return &SegTranscodingMetadata{AuthToken: &net.AuthToken{SessionId: sess}, Profiles: profile}
+	return &SegTranscodingMetadata{AuthToken: &net.AuthToken{SessionId: sess}, Profiles: profile, Duration: 1}
 }
 
 func TestLocalTranscoder(t *testing.T) {
@@ -331,7 +331,7 @@ func TestTranscode_DurationValidation(t *testing.T) {
 	}{
 		{
 			name:        "Long Duration",
-			duration:    601 * time.Second, // 10 minutes and 1 second
+			duration:    31 * time.Second, // Greater than 30 seconds
 			expectedErr: "invalid segment duration",
 		},
 		{
@@ -347,6 +347,11 @@ func TestTranscode_DurationValidation(t *testing.T) {
 		{
 			name:        "Valid Duration",
 			duration:    1 * time.Second, // 1 second
+			expectedErr: "",
+		},
+		{
+			name:        "Maximum Allowed Duration",
+			duration:    30 * time.Second, // Exactly 30 seconds
 			expectedErr: "",
 		},
 	}

--- a/core/transcoder_test.go
+++ b/core/transcoder_test.go
@@ -340,11 +340,6 @@ func TestTranscode_DurationValidation(t *testing.T) {
 			expectedErr: "invalid segment duration",
 		},
 		{
-			name:        "Zero Duration",
-			duration:    0, // Invalid duration
-			expectedErr: "invalid segment duration",
-		},
-		{
 			name:        "Valid Duration",
 			duration:    1 * time.Second, // 1 second
 			expectedErr: "",


### PR DESCRIPTION
This commit adds validation logic to the Transcode function to ensure input segment durations are within acceptable limits. This prevents excessively long durations from creating large `out_*.tempfile` files that could exhaust disk space. The commit also includes tests to verify proper handling of valid and invalid durations. 

@leszko, @j0sh opened up this draft to start the discussion. Maybe we already have logic that should prevent this. Additionally, we could also validate the input size to make it more rigid.

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

It fixes a problem several orchestrators ran into that crashed their transcoders due to insufficient disk space errors.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Added validation logic to the transcode function which prevents input file with to large durations from being transcoded. 
- Adde tests to ensure this logic works.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

> [!IMPORTANT]
> Still have to test these changes hence the draft.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Yes, this is internally tracked [here](https://linear.app/livepeer/issue/ENG-2670/transcoder-creates-excessively-large-temporary-files-due-to-invalid).

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass - ❌ Tests still failing.
- ~[ ] README and other documentation updated~
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
