### PR TITLE
Bump MediaMTX to 1.11.2-livepeer-3

### DIFF
--- a/docker/Dockerfile.mediamtx
+++ b/docker/Dockerfile.mediamtx
@@ -1,4 +1,4 @@
-ARG MEDIAMTX_VERSION="1.11.2-livepeer-2"
+ARG MEDIAMTX_VERSION="1.11.2-livepeer-3"
 
 FROM golang:1.23 AS builder
 


### PR DESCRIPTION
Incorporates this change to extend the track gather duration and shortens startup time: https://github.com/livepeer/mediamtx/pull/2