### PR TITLE
ai/live: updates to WHIP endpoint for stream creation

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1401,7 +1401,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 					pricePerUnit = pricePerUnitBase
 					currency = currencyBase
 					glog.Warningf("No 'pricePerUnit' specified for model '%v' in pipeline '%v'. Using default value from `-pricePerUnit`: %v", config.ModelID, config.Pipeline, *cfg.PricePerUnit)
-				} else if pricePerUnit.Sign() < 0 {
+				} else if pricePerUnit.Sign() <= 0 {
 					panic(fmt.Errorf("'pricePerUnit' value specified for model '%v' in pipeline '%v' must be a valid positive number, provided %v", config.ModelID, config.Pipeline, config.PricePerUnit))
 				}
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1401,7 +1401,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 					pricePerUnit = pricePerUnitBase
 					currency = currencyBase
 					glog.Warningf("No 'pricePerUnit' specified for model '%v' in pipeline '%v'. Using default value from `-pricePerUnit`: %v", config.ModelID, config.Pipeline, *cfg.PricePerUnit)
-				} else if pricePerUnit.Sign() <= 0 {
+				} else if pricePerUnit.Sign() < 0 {
 					panic(fmt.Errorf("'pricePerUnit' value specified for model '%v' in pipeline '%v' must be a valid positive number, provided %v", config.ModelID, config.Pipeline, config.PricePerUnit))
 				}
 

--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -493,7 +493,7 @@ func getRequestURL(r *http.Request) string {
 	if r.TLS != nil {
 		scheme = "https"
 	}
-	return fmt.Sprintf("%s://%s/%s", scheme, r.Host, r.URL.Path)
+	return fmt.Sprintf("%s://%s%s", scheme, r.Host, r.URL.Path)
 }
 
 // split h264 nalus

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -898,7 +898,13 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			sourceTypeStr := "livepeer-whip"
 			queryParams := r.URL.Query().Encode()
 			orchestrator := r.URL.Query().Get("orchestrator")
-
+			if len(pipelineParams) == 0 {
+				for k, v := range r.URL.Query() {
+					if k != "pipeline" && k != "streamId" {
+						pipelineParams[k] = v[0]
+					}
+				}
+			}
 			// collect RTMP outputs
 			var rtmpOutputs []string
 

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -890,19 +890,20 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			}
 			mediamtxOutputURL := internalOutputHost + streamName + "-out"
 			mediaMTXOutputAlias := fmt.Sprintf("%s%s-%s-out", internalOutputHost, streamName, requestID)
-			outputURL := ""
-			streamID := ""
+			outputURL := r.URL.Query().Get("rtmpOutput")
+			streamID := r.URL.Query().Get("streamId")
 			pipelineID := ""
 			pipeline := r.URL.Query().Get("pipeline")
 			pipelineParams := make(map[string]interface{})
 			sourceTypeStr := "livepeer-whip"
 			queryParams := r.URL.Query().Encode()
 			orchestrator := r.URL.Query().Get("orchestrator")
-			if len(pipelineParams) == 0 {
-				for k, v := range r.URL.Query() {
-					if k != "pipeline" && k != "streamId" {
-						pipelineParams[k] = v[0]
-					}
+			rawParams := r.URL.Query().Get("params")
+			if rawParams != "" {
+				if err := json.Unmarshal([]byte(rawParams), &pipelineParams); err != nil {
+					clog.Errorf(ctx, "Invalid pipeline params: %s", err)
+					http.Error(w, "Invalid pipeline params", http.StatusBadRequest)
+					return
 				}
 			}
 			// collect RTMP outputs

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -893,7 +893,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 			outputURL := ""
 			streamID := ""
 			pipelineID := ""
-			pipeline := ""
+			pipeline := r.URL.Query().Get("pipeline")
 			pipelineParams := make(map[string]interface{})
 			sourceTypeStr := "livepeer-whip"
 			queryParams := r.URL.Query().Encode()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Updates the Gateway WHIP endpoint to setup stream similar to post request from MediaMTX.

Fixes bug in Location url to remove additional `/`

Question:

Should this always be behind the live ai auth webhook?  If yes, is there any docs on how the auth webhook should be structured and what is returned?

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Fix `Location` url returned in header by removing extra `/` before URL path after port
- add parsing query string to WHIP endpoint on gateway similar to `StartLiveVideo`
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Built and tested locally

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
