### PR TITLE
Reduce the initial Realtime Video AI Fees

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1029,7 +1029,7 @@ func submitAudioToText(ctx context.Context, params aiRequestParams, sess *AISess
 	return &res, nil
 }
 
-const initPixelsToPay = 30 * 30 * 3200 * 1800 // 30 seconds, 30fps, 1800p
+const initPixelsToPay = 10 * 30 * 3200 * 1800 // 10 seconds, 30fps, 1800p
 
 func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *AISession, req worker.GenLiveVideoToVideoJSONRequestBody) (any, error) {
 	startTime := time.Now()


### PR DESCRIPTION
Reduce the initial payment from 30s to 10s.

The rationale is that:
- We highly reduced the startup time
- We're starting to introduce public Os, so this value will actually start to matter