### PR TITLE
Add ingest stats to stream status

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -614,8 +614,8 @@ func (s *SlowOrchChecker) GetCount() int {
 func LiveErrorEventSender(ctx context.Context, streamID string, event map[string]string) func(err error) {
 	return func(err error) {
 		GatewayStatus.StoreIfNotExists(streamID, "error", map[string]interface{}{
-			"error":      err.Error(),
-			"error_time": time.Now().UnixMilli(),
+			"error_message": err.Error(),
+			"error_time":    time.Now().UnixMilli(),
 		})
 
 		ev := maps.Clone(event)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -940,8 +940,8 @@ func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID stri
 			for _, s := range stats.TrackStats {
 				clog.Info(ctx, "whip InboundRTPStreamStats", "kind", s.Type, "jitter", fmt.Sprintf("%.3f", s.Jitter), "packets_lost", s.PacketsLost, "packets_received", s.PacketsReceived, "rtt", s.RTT)
 			}
-			GatewayStatus.Store(streamID, map[string]interface{}{
-				"ingest_metrics": stats,
+			GatewayStatus.StoreKey(streamID, "ingest_metrics", map[string]interface{}{
+				"stats": stats,
 			})
 
 			monitor.SendQueueEventAsync("stream_ingest_metrics", map[string]interface{}{

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -940,6 +940,9 @@ func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID stri
 			for _, s := range stats.TrackStats {
 				clog.Info(ctx, "whip InboundRTPStreamStats", "kind", s.Type, "jitter", fmt.Sprintf("%.3f", s.Jitter), "packets_lost", s.PacketsLost, "packets_received", s.PacketsReceived, "rtt", s.RTT)
 			}
+			GatewayStatus.Store(streamID, map[string]interface{}{
+				"ingest_metrics": stats,
+			})
 
 			monitor.SendQueueEventAsync("stream_ingest_metrics", map[string]interface{}{
 				"timestamp":   time.Now().UnixMilli(),

--- a/server/ai_pipeline_status.go
+++ b/server/ai_pipeline_status.go
@@ -35,15 +35,28 @@ func (s *streamStatusStore) Get(streamID string) (map[string]interface{}, bool) 
 }
 
 // StoreIfNotExists stores a status only if the streamID doesn't already exist or keyToCheck does not exist on the status
-func (s *streamStatusStore) StoreIfNotExists(streamID string, keyToCheck string, status map[string]interface{}) {
+func (s *streamStatusStore) StoreIfNotExists(streamID string, key string, status map[string]interface{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	status, exists := s.store[streamID]
 	if !exists {
-		s.store[streamID] = status
+		s.storeKey(streamID, key, status)
 		return
 	}
-	if _, ok := status[keyToCheck]; !ok {
-		s.store[streamID] = status
+	if _, ok := status[key]; !ok {
+		s.storeKey(streamID, key, status)
 	}
+}
+
+func (s *streamStatusStore) StoreKey(streamID, key string, status map[string]interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.storeKey(streamID, key, status)
+}
+
+func (s *streamStatusStore) storeKey(streamID, key string, status map[string]interface{}) {
+	if _, ok := s.store[streamID]; !ok {
+		s.store[streamID] = make(map[string]interface{})
+	}
+	s.store[streamID][key] = status
 }

--- a/server/ai_pipeline_status.go
+++ b/server/ai_pipeline_status.go
@@ -38,12 +38,12 @@ func (s *streamStatusStore) Get(streamID string) (map[string]interface{}, bool) 
 func (s *streamStatusStore) StoreIfNotExists(streamID string, key string, status map[string]interface{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	status, exists := s.store[streamID]
+	existing, exists := s.store[streamID]
 	if !exists {
 		s.storeKey(streamID, key, status)
 		return
 	}
-	if _, ok := status[key]; !ok {
+	if _, ok := existing[key]; !ok {
 		s.storeKey(streamID, key, status)
 	}
 }


### PR DESCRIPTION
Expose ingest stats via the stream status endpoint so that the front end can monitor ingest connection quality.