### PR TITLE
Fix retrying when the session is inUse

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1546,7 +1546,7 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 		}
 
 		// when no capacity error is received, retry with another session, but do not suspend the session
-		if isInvalidTicketSenderNonce(err) || isNoCapacityError(err) {
+		if (isInvalidTicketSenderNonce(err) || isNoCapacityError(err)) && cap != core.Capability_LiveVideoToVideo {
 			retryableSessions = append(retryableSessions, sess)
 			continue
 		}

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1547,8 +1547,11 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 
 		// when no capacity error is received, retry with another session
 		if isInvalidTicketSenderNonce(err) || isNoCapacityError(err) {
-			// for non realtime video, get the session back to the pool as soon as the request completes
-			if cap != core.Capability_LiveVideoToVideo {
+			if cap == core.Capability_LiveVideoToVideo {
+				// for live video, remove the session from the pool to avoid retrying it
+				params.sessManager.Remove(ctx, sess)
+			} else {
+				// for non realtime video, get the session back to the pool as soon as the request completes
 				retryableSessions = append(retryableSessions, sess)
 			}
 			continue

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1545,9 +1545,12 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 			continue
 		}
 
-		// when no capacity error is received, retry with another session, but do not suspend the session
-		if (isInvalidTicketSenderNonce(err) || isNoCapacityError(err)) && cap != core.Capability_LiveVideoToVideo {
-			retryableSessions = append(retryableSessions, sess)
+		// when no capacity error is received, retry with another session
+		if isInvalidTicketSenderNonce(err) || isNoCapacityError(err) {
+			// for non realtime video, get the session back to the pool as soon as the request completes
+			if cap != core.Capability_LiveVideoToVideo {
+				retryableSessions = append(retryableSessions, sess)
+			}
 			continue
 		}
 


### PR DESCRIPTION
Update the selection logic to remove the session from the pool when the Orchestrator has no capacity, but at the same time retry the selection logic.