### PR TITLE
Only set first error

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -583,10 +583,19 @@ func (s *SlowOrchChecker) GetCount() int {
 
 func LiveErrorEventSender(ctx context.Context, streamID string, event map[string]string) func(err error) {
 	return func(err error) {
-		GatewayStatus.Store(streamID, map[string]interface{}{
-			"last_error":      err.Error(),
-			"last_error_time": time.Now().UnixMilli(),
-		})
+		status, ok := GatewayStatus.Get(streamID)
+		if !ok {
+			GatewayStatus.Store(streamID, map[string]interface{}{
+				"last_error":      err.Error(),
+				"last_error_time": time.Now().UnixMilli(),
+			})
+		}
+		if _, ok := status["last_error"]; !ok {
+			GatewayStatus.Store(streamID, map[string]interface{}{
+				"last_error":      err.Error(),
+				"last_error_time": time.Now().UnixMilli(),
+			})
+		}
 
 		ev := maps.Clone(event)
 		ev["capability"] = clog.GetVal(ctx, "capability")

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -583,19 +583,10 @@ func (s *SlowOrchChecker) GetCount() int {
 
 func LiveErrorEventSender(ctx context.Context, streamID string, event map[string]string) func(err error) {
 	return func(err error) {
-		status, ok := GatewayStatus.Get(streamID)
-		if !ok {
-			GatewayStatus.Store(streamID, map[string]interface{}{
-				"last_error":      err.Error(),
-				"last_error_time": time.Now().UnixMilli(),
-			})
-		}
-		if _, ok := status["last_error"]; !ok {
-			GatewayStatus.Store(streamID, map[string]interface{}{
-				"last_error":      err.Error(),
-				"last_error_time": time.Now().UnixMilli(),
-			})
-		}
+		GatewayStatus.StoreIfNotExists(streamID, "error", map[string]interface{}{
+			"error":      err.Error(),
+			"error_time": time.Now().UnixMilli(),
+		})
 
 		ev := maps.Clone(event)
 		ev["capability"] = clog.GetVal(ctx, "capability")

--- a/server/ai_pipeline_status.go
+++ b/server/ai_pipeline_status.go
@@ -33,3 +33,17 @@ func (s *streamStatusStore) Get(streamID string) (map[string]interface{}, bool) 
 	status, exists := s.store[streamID]
 	return status, exists
 }
+
+// StoreIfNotExists stores a status only if the streamID doesn't already exist or keyToCheck does not exist on the status
+func (s *streamStatusStore) StoreIfNotExists(streamID string, keyToCheck string, status map[string]interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	status, exists := s.store[streamID]
+	if !exists {
+		s.store[streamID] = status
+		return
+	}
+	if _, ok := status[keyToCheck]; !ok {
+		s.store[streamID] = status
+	}
+}


### PR DESCRIPTION
Only set the first error seen in each pipeline for the purpose of reporting to the app. Subsequent errors will generally be effects of the first error so it is the first one we're most interested in as the root cause.

The old behaviour meant that on the front end we would generally see a `whip disconnected` error for a lot of different error scenarios because we usually want to disconnect the ingest as a result of any errors to allow the client to retry.