### PR TITLE
ai/live: Avoid unnecessary swaps

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -107,7 +107,6 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 				clog.Infof(ctx, "Error closing trickle publisher. err=%v", err)
 			}
 			cancel()
-			stopProcessing(ctx, params, errors.New("trickle publisher closed"))
 			return
 		}
 		thisSeq, atMax := slowOrchChecker.BeginSegment()

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -48,10 +48,6 @@ func NewOrchestratorSwapper(params aiRequestParams) *orchestratorSwapper {
 }
 
 func (os *orchestratorSwapper) shouldSwap(ctx context.Context) bool {
-	if !os.params.inputStreamExists() {
-		clog.Info(ctx, "No input stream, skipping orchestrator swap")
-		return false
-	}
 	// Measure how many swaps have been done recently to avoid to many swaps in a short time
 	if time.Since(os.lastSwapped) < recentSwapInterval {
 		os.recentSwapsCount++

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -676,6 +676,10 @@ func processStream(ctx context.Context, params aiRequestParams, req worker.GenLi
 				firstProcessed <- struct{}{}
 			}
 			<-perOrchCtx.Done()
+			if !params.inputStreamExists() {
+				clog.Info(ctx, "No input stream, skipping orchestrator swap")
+				break
+			}
 			if !orchSwapper.shouldSwap(ctx) {
 				err = errors.New("Not swapping: kicking")
 				break


### PR DESCRIPTION
[ai/live: Avoid unnecessary swaps.](https://github.com/livepeer/go-livepeer/commit/3d1a28d53c355b286ffe163137f2b0a31fcda4bc) 
This fixes a race condition where a RTMP input shutting down
would trigger a swap if the connection was not yet fully
un-registered.

Specifically, the sequence of events is something like:

1. MediaMTX signals an input is closed

2. Segmenter is closed

3. Trickle publisher cancels the orchestrator context

4. Cancelling the orchestrator context triggers a swap

5. Input is marked as offline

Fix this by ensuring that we mark the input offline first
*before* cancelling the context.

We create a parent context for orchestrators and cancel that
after the input is marked as offline. Hence, having the trickle
publisher cancel the context is no longer necessary.

This usually affects RTMP; WHIP does not seem affected due to
a different order of operations: on disconnect, WHIP first
marks the input as offline, then closes the segmenter.

We *might* be able to adjust RTMP to have the same behavior as WHIP
but we generally want this change anyway, because early context
cancellation makes tear-down even more non-deterministic which is
undesirable. By making context cancellation happen later for client
disconnects, we retain more control of state transitions.

[* Don't call stopProcessing on context cancellations.](https://github.com/livepeer/go-livepeer/commit/1d2284b98b59899b8ae7be134349e0a7a7468ad7) 
The context is cancelled; nothing further needs to be done.
This avoids sending unnecessary events over the wire.

In general, the rule of thumb should be: if a chunk of code "owns"
the reason for triggering a swap, then it needs to call stopProcessing
(and cancel the context through that). Otherwise, the cancel is caused
from something outside that chunk of code, so there's no need to call
stopProcessing again.

* Replace kickOrch with stopProcessing.

stopProcessing sends out an error report in addition to kicking the
orchestrator. If we're kicking an orch and initiating a swap, it is
helpful to understand why.

* Clean up some logging and fix a minor bug with a missed return.

[* Check for input stream existence outside the swap.](https://github.com/livepeer/go-livepeer/commit/386869e0458a1e53e9710c13fa69ec4ef99a3ef3) 
This avoids propagating an error to kickInput and and minimizes
unnecessary error reports and MediaMTX disconnect calls.