### PR TITLE
Enable Orch Swapping

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -713,14 +713,7 @@ func processStream(ctx context.Context, params aiRequestParams, req worker.GenLi
 				}
 				break
 			}
-			// Temporarily disable Orch Swapping, because of the following issues:
-			// 1. Frontend Playback refresh, fixed here: https://github.com/livepeer/ui-kit/pull/617
-			// 2. Suspension happening too many times, discussed here: https://github.com/livepeer/go-livepeer/pull/3614
-			clog.Infof(ctx, "[Temp Disabled] Retrying stream with a different orchestrator")
-			if err == nil {
-				err = errors.New("Swap disabled: kicking")
-			}
-			break
+			clog.Infof(ctx, "Retrying stream with a different orchestrator")
 
 			// will swap, but first notify with the reason for the swap
 			if err == nil {


### PR DESCRIPTION
Enable Orchestrator Swapping.

This should be merged when:
1. This frontend fix is merged and deployed: https://github.com/livepeer/ui-kit/pull/617
    - Otherwise, a user may see a grey playback screen after the Orchestrator Swap
2. We sort out the ICE issue with connected/closed state: https://github.com/livepeer/go-livepeer/pull/3629
    - Otherwise, the Orch Swap happens even if the stream was closed correctly, this causes an additional request to a new Orchestraror; not the end of the world, but it can temp eat up our capacity