### PR TITLE
Change binding host for docker containers from 0.0.0.0 to 127.0.0.1

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -387,7 +387,7 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 		PortBindings: nat.PortMap{
 			containerPort: []nat.PortBinding{
 				{
-					HostIP:   "0.0.0.0",
+					HostIP:   "127.0.0.1",
 					HostPort: containerHostPort,
 				},
 			},


### PR DESCRIPTION
@pwilczynskiclearcode pointed out that we probably should not bind to 0.0.0.0.

@rickstaa @victorges @ad-astra-video is there any reason we would need `0.0.0.0? If not then I suggest changing it to localhost only.