### PR TITLE
Add timeout for the initial Realtime Video request

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1056,7 +1056,10 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 	defer completeBalanceUpdate(sess.BroadcastSession, balUpdate)
 
 	// Send request to orchestrator
-	resp, err := client.GenLiveVideoToVideoWithResponse(ctx, req, paymentHeaders)
+	reqTimeout := 5 * time.Second
+	reqCtx, cancel := context.WithTimeout(ctx, reqTimeout)
+	defer cancel()
+	resp, err := client.GenLiveVideoToVideoWithResponse(reqCtx, req, paymentHeaders)
 	if err != nil {
 		return nil, err
 	}
@@ -1533,10 +1536,6 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 			break
 		}
 
-		if cap == core.Capability_LiveVideoToVideo {
-			ctx, cancel = context.WithTimeout(ctx, 15*time.Second)
-			defer cancel()
-		}
 		resp, err = submitFn(ctx, params, sess)
 		if err == nil {
 			params.sessManager.Complete(ctx, sess)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1533,6 +1533,10 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 			break
 		}
 
+		if cap == core.Capability_LiveVideoToVideo {
+			ctx, cancel = context.WithTimeout(ctx, 15*time.Second)
+			defer cancel()
+		}
 		resp, err = submitFn(ctx, params, sess)
 		if err == nil {
 			params.sessManager.Complete(ctx, sess)


### PR DESCRIPTION
Started a PR to discuss the timeout for the initial Realtime Video request. I've set it to `15s`, but we can decrease it or make it configurable with a flag.