### PR TITLE
ai/box: Dockerize box

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ box-rebuild:
 ifeq ($(strip ${REBUILD}),false)
 	@echo "Skipping rebuild of components"
 else
-		@$(MAKE) box-runner
+	@$(MAKE) box-runner
 	ifeq ($(strip ${DOCKER}),true)
 		docker build -t livepeer/go-livepeer -f docker/Dockerfile .
 	else

--- a/Makefile
+++ b/Makefile
@@ -130,15 +130,28 @@ swagger:
 
 # Command to run Livepeer Realtime AI Video in a Box
 .PHONY: box
-box: livepeer box-runner
+box: box-rebuild
 	./box/box.sh
 
+.PHONY: box-rebuild
+box-rebuild:
+ifeq ($(strip ${REBUILD}),false)
+	@echo "Skipping rebuild of components"
+else
+		@$(MAKE) box-runner
+	ifeq ($(strip ${DOCKER}),true)
+		docker build -t livepeer/go-livepeer -f docker/Dockerfile .
+	else
+		@$(MAKE) livepeer
+	endif
+endif
+
 .PHONY: box-gateway
-box-gateway: livepeer
+box-gateway: box-rebuild
 	./box/gateway.sh
 
 .PHONY: box-orchestrator
-box-orchestrator: livepeer
+box-orchestrator: box-rebuild
 	./box/orchestrator.sh
 
 .PHONY: box-mediamtx

--- a/Makefile
+++ b/Makefile
@@ -139,11 +139,11 @@ ifeq ($(strip ${REBUILD}),false)
 	@echo "Skipping rebuild of components"
 else
 	@$(MAKE) box-runner
-	ifeq ($(strip ${DOCKER}),true)
-		docker build -t livepeer/go-livepeer -f docker/Dockerfile .
-	else
-		@$(MAKE) livepeer
-	endif
+    ifeq ($(strip ${DOCKER}),true)
+	    docker build -t livepeer/go-livepeer -f docker/Dockerfile .
+    else
+	    @$(MAKE) livepeer
+    endif
 endif
 
 .PHONY: box-gateway

--- a/box/box.md
+++ b/box/box.md
@@ -56,7 +56,7 @@ export PIPELINE=comfyui
 ```bash
 cd ../ai-runner/runner
 ./dl_checkpoints.sh --tensorrt
-export MODEL_DIR=$(pwd)/models
+export AI_MODELS_DIR=$(pwd)/models
 ```
 
 2. Start everything with the following command

--- a/box/box.md
+++ b/box/box.md
@@ -1,5 +1,9 @@
 # Realtime Video AI in a Box
 
