### PR TITLE
server: Make sure ffmpeg process is killed when pipeline stops

### DIFF
--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -37,7 +37,8 @@ type MediaSegmenter struct {
 
 func (ms *MediaSegmenter) RunSegmentation(ctx context.Context, in string, segmentHandler SegmentHandler) {
 	outFilePattern := filepath.Join(ms.Workdir, randomString()+"-%d"+outFileSuffix)
-	completionSignal := make(chan bool, 1)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel() // the context should be cancelled before the end of the function, this is just a sanity measure
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
@@ -47,12 +48,11 @@ func (ms *MediaSegmenter) RunSegmentation(ctx context.Context, in string, segmen
 	//      processes that don't immediately fail are not fully retryable otherwise
 	//
 	// create first named pipe to preempt races between ffmpeg and processSegments
-	ctx, cancel := context.WithCancel(ctx)
 	createNamedPipe(fmt.Sprintf(outFilePattern, 0))
 	go func() {
 		defer wg.Done()
 		defer cancel()
-		processSegments(ctx, segmentHandler, outFilePattern, completionSignal)
+		processSegments(ctx, segmentHandler, outFilePattern)
 	}()
 
 	retryCount := 0
@@ -91,7 +91,7 @@ func (ms *MediaSegmenter) RunSegmentation(ctx context.Context, in string, segmen
 		clog.Infof(ctx, "Segmentation stopped, will retry. retryCount=%d ffmpeg output: %s", retryCount, output)
 		retryCount++
 	}
-	completionSignal <- true
+	cancel()
 	clog.Infof(ctx, "sent completion signal, now waiting")
 	wg.Wait()
 }
@@ -204,7 +204,7 @@ func openNonBlockingWithRetry(name string, timeout time.Duration, completed <-ch
 	}
 }
 
-func processSegments(ctx context.Context, segmentHandler SegmentHandler, outFilePattern string, completionSignal <-chan bool) {
+func processSegments(ctx context.Context, segmentHandler SegmentHandler, outFilePattern string) {
 
 	// things protected by the mutex mu
 	mu := &sync.Mutex{}
@@ -212,9 +212,9 @@ func processSegments(ctx context.Context, segmentHandler SegmentHandler, outFile
 	var currentSegment *os.File = nil
 	pipeCompletion := make(chan bool, 1)
 
-	// Start a goroutine to wait for the completion signal
+	// Start a goroutine to wait for the context to be cancelled
 	go func() {
-		<-completionSignal
+		<-ctx.Done()
 		mu.Lock()
 		defer mu.Unlock()
 		if currentSegment != nil {

--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -83,6 +83,10 @@ func (ms *MediaSegmenter) RunSegmentation(ctx context.Context, in string, segmen
 			"-f", "segment",
 			outFilePattern,
 		)
+		cmd.Cancel = func() error {
+			return cmd.Process.Signal(syscall.SIGTERM)
+		}
+		cmd.WaitDelay = 5 * time.Second
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			clog.Errorf(ctx, "Error receiving RTMP: %v ffmpeg output: %s", err, output)

--- a/media/rtmp2segment.go
+++ b/media/rtmp2segment.go
@@ -83,6 +83,7 @@ func (ms *MediaSegmenter) RunSegmentation(ctx context.Context, in string, segmen
 			"-f", "segment",
 			outFilePattern,
 		)
+		// Change Cancel function to send a SIGTERM instead of SIGKILL. Still send a SIGKILL after 5s (WaitDelay) if it's stuck.
 		cmd.Cancel = func() error {
 			return cmd.Process.Signal(syscall.SIGTERM)
 		}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -561,9 +561,9 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 
 		// this function is called when the pipeline hits a fatal error, we kick the input connection to allow
 		// the client to reconnect and restart the pipeline
-		pipelineCtx, pipelineCancel := context.WithCancel(ctx)
+		segmenterCtx, cancelSegmenter := context.WithCancel(clog.Clone(context.Background(), ctx))
 		stopPipeline := func(err error) {
-			defer pipelineCancel()
+			defer cancelSegmenter()
 			if err == nil {
 				return
 			}
@@ -600,7 +600,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		// Kick off the RTMP pull and segmentation as soon as possible
 		go func() {
 			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir, MediaMTXClient: mediaMTXClient}
-			ms.RunSegmentation(pipelineCtx, mediaMTXInputURL, ssr.Read)
+			ms.RunSegmentation(segmenterCtx, mediaMTXInputURL, ssr.Read)
 			monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
 				"type":        "gateway_ingest_stream_closed",
 				"timestamp":   time.Now().UnixMilli(),

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -561,7 +561,9 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 
 		// this function is called when the pipeline hits a fatal error, we kick the input connection to allow
 		// the client to reconnect and restart the pipeline
+		pipelineCtx, pipelineCancel := context.WithCancel(ctx)
 		stopPipeline := func(err error) {
+			defer pipelineCancel()
 			if err == nil {
 				return
 			}
@@ -598,7 +600,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		// Kick off the RTMP pull and segmentation as soon as possible
 		go func() {
 			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir, MediaMTXClient: mediaMTXClient}
-			ms.RunSegmentation(ctx, mediaMTXInputURL, ssr.Read)
+			ms.RunSegmentation(pipelineCtx, mediaMTXInputURL, ssr.Read)
 			monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
 				"type":        "gateway_ingest_stream_closed",
 				"timestamp":   time.Now().UnixMilli(),


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to make sure we don't leak ffmpeg processes when segmenting RTMP input.
Fixed it by providing a context that will be cancelled when the pipeline stops. 

IMHO we should adopt this pattern for most of our long-running logic as I think it's
simpler to reason about than having multiple custom cancellation signals. I know this
is not the consensus among the team tho, so I kept the changes only to the specific
part I was trying to fix.

I then removed the `completionSignal` from the `processSegments` function only
because it became redundant with the context now, so I think it's cleaner like this. I
didn't refactor the other unrelated parts like its internal `pipeCompletion` chan tho.

**Specific updates (required)**
- Create a ctx that is cancelled when the pipeline stops
- Pass that context down to the rtmp2segment function
- Make sure it is used for the ffmpeg process we create there

**How did you test each of these updates (required)**
~~Box~~ My tensordock VM can't be allocated anymore and it's taking forever to setup box on my mac.

For now, testing on code review 😅 

**Does this pull request close any open issues?**
part of INF-161 but I guess this one is a super-issue

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
