### PR TITLE
ai/worker: Name colocated GPU slots consistently

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1216,14 +1216,16 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			gpus = []string{"emulated-0"}
 		}
 
-		// Additional GPU entries to allow running multiple Runner Containers on the same GPU
-		var colocatedGpus []string
-		for i := 1; i < *cfg.AIRunnerContainersPerGPU; i++ {
-			for _, g := range gpus {
-				colocatedGpus = append(colocatedGpus, fmt.Sprintf("colocated-%d-%s", i, g))
+		if *cfg.AIRunnerContainersPerGPU > 1 {
+			// Transform GPU entries to allow running multiple Runner Containers on the same GPU
+			var colocatedGpus []string
+			for i := range *cfg.AIRunnerContainersPerGPU {
+				for _, g := range gpus {
+					colocatedGpus = append(colocatedGpus, fmt.Sprintf("colocated-%d-%s", i, g))
+				}
 			}
+			gpus = colocatedGpus
 		}
-		gpus = append(gpus, colocatedGpus...)
 
 		modelsDir := *cfg.AIModelsDir
 		if modelsDir == "" {


### PR DESCRIPTION
It can be a little confusing to see one container starting on GPU `0` then another one on `colocated-1-0`.

I think it makes more sense to have consistent naming and just call all of them colocated when we allow more than 1 container per GPU. WDYT?