### PR TITLE
Don't delete the stream from state if requestID doesn't match

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -1111,7 +1111,7 @@ func cleanupControl(ctx context.Context, params aiRequestParams) {
 	node := params.node
 	node.LiveMu.Lock()
 	pub, ok := node.LivePipelines[stream]
-	if !ok {
+	if !ok || pub.RequestID != params.liveParams.requestID {
 		// already cleaned up
 		node.LiveMu.Unlock()
 		return
@@ -1123,7 +1123,7 @@ func cleanupControl(ctx context.Context, params aiRequestParams) {
 	}
 	node.LiveMu.Unlock()
 
-	if pub != nil && pub.ControlPub != nil && pub.RequestID == params.liveParams.requestID {
+	if pub.ControlPub != nil {
 		if err := pub.ControlPub.Close(); err != nil {
 			slog.Info("Error closing trickle publisher", "err", err)
 		}


### PR DESCRIPTION
There is a bug where a previous pipeline of the same streamID can cause a more recent pipeline to fail.

Example [logs](https://eu-metrics-monitoring.livepeer.live/grafana/explore?schemaVersion=1&panes=%7B%22sgv%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bcontainer%3D~%5C%22ai-gateway%7Clive-video-to-video_comfyui_.%2A%5C%22%7D%20%7C~%20%5C%22337983a7%7Cstr_1MGM13e5t1QguMwv%5C%22%22,%22queryType%22:%22range%22,%22direction%22:%22backward%22,%22hide%22:false%7D,%7B%22refId%22:%22B%22,%22expr%22:%22%7Bcontainer%3D%5C%22mediamtx%5C%22%7D%20%7C%3D%20%5C%22337983a7%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22code%22,%22direction%22:%22backward%22,%22hide%22:true%7D%5D,%22range%22:%7B%22from%22:%221751900866181%22,%22to%22:%221751900882336%22%7D%7D%7D&orgId=1) showing the bug:

```
I0707 15:07:46.616171       1 ai_mediaserver.go:1097] request_id=be334f7e stream=stk_zrpiNFnPaXHVmcwy source_type=livepeer-whip stream_id=str_1MGM13e5t1QguMwv model_id=comfyui manifest_id=8e5a0beb url=https://cal-2.lvpr.io:20006/ai/trickle/8e5a0beb-out Live video pipeline finished
....
I0707 15:07:53.241637       ai_live_video.go:258] request_id=337983a7 stream=stk_zrpiNFnPaXHVmcwy source_type=livepeer-whip stream_id=str_1MGM13e5t1QguMwv model_id=comfyui manifest_id=b7cebeb6 url=https://cal-2.lvpr.io:20006/ai/trickle/b7cebeb6-out trickle subscribe stopping, input stream does not exist.
```

RequestID `337983a7` had recently started up but the trickle subscribe stopped due to this [input stream check](https://github.com/livepeer/go-livepeer/blob/9717ba2658726ea376b7710bc0f0285e5f0518c5/server/ai_live_video.go#L252), this was because a previous stream with requestID `be334f7e` was shutting down and removed the stream in this `cleanupControl` function. 