### PR TITLE
Send whip stats as a kafka event

### DIFF
--- a/box/gateway.sh
+++ b/box/gateway.sh
@@ -3,7 +3,7 @@
 DOCKER=${DOCKER:-false}
 
 if [ "$DOCKER" = "false" ]; then
-    ./livepeer -gateway -rtmpAddr :1936 -httpAddr :5936 -orchAddr localhost:8935 -v 6 -monitor
+    LIVE_AI_WHIP_ADDR=":7280" ./livepeer -gateway -rtmpAddr :1936 -httpAddr :5936 -orchAddr localhost:8935 -v 6 -monitor
 else
-    docker run --rm --name gateway --network host livepeer/go-livepeer -gateway -rtmpAddr :1936 -httpAddr :5936 -orchAddr localhost:8935 -v 6 -monitor
+    docker run -e LIVE_AI_WHIP_ADDR=":7280" --rm --name gateway --network host livepeer/go-livepeer -gateway -rtmpAddr :1936 -httpAddr :5936 -orchAddr localhost:8935 -v 6 -monitor
 fi

--- a/media/whip_connection.go
+++ b/media/whip_connection.go
@@ -87,10 +87,11 @@ type PeerConnStats struct {
 }
 
 type TrackStats struct {
-	Kind        webrtc.RTPCodecType
-	Jitter      float64
-	PacketsLost int64
-	RTT         time.Duration
+	Kind            webrtc.RTPCodecType
+	Jitter          float64
+	PacketsLost     int64
+	PacketsReceived uint64
+	RTT             time.Duration
 }
 
 type MediaStats struct {
@@ -208,10 +209,11 @@ func (m *MediaState) Stats() (*MediaStats, error) {
 			continue
 		}
 		trackStats = append(trackStats, TrackStats{
-			Kind:        t.Kind(),
-			Jitter:      s.InboundRTPStreamStats.Jitter,
-			PacketsLost: s.InboundRTPStreamStats.PacketsLost,
-			RTT:         s.RemoteInboundRTPStreamStats.RoundTripTime,
+			Kind:            t.Kind(),
+			Jitter:          s.InboundRTPStreamStats.Jitter,
+			PacketsLost:     s.InboundRTPStreamStats.PacketsLost,
+			PacketsReceived: s.InboundRTPStreamStats.PacketsReceived,
+			RTT:             s.RemoteInboundRTPStreamStats.RoundTripTime,
 		})
 	}
 	return &MediaStats{

--- a/media/whip_connection.go
+++ b/media/whip_connection.go
@@ -62,7 +62,7 @@ func (w *WHIPConnection) AwaitClose() error {
 func (w *WHIPConnection) Stats() (*MediaStats, error) {
 	p := w.getWHIPConnection()
 	if p == nil {
-		return nil, nil
+		return nil, errors.New("whip connection was nil")
 	}
 	return p.Stats()
 }

--- a/media/whip_connection.go
+++ b/media/whip_connection.go
@@ -87,11 +87,9 @@ type WHIPPeerConnection interface {
 }
 
 type PeerConnStats struct {
-	ID              string
-	BytesReceived   uint64
-	BytesSent       uint64
-	PacketsReceived uint32
-	PacketsSent     uint32
+	ID            string
+	BytesReceived uint64
+	BytesSent     uint64
 }
 
 type TrackStats struct {
@@ -194,11 +192,9 @@ func (m *MediaState) Stats() (*MediaStats, error) {
 	for _, stat := range pcStatsReport {
 		if s, ok := stat.(webrtc.TransportStats); ok {
 			pcStats = PeerConnStats{
-				ID:              s.ID,
-				BytesReceived:   s.BytesReceived,
-				BytesSent:       s.BytesSent,
-				PacketsReceived: s.PacketsReceived,
-				PacketsSent:     s.PacketsSent,
+				ID:            s.ID,
+				BytesReceived: s.BytesReceived,
+				BytesSent:     s.BytesSent,
 			}
 			break
 		}

--- a/media/whip_connection.go
+++ b/media/whip_connection.go
@@ -59,6 +59,14 @@ func (w *WHIPConnection) AwaitClose() error {
 	return p.AwaitClose()
 }
 
+func (w *WHIPConnection) Stats() (*MediaStats, error) {
+	p := w.getWHIPConnection()
+	if p == nil {
+		return nil, nil
+	}
+	return p.Stats()
+}
+
 func (w *WHIPConnection) Close() {
 	w.mu.Lock()
 	// set closed = true so getWHIPConnection returns immediately

--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -486,7 +486,7 @@ func runStats(ctx context.Context, mediaState *MediaState, statsReceiver func(st
 			}
 			clog.Info(ctx, "whip TransportStats", "ID", stats.PeerConnStats.ID, "bytes_received", stats.PeerConnStats.BytesReceived, "bytes_sent", stats.PeerConnStats.BytesSent, "packets_received", stats.PeerConnStats.PacketsReceived, "packets_sent", stats.PeerConnStats.PacketsSent)
 			for _, s := range stats.TrackStats {
-				clog.Info(ctx, "whip InboundRTPStreamStats", "kind", s.Kind, "jitter", s.Jitter, "packets_lost", s.PacketsLost, "rtt", s.RTT)
+				clog.Info(ctx, "whip InboundRTPStreamStats", "kind", s.Kind, "jitter", s.Jitter, "packets_lost", s.PacketsLost, "packets_received", s.PacketsReceived, "rtt", s.RTT)
 			}
 		}
 	}

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -212,10 +212,8 @@ type (
 		mAILiveAttempts         *stats.Int64Measure
 		mAINumOrchs             *stats.Int64Measure
 
-		mAIWhipTransportBytesReceived   *stats.Int64Measure
-		mAIWhipTransportBytesSent       *stats.Int64Measure
-		mAIWhipTransportPacketsReceived *stats.Int64Measure
-		mAIWhipTransportPacketsSent     *stats.Int64Measure
+		mAIWhipTransportBytesReceived *stats.Int64Measure
+		mAIWhipTransportBytesSent     *stats.Int64Measure
 
 		lock        sync.Mutex
 		emergeTimes map[uint64]map[uint64]time.Time // nonce:seqNo
@@ -395,8 +393,6 @@ func InitCensus(nodeType NodeType, version string) {
 
 	census.mAIWhipTransportBytesReceived = stats.Int64("ai_whip_transport_bytes_received", "Number of bytes received on a WHIP connection", "byte")
 	census.mAIWhipTransportBytesSent = stats.Int64("ai_whip_transport_bytes_sent", "Number of bytes sent on a WHIP connection", "byte")
-	census.mAIWhipTransportPacketsReceived = stats.Int64("ai_whip_transport_packets_received", "Number of packets received on a WHIP connection", "tot")
-	census.mAIWhipTransportPacketsSent = stats.Int64("ai_whip_transport_packets_sent", "Number of packets sent on a WHIP connection", "tot")
 
 	glog.Infof("Compiler: %s Arch %s OS %s Go version %s", runtime.Compiler, runtime.GOARCH, runtime.GOOS, runtime.Version())
 	glog.Infof("Livepeer version: %s", version)
@@ -1050,20 +1046,6 @@ func InitCensus(nodeType NodeType, version string) {
 			Name:        "ai_whip_transport_bytes_sent",
 			Measure:     census.mAIWhipTransportBytesSent,
 			Description: "Number of bytes sent on a WHIP connection",
-			TagKeys:     baseTags,
-			Aggregation: view.LastValue(),
-		},
-		{
-			Name:        "ai_whip_transport_packets_received",
-			Measure:     census.mAIWhipTransportPacketsReceived,
-			Description: "Number of packets received on a WHIP connection",
-			TagKeys:     baseTags,
-			Aggregation: view.LastValue(),
-		},
-		{
-			Name:        "ai_whip_transport_packets_sent",
-			Measure:     census.mAIWhipTransportPacketsSent,
-			Description: "Number of packets sent on a WHIP connection",
 			TagKeys:     baseTags,
 			Aggregation: view.LastValue(),
 		},
@@ -2016,14 +1998,6 @@ func AIWhipTransportBytesReceived(bytes int64) {
 
 func AIWhipTransportBytesSent(bytes int64) {
 	stats.Record(census.ctx, census.mAIWhipTransportBytesSent.M(bytes))
-}
-
-func AIWhipTransportPacketsReceived(packets int64) {
-	stats.Record(census.ctx, census.mAIWhipTransportPacketsReceived.M(packets))
-}
-
-func AIWhipTransportPacketsSent(packets int64) {
-	stats.Record(census.ctx, census.mAIWhipTransportPacketsSent.M(packets))
 }
 
 // AIJobProcessed records orchestrator AI job processing metrics.

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -931,10 +931,8 @@ func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID stri
 			if monitor.Enabled {
 				monitor.AIWhipTransportBytesReceived(int64(stats.PeerConnStats.BytesReceived))
 				monitor.AIWhipTransportBytesSent(int64(stats.PeerConnStats.BytesSent))
-				monitor.AIWhipTransportPacketsReceived(int64(stats.PeerConnStats.PacketsReceived))
-				monitor.AIWhipTransportPacketsSent(int64(stats.PeerConnStats.PacketsSent))
 			}
-			clog.Info(ctx, "whip TransportStats", "ID", stats.PeerConnStats.ID, "bytes_received", stats.PeerConnStats.BytesReceived, "bytes_sent", stats.PeerConnStats.BytesSent, "packets_received", stats.PeerConnStats.PacketsReceived, "packets_sent", stats.PeerConnStats.PacketsSent)
+			clog.Info(ctx, "whip TransportStats", "ID", stats.PeerConnStats.ID, "bytes_received", stats.PeerConnStats.BytesReceived, "bytes_sent", stats.PeerConnStats.BytesSent)
 			for _, s := range stats.TrackStats {
 				clog.Info(ctx, "whip InboundRTPStreamStats", "kind", s.Kind, "jitter", s.Jitter, "packets_lost", s.PacketsLost, "packets_received", s.PacketsReceived, "rtt", s.RTT)
 			}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -925,7 +925,8 @@ func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID stri
 		case <-ticker.C:
 			stats, err := whipConn.Stats()
 			if err != nil {
-				return
+				clog.Errorf(ctx, "WHIP stats returned error: %s", err)
+				continue
 			}
 			if monitor.Enabled {
 				monitor.AIWhipTransportBytesReceived(int64(stats.PeerConnStats.BytesReceived))

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -913,6 +913,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 		whipConn.SetWHIPConnection(conn) // might be nil if theres an error and thats okay
 	})
 }
+
 func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID string, pipelineID string, requestID string) {
 	// Periodically check whip stats and write logs and metrics
 	ticker := time.NewTicker(5 * time.Second)
@@ -947,6 +948,7 @@ func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID stri
 		}
 	}
 }
+
 func (ls *LivepeerServer) WithCode(code int) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		corsHeaders(w, r.Method)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -750,8 +750,6 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			whepURL = "http://localhost:8889/" // default mediamtx output
 		}
 		whepURL = whepURL + streamName + "-out/whep"
-		streamID := ""
-		pipelineID := ""
 
 		go func() {
 			internalOutputHost := os.Getenv("LIVE_AI_PLAYBACK_HOST") // TODO proper cli arg
@@ -760,6 +758,8 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			}
 			mediamtxOutputURL := internalOutputHost + streamName + "-out"
 			outputURL := ""
+			streamID := ""
+			pipelineID := ""
 			pipeline := ""
 			pipelineParams := make(map[string]interface{})
 			sourceTypeStr := "livepeer-whip"
@@ -898,17 +898,45 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			if err != nil {
 				stopPipeline(err)
 			}
+
+			statsContext, statsCancel := context.WithCancel(ctx)
+			defer statsCancel()
+			go runStats(statsContext, whipConn, streamID, pipelineID, requestID)
+
 			whipConn.AwaitClose()
 			ssr.Close()
 			cleanupControl(ctx, params)
 			clog.Info(ctx, "Live cleaned up")
 		}()
 
-		conn := server.CreateWHIP(ctx, ssr, whepURL, w, r, func(stats *media.MediaStats) {
-			if streamID == "" || pipelineID == "" {
-				clog.V(common.DEBUG).Info(ctx, "ignoring whip stats, streamID or pipelineID not set yet")
+		conn := server.CreateWHIP(ctx, ssr, whepURL, w, r)
+		whipConn.SetWHIPConnection(conn) // might be nil if theres an error and thats okay
+	})
+}
+func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID string, pipelineID string, requestID string) {
+	// Periodically check whip stats and write logs and metrics
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			stats, err := whipConn.Stats()
+			if err != nil {
 				return
 			}
+			if monitor.Enabled {
+				monitor.AIWhipTransportBytesReceived(int64(stats.PeerConnStats.BytesReceived))
+				monitor.AIWhipTransportBytesSent(int64(stats.PeerConnStats.BytesSent))
+				monitor.AIWhipTransportPacketsReceived(int64(stats.PeerConnStats.PacketsReceived))
+				monitor.AIWhipTransportPacketsSent(int64(stats.PeerConnStats.PacketsSent))
+			}
+			clog.Info(ctx, "whip TransportStats", "ID", stats.PeerConnStats.ID, "bytes_received", stats.PeerConnStats.BytesReceived, "bytes_sent", stats.PeerConnStats.BytesSent, "packets_received", stats.PeerConnStats.PacketsReceived, "packets_sent", stats.PeerConnStats.PacketsSent)
+			for _, s := range stats.TrackStats {
+				clog.Info(ctx, "whip InboundRTPStreamStats", "kind", s.Kind, "jitter", s.Jitter, "packets_lost", s.PacketsLost, "packets_received", s.PacketsReceived, "rtt", s.RTT)
+			}
+
 			monitor.SendQueueEventAsync("stream_ingest_metrics", map[string]interface{}{
 				"timestamp":   time.Now().UnixMilli(),
 				"stream_id":   streamID,
@@ -916,11 +944,9 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 				"request_id":  requestID,
 				"stats":       stats,
 			})
-		})
-		whipConn.SetWHIPConnection(conn) // might be nil if theres an error and thats okay
-	})
+		}
+	}
 }
-
 func (ls *LivepeerServer) WithCode(code int) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		corsHeaders(w, r.Method)


### PR DESCRIPTION
We want to monitor stream jitter and other stats in our analytics so we need to send this data out via kafka events.