### PR TITLE
ai/live: Error reporting adjustments

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -298,7 +298,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 				if segmentAge < maxSegmentDelay && params.inputStreamExists() {
 					// we have some recent input but no output from orch, so kick
 					suspendOrchestrator(ctx, params)
-					stopProcessing(ctx, params, errors.New("no segments from orchestrator"))
+					stopProcessing(ctx, params, fmt.Errorf("trickle subscrbe error, swapping: %w", err))
 					return
 				}
 				clog.InfofErr(ctx, "trickle subscribe error copying segment seq=%d", seq, err)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -622,6 +622,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		go func() {
 			ms := media.MediaSegmenter{Workdir: ls.LivepeerNode.WorkDir, MediaMTXClient: mediaMTXClient}
 			ms.RunSegmentation(segmenterCtx, mediaMTXInputURL, ssr.Read)
+			sendErrorEvent(errors.New("mediamtx ingest disconnected"))
 			monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
 				"type":        "gateway_ingest_stream_closed",
 				"timestamp":   time.Now().UnixMilli(),


### PR DESCRIPTION
* Report an event when mediamtx ingest (RTMP) terminates. Otherwise we end up with a lot of unrelated errors due to tear-down and it's not as easy to identify the actual reason for a termination.

* Return the actual error when initiating a suspension / swap from trickle subscriptions. Having "No new segments from orchestrator" as the only reason for a swap is not too informative.