### PR TITLE
ai/worker: Handle LOADING state on containers healthcheck

### DIFF
--- a/ai/worker/container.go
+++ b/ai/worker/container.go
@@ -114,7 +114,9 @@ func runnerWaitUntilReady(ctx context.Context, client *ClientWithResponses, poll
 		case <-ctx.Done():
 			return fmt.Errorf("timed out waiting for runner: %w", lastErr)
 		case <-ticker.C:
-			health, err := client.HealthWithResponse(ctx)
+			reqCtx, cancel := context.WithTimeout(ctx, healthcheckTimeout)
+			health, err := client.HealthWithResponse(reqCtx)
+			cancel()
 			if err != nil {
 				lastErr = err
 			} else if httpStatus := health.StatusCode(); httpStatus != http.StatusOK {

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -40,6 +40,7 @@ const containerCreator = "ai-worker"
 
 var containerTimeout = 3 * time.Minute
 var containerWatchInterval = 5 * time.Second
+var healthcheckTimeout = 5 * time.Second
 var maxHealthCheckFailures = 2
 
 // This only works right now on a single GPU because if there is another container
@@ -572,7 +573,7 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer) {
 			m.returnContainer(rc)
 			continue
 		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(context.Background(), containerWatchInterval)
+			ctx, cancel := context.WithTimeout(context.Background(), healthcheckTimeout)
 			health, err := rc.Client.HealthWithResponse(ctx)
 			cancel()
 

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -606,6 +606,7 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer) {
 				failures = 0
 				continue
 			case "LOADING":
+				// TODO: Consider starting live containers as busy since they might take a while until the first healthcheck returns
 				failures = 0
 				if !isBorrowed {
 					slog.Info("Container is loading, removing from pool", slog.String("container", rc.Name))

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -32,13 +32,13 @@ import (
 const containerModelDir = "/models"
 const containerPort = "8000/tcp"
 const pollingInterval = 500 * time.Millisecond
-const containerTimeout = 3 * time.Minute
 const externalContainerTimeout = 2 * time.Minute
 const optFlagsContainerTimeout = 5 * time.Minute
 const containerRemoveTimeout = 30 * time.Second
 const containerCreatorLabel = "creator"
 const containerCreator = "ai-worker"
 
+var containerTimeout = 3 * time.Minute
 var containerWatchInterval = 5 * time.Second
 var maxHealthCheckFailures = 2
 
@@ -609,10 +609,11 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer) {
 				failures = 0
 				continue
 			case "LOADING": // TODO: Use enum when ai-runner SDK is updated
-				failures = 0
 				if !isBorrowed {
 					slog.Info("Container is loading, removing from pool", slog.String("container", rc.Name))
+					failures = 0
 					loadingStartTime = time.Now()
+
 					m.mu.Lock()
 					m.borrowContainerLocked(context.Background(), rc)
 					m.mu.Unlock()

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -601,12 +601,16 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer) {
 			case OK:
 				failures = 0
 				continue
-			default:
+			case ERROR:
 				failures++
 				slog.Error("Container not healthy",
 					slog.String("container", rc.Name),
 					slog.String("status", string(status)),
 					slog.String("failures", strconv.Itoa(failures)))
+			default:
+				slog.Error("Unknown container status",
+					slog.String("container", rc.Name),
+					slog.String("status", string(status)))
 			}
 		}
 	}

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"regexp"
 	"runtime/debug"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -621,11 +620,10 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer) {
 				}
 				continue
 			case ERROR:
-				failures++
-				slog.Error("Container not healthy",
+				failures = maxHealthCheckFailures
+				slog.Error("Container returned ERROR state, restarting immediately",
 					slog.String("container", rc.Name),
-					slog.String("status", string(status)),
-					slog.String("failures", strconv.Itoa(failures)))
+					slog.String("status", string(status)))
 			default:
 				slog.Error("Unknown container status",
 					slog.String("container", rc.Name),

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -708,11 +708,11 @@ func TestDockerManager_destroyContainer(t *testing.T) {
 
 func TestDockerManager_watchContainer(t *testing.T) {
 	// Override the containerWatchInterval for testing purposes.
-	originalContainerWatchInterval, originalPipelineStartGracePeriod := containerWatchInterval, pipelineStartGracePeriod
+	originalContainerWatchInterval, originalHealthcheckAvailableGracePeriod := containerWatchInterval, healthcheckAvailableGracePeriod
 	containerWatchInterval = 10 * time.Millisecond
-	pipelineStartGracePeriod = 0
+	healthcheckAvailableGracePeriod = 0
 	defer func() {
-		containerWatchInterval, pipelineStartGracePeriod = originalContainerWatchInterval, originalPipelineStartGracePeriod
+		containerWatchInterval, healthcheckAvailableGracePeriod = originalContainerWatchInterval, originalHealthcheckAvailableGracePeriod
 	}()
 
 	setup := func() (*MockDockerClient, *DockerManager, *MockServer, *RunnerContainer) {
@@ -868,8 +868,8 @@ func TestDockerManager_watchContainer(t *testing.T) {
 	}
 
 	t.Run("RespectStartupGracePeriod", func(t *testing.T) {
-		pipelineStartGracePeriod = 50 * time.Millisecond
-		defer func() { pipelineStartGracePeriod = 0 }()
+		healthcheckAvailableGracePeriod = 50 * time.Millisecond
+		defer func() { healthcheckAvailableGracePeriod = 0 }()
 
 		mockDockerClient, dockerManager, mockServer, rc := setup()
 		defer mockServer.Close()
@@ -899,8 +899,8 @@ func TestDockerManager_watchContainer(t *testing.T) {
 	})
 
 	t.Run("ReturnContainerWhenIdle", func(t *testing.T) {
-		pipelineStartGracePeriod = 50 * time.Millisecond
-		defer func() { pipelineStartGracePeriod = 0 }()
+		healthcheckAvailableGracePeriod = 50 * time.Millisecond
+		defer func() { healthcheckAvailableGracePeriod = 0 }()
 
 		mockDockerClient, dockerManager, mockServer, rc := setup()
 		defer mockServer.Close()

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -211,8 +211,8 @@ func TestDockerManager_Warm(t *testing.T) {
 	defer updateDuringTest(&dockerWaitUntilRunningFunc, func(ctx context.Context, client DockerClient, containerID string, pollingInterval time.Duration) error {
 		return nil
 	})()
-	defer updateDuringTest(&runnerWaitUntilReadyFunc, func(ctx context.Context, client *ClientWithResponses, pollingInterval time.Duration) error {
-		return nil
+	defer updateDuringTest(&runnerWaitUntilReadyFunc, func(ctx context.Context, client *ClientWithResponses, pollingInterval time.Duration) (bool, error) {
+		return false, nil
 	})()
 
 	mockDockerClient.On("ContainerCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(container.CreateResponse{ID: containerID}, nil)
@@ -255,8 +255,8 @@ func TestDockerManager_Borrow(t *testing.T) {
 	defer updateDuringTest(&dockerWaitUntilRunningFunc, func(ctx context.Context, client DockerClient, containerID string, pollingInterval time.Duration) error {
 		return nil
 	})()
-	defer updateDuringTest(&runnerWaitUntilReadyFunc, func(ctx context.Context, client *ClientWithResponses, pollingInterval time.Duration) error {
-		return nil
+	defer updateDuringTest(&runnerWaitUntilReadyFunc, func(ctx context.Context, client *ClientWithResponses, pollingInterval time.Duration) (bool, error) {
+		return false, nil
 	})()
 
 	mockDockerClient.On("ContainerCreate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(container.CreateResponse{ID: containerID}, nil)
@@ -563,8 +563,8 @@ func TestDockerManager_createContainer(t *testing.T) {
 	defer updateDuringTest(&dockerWaitUntilRunningFunc, func(ctx context.Context, client DockerClient, containerID string, pollingInterval time.Duration) error {
 		return nil
 	})()
-	defer updateDuringTest(&runnerWaitUntilReadyFunc, func(ctx context.Context, client *ClientWithResponses, pollingInterval time.Duration) error {
-		return nil
+	defer updateDuringTest(&runnerWaitUntilReadyFunc, func(ctx context.Context, client *ClientWithResponses, pollingInterval time.Duration) (bool, error) {
+		return false, nil
 	})()
 
 	// Mock allocGPU and getContainerImageName methods.

--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -695,7 +695,7 @@ func (w *Worker) Warm(ctx context.Context, pipeline string, modelID string, endp
 		Endpoint:         endpoint,
 		containerTimeout: externalContainerTimeout,
 	}
-	rc, err := NewRunnerContainer(ctx, cfg, endpoint.URL)
+	rc, _, err := NewRunnerContainer(ctx, cfg, endpoint.URL)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This implements handling of the LOADING state on the worker code
and optimizes handling based on latest updates on https://github.com/livepeer/ai-runner/pull/568

By borrowing containers from the watch loop, we make sure the O will not
accept any job for that container while it is still loading.

**Specific updates (required)**
- Add LOADING state handling
- Refactor watch container logic a bit to react faster and be more lenient to new states we wanna create in the future

**How did you test each of these updates (required)**
box

**Does this pull request close any open issues?**
Included in INF-119

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
