### PR TITLE
ai/live: Rename LivePipelines to LiveSessions

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -167,6 +167,7 @@ type LivepeerNode struct {
 
 type LiveSession struct {
 	RequestID   string
+	Message     string
 	ControlPub  *trickle.TricklePublisher
 	StopControl func()
 }

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -151,9 +151,9 @@ type LivepeerNode struct {
 	serviceURI       url.URL
 	segmentMutex     *sync.RWMutex
 
-	// For live video pipelines, cache for live pipelines; key is the stream name
-	LivePipelines map[string]*LivePipeline
-	LiveMu        *sync.RWMutex
+	// Connections for AI live video; key is the stream name
+	LiveSessions map[string]*LiveSession
+	LiveMu       *sync.RWMutex
 
 	MediaMTXApiPassword        string
 	LiveAITrickleHostForRunner string
@@ -165,7 +165,7 @@ type LivepeerNode struct {
 	GatewayHost string
 }
 
-type LivePipeline struct {
+type LiveSession struct {
 	RequestID   string
 	ControlPub  *trickle.TricklePublisher
 	StopControl func()
@@ -186,7 +186,7 @@ func NewLivepeerNode(e eth.LivepeerEthClient, wd string, dbh *common.DB) (*Livep
 		priceInfoForCaps: make(map[string]CapabilityPrices),
 		StorageConfigs:   make(map[string]*transcodeConfig),
 		storageMutex:     &sync.RWMutex{},
-		LivePipelines:    make(map[string]*LivePipeline),
+		LiveSessions:     make(map[string]*LiveSession),
 		LiveMu:           &sync.RWMutex{},
 	}, nil
 }

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -578,6 +578,14 @@ func (a aiRequestParams) inputStreamExists() bool {
 	return ok && p.RequestID == a.liveParams.requestID
 }
 
+func cleanupControl(ctx context.Context, controlPub *trickle.TricklePublisher, stopControl func()) {
+	// TODO simplify BUT be careful of a subtle interactions between stopControl & keepalive timer!
+	if err := controlPub.Close(); err != nil {
+		clog.InfofErr(ctx, "Error closing control publisher", err)
+	}
+	stopControl()
+}
+
 // Detect 'slow' orchs by keeping track of in-flight segments
 // Count the difference between segments produced and segments completed
 type SlowOrchChecker struct {

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -369,20 +369,20 @@ func startControlPublish(ctx context.Context, control *url.URL, params aiRequest
 		})
 	}
 
-	if control, exists := params.node.LivePipelines[stream]; exists {
+	if control, exists := params.node.LiveSessions[stream]; exists {
 		clog.Info(ctx, "Stopping existing control loop", "existing_request_id", control.RequestID)
 		control.ControlPub.Close()
 		// TODO better solution than allowing existing streams to stomp over one another
 	}
 
-	params.node.LivePipelines[stream] = &core.LivePipeline{
+	params.node.LiveSessions[stream] = &core.LiveSession{
 		ControlPub:  controlPub,
 		StopControl: stop,
 		RequestID:   params.liveParams.requestID,
 	}
 	if monitor.Enabled {
-		monitor.AICurrentLiveSessions(len(params.node.LivePipelines))
-		logCurrentLiveSessions(params.node.LivePipelines)
+		monitor.AICurrentLiveSessions(len(params.node.LiveSessions))
+		logCurrentLiveSessions(params.node.LiveSessions)
 	}
 
 	// send a keepalive periodically to keep both ends of the connection alive
@@ -574,7 +574,7 @@ func (a aiRequestParams) inputStreamExists() bool {
 	}
 	a.node.LiveMu.RLock()
 	defer a.node.LiveMu.RUnlock()
-	p, ok := a.node.LivePipelines[a.liveParams.stream]
+	p, ok := a.node.LiveSessions[a.liveParams.stream]
 	return ok && p.RequestID == a.liveParams.requestID
 }
 

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -362,6 +362,15 @@ func startControlPublish(ctx context.Context, control *url.URL, params aiRequest
 		return errors.New("Nonexistent or mismatched session when starting control publisher")
 	}
 
+	if sess.Message != "" {
+		// there is a cached message so send it
+		// do it here before we start the ticker or set any session fields
+		// TODO don't hold the LiveMu lock
+		if err := controlPub.Write(strings.NewReader(sess.Message)); err != nil {
+			return fmt.Errorf("Could not send cached control message: %w", err)
+		}
+	}
+
 	ticker := time.NewTicker(10 * time.Second)
 	done := make(chan bool, 1)
 	once := sync.Once{}

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -349,12 +349,11 @@ func copySegmentWithTimeout(segment *http.Response, w io.Writer, timeout time.Du
 	}
 }
 
-func startControlPublish(ctx context.Context, control *url.URL, params aiRequestParams) {
+func startControlPublish(ctx context.Context, control *url.URL, params aiRequestParams) error {
 	stream := params.liveParams.stream
 	controlPub, err := trickle.NewTricklePublisher(control.String())
 	if err != nil {
-		clog.InfofErr(ctx, "error starting control publisher", err)
-		return
+		return fmt.Errorf("error starting control publisher: %w", err)
 	}
 	params.node.LiveMu.Lock()
 	defer params.node.LiveMu.Unlock()
@@ -403,6 +402,7 @@ func startControlPublish(ctx context.Context, control *url.URL, params aiRequest
 			}
 		}
 	}()
+	return nil
 }
 
 const clearStreamDelay = 1 * time.Minute

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -732,14 +732,16 @@ func (ls *LivepeerServer) UpdateLiveVideo() http.Handler {
 			return
 		}
 
+		msg := string(params)
+		p.Message = msg
 
 		if p.ControlPub == nil {
 			// Don't have an orchestrator yet, or in-between orchs
 			return
 		}
 
-		clog.V(6).Infof(ctx, "Sending Live Video Update Control API stream=%s, params=%s", stream, string(params))
-		if err := p.ControlPub.Write(strings.NewReader(string(params))); err != nil {
+		clog.Info(ctx, "Sending Live Video Update Control API", "stream", stream, "params", msg)
+		if err := p.ControlPub.Write(strings.NewReader(msg)); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -669,7 +669,9 @@ func startProcessing(ctx context.Context, params aiRequestParams, res interface{
 	}
 	clog.V(common.VERBOSE).Infof(ctx, "pub %s sub %s control %s events %s", pub, sub, control, events)
 
-	startControlPublish(ctx, control, params)
+	if err := startControlPublish(ctx, control, params); err != nil {
+		return err
+	}
 	startTricklePublish(ctx, pub, params, params.liveParams.sess)
 	startTrickleSubscribe(ctx, sub, params, params.liveParams.sess)
 	startEventsSubscribe(ctx, events, params, params.liveParams.sess)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -799,6 +799,9 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 		}
 		ctx = clog.AddVal(ctx, "stream", streamName)
 
+		sourceTypeStr := "livepeer-whip"
+		ctx = clog.AddVal(ctx, "source_type", sourceTypeStr)
+
 		ssr := media.NewSwitchableSegmentReader()
 
 		whipConn := media.NewWHIPConnection()
@@ -820,11 +823,8 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			pipelineID := ""
 			pipeline := ""
 			pipelineParams := make(map[string]interface{})
-			sourceTypeStr := "livepeer-whip"
 			queryParams := r.URL.Query().Encode()
 			orchestrator := r.URL.Query().Get("orchestrator")
-
-			ctx = clog.AddVal(ctx, "source_type", sourceTypeStr)
 
 			if LiveAIAuthWebhookURL != nil {
 				authResp, err := authenticateAIStream(LiveAIAuthWebhookURL, ls.liveAIAuthApiKey, AIAuthRequest{

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -719,7 +719,7 @@ func (ls *LivepeerServer) UpdateLiveVideo() http.Handler {
 		}
 		ls.LivepeerNode.LiveMu.RLock()
 		defer ls.LivepeerNode.LiveMu.RUnlock()
-		p, ok := ls.LivepeerNode.LivePipelines[stream]
+		p, ok := ls.LivepeerNode.LiveSessions[stream]
 		if !ok {
 			// Stream not found
 			http.Error(w, "Stream not found", http.StatusNotFound)
@@ -1022,16 +1022,16 @@ func cleanupControl(ctx context.Context, params aiRequestParams) {
 	stream := params.liveParams.stream
 	node := params.node
 	node.LiveMu.Lock()
-	pub, ok := node.LivePipelines[stream]
+	pub, ok := node.LiveSessions[stream]
 	if !ok {
 		// already cleaned up
 		node.LiveMu.Unlock()
 		return
 	}
-	delete(node.LivePipelines, stream)
+	delete(node.LiveSessions, stream)
 	if monitor.Enabled {
-		monitor.AICurrentLiveSessions(len(node.LivePipelines))
-		logCurrentLiveSessions(node.LivePipelines)
+		monitor.AICurrentLiveSessions(len(node.LiveSessions))
+		logCurrentLiveSessions(node.LiveSessions)
 	}
 	node.LiveMu.Unlock()
 
@@ -1043,7 +1043,7 @@ func cleanupControl(ctx context.Context, params aiRequestParams) {
 	}
 }
 
-func logCurrentLiveSessions(pipelines map[string]*core.LivePipeline) {
+func logCurrentLiveSessions(pipelines map[string]*core.LiveSession) {
 	var streams []string
 	for k := range pipelines {
 		streams = append(streams, k)


### PR DESCRIPTION
I would like to use the [liveRequestParams](https://github.com/livepeer/go-livepeer/blob/4be352d6314f23b4c82414eb0fd9c2a6b3052bdc/server/ai_process.go#L95-L121) instead of having the LiveSessions structure but there is a bit of an issue with circular dependencies, so drafting the PR for now