### PR TITLE
ai/live: Timestamp corrector improvements

### DIFF
--- a/media/timestamp_corrector_test.go
+++ b/media/timestamp_corrector_test.go
@@ -200,6 +200,10 @@ func TestTimestampCorrector_UAFilter(t *testing.T) {
 			name: "Facebook on iPhone",
 			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/510.0.0.47.116;FBBV/743276974;FBDV/iPhone17,3;FBMD/iPhone;FBSN/iOS;FBSV/18.5;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/80]",
 		},
+		{
+			name: "Edge on iPhone",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 17_7_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 EdgiOS/137.3296.65 Mobile/15E148 Safari/605.1.15",
+		},
 	}
 	noMatches := []struct {
 		name string
@@ -222,8 +226,16 @@ func TestTimestampCorrector_UAFilter(t *testing.T) {
 			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:139.0) Gecko/20100101 Firefox/139.0",
 		},
 		{
+			name: "Edge on MacOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36 Edg/137.0.3296.68",
+		},
+		{
 			name: "Chrome on Android",
 			ua:   "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Mobile Safari/537.36",
+		},
+		{
+			name: "Edge on Android",
+			ua:   "Mozilla/5.0 (Linux; Android 10; HD1913) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.7151.73 Mobile Safari/537.36 EdgA/137.0.3296.65",
 		},
 		{
 			name: "Chrome on Linux",
@@ -232,6 +244,10 @@ func TestTimestampCorrector_UAFilter(t *testing.T) {
 		{
 			name: "Chrome on Windows",
 			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+		},
+		{
+			name: "Edge on Windows",
+			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36 Edg/137.0.3296.68",
 		},
 	}
 

--- a/media/timestamp_corrector_test.go
+++ b/media/timestamp_corrector_test.go
@@ -23,7 +23,6 @@ func makeClock(times []time.Time) (nowFunc func() time.Time) {
 
 func TestTimestampCorrector_NoFix_NormalClock(t *testing.T) {
 	fps := 30.0
-	tc := NewTimestampCorrector(fps)
 	ctx := context.Background()
 	assert := assert.New(t)
 
@@ -31,7 +30,11 @@ func TestTimestampCorrector_NoFix_NormalClock(t *testing.T) {
 	t0 := time.Date(2025, 5, 30, 0, 0, 0, 0, time.UTC)
 	dtNs := time.Duration((1.0/fps)*0.5*1e9) * time.Nanosecond
 	t1 := t0.Add(dtNs)
-	tc.now = makeClock([]time.Time{t0, t1})
+
+	tc := NewTimestampCorrector(TimestampCorrectorConfig{
+		FPS:   fps,
+		Clock: makeClock([]time.Time{t0, t1}),
+	})
 
 	ts1 := int64(1000)
 	out1 := tc.Process(ctx, ts1)
@@ -50,15 +53,18 @@ func TestTimestampCorrector_NoFix_NormalClock(t *testing.T) {
 
 func TestTimestampCorrector_Fix_iOS_Bug(t *testing.T) {
 	fps := 30.0
-	tc := NewTimestampCorrector(fps)
 	ctx := context.Background()
 	assert := assert.New(t)
 
 	// simulate two packets spaced normally but with an inflated tsDelta to trigger fix
 	t0 := time.Date(2025, 5, 30, 0, 0, 0, 0, time.UTC)
-	dtNs := time.Duration(tc.frameInterval*1e9) * time.Nanosecond
+	dtNs := time.Duration((1.0/fps)*1e9) * time.Nanosecond
 	t1 := t0.Add(dtNs)
-	tc.now = makeClock([]time.Time{t0, t1})
+
+	tc := NewTimestampCorrector(TimestampCorrectorConfig{
+		FPS:   fps,
+		Clock: makeClock([]time.Time{t0, t1}),
+	})
 
 	ts1 := int64(1000)
 	out1 := tc.Process(ctx, ts1)
@@ -81,18 +87,21 @@ func TestTimestampCorrector_Fix_iOS_Bug(t *testing.T) {
 
 func TestTimestampCorrector_Burst(t *testing.T) {
 	fps := 30.0
-	tc := NewTimestampCorrector(fps)
 	ctx := context.Background()
 	assert := assert.New(t)
 
 	// simulate burst: dt < expectedWallclockDelta
 	t0 := time.Date(2025, 5, 30, 0, 0, 0, 0, time.UTC)
-	dtNs := time.Duration(tc.frameInterval*1e9) * time.Nanosecond
+	dtNs := time.Duration((1.0/fps)*1e9) * time.Nanosecond
 	fastNs := dtNs / 2 // corresponds to roughly 17ms - below 33ms minimum
 	t1 := t0.Add(fastNs)
 	// then a normal interval
 	t2 := t0.Add(dtNs)
-	tc.now = makeClock([]time.Time{t0, t1, t2})
+
+	tc := NewTimestampCorrector(TimestampCorrectorConfig{
+		FPS:   fps,
+		Clock: makeClock([]time.Time{t0, t1, t2}),
+	})
 
 	ts1 := int64(0)
 	out1 := tc.Process(ctx, ts1)
@@ -107,4 +116,201 @@ func TestTimestampCorrector_Burst(t *testing.T) {
 	ts3 := ts2 + 100
 	out3 := tc.Process(ctx, ts3)
 	assert.Equal(ts3, out3, "post-flush normal call changed ts")
+}
+
+func TestTimestampCorrector_WithMatchingUA(t *testing.T) {
+	// UA is Safari on MacOS - should trigger timestamp correction
+	userAgent := "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Safari/605.1.15"
+	fps := 30.0
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	// simulate two packets spaced normally but with an inflated tsDelta to trigger fix
+	t0 := time.Date(2025, 5, 30, 0, 0, 0, 0, time.UTC)
+	dtNs := time.Duration((1.0/fps)*1e9) * time.Nanosecond
+	t1 := t0.Add(dtNs)
+
+	tc := NewTimestampCorrector(TimestampCorrectorConfig{
+		FPS:       fps,
+		Clock:     makeClock([]time.Time{t0, t1}),
+		UserAgent: userAgent,
+	})
+
+	ts1 := int64(1000)
+	out1 := tc.Process(ctx, ts1)
+	assert.Equal(ts1, out1, "first call changed ts")
+
+	// choose a delta large enough: > thresholdFreq*dt
+	dtSec := dtNs.Seconds()
+	largeDelta := int64((tc.thresholdFreq * dtSec) + 2)
+	ts2 := ts1 + largeDelta
+	out2 := tc.Process(ctx, ts2)
+	expected2 := multiplyAndDivide(ts2, 90_000, 1_000_000)
+	assert.Equal(expected2, out2, "bug-clock second call")
+
+	// subsequent calls also fixed
+	ts3 := ts2 + 20000
+	out3 := tc.Process(ctx, ts3)
+	expected3 := multiplyAndDivide(ts3, 90_000, 1_000_000)
+	assert.Equal(expected3, out3, "subsequent bug-clock call")
+
+}
+
+func TestTimestampCorrector_WithNonMatchingUA(t *testing.T) {
+	// UA is chrome on MacOS
+	// Should *not* trigger timestamp correction even if it's detected as being broken
+	userAgent := "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
+	fps := 30.0
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	// simulate two packets spaced normally but with an inflated tsDelta to trigger fix
+	t0 := time.Date(2025, 5, 30, 0, 0, 0, 0, time.UTC)
+	dtNs := time.Duration((1.0/fps)*1e9) * time.Nanosecond
+	t1 := t0.Add(dtNs)
+
+	tc := NewTimestampCorrector(TimestampCorrectorConfig{
+		FPS:       fps,
+		Clock:     makeClock([]time.Time{t0, t1}),
+		UserAgent: userAgent,
+	})
+
+	ts1 := int64(1000)
+	out1 := tc.Process(ctx, ts1)
+	assert.Equal(ts1, out1, "first call changed ts")
+
+	// choose a delta large enough: > thresholdFreq*dt
+	dtSec := dtNs.Seconds()
+	largeDelta := int64((tc.thresholdFreq * dtSec) + 2)
+	ts2 := ts1 + largeDelta
+	out2 := tc.Process(ctx, ts2)
+	expected2 := ts2
+	assert.Equal(expected2, out2, "bug-clock second call")
+
+	// subsequent calls also fixed
+	ts3 := ts2 + 20000
+	out3 := tc.Process(ctx, ts3)
+	expected3 := ts3
+	assert.Equal(expected3, out3, "subsequent bug-clock call")
+
+}
+
+func TestTimestampCorrector_Disabled(t *testing.T) {
+	// Should *not* trigger timestamp correction even if it's detected as being broken
+
+	fps := 30.0
+	ctx := context.Background()
+	assert := assert.New(t)
+
+	// simulate two packets spaced normally but with an inflated tsDelta to trigger fix
+	t0 := time.Date(2025, 5, 30, 0, 0, 0, 0, time.UTC)
+	dtNs := time.Duration((1.0/fps)*1e9) * time.Nanosecond
+	t1 := t0.Add(dtNs)
+
+	tc := NewTimestampCorrector(TimestampCorrectorConfig{
+		FPS:     fps,
+		Clock:   makeClock([]time.Time{t0, t1}),
+		Disable: true,
+	})
+
+	ts1 := int64(1000)
+	out1 := tc.Process(ctx, ts1)
+	assert.Equal(ts1, out1, "first call changed ts")
+
+	// choose a delta large enough: > thresholdFreq*dt
+	dtSec := dtNs.Seconds()
+	largeDelta := int64((tc.thresholdFreq * dtSec) + 2)
+	ts2 := ts1 + largeDelta
+	out2 := tc.Process(ctx, ts2)
+	expected2 := ts2
+	assert.Equal(expected2, out2, "bug-clock second call")
+
+	// subsequent calls also fixed
+	ts3 := ts2 + 20000
+	out3 := tc.Process(ctx, ts3)
+	expected3 := ts3
+	assert.Equal(expected3, out3, "subsequent bug-clock call")
+
+}
+
+func TestTimestampCorrector_UAFilter(t *testing.T) {
+	matches := []struct {
+		name string
+		ua   string
+	}{
+		{
+			name: "Safari on MacOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Safari/605.1.15",
+		},
+		{
+			name: "Safari on iPhone",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 15_6_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.6.1 Mobile/15E148 Safari/604.1",
+		},
+		{
+			name: "Chrome on iPhone",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/137.0.7151.79 Mobile/15E148 Safari/604.1",
+		},
+		{
+			name: "Twitter on iPhone",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/22F76 Twitter for iPhone/11.1.5",
+		},
+		{
+			name: "Firefox on iPhone",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/139.1 Mobile/15E148 Safari/605.1.15",
+		},
+		{
+			name: "Facebook on iPhone",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/510.0.0.47.116;FBBV/743276974;FBDV/iPhone17,3;FBMD/iPhone;FBSN/iOS;FBSV/18.5;FBSS/3;FBCR/;FBID/phone;FBLC/en_US;FBOP/80]",
+		},
+	}
+	noMatches := []struct {
+		name string
+		ua   string
+	}{
+		{
+			name: "Chrome on MacOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+		},
+		{
+			name: "Older Safari on MacOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+		},
+		{
+			name: "Headless Chrome on MacOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/137.0.0.0 Safari/537.36",
+		},
+		{
+			name: "Firefox on MacOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:139.0) Gecko/20100101 Firefox/139.0",
+		},
+		{
+			name: "Chrome on Android",
+			ua:   "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Mobile Safari/537.36",
+		},
+		{
+			name: "Chrome on Linux",
+			ua:   "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+		},
+		{
+			name: "Chrome on Windows",
+			ua:   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
+		},
+	}
+
+	t.Run("Matches", func(t *testing.T) {
+		for _, tc := range matches {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.True(t, shouldFix(tc.ua), tc.ua)
+			})
+		}
+	})
+
+	t.Run("Does not match", func(t *testing.T) {
+		for _, tc := range noMatches {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.False(t, shouldFix(tc.ua), tc.ua)
+			})
+		}
+	})
+
 }


### PR DESCRIPTION
* Attempt to only apply the fix on iOS or Mac Safari to reduce the incidence of false positives at the risk of false negatives

* Add a kill switch that is configurable via env var LIVE_AI_DISABLE_TS_CORRECTION=1

* Configuration QoL improvements for the timestamp corrector API

* New test cases covering the above