### PR TITLE
Context logging adjustments

### DIFF
--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -73,6 +73,9 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 
 	userAgent := r.Header.Get("User-Agent")
 	clog.Info(ctx, "Client info", "user-agent", userAgent)
+	if strings.Contains(userAgent, "Headless") {
+		clog.AddVal(ctx, "e2e", "true")
+	}
 
 	// Must have Content-Type: application/sdp (the spec strongly recommends it)
 	if r.Header.Get("Content-Type") != "application/sdp" {

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1446,7 +1446,9 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 		return nil, fmt.Errorf("unsupported request type %T", req)
 	}
 	capName := cap.String()
-	ctx = clog.AddVal(ctx, "capability", capName)
+	if capName != "Live video to video" {
+		ctx = clog.AddVal(ctx, "capability", capName)
+	}
 	ctx = clog.AddVal(ctx, "model_id", modelID)
 
 	clog.V(common.VERBOSE).Infof(ctx, "Received AI request model_id=%s", modelID)


### PR DESCRIPTION
* Add e2e=true if this is an e2e test (WHIP only)

* Remove the `capability` kv since that is long and un-informative