### PR TITLE
ai/live: Skip interleaving in segmenter

### DIFF
--- a/media/rtp_segmenter.go
+++ b/media/rtp_segmenter.go
@@ -126,11 +126,11 @@ func (s *RTPSegmenter) WriteVideo(source RTPTrack, pts, dts int64, au [][]byte) 
 	for _, t := range s.tracks {
 		if t.rtpTrack == source {
 			// Check if packet is too old (below low watermark)
-			/*if s.tsWatermark > 0 && dts < s.tsWatermark {
+			if s.tsWatermark > 0 && dts < s.tsWatermark {
 				// Packet is too old, discard it
 				// TODO increment some metric for this connection?
-				return nil
-			}*/
+				//return nil
+			}
 
 			// Add new packet
 			s.videoQueue = append(s.videoQueue, &videoPacket{t, pts, dts, au})
@@ -148,11 +148,11 @@ func (s *RTPSegmenter) WriteAudio(source RTPTrack, pts int64, au [][]byte) error
 			rescaledPts := multiplyAndDivide(pts, 90000, int64(source.Codec().ClockRate))
 
 			// Check if packet is too old (below low watermark)
-			/*if s.tsWatermark > 0 && rescaledPts < s.tsWatermark {
+			if s.tsWatermark > 0 && rescaledPts < s.tsWatermark {
 				// Packet is too old, discard it
 				// TODO increment some metric for this connection?
-				return nil
-			}*/
+				//return nil
+			}
 
 			// Add new packet
 			s.audioQueue = append(s.audioQueue, &audioPacket{t, rescaledPts, au})

--- a/media/rtp_segmenter.go
+++ b/media/rtp_segmenter.go
@@ -126,11 +126,11 @@ func (s *RTPSegmenter) WriteVideo(source RTPTrack, pts, dts int64, au [][]byte) 
 	for _, t := range s.tracks {
 		if t.rtpTrack == source {
 			// Check if packet is too old (below low watermark)
-			if s.tsWatermark > 0 && dts < s.tsWatermark {
+			/*if s.tsWatermark > 0 && dts < s.tsWatermark {
 				// Packet is too old, discard it
 				// TODO increment some metric for this connection?
 				return nil
-			}
+			}*/
 
 			// Add new packet
 			s.videoQueue = append(s.videoQueue, &videoPacket{t, pts, dts, au})
@@ -148,11 +148,11 @@ func (s *RTPSegmenter) WriteAudio(source RTPTrack, pts int64, au [][]byte) error
 			rescaledPts := multiplyAndDivide(pts, 90000, int64(source.Codec().ClockRate))
 
 			// Check if packet is too old (below low watermark)
-			if s.tsWatermark > 0 && rescaledPts < s.tsWatermark {
+			/*if s.tsWatermark > 0 && rescaledPts < s.tsWatermark {
 				// Packet is too old, discard it
 				// TODO increment some metric for this connection?
 				return nil
-			}
+			}*/
 
 			// Add new packet
 			s.audioQueue = append(s.audioQueue, &audioPacket{t, rescaledPts, au})
@@ -207,6 +207,7 @@ func (s *RTPSegmenter) setupTracks(rtpTracks []RTPTrack) []*trackWriter {
 }
 
 func (s *RTPSegmenter) interleaveAndWrite() error {
+	s.flushQueues(0)
 	if !s.hasAudio || !s.hasVideo {
 		// only have one or the other, nothing to interleave
 		// so flush immediately

--- a/media/rtp_segmenter_test.go
+++ b/media/rtp_segmenter_test.go
@@ -63,6 +63,8 @@ func newStubTSWriter(w io.Writer, t []*mpegts.Track) MpegtsWriter {
 
 func TestRTPSegmenterQueueLimit(t *testing.T) {
 
+	t.Skip("inapplicable for now")
+
 	require := require.New(t)
 	ssr := NewSwitchableSegmentReader()
 	seg := NewRTPSegmenter([]RTPTrack{videoTrack, audioTrack}, ssr, 0)
@@ -232,6 +234,9 @@ func TestRTPSegmenterConcurrency(t *testing.T) {
 }
 
 func TestRTPSegmenterLatePacketDropping(t *testing.T) {
+
+	t.Skip("inapplicable for now")
+
 	require := require.New(t)
 	ssr := NewSwitchableSegmentReader()
 	seg := NewRTPSegmenter([]RTPTrack{videoTrack, audioTrack}, ssr, 0)
@@ -398,7 +403,7 @@ func TestRTPSegmenterMixedOrder(t *testing.T) {
 	out := string(out1) + "/ " + string(out2)
 
 	// Check results.
-	expected := "V0 A1 A2 V3 V4 A5 / V6 "
+	expected := "V0 A1 V3 V4 / V6 A2 A5 "
 	require.Equal(expected, out)
 }
 
@@ -451,6 +456,6 @@ func TestRTPSegmenterDropKeyframe(t *testing.T) {
 	out := string(out1) + "/ " + string(out2)
 
 	// Check results.
-	expected := "V0 A1 A3 / A4 A5 A6 A8 A9 A10 V11 A12 A13 "
+	expected := "V0 A1 A3 A4 A5 A6 / V2 A8 A9 A10 A12 A13 V7 V11 "
 	require.Equal(expected, out)
 }


### PR DESCRIPTION
The interleaver in the RTP segmenter has several issues [1].

Try to avoid those issues by skipping interleaving entirely.

Normally this is a terrible idea because it means that audio and video could arrive relatively far apart leading to sync issues during playback. However:

1. We aren't playing back the ingest stream. We control the demuxer on the runner, and it doesn't care about the relative timings between tracks.

2. We do remux the output through a proper interleaver. So the sync should eventually fix itself on the runner side.

This is a bit of a YOLO move.

If things don't work out, it is easy to revert. If this does turn out to be a good move, then we'll come back in here and clean up a bunch of this now-unused code.

---

[1] Some of the issues are described in https://github.com/livepeer/go-livepeer/pull/3516

Worse things can happen when the segmenter's track queue fills up. When a queue is full, packets are flushed out and a high-watermark is set so we aren't writing packets out of order.

However, if another track is delayed (usually due to the RTP reorderer buffering late / lost packets) then those delayed packets could arrive at the segmenter *under* the high-water mark and be dropped. Sometimes we cannot recover from this sequence at all, depending on the arrival order.

Rather than try to fix interleaving, let's see if *not* interleaving helps. Hold my beer.