### PR TITLE
Clone session for Realtime Video AI Processing

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1032,6 +1032,8 @@ func submitAudioToText(ctx context.Context, params aiRequestParams, sess *AISess
 const initPixelsToPay = 10 * 30 * 3200 * 1800 // 10 seconds, 30fps, 1800p
 
 func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *AISession, req worker.GenLiveVideoToVideoJSONRequestBody) (any, error) {
+	sess = sess.Clone()
+
 	// Storing sess in the liveParams; it's ugly, but we need to pass it back and don't want to break this function interface
 	params.liveParams.sess = sess
 	params.liveParams.startTime = time.Now()

--- a/server/ai_session.go
+++ b/server/ai_session.go
@@ -605,3 +605,13 @@ func (c *AISessionManager) getSelector(ctx context.Context, cap core.Capability,
 
 	return sel, nil
 }
+
+func (s *AISession) Clone() *AISession {
+	bSess := s.BroadcastSession.Clone()
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	newSess := *s
+	newSess.BroadcastSession = bSess
+	return &newSess
+}


### PR DESCRIPTION
The root reason for this change is that the "insufficient balance" error still sometimes happens on the Orchestrator. Upon investigation, I found that the problem is that the sess.Balance was shared between different streams causing one stream not accounting correctly. The simple fix is to always clone Balances (and other session params) before using it further in the Realtime Video pipeline.

Note that this change touches only Realtime Video (no other parts of the go-livepeer system).

