### PR TITLE
Temp disable Orch Swapping

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -674,7 +674,11 @@ func processStream(ctx context.Context, params aiRequestParams, req worker.GenLi
 			if !orchSwapper.shouldSwap(ctx) {
 				break
 			}
-			clog.Infof(ctx, "Retrying stream with a different orchestrator")
+			// Temporarily disable Orch Swapping, because of the following issues:
+			// 1. Frontend Playback refresh, fixes here: https://github.com/livepeer/ui-kit/pull/617
+			// 2. Suspension happening too many times, discussed here: https://github.com/livepeer/go-livepeer/pull/3614
+			clog.Infof(ctx, "[Temp Disabled] Retrying stream with a different orchestrator")
+			break
 		}
 		params.liveParams.kickInput(err)
 	}()

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -675,7 +675,7 @@ func processStream(ctx context.Context, params aiRequestParams, req worker.GenLi
 				break
 			}
 			// Temporarily disable Orch Swapping, because of the following issues:
-			// 1. Frontend Playback refresh, fixes here: https://github.com/livepeer/ui-kit/pull/617
+			// 1. Frontend Playback refresh, fixed here: https://github.com/livepeer/ui-kit/pull/617
 			// 2. Suspension happening too many times, discussed here: https://github.com/livepeer/go-livepeer/pull/3614
 			clog.Infof(ctx, "[Temp Disabled] Retrying stream with a different orchestrator")
 			break


### PR DESCRIPTION
Temporarily disable Orch Swapping, because of the following issues:
1. During the Orch Swap, in 50% of cases, I see the grey playback in the frontend, so we should first merge and deploy the frontend fix: https://github.com/livepeer/ui-kit/pull/617
2. When I checked the logs, the Orchestrator Swap happens also when the ingest is done, it's related to the discussions about the suspension mechanism: https://github.com/livepeer/go-livepeer/pull/3614