### PR TITLE
ai/live: Fix fetching events twice.

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -473,7 +473,7 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 				}
 			}
 
-			clog.V(8).Infof(ctx, "Received event for stream=%s event=%+v", stream, event)
+			clog.V(8).Infof(ctx, "Received event for seq=%d event=%+v", trickle.GetSeq(segment), event)
 
 			// record the event time
 			lastEventMu.Lock()


### PR DESCRIPTION
Sometimes we fetch the first few events twice at the beginning of a job. Mostly harmless but it does cause us to re-transmit the same events to Kafka.

This is due to a race condition on the pytrickle client paired with lax server handling of the latest write index. The pytrickle client initiates the POST immediately for 0 and 1 (preconnect), however sometimes the server may receive 1 first, then 0. This would have set the "latest write" to 0 insteaead of 1.

Aftert he gotrickle event subscriber fetches the first two events, it attempts to pre-connect to sequence 2 but receives an error since the latest write is marked as 0 on the server, not 1.

Fix this by setting the latest write index when we receive the first byte of the *body* rather than the POST header.