### PR TITLE
ai/live: Add a MediaMTX output alias with the request ID. 

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -278,7 +278,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 func ffmpegOutput(ctx context.Context, outputUrl string, r io.Reader, params aiRequestParams) {
 	// Clone the context since we can call this function multiple times
 	// Adding rtmpOut val multiple times to the same context will just stomp over old ones
-	ctx = clog.Clone(ctx, context.Background())
+	ctx = clog.Clone(ctx, ctx)
 	ctx = clog.AddVal(ctx, "rtmpOut", outputUrl)
 
 	defer func() {

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -276,7 +276,11 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 }
 
 func ffmpegOutput(ctx context.Context, outputUrl string, r io.Reader, params aiRequestParams) {
+	// Clone the context since we can call this function multiple times
+	// Adding rtmpOut val multiple times to the same context will just stomp over old ones
+	ctx = clog.Clone(ctx, context.Background())
 	ctx = clog.AddVal(ctx, "rtmpOut", outputUrl)
+
 	defer func() {
 		if rec := recover(); rec != nil {
 			// panicked, so shut down the stream and handle it

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -467,6 +467,16 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			return
 		}
 
+		// collect all RTMP outputs
+		var rtmpOutputs []string
+		if outputURL != "" {
+			rtmpOutputs = append(rtmpOutputs, outputURL)
+		}
+		if mediaMTXOutputURL != "" {
+			rtmpOutputs = append(rtmpOutputs, mediaMTXOutputURL)
+		}
+		clog.Info(ctx, "RTMP outputs", "destinations", rtmpOutputs)
+
 		// if auth webhook returns pipeline config these will be replaced
 		pipeline := qp.Get("pipeline")
 		rawParams := qp.Get("params")
@@ -589,8 +599,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 
 			liveParams: &liveRequestParams{
 				segmentReader:          ssr,
-				outputRTMPURL:          outputURL,
-				mediaMTXOutputRTMPURL:  mediaMTXOutputURL,
+				rtmpOutputs:            rtmpOutputs,
 				stream:                 streamName,
 				paymentProcessInterval: ls.livePaymentInterval,
 				outSegmentTimeout:      ls.outSegmentTimeout,
@@ -828,6 +837,9 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			queryParams := r.URL.Query().Encode()
 			orchestrator := r.URL.Query().Get("orchestrator")
 
+			// collect RTMP outputs
+			var rtmpOutputs []string
+
 			ctx = clog.AddVal(ctx, "source_type", sourceTypeStr)
 
 			if LiveAIAuthWebhookURL != nil {
@@ -930,6 +942,14 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 				monitor.AILiveVideoAttempt()
 			}
 
+			if outputURL != "" {
+				rtmpOutputs = append(rtmpOutputs, outputURL)
+			}
+			if mediamtxOutputURL != "" {
+				rtmpOutputs = append(rtmpOutputs, mediamtxOutputURL)
+			}
+			clog.Info(ctx, "RTMP outputs", "destinations", rtmpOutputs)
+
 			params := aiRequestParams{
 				node:        ls.LivepeerNode,
 				os:          drivers.NodeStorage.NewSession(requestID),
@@ -937,8 +957,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 
 				liveParams: &liveRequestParams{
 					segmentReader:          ssr,
-					outputRTMPURL:          outputURL,
-					mediaMTXOutputRTMPURL:  mediamtxOutputURL,
+					rtmpOutputs:            rtmpOutputs,
 					stream:                 streamName,
 					paymentProcessInterval: ls.livePaymentInterval,
 					outSegmentTimeout:      ls.outSegmentTimeout,

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -94,15 +94,14 @@ type aiRequestParams struct {
 
 // For live video pipelines
 type liveRequestParams struct {
-	segmentReader         *media.SwitchableSegmentReader
-	outputRTMPURL         string
-	mediaMTXOutputRTMPURL string
-	stream                string
-	requestID             string
-	streamID              string
-	pipelineID            string
-	pipeline              string
-	orchestrator          string
+	segmentReader *media.SwitchableSegmentReader
+	rtmpOutputs   []string
+	stream        string
+	requestID     string
+	streamID      string
+	pipelineID    string
+	pipeline      string
+	orchestrator  string
 
 	paymentProcessInterval time.Duration
 	outSegmentTimeout      time.Duration


### PR DESCRIPTION
[ai/live: Add a MediaMTX output alias with the request ID.](https://github.com/livepeer/go-livepeer/commit/fdc56a95705f841d7015dfc4aadc853486836945)

Send this alias down with the WHEP connection.

This allows us to handle rapid reconnects where the first
connection might not have been completely torn down and the
original output stream is still active.

Since we don't allow incoming streams in MediaMTX to kick old
ones off, this fixes a bug that occurs sometimes where playback
would fail after a reconnect.

As part of this work, also:

[ai/live: Combine RTMP outputs into a single slice](https://github.com/livepeer/go-livepeer/commit/d01494562d7f6b21804bcb7106c85d2911c7df03)

[Fix context logging of RTMP outputs](https://github.com/livepeer/go-livepeer/commit/45bb5ffc313a95b82b775d7c6cbb3670977d6cec)