### PR TITLE
ai/live: Work around iOS microsecond timestamp bug.

### DIFF
--- a/media/timestamp_corrector.go
+++ b/media/timestamp_corrector.go
@@ -1,0 +1,92 @@
+package media
+
+import (
+	"context"
+	"time"
+
+	"github.com/livepeer/go-livepeer/clog"
+)
+
+// TimestampCorrector detects a bug with iOS 18.4.1+ where
+// timestamps come in with microsecond frequency -
+// 1000khz rather than the 90khz that RTP requires
+// If needed, divides incoming timestamps by 90_000 / 1_000_000.
+// https://bugs.webkit.org/show_bug.cgi?id=292273
+type TimestampCorrector struct {
+	// configuration
+	frameInterval float64          // expected time between successive frames
+	thresholdFreq float64          // threshold in Hz to trigger correction
+	now           func() time.Time // function to obtain current time, injected for testing
+
+	// detection state
+	firstTS       int64
+	firstArrival  time.Time
+	detectionDone bool
+	needsFix      bool
+}
+
+// NewTimestampCorrector creates a detector based on your target fps.
+func NewTimestampCorrector(fps float64) *TimestampCorrector {
+	return &TimestampCorrector{
+		frameInterval: 1.0 / fps,
+		thresholdFreq: 800_000,  // anything above 800 kHz flags the bug
+		now:           time.Now, // default to real clock
+	}
+}
+
+// Process inspects the supplied timestamp against wall‐clock arrival time,
+// decides whether the iOS bug is present, and if so converts to 90khz from 1000khz
+// (1000khz == microsecond time base) Returns the (possibly corrected) timestamp.
+func (c *TimestampCorrector) Process(ctx context.Context, ts int64) int64 {
+
+	// detection phase
+	if !c.detectionDone {
+		now := c.now()
+
+		if c.firstArrival.IsZero() {
+			if ts != 0 {
+				// Normally this is not a problem *except* if this client
+				// has the iOS bug and we need to convert the first ts.
+				// Could result in sending a very large first ts then small ones
+				//
+				// NB: we can't simply add rescaled deltas to the first timestamp
+				// 		 because that could break audio sync
+				clog.Info(ctx, "TSCorrector: First timestamp was not zero!", "ts", ts)
+			}
+			c.firstArrival = now
+			c.firstTS = ts
+			return ts
+		}
+
+		if c.firstTS == ts {
+			// handle frames split across packets
+			return ts
+		}
+
+		dt := now.Sub(c.firstArrival).Seconds()
+		if dt < c.frameInterval {
+			// burst / flush (too fast)
+			// usually from waiting for a late / lost packet
+			clog.Info(ctx, "TSCorrector: Burst packet, speculatively setting wallclock delta", "dt_ms", dt*1000, "diff_ms", (c.frameInterval-dt)*1000)
+			dt = c.frameInterval
+		}
+
+		tsDelta := float64(ts - c.firstTS)
+		freq := tsDelta / dt
+		if freq > c.thresholdFreq {
+			// TODO remove this entire file once we stop seeing this log line
+			clog.Info(ctx, "TSCorrector: Frequency too high! Starting microsecond timestamp mode", "freq", freq, "first", c.firstTS, "ts", ts, "delta", tsDelta, "dt_ms", dt*1000)
+			c.needsFix = true
+		} else {
+			clog.Info(ctx, "TSCorrector: All good", "freq", freq, "first", c.firstTS, "ts", ts, "delta", tsDelta, "dt_ms", dt*1000)
+		}
+		c.detectionDone = true
+	}
+
+	// apply correction once flagged
+	if c.needsFix {
+		return multiplyAndDivide(ts, 90_000, 1_000_000)
+	}
+
+	return ts
+}

