### PR TITLE
AI Gateway new prometheus metric - ai_orchestrators_available_total

### DIFF
--- a/server/ai_session.go
+++ b/server/ai_session.go
@@ -11,6 +11,7 @@ import (
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/monitor"
 	"github.com/livepeer/go-tools/drivers"
 	"github.com/livepeer/lpms/stream"
 )
@@ -445,6 +446,8 @@ func (sel *AISessionSelector) getSessions(ctx context.Context) ([]*BroadcastSess
 
 	// Set numOrchs to the pool size so that discovery tries to find maximum # of compatible orchs within a timeout
 	numOrchs := sel.node.OrchestratorPool.Size()
+
+	monitor.AINumOrchestrators(numOrchs, sel.modelID)
 
 	// Use a dummy manifestID specific to the capability + modelID
 	// Typically, a manifestID would identify a stream


### PR DESCRIPTION
**What does this pull request do?**

It adds a new prometheus metric `ai_orchestrators_available_total` sending the number of Orchestrators that are known to the AI Gateway. It should be the number of Os that's registered on-chain or returned by the [-orchWebhookUrl](https://github.com/livepeer/go-livepeer/blob/master/doc/orchwebhook.md).


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
