### PR TITLE
BYOC: fix payment ticket count calc

### DIFF
--- a/server/job_rpc.go
+++ b/server/job_rpc.go
@@ -801,6 +801,12 @@ func createPayment(ctx context.Context, jobReq *JobRequest, orchToken JobToken, 
 		payment.TicketSenderParams = senderParams
 
 		ratPrice, _ := common.RatPriceInfo(payment.ExpectedPrice)
+		balanceForOrch := node.Balances.Balance(orchAddr, core.ManifestID(jobReq.Capability))
+		balanceForOrchStr := ""
+		if balanceForOrch != nil {
+			balanceForOrchStr = balanceForOrch.FloatString(3)
+		}
+
 		clog.V(common.DEBUG).Infof(ctx, "Created new payment - capability=%v recipient=%v faceValue=%v winProb=%v price=%v numTickets=%v balance=%v",
 			jobReq.Capability,
 			tickets.Recipient.Hex(),
@@ -808,7 +814,7 @@ func createPayment(ctx context.Context, jobReq *JobRequest, orchToken JobToken, 
 			tickets.WinProbRat().FloatString(10),
 			ratPrice.FloatString(3)+" wei/unit",
 			ticketCnt,
-			node.Balances.Balance(orchAddr, core.ManifestID(jobReq.Capability)).FloatString(3),
+			balanceForOrchStr,
 		)
 	}
 

--- a/server/job_rpc.go
+++ b/server/job_rpc.go
@@ -790,7 +790,7 @@ func createPayment(ctx context.Context, jobReq *JobRequest, orchToken JobToken, 
 
 		totalEV := big.NewRat(0, 1)
 		senderParams := make([]*net.TicketSenderParams, len(tickets.SenderParams))
-		for i := 0; i < len(senderParams); i++ {
+		for i := 0; i < len(tickets.SenderParams); i++ {
 			senderParams[i] = &net.TicketSenderParams{
 				SenderNonce: tickets.SenderParams[i].SenderNonce,
 				Sig:         tickets.SenderParams[i].Sig,

--- a/server/job_rpc_test.go
+++ b/server/job_rpc_test.go
@@ -19,12 +19,15 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/golang/protobuf/proto"
 	"github.com/livepeer/go-livepeer/ai/worker"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/net"
+	"github.com/livepeer/go-livepeer/pm"
 	"github.com/livepeer/go-tools/drivers"
 	"github.com/livepeer/lpms/stream"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type mockJobOrchestrator struct {
@@ -836,4 +839,98 @@ func TestSubmitJob_MethodNotAllowed(t *testing.T) {
 
 	resp := w.Result()
 	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+func TestCreatePayment(t *testing.T) {
+	ctx := context.TODO()
+	node, _ := core.NewLivepeerNode(nil, "/tmp/thisdirisnotactuallyusedinthistest", nil)
+	mockSender := pm.MockSender{}
+	mockSender.On("StartSession", mock.Anything).Return("foo").Times(4)
+	node.Sender = &mockSender
+
+	node.Balances = core.NewAddressBalances(10)
+	defer node.Balances.StopCleanup()
+
+	jobReq := JobRequest{
+		Capability: "test-payment-cap",
+	}
+	sender := JobSender{
+		Addr: "0x1111111111111111111111111111111111111111",
+		Sig:  "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+	}
+
+	orchTocken := JobToken{
+		TicketParams: &net.TicketParams{
+			Recipient:         ethcommon.HexToAddress("0x1111111111111111111111111111111111111111").Bytes(),
+			FaceValue:         big.NewInt(1000).Bytes(),
+			WinProb:           big.NewInt(1).Bytes(),
+			RecipientRandHash: []byte("hash"),
+			Seed:              big.NewInt(1234).Bytes(),
+			ExpirationBlock:   big.NewInt(100000).Bytes(),
+		},
+		SenderAddress: &sender,
+		Balance:       0,
+		Price: &net.PriceInfo{
+			PricePerUnit:  10,
+			PixelsPerUnit: 1,
+		},
+	}
+
+	var pmTickets net.Payment
+
+	//payment with one ticket
+	jobReq.Timeout = 1
+	mockSender.On("CreateTicketBatch", "foo", jobReq.Timeout).Return(mockTicketBatch(jobReq.Timeout), nil).Once()
+	payment, err := createPayment(ctx, &jobReq, orchTocken, node)
+	assert.Nil(t, err)
+	pmPayment, err := base64.StdEncoding.DecodeString(payment)
+	assert.Nil(t, err)
+	err = proto.Unmarshal(pmPayment, &pmTickets)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(pmTickets.TicketSenderParams))
+
+	//test 2 tickets
+	jobReq.Timeout = 2
+	mockSender.On("CreateTicketBatch", "foo", jobReq.Timeout).Return(mockTicketBatch(jobReq.Timeout), nil).Once()
+	payment, err = createPayment(ctx, &jobReq, orchTocken, node)
+	assert.Nil(t, err)
+	pmPayment, err = base64.StdEncoding.DecodeString(payment)
+	assert.Nil(t, err)
+	err = proto.Unmarshal(pmPayment, &pmTickets)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(pmTickets.TicketSenderParams))
+
+	//test 600 tickets
+	jobReq.Timeout = 600
+	mockSender.On("CreateTicketBatch", "foo", jobReq.Timeout).Return(mockTicketBatch(jobReq.Timeout), nil).Once()
+	payment, err = createPayment(ctx, &jobReq, orchTocken, node)
+	assert.Nil(t, err)
+	pmPayment, err = base64.StdEncoding.DecodeString(payment)
+	assert.Nil(t, err)
+	err = proto.Unmarshal(pmPayment, &pmTickets)
+	assert.Nil(t, err)
+	assert.Equal(t, 600, len(pmTickets.TicketSenderParams))
+}
+
+func mockTicketBatch(count int) *pm.TicketBatch {
+	senderParams := make([]*pm.TicketSenderParams, count)
+	for i := 0; i < count; i++ {
+		senderParams[i] = &pm.TicketSenderParams{
+			SenderNonce: uint32(i + 1),
+			Sig:         pm.RandBytes(42),
+		}
+	}
+
+	return &pm.TicketBatch{
+		TicketParams: &pm.TicketParams{
+			Recipient:       pm.RandAddress(),
+			FaceValue:       big.NewInt(1234),
+			WinProb:         big.NewInt(5678),
+			Seed:            big.NewInt(7777),
+			ExpirationBlock: big.NewInt(1000),
+		},
+		TicketExpirationParams: &pm.TicketExpirationParams{},
+		Sender:                 pm.RandAddress(),
+		SenderParams:           senderParams,
+	}
 }

--- a/server/job_rpc_test.go
+++ b/server/job_rpc_test.go
@@ -997,6 +997,7 @@ func mockTicketBatch(count int) *pm.TicketBatch {
 		Sender:                 pm.RandAddress(),
 		SenderParams:           senderParams,
 	}
+}
 
 func TestSubmitJob_OrchestratorSelectionParams(t *testing.T) {
 	// Create mock HTTP servers for orchestrators


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Updates `createPayment` to accurately calculate ticket count.  

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- The slice created with `make` did not have a length as expected. Instead it has a capacity of the provided `len(ticket.SenderParams)`
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Tested locally using Agent SPE request example and observed the ticket count changed with each change in `timeout_seconds` in the request to accurately send 1 ticket per second of expected compute.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
