### PR TITLE
ai: fix startup to allow 0 price on ai models

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1401,7 +1401,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 					pricePerUnit = pricePerUnitBase
 					currency = currencyBase
 					glog.Warningf("No 'pricePerUnit' specified for model '%v' in pipeline '%v'. Using default value from `-pricePerUnit`: %v", config.ModelID, config.Pipeline, *cfg.PricePerUnit)
-				} else if pricePerUnit.Sign() <= 0 {
+				} else if pricePerUnit.Sign() < 0 {
 					panic(fmt.Errorf("'pricePerUnit' value specified for model '%v' in pipeline '%v' must be a valid positive number, provided %v", config.ModelID, config.Pipeline, config.PricePerUnit))
 				}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Update model config parsing so price of 0 is allowed.  Mainly geared toward helping testing with no deposit/reserve running a full Gateway and Orchestrator stack.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Changed model config parsing to allow price of 0.
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
