### PR TITLE
ai/live: Set dts = pts

### DIFF
--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -281,6 +281,7 @@ func handleRTP(ctx context.Context, segmenter *RTPSegmenter, timeDecoder *rtptim
 			}
 
 			// h264 video from here on
+			// https://datatracker.ietf.org/doc/html/rfc6184
 
 			if currentTS != p.Timestamp && len(au) > 0 {
 				// received a new frame, but previous frame was incomplete (lost marker bit)


### PR DESCRIPTION
The DTS extractor seems unreliable and I don't understand it enough
right now to make changes confidently.

Also check whether B-frames may be allowed, but only log if so instead of erroring out. In general this should only lead to decoding artifacts instead of outright failures, but we can use this information to diagnose and tighten up checks later.

In general we should never be getting B-frames from WebRTC.