### PR TITLE
ai/live: Return an error when we kick due to a failed swap.

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -673,12 +673,14 @@ func processStream(ctx context.Context, params aiRequestParams, req worker.GenLi
 			}
 			<-perOrchCtx.Done()
 			if !orchSwapper.shouldSwap(ctx) {
+				err = errors.New("Not swapping: kicking")
 				break
 			}
 			// Temporarily disable Orch Swapping, because of the following issues:
 			// 1. Frontend Playback refresh, fixed here: https://github.com/livepeer/ui-kit/pull/617
 			// 2. Suspension happening too many times, discussed here: https://github.com/livepeer/go-livepeer/pull/3614
 			clog.Infof(ctx, "[Temp Disabled] Retrying stream with a different orchestrator")
+			err = errors.New("Swap disabled: kicking")
 			break
 		}
 		params.liveParams.kickInput(err)


### PR DESCRIPTION
This improves traceability when we have an error reason.

Alternative to https://github.com/livepeer/go-livepeer/pull/3652 so we don't change any order of operations just to support a temporarily disabled feature (and which has been working OK for a long time)