### PR TITLE
Revert "ai/live: Don't suspend orchestrator if the client has not sent data."

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -148,9 +148,6 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 					segment.Close()
 					return
 				}
-				params.liveParams.mu.Lock()
-				params.liveParams.lastSegmentTime = startTime
-				params.liveParams.mu.Unlock()
 				logToDisk(ctx, reader, params.node.WorkDir, params.liveParams.requestID, seq)
 				n, err := segment.Write(r)
 				if err == nil {
@@ -289,27 +286,9 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 
 			n, err := copySegment(ctx, segment, outWriter, seq, params)
 			if err != nil {
-				if errors.Is(err, context.Canceled) {
-					clog.Info(ctx, "trickle subscribe stopping - context canceled")
-					return
-				}
-				// Check whether the client has sent data recently.
-				// TODO ensure the threshold is some multiple of LIVE_AI_MIN_SEG_DUR
-				params.liveParams.mu.Lock()
-				lastSegmentTime := params.liveParams.lastSegmentTime
-				params.liveParams.mu.Unlock()
-				segmentAge := time.Since(lastSegmentTime)
-				maxSegmentDelay := params.liveParams.outSegmentTimeout / 2
-				if segmentAge < maxSegmentDelay && params.inputStreamExists() {
-					// we have some recent input but no output from orch, so kick
-					suspendOrchestrator(ctx, params)
-					stopProcessing(ctx, params, errors.New("no segments from orchestrator"))
-					return
-				}
-				clog.InfofErr(ctx, "trickle subscribe error copying segment seq=%d", seq, err)
-				subscriber.SetSeq(seq)
-				retries++
-				continue
+				suspendOrchestrator(ctx, params)
+				stopProcessing(ctx, params, fmt.Errorf("trickle subscribe error copying: %w", err))
+				return
 			}
 			if firstSegment {
 				firstSegment = false
@@ -435,7 +414,6 @@ func copySegment(ctx context.Context, segment *http.Response, w io.Writer, seq i
 
 	select {
 	case <-ctx.Done():
-		// NB: if the orch context is cancelled, it isn't really a timeout
 		return 0, fmt.Errorf("copy operation timed out: %w", ctx.Err())
 	case res := <-resultChan:
 		return res.n, res.err

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/livepeer/go-livepeer/ai/worker"
@@ -121,12 +120,6 @@ type liveRequestParams struct {
 	startTime time.Time
 	// sess is passed from the orchestrator selection, ugly hack
 	sess *AISession
-
-	// Everything below needs to be protected by `mu` for concurrent modification + access
-	mu sync.Mutex
-
-	// when the write for the last segment started
-	lastSegmentTime time.Time
 }
 
 // CalculateTextToImageLatencyScore computes the time taken per pixel for an text-to-image request.


### PR DESCRIPTION
I temporarily revert this PR, because it was not planned for today's deployment. I'll get it back after the deployment.