### PR TITLE
Allow specifying capacity to repeat the same warm model

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1291,9 +1291,17 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 			if *cfg.AIWorker {
 				modelConstraint := &core.ModelConstraint{Warm: config.Warm, Capacity: 1}
-				// External containers do auto-scale; default to 1 or use provided capacity.
-				if config.URL != "" && config.Capacity != 0 {
-					modelConstraint.Capacity = config.Capacity
+				modelsCount := 1
+				if config.Capacity != 0 {
+					if config.URL == "" {
+						// Use multiple same configs if External Container is not used and capacity is set
+						modelsCount = config.Capacity
+					} else {
+						// External containers do auto-scale; default to 1 or use provided capacity.
+						if config.URL != "" && config.Capacity != 0 {
+							modelConstraint.Capacity = config.Capacity
+						}
+					}
 				}
 
 				// Ensure the AI worker has the image needed to serve the job.
@@ -1302,14 +1310,16 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 					glog.Errorf("Error ensuring AI worker image available for %v: %v", config.Pipeline, err)
 				}
 
-				if config.Warm || config.URL != "" {
-					// Register external container endpoint if URL is provided.
-					endpoint := worker.RunnerEndpoint{URL: config.URL, Token: config.Token}
+				for i := 0; i < modelsCount; i++ {
+					if config.Warm || config.URL != "" {
+						// Register external container endpoint if URL is provided.
+						endpoint := worker.RunnerEndpoint{URL: config.URL, Token: config.Token}
 
-					// Warm the AI worker container or register the endpoint.
-					if err := n.AIWorker.Warm(ctx, config.Pipeline, config.ModelID, endpoint, config.OptimizationFlags); err != nil {
-						glog.Errorf("Error AI worker warming %v container: %v", config.Pipeline, err)
-						return
+						// Warm the AI worker container or register the endpoint.
+						if err := n.AIWorker.Warm(ctx, config.Pipeline, config.ModelID, endpoint, config.OptimizationFlags); err != nil {
+							glog.Errorf("Error AI worker warming %v container: %v", config.Pipeline, err)
+							return
+						}
 					}
 				}
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1298,9 +1298,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 						modelsCount = config.Capacity
 					} else {
 						// External containers do auto-scale; default to 1 or use provided capacity.
-						if config.URL != "" && config.Capacity != 0 {
-							modelConstraint.Capacity = config.Capacity
-						}
+						modelConstraint.Capacity = config.Capacity
 					}
 				}
 


### PR DESCRIPTION
This allows the following configuration for the warm containers.
```json
[
  {
    "model_id": "noop",
    "pipeline": "live-video-to-video",
    "warm": true,
    "capacity": 3
  }
]
```

Instead of before if you wanted multiple same warm containers, you had to write the following:
```json
[
  {
    "model_id": "noop",
    "pipeline": "live-video-to-video",
    "warm": true
  },
  {
    "model_id": "noop",
    "pipeline": "live-video-to-video",
    "warm": true
  },
  {
    "model_id": "noop",
    "pipeline": "live-video-to-video",
    "warm": true
  }
]
```

@pwilczynskiclearcode You'll like it!