### PR TITLE
server/ai: Add a limit of retries on the same session

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1548,12 +1548,14 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 		// Don't suspend the session if the error is a transient error.
 
 		if isRetryableError(err) && sessTries[sess.Transcoder()] < maxSameSessTries {
+			clog.Infof(ctx, "Error submitting request with retryable error modelID=%v try=%v orch=%v err=%v", modelID, tries, sess.Transcoder(), err)
 			params.sessManager.Complete(ctx, sess)
 			continue
 		}
 
 		// retry some specific errors with another session. re-check for retryable errors in case max retries were hit above
 		if isRetryableError(err) || isInvalidTicketSenderNonce(err) || isNoCapacityError(err) {
+			clog.Infof(ctx, "Error submitting request with non-retryable error modelID=%v try=%v orch=%v err=%v", modelID, tries, sess.Transcoder(), err)
 			if cap == core.Capability_LiveVideoToVideo {
 				// for live video, remove the session from the pool to avoid retrying it
 				params.sessManager.Remove(ctx, sess)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -40,7 +40,7 @@ const (
 	defaultTextToSpeechModelID     = "parler-tts/parler-tts-large-v1"
 
 	maxTries         = 20
-	maxSameSessTries = 2
+	maxSameSessTries = 3
 )
 
 var errWrongFormat = fmt.Errorf("result not in correct format")


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to fix [the issue observed](https://discord.com/channels/423160867534929930/1367162990192758824/1367582631025180672) where we keep retrying for the same O that is in an inconsistent
state and generating invalid tickets. This adds a shorter maximum number of attempts to make
with the same O, which should allow for a session swap within the set up period of the stream.

**Specific updates (required)**
- Update selection retry logic with a max retries per session

**How did you test each of these updates (required)**
Not sure how to test actually. Just ensuring tests pass.

**Does this pull request close any open issues?**
INF-182

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
