### PR TITLE
ai/live: Set idle timeout.

### DIFF
--- a/server/segment_rpc.go
+++ b/server/segment_rpc.go
@@ -63,6 +63,9 @@ var httpClient = &http.Client{
 		// transparently support HTTP/2 while maintaining the flexibility to use HTTP/1 by running
 		// with GODEBUG=http2client=0
 		ForceAttemptHTTP2: true,
+
+		// Close the underlying connection if unused; otherwise they hang open for a long time
+		IdleConnTimeout: 1 * time.Minute,
 	},
 	// Don't set a timeout here; pass a context to the request
 }

--- a/trickle/trickle_publisher.go
+++ b/trickle/trickle_publisher.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"sync"
+	"time"
 )
 
 var StreamNotFoundErr = errors.New("stream not found")
@@ -291,6 +292,9 @@ func httpClient() *http.Client {
 		// DisableKeepAlives: true,
 		// ignore orch certs for now
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+
+		// Prevent old TCP connections from accumulating
+		IdleConnTimeout: 1 * time.Minute,
 	}}
 }
 


### PR DESCRIPTION
We are accumulating hundreds of TCP connections per orchestrator on the gateways, and not having an idle timeout is probably why.

The timeout is set to 90 seconds to match the behavior of golang's [default HTTP client](https://github.com/golang/go/blob/6ebb5f56d9ed35588970ce69cbad63508403bb8d/src/net/http/transport.go#L53)