--- a/media/timestamp_corrector_test.go
+++ b/media/timestamp_corrector_test.go
@@ -1,0 +1,110 @@
+package media
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// makeClock returns a Now() function that returns successive times from the slice.
+func makeClock(times []time.Time) (nowFunc func() time.Time) {
+	idx := 0
+	return func() time.Time {
+		if idx < len(times) {
+			t := times[idx]
+			idx++
+			return t
+		}
+		return times[len(times)-1]
+	}
+}
+
+func TestTimestampCorrector_NoFix_NormalClock(t *testing.T) {
+	fps := 30.0
+	tc := NewTimestampCorrector(fps)
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	// simulate two packets spaced at expectedWallclockDelta, tsDelta=expectedWallclockDelta*90k
+	t0 := time.Date(2025, 5, 30, 0, 0, 0, 0, time.UTC)
+	dtNs := time.Duration((1.0/fps)*0.5*1e9) * time.Nanosecond
+	t1 := t0.Add(dtNs)
+	tc.now = makeClock([]time.Time{t0, t1})
+
+	ts1 := int64(1000)
+	out1 := tc.Process(ctx, ts1)
+	assert.Equal(ts1, out1, "first call changed ts")
+
+	// tsDelta should correspond to 90k Hz, below threshold
+	ts2 := ts1 + int64((dtNs.Seconds() * 90000))
+	out2 := tc.Process(ctx, ts2)
+	assert.Equal(ts2, out2, "normal-clock second call changed ts")
+
+	// subsequent calls remain unmodified
+	ts3 := ts2 + 3000
+	out3 := tc.Process(ctx, ts3)
+	assert.Equal(ts3, out3, "subsequent normal-clock call changed ts")
+}
+
+func TestTimestampCorrector_Fix_iOS_Bug(t *testing.T) {
+	fps := 30.0
+	tc := NewTimestampCorrector(fps)
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	// simulate two packets spaced normally but with an inflated tsDelta to trigger fix
+	t0 := time.Date(2025, 5, 30, 0, 0, 0, 0, time.UTC)
+	dtNs := time.Duration(tc.frameInterval*1e9) * time.Nanosecond
+	t1 := t0.Add(dtNs)
+	tc.now = makeClock([]time.Time{t0, t1})
+
+	ts1 := int64(1000)
+	out1 := tc.Process(ctx, ts1)
+	assert.Equal(ts1, out1, "first call changed ts")
+
+	// choose a delta large enough: > thresholdFreq*dt
+	dtSec := dtNs.Seconds()
+	largeDelta := int64((tc.thresholdFreq * dtSec) + 2)
+	ts2 := ts1 + largeDelta
+	out2 := tc.Process(ctx, ts2)
+	expected2 := multiplyAndDivide(ts2, 90_000, 1_000_000)
+	assert.Equal(expected2, out2, "bug-clock second call")
+
+	// subsequent calls also fixed
+	ts3 := ts2 + 20000
+	out3 := tc.Process(ctx, ts3)
+	expected3 := multiplyAndDivide(ts3, 90_000, 1_000_000)
+	assert.Equal(expected3, out3, "subsequent bug-clock call")
+}
+
+func TestTimestampCorrector_Burst(t *testing.T) {
+	fps := 30.0
+	tc := NewTimestampCorrector(fps)
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	// simulate burst: dt < expectedWallclockDelta
+	t0 := time.Date(2025, 5, 30, 0, 0, 0, 0, time.UTC)
+	dtNs := time.Duration(tc.frameInterval*1e9) * time.Nanosecond
+	fastNs := dtNs / 2 // corresponds to roughly 17ms - below 33ms minimum
+	t1 := t0.Add(fastNs)
+	// then a normal interval
+	t2 := t0.Add(dtNs)
+	tc.now = makeClock([]time.Time{t0, t1, t2})
+
+	ts1 := int64(0)
+	out1 := tc.Process(ctx, ts1)
+	assert.Equal(ts1, out1, "first call mutated ts")
+
+	// we can have a gap of roughly 280ms during a <33ms burst
+	ts2 := int64(26000)
+	out2 := tc.Process(ctx, ts2)
+	assert.Equal(ts2, out2, "flush-phase call changed ts")
+
+	// now a normal spacing with small tsDelta → detectionDone becomes true but no fix
+	ts3 := ts2 + 100
+	out3 := tc.Process(ctx, ts3)
+	assert.Equal(ts3, out3, "post-flush normal call changed ts")
+}

--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -66,6 +66,8 @@ type WHIPServer struct {
 func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReader, whepURL string, w http.ResponseWriter, r *http.Request) *MediaState {
 	clog.Infof(ctx, "creating whip")
 
+	clog.Info(ctx, "Client info", "user-agent", r.Header.Get("User-Agent"))
+
 	// Must have Content-Type: application/sdp (the spec strongly recommends it)
 	if r.Header.Get("Content-Type") != "application/sdp" {
 		http.Error(w, "Unsupported Media Type, expected application/sdp", http.StatusUnsupportedMediaType)
@@ -219,12 +221,14 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 
 func handleRTP(ctx context.Context, segmenter *RTPSegmenter, timeDecoder *rtptime.GlobalDecoder2, track *webrtc.TrackRemote) {
 	var frame rtp.Depacketizer
+	var tsCorrector *TimestampCorrector
 	codec := track.Codec().MimeType
 	incomingTrack := &IncomingTrack{track: track}
 	isAudio := false
 	switch codec {
 	case webrtc.MimeTypeH264:
 		frame = &codecs.H264Packet{IsAVC: true}
+		tsCorrector = NewTimestampCorrector(30.0)
 	case webrtc.MimeTypeOpus:
 		frame = &codecs.OpusPacket{}
 		isAudio = true
@@ -278,6 +282,8 @@ func handleRTP(ctx context.Context, segmenter *RTPSegmenter, timeDecoder *rtptim
 
 			// h264 video from here on
 			// https://datatracker.ietf.org/doc/html/rfc6184
+
+			pts = tsCorrector.Process(ctx, pts)
 
 			if currentTS != p.Timestamp && len(au) > 0 {
 				// received a new frame, but previous frame was incomplete (lost marker bit)


### PR DESCRIPTION
iOS 18.4.1 onwards has a bug in its Webkit based browser that causes it to emit RTP timestamps for video at microsecond resolution (1000khz) instead of the 90khz that RTP video timestamps expect.

Attempt to detect this problem by comparing the first two timestamps.

Note this is NOT a signaling issue; the SDP has the correct clock rates.

Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=292273
Webkit fix: https://github.com/WebKit/WebKit/pull/44687