+## Requirements
+- Docker is installed (executing `docker` should succeed)
+- [ffmpeg](https://ffmpeg.org/) is installed (executing `ffmpeg` and `ffplay` should succeed)
+
 ## Usage (Linux AMD64)
 
 ```

--- a/box/box.md
+++ b/box/box.md
@@ -52,18 +52,19 @@ export PIPELINE=comfyui
 ```bash
 cd ../ai-runner/runner
 ./dl_checkpoints.sh --tensorrt
+export MODEL_DIR=$(pwd)/models
 ```
 
-2Start everything with the following command
+2. Start everything with the following command
 ```bash
 make box
 ```
-3Start streaming
+3. Start streaming
 ```bash
 make box-stream
 ```
 
-4Playback the stream
+4. Playback the stream
 ```bash
 make box-playback
 ```

--- a/box/box.md
+++ b/box/box.md
@@ -1,38 +1,10 @@
 # Realtime Video AI in a Box
 
-## Requirements
-- go-livepeer compilation configuration (executing `make` should succeed)
-- [mediamtx](https://github.com/bluenviron/mediamtx) is installed (executing `mediamtx` should succeed)
-- [ffmpeg](https://ffmpeg.org/) is installed (executing `ffmpeg` and `ffplay` should succeed)
-- Docker installed
+## Usage (Linux AMD64)
 
-## Setup
-
-### Pipeline
-
-The box runs the `noop` pipeline by default, which doesn't need a GPU to function. If you want to run the `comfyui` pipeline instead, make sure you set the `PIPELINE` env in **all** your shell sessions:
-```bash
-export PIPELINE=comfyui
 ```
-
-If you do run the `comfyui` pipeline, make sure you've also downloaded the required models with:
-```bash
-cd ../ai-runner/runner
-./dl_checkpoints.sh --tensorrt
+export DOCKER=true
 ```
-
-This will make the models available in the `./ai-runner/runner/models` folder, which is mounted by the orchestrator on the runner containers.
-
-### RTMP Output
-
-If you also want to send the inference output to an external RTMP endpoint, set the `RTMP_OUTPUT` env var:
-```bash
-export RTMP_OUTPUT=rtmp://rtmp.livepeer.com/live/$STREAM_KEY
-```
-
-This one is only required for the `box-stream` command.
-
-## Usage
 
 1. Start everything with the following command
 ```bash
@@ -44,11 +16,86 @@ make box-stream
 ```
 
 3. Playback the stream
-```
+```bash
 make box-playback
 ```
 
-## Usage (each service separately)
+## Usage (M1 / Linux ARM64)
+
+It requires the following points:
+- go-livepeer compilation configuration (executing `make` should succeed)
+- [mediamtx](https://github.com/bluenviron/mediamtx) is installed (executing `mediamtx` should succeed)
+
+1. Start everything with the following command
+```bash
+make box
+```
+2. Start streaming
+```bash
+make box-stream
+```
+
+3. Playback the stream
+```bash
+make box-playback
+```
+
+## Usage with ComfyUI Pipeline (requires GPU)
+
+```
+export DOCKER=true
+export PIPELINE=comfyui
+```
+
+1. Download models
+
+```bash
+cd ../ai-runner/runner
+./dl_checkpoints.sh --tensorrt
+```
+
+2Start everything with the following command
+```bash
+make box
+```
+3Start streaming
+```bash
+make box-stream
+```
+
+4Playback the stream
+```bash
+make box-playback
+```
+
+## Additional Configuration
+
+### RTMP Output
+
+If you also want to send the inference output to an external RTMP endpoint, set the `RTMP_OUTPUT` env var:
+```bash
+export RTMP_OUTPUT=rtmp://rtmp.livepeer.com/live/$STREAM_KEY
+```
+
+This one is only required for the `box-stream` command. It is useful when you cannot use the `box-playback` command to play the stream, for example when you are using a remote non-UI machine.
+
+### Docker
+If you want to run the box in a docker container, set the `DOCKER` env var:
+```bash
+export DOCKER=true
+```
+
+In general the Docker setup is simpler, but it's not possible to build the `go-liveeer` Docker image on M1 / Linux ARM64 machines.
+
+### Rebuild
+
+By default, all dependencies are rebuilt every time you run the `make box` command. However, if you don't want this to happen, you can set the following env variable.
+
+```bash
+export REBUILD=false
+```
+
+### Each component separately
 
 You can also run each service separately.
 ```bash
@@ -59,7 +106,7 @@ make box-stream
 make box-playback
 ```
 
-## Rebuilding runner
+### Rebuilding runner
 To rebuild and restart the runner, run the following command:
 ```bash
 make box-runner

--- a/box/gateway.sh
+++ b/box/gateway.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
-./livepeer -gateway -rtmpAddr :1936 -httpAddr :5936 -orchAddr localhost:8935 -v 6 -monitor
+
+DOCKER=${DOCKER:-false}
+
+if [ "$DOCKER" = "false" ]; then
+    ./livepeer -gateway -rtmpAddr :1936 -httpAddr :5936 -orchAddr localhost:8935 -v 6 -monitor
+else
+    docker run --rm --name gateway --network host livepeer/go-livepeer -gateway -rtmpAddr :1936 -httpAddr :5936 -orchAddr localhost:8935 -v 6 -monitor
+fi

--- a/box/mediamtx.sh
+++ b/box/mediamtx.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
-mediamtx ./box/mediamtx.yml
+
+DOCKER=${DOCKER:-false}
+
+if [ "$DOCKER" = "false" ]; then
+    mediamtx ./box/mediamtx.yml
+else
+    docker run --rm --name mediamtx --network host -v $(pwd)/box/mediamtx.yml:/mediamtx.yml livepeerci/mediamtx
+fi

--- a/box/orchestrator.sh
+++ b/box/orchestrator.sh
@@ -12,10 +12,11 @@ fi
 NVIDIA=""
 AI_MODELS_DIR=${AI_MODELS_DIR:-}
 if [[ "$PIPELINE" != "noop" ]]; then
-  NVIDIA="all"
-  if [[ -z "$AI_MODELS_DIR" ]]; then
+  NVIDIA="-nvidia all"
+  if [[ "$AI_MODELS_DIR" = "" ]]; then
       AI_MODELS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../runner/models && pwd )"
   fi
+  AI_MODELS_DIR_FLAG="-aiModelsDir ${AI_MODELS_DIR}"
 fi
 
 if [ "$DOCKER" = "false" ]; then
@@ -23,8 +24,8 @@ if [ "$DOCKER" = "false" ]; then
     -orchestrator \
     -aiWorker \
     -aiModels ./box/aiModels-${PIPELINE}.json \
-    -aiModelsDir $AI_MODELS_DIR \
-    -nvidia $NVIDIA \
+    ${AI_MODELS_DIR_FLAG} \
+    ${NVIDIA} \
     -serviceAddr localhost:8935 \
     -transcoder \
     -v 6 \

--- a/box/orchestrator.sh
+++ b/box/orchestrator.sh
@@ -35,7 +35,7 @@ else
   docker run --rm --name orchestrator \
     --network host \
     -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $(pwd)/box/${MODEL_JSON}:/opt/aiModels.json \
+    -v ./box/aiModels-${PIPELINE}.json:/opt/aiModels.json \
     -v /opt/models:/opt/models \
   livepeer/go-livepeer \
     -orchestrator \

--- a/box/orchestrator.sh
+++ b/box/orchestrator.sh
@@ -36,12 +36,11 @@ else
     --network host \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v ./box/aiModels-${PIPELINE}.json:/opt/aiModels.json \
-    -v /opt/models:/opt/models \
   livepeer/go-livepeer \
     -orchestrator \
     -aiWorker \
     -aiModels /opt/aiModels.json \
-    -aiModelsDir /opt/models \
+    ${AI_MODELS_DIR_FLAG} \
     -serviceAddr 127.0.0.1:8935 \
     -transcoder \
     -v 6 \

--- a/box/orchestrator.sh
+++ b/box/orchestrator.sh
@@ -14,7 +14,7 @@ AI_MODELS_DIR=${AI_MODELS_DIR:-}
 if [[ "$PIPELINE" != "noop" ]]; then
   NVIDIA="-nvidia all"
   if [[ "$AI_MODELS_DIR" = "" ]]; then
-      AI_MODELS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../runner/models && pwd )"
+      AI_MODELS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd ../ai-runner/runner/models && pwd )"
   fi
   AI_MODELS_DIR_FLAG="-aiModelsDir ${AI_MODELS_DIR}"
 fi

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1212,7 +1212,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 		} else {
 			glog.Warningf("!!! No GPU discovered, using CPU for AIWorker !!!")
-			// Create 2 fake GPU instances, intended for the local non-GPU setup
+			// Create 1 fake GPU instances, intended for the local non-GPU setup
 			gpus = []string{"emulated-0"}
 		}
 


### PR DESCRIPTION
Adds the following features:
- `DOCKER=true` => Executes box in Docker containers (simpler setup, especially in TensorDock)
- `REBUILD=false` => Skips rebuilding all components

In general, it would be the best to run always everything as Docker containers, because `go-livepeer` setup is a pain (all ffmpeg deps, etc.). However, we're currently not building ARM64 images for M1.