### PR TITLE
Rename "capacity" to "count" in the aiModels.json

### DIFF
--- a/box/aiModels-comfyui.json
+++ b/box/aiModels-comfyui.json
@@ -3,6 +3,6 @@
     "model_id": "comfyui",
     "pipeline": "live-video-to-video",
     "warm": true,
-    "capacity": 1
+    "count": 1
   }
 ]

--- a/box/aiModels-noop.json
+++ b/box/aiModels-noop.json
@@ -3,6 +3,6 @@
     "model_id": "noop",
     "pipeline": "live-video-to-video",
     "warm": true,
-    "capacity": 1
+    "count": 1
   }
 ]

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1299,7 +1299,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			if *cfg.AIWorker {
 				modelConstraint := &core.ModelConstraint{Warm: config.Warm, Capacity: 1}
 				// External containers do auto-scale; default to 1 or use provided capacity.
-				if config.URL != "" && config.Capacity != 0 {
+				if config.URL != "" {
 					modelConstraint.Capacity = config.Capacity
 				}
 				modelsCount := 1

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1298,15 +1298,13 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 			if *cfg.AIWorker {
 				modelConstraint := &core.ModelConstraint{Warm: config.Warm, Capacity: 1}
+				// External containers do auto-scale; default to 1 or use provided capacity.
+				if config.URL != "" && config.Capacity != 0 {
+					modelConstraint.Capacity = config.Capacity
+				}
 				modelsCount := 1
-				if config.Capacity != 0 {
-					if config.URL == "" {
-						// Use multiple same configs if External Container is not used and capacity is set
-						modelsCount = config.Capacity
-					} else {
-						// External containers do auto-scale; default to 1 or use provided capacity.
-						modelConstraint.Capacity = config.Capacity
-					}
+				if config.Count != 0 {
+					modelsCount = config.Count
 				}
 
 				// Ensure the AI worker has the image needed to serve the job.

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1297,7 +1297,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				panic(fmt.Errorf("Pipeline is not valid capability: %v\n", config.Pipeline))
 			}
 			if *cfg.AIWorker {
-				modelConstraint := &core.ModelConstraint{Warm: config.Warm, Capacity: 1}
+				modelConstraint := &core.ModelConstraint{Warm: config.Warm, Capacity: config.Capacity}
 				// External containers do auto-scale; default to 1 or use provided capacity.
 				if config.URL != "" && config.Capacity != 0 {
 					modelConstraint.Capacity = config.Capacity

--- a/core/ai.go
+++ b/core/ai.go
@@ -79,6 +79,7 @@ type AIModelConfig struct {
 	Token             string                   `json:"token,omitempty"`
 	Warm              bool                     `json:"warm,omitempty"`
 	Capacity          int                      `json:"capacity,omitempty"`
+	Count             int                      `json:"count,omitempty"`
 	OptimizationFlags worker.OptimizationFlags `json:"optimization_flags,omitempty"`
 	// used by orchestrator
 	Gateway       string  `json:"gateway"`


### PR DESCRIPTION
@ad-astra-video please check if it works for the AI Jobs.

This change is non-backward-compatible, but there are only 3 Os using it right now, so we can handle.

The context for this change is this GH Issue: https://github.com/livepeer/go-livepeer/issues/3627

FYI: @pwilczynskiclearcode (but from what I see we haven't used "capacity" in our infra, so it should be fine)
FYI: @victorges 