### PR TITLE
Allow to filter Orchestrators by "contains" (not only by exact match)

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1532,7 +1532,8 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 			break
 		}
 		sessTries[sess.Transcoder()]++
-		if params.liveParams.orchestrator != "" && strings.Contains(sess.Transcoder(), params.liveParams.orchestrator) {
+		params.liveParams.orchestrator = "128.0.0.1"
+		if params.liveParams.orchestrator != "" && !strings.Contains(sess.Transcoder(), params.liveParams.orchestrator) {
 			// user requested a specific orchestrator, so ignore all the others
 			clog.Infof(ctx, "Skipping orchestrator=%s because user request specific orchestrator=%s", sess.Transcoder(), params.liveParams.orchestrator)
 			retryableSessions = append(retryableSessions, sess)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1532,7 +1532,6 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 			break
 		}
 		sessTries[sess.Transcoder()]++
-		params.liveParams.orchestrator = "128.0.0.1"
 		if params.liveParams.orchestrator != "" && !strings.Contains(sess.Transcoder(), params.liveParams.orchestrator) {
 			// user requested a specific orchestrator, so ignore all the others
 			clog.Infof(ctx, "Skipping orchestrator=%s because user request specific orchestrator=%s", sess.Transcoder(), params.liveParams.orchestrator)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1532,7 +1532,7 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 			break
 		}
 		sessTries[sess.Transcoder()]++
-		if params.liveParams.orchestrator != "" && params.liveParams.orchestrator != sess.Transcoder() {
+		if params.liveParams.orchestrator != "" && strings.Contains(sess.Transcoder(), params.liveParams.orchestrator) {
 			// user requested a specific orchestrator, so ignore all the others
 			clog.Infof(ctx, "Skipping orchestrator=%s because user request specific orchestrator=%s", sess.Transcoder(), params.liveParams.orchestrator)
 			retryableSessions = append(retryableSessions, sess)


### PR DESCRIPTION
This will allow to specify https://daydream.live/create?orchestrator=lvpr to use only Inc Os.