### PR TITLE
box: Support streamdiffusion pipeline

### DIFF
--- a/box/aiModels-streamdiffusion.json
+++ b/box/aiModels-streamdiffusion.json
@@ -1,0 +1,8 @@
+[
+  {
+    "model_id": "streamdiffusion",
+    "pipeline": "live-video-to-video",
+    "warm": true,
+    "capacity": 1
+  }
+]

--- a/box/build-runner.sh
+++ b/box/build-runner.sh
@@ -3,8 +3,8 @@ set -ex
 
 PIPELINE=${PIPELINE:-noop}
 
-if [[ "$PIPELINE" != "noop" && "$PIPELINE" != "comfyui" ]]; then
-  echo "Error: PIPELINE must be either 'noop' or 'comfyui'"
+if [[ "$PIPELINE" != "noop" && "$PIPELINE" != "comfyui" && "$PIPELINE" != "streamdiffusion" ]]; then
+  echo "Error: PIPELINE must be either 'noop', 'comfyui' or 'streamdiffusion'"
   exit 1
 fi
 

--- a/box/orchestrator.sh
+++ b/box/orchestrator.sh
@@ -4,6 +4,7 @@ set -e
 DOCKER=${DOCKER:-false}
 PIPELINE=${PIPELINE:-noop}
 AI_RUNNER_CONTAINERS_PER_GPU=${AI_RUNNER_CONTAINERS_PER_GPU:-1}
+VERBOSE=${VERBOSE:-0}
 
 DOCKER_HOSTNAME="172.17.0.1"
 if [[ "$(uname)" == "Darwin" ]]; then
@@ -21,6 +22,11 @@ if [[ "$PIPELINE" != "noop" ]]; then
   AI_MODELS_DIR_FLAG="-aiModelsDir ${AI_MODELS_DIR}"
 fi
 
+VERBOSE_FLAG=""
+if [ "$VERBOSE" = "1" ]; then
+  VERBOSE_FLAG="-aiVerboseLogs"
+fi
+
 if [ "$DOCKER" = "false" ]; then
   ./livepeer \
     -orchestrator \
@@ -28,6 +34,7 @@ if [ "$DOCKER" = "false" ]; then
     -aiModels ./box/aiModels-${PIPELINE}.json \
     -aiRunnerContainersPerGPU ${AI_RUNNER_CONTAINERS_PER_GPU} \
     ${AI_MODELS_DIR_FLAG} \
+    ${VERBOSE_FLAG} \
     ${NVIDIA} \
     -serviceAddr localhost:8935 \
     -transcoder \
@@ -44,6 +51,7 @@ else
     -aiWorker \
     -aiModels /opt/aiModels.json \
     -aiRunnerContainersPerGPU ${AI_RUNNER_CONTAINERS_PER_GPU} \
+    ${VERBOSE_FLAG} \
     ${AI_MODELS_DIR_FLAG} \
     -serviceAddr 127.0.0.1:8935 \
     -transcoder \


### PR DESCRIPTION
This is used to test https://github.com/livepeer/ai-runner/pull/616

To start the box with streamdiffusion:
`PIPELINE=streamdiffusion make box`

Once you get it to load (orch will print the log that the container went idle, after loading), you can test a stream with:

`PIPELINE=streamdiffusion make box-stream`

And use RTMP output env if you wanna see the result (or use a GUI machine). Check box docs for more info.

To check logs from runner just use
`docker logs -f live_app_streamdiffusion_8900`
(or sth like that, check container name with `docker ps`)