### PR TITLE
Fix make box syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,21 +130,20 @@ swagger:
 
 # Command to run Livepeer Realtime AI Video in a Box
 .PHONY: box
-ifeq ($(strip ${REBUILD}),false)
-box:
-	@echo "Skipping rebuild of components"
-else
 box: box-rebuild
-endif
 	./box/box.sh
 
 .PHONY: box-rebuild
 box-rebuild:
-	@$(MAKE) box-runner
-ifeq ($(strip ${DOCKER}),true)
-	docker build -t livepeer/go-livepeer -f docker/Dockerfile .
+ifeq ($(strip ${REBUILD}),false)
+	@echo "Skipping rebuild of components"
 else
-	@$(MAKE) livepeer
+	@$(MAKE) box-runner
+    ifeq ($(strip ${DOCKER}),true)
+	    docker build -t livepeer/go-livepeer -f docker/Dockerfile .
+    else
+	    @$(MAKE) livepeer
+    endif
 endif
 
 .PHONY: box-gateway

--- a/Makefile
+++ b/Makefile
@@ -130,20 +130,21 @@ swagger:
 
 # Command to run Livepeer Realtime AI Video in a Box
 .PHONY: box
+ifeq ($(strip ${REBUILD}),false)
+box:
+	@echo "Skipping rebuild of components"
+else
 box: box-rebuild
+endif
 	./box/box.sh
 
 .PHONY: box-rebuild
 box-rebuild:
-ifeq ($(strip ${REBUILD}),false)
-	@echo "Skipping rebuild of components"
-else
 	@$(MAKE) box-runner
-	ifeq ($(strip ${DOCKER}),true)
-		docker build -t livepeer/go-livepeer -f docker/Dockerfile .
-	else
-		@$(MAKE) livepeer
-	endif
+ifeq ($(strip ${DOCKER}),true)
+	docker build -t livepeer/go-livepeer -f docker/Dockerfile .
+else
+	@$(MAKE) livepeer
 endif
 
 .PHONY: box-gateway

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -616,7 +616,7 @@ func removeExistingContainers(ctx context.Context, client DockerClient) error {
 	filters := filters.NewArgs(filters.Arg("label", containerCreatorLabel+"="+containerCreator))
 	containers, err := client.ContainerList(ctx, container.ListOptions{All: true, Filters: filters})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list containers: %w", err)
 	}
 
 	for _, c := range containers {

--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -54,12 +54,12 @@ type Worker struct {
 func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string) (*Worker, error) {
 	dockerClient, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating docker client: %w", err)
 	}
 
 	manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, dockerClient)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating docker manager: %w", err)
 	}
 
 	return &Worker{

--- a/box/orchestrator.sh
+++ b/box/orchestrator.sh
@@ -3,10 +3,10 @@
 DOCKER=${DOCKER:-false}
 PIPELINE=${PIPELINE:-noop}
 
-DOCKER_HOST="172.17.0.1"
+DOCKER_HOSTNAME="172.17.0.1"
 if [[ "$(uname)" == "Darwin" ]]; then
   # Docker on macOS has a special host address
-  DOCKER_HOST="host.docker.internal"
+  DOCKER_HOSTNAME="host.docker.internal"
 fi
 
 NVIDIA=""
@@ -29,7 +29,7 @@ if [ "$DOCKER" = "false" ]; then
     -serviceAddr localhost:8935 \
     -transcoder \
     -v 6 \
-    -liveAITrickleHostForRunner "$DOCKER_HOST:8935" \
+    -liveAITrickleHostForRunner "$DOCKER_HOSTNAME:8935" \
     -monitor
 else
   docker run --rm --name orchestrator \


### PR DESCRIPTION
For some reason the existing makefile syntax wasn't working on my machine so I have refactored the conditional a bit. This was the error:
```
ifeq (,true)
/bin/bash: -c: line 0: syntax error near unexpected token `,true'
/bin/bash: -c: line 0: `ifeq (,true)'
make: *** [box-rebuild] Error 2
```
I also had a conflict with us using the DOCKER_HOST variable, this is a built in config variable used by docker which I needed to set to allow go-livepeer to talk to docker desktop.