### PR TITLE
ai/live: Send trickle errors down to processStream

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -299,7 +299,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 				if segmentAge < maxSegmentDelay && params.inputStreamExists() {
 					// we have some recent input but no output from orch, so kick
 					suspendOrchestrator(ctx, params)
-					stopProcessing(ctx, params, fmt.Errorf("trickle subscrbe error, swapping: %w", err))
+					stopProcessing(ctx, params, fmt.Errorf("trickle subscribe error, swapping: %w", err))
 					return
 				}
 				clog.InfofErr(ctx, "trickle subscribe error copying segment seq=%d", seq, err)
@@ -681,8 +681,7 @@ func (a aiRequestParams) inputStreamExists() bool {
 
 func stopProcessing(ctx context.Context, params aiRequestParams, err error) {
 	clog.InfofErr(ctx, "Stopping processing", err)
-	params.liveParams.sendErrorEvent(err)
-	params.liveParams.kickOrch()
+	params.liveParams.kickOrch(err)
 }
 
 // Detect 'slow' orchs by keeping track of in-flight segments

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -115,7 +115,7 @@ type liveRequestParams struct {
 	// Stops the pipeline with an error. Also kicks the input
 	kickInput func(error)
 	// Cancels the execution for the given Orchestrator session
-	kickOrch context.CancelFunc
+	kickOrch context.CancelCauseFunc
 
 	// Report an error event
 	sendErrorEvent func(error)


### PR DESCRIPTION
This mitigates more tricky timing conditions. For example, stream EOS and the "swap disabled" message come close enough together that Metabase timestamps don't have enough granularity to distinguish them, so they get displayed out of order. This is not great because we rely on the first error to be most proximate to the root cause.

<img width="683" height="230" alt="image" src="https://github.com/user-attachments/assets/e8b14c49-42b4-4d44-a2ae-f93742d5b013" />

Return any trickle errors down to processStream and preferentially use those if available.

This also ensures we see a single error reason from trickle when swapping or kicking, rather than potentially several. The first error is generally closest to the root cause of an issue.

If an orchestrator will be swapped, we report the error. If we are kicking the connection instead of swapping, then the kickInput function reports the error.

Also see:
* https://github.com/livepeer/go-livepeer/pull/3666
* https://github.com/livepeer/go-livepeer/pull/3663