### PR TITLE
server: Add selection retries for live-video-to-video pipelines

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1546,7 +1546,7 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 		}
 
 		// when no capacity error is received, retry with another session, but do not suspend the session
-		if (isInvalidTicketSenderNonce(err) || isNoCapacityError(err)) && cap != core.Capability_LiveVideoToVideo {
+		if isInvalidTicketSenderNonce(err) || isNoCapacityError(err) {
 			retryableSessions = append(retryableSessions, sess)
 			continue
 		}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This adds back the selection retries removed by https://github.com/livepeer/go-livepeer/pull/3444 since now
the Orchestrators _can_ in fact process more than 1 stream at a time. We've also noticed
a race condition on selection process that could be easily solved by adding these retries again.

We need @leszko for more context on this, but we'll deploy this on staging to see if we see improvements
in the staging load test results under a lot of traffic.

**Specific updates (required)**
- Remove the check for live-video-to-video pipelines that removes retries

**How did you test each of these updates (required)**
Will do in staging


**Does this pull request close any open issues?**
Related to INF-161

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
