### PR TITLE
Check ICE State before suspending Orchestrator

### DIFF
--- a/media/whip_connection.go
+++ b/media/whip_connection.go
@@ -145,13 +145,14 @@ type MediaStats struct {
 
 // MediaState manages the lifecycle of a media connection
 type MediaState struct {
-	pc     WHIPPeerConnection
-	getter stats.Getter
-	tracks []RTPTrack
-	mu     *sync.Mutex
-	cond   *sync.Cond
-	closed bool
-	err    error
+	pc       WHIPPeerConnection
+	getter   stats.Getter
+	tracks   []RTPTrack
+	mu       *sync.Mutex
+	cond     *sync.Cond
+	iceState webrtc.ICEConnectionState
+	closed   bool
+	err      error
 }
 
 // NewMediaState creates a new MediaState with the given peerconnection
@@ -288,4 +289,10 @@ func (m *MediaState) Stats() (*MediaStats, error) {
 		TrackStats:    trackStats,
 		ConnQuality:   connQuality,
 	}, nil
+}
+
+func (m *MediaState) IceState() webrtc.ICEConnectionState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.iceState
 }

--- a/media/whip_connection.go
+++ b/media/whip_connection.go
@@ -291,6 +291,12 @@ func (m *MediaState) Stats() (*MediaStats, error) {
 	}, nil
 }
 
+func (m *MediaState) SetIceState(iceState webrtc.ICEConnectionState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.iceState = iceState
+}
+
 func (m *MediaState) IceState() webrtc.ICEConnectionState {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -105,6 +105,10 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 
 	// PeerConnection state management
 	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
+		mediaState.mu.Lock()
+		mediaState.iceState = connectionState
+		mediaState.mu.Unlock()
+
 		clog.Info(ctx, "ice connection state changed", "state", connectionState)
 		if connectionState == webrtc.ICEConnectionStateFailed {
 			mediaState.CloseError(errors.New("ICE connection state failed"))

--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -105,9 +105,7 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 
 	// PeerConnection state management
 	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
-		mediaState.mu.Lock()
-		mediaState.iceState = connectionState
-		mediaState.mu.Unlock()
+		mediaState.SetIceState(connectionState)
 
 		clog.Info(ctx, "ice connection state changed", "state", connectionState)
 		if connectionState == webrtc.ICEConnectionStateFailed {

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -809,6 +809,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			whepURL = "http://localhost:8889/" // default mediamtx output
 		}
 		whepURL = whepURL + streamName + "-out/whep"
+		conn := server.CreateWHIP(ctx, ssr, whepURL, w, r)
 
 		go func() {
 			internalOutputHost := os.Getenv("LIVE_AI_PLAYBACK_HOST") // TODO proper cli arg
@@ -946,6 +947,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 					stopPipeline:           stopPipeline,
 					sendErrorEvent:         sendErrorEvent,
 					orchestrator:           orchestrator,
+					whipConn:               conn,
 				},
 			}
 
@@ -968,7 +970,6 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			clog.Info(ctx, "Live cleaned up")
 		}()
 
-		conn := server.CreateWHIP(ctx, ssr, whepURL, w, r)
 		whipConn.SetWHIPConnection(conn) // might be nil if theres an error and thats okay
 	})
 }

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -118,6 +118,9 @@ type liveRequestParams struct {
 	startTime time.Time
 	// sess is passed from the orchestrator selection, ugly hack
 	sess *AISession
+
+	// Whip Only
+	whipConn *media.MediaState
 }
 
 // CalculateTextToImageLatencyScore computes the time taken per pixel for an text-to-image request.


### PR DESCRIPTION
Before sending a "out segment timeout" error (and suspending Orchestrator), first check if the ICE Connection is connected.