### PR TITLE
ai/live: Allow context cancellation in trickle subscriber.

### DIFF
--- a/trickle/trickle_test.go
+++ b/trickle/trickle_test.go
@@ -2,6 +2,8 @@ package trickle
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,7 +31,8 @@ func TestTrickle_Close(t *testing.T) {
 	require.Nil(err)
 	require.Error(StreamNotFoundErr, pub.Write(bytes.NewReader([]byte("first post"))))
 
-	sub := NewTrickleSubscriber(channelURL)
+	sub, err := NewTrickleSubscriber(subConfig(channelURL))
+	require.Nil(err)
 	sub.SetSeq(0)
 
 	// this is lame but there is a little race condition under the hood
@@ -79,7 +82,8 @@ func TestTrickle_Close(t *testing.T) {
 	require.Error(EOS, pub.Write(bytes.NewReader([]byte("invalid"))))
 
 	// Spinning up a second subscriber should return 404
-	sub2 := NewTrickleSubscriber(channelURL)
+	sub2, err := NewTrickleSubscriber(subConfig(channelURL))
+	require.Nil(err)
 	_, err = sub2.Read()
 	require.Error(StreamNotFoundErr, err)
 
@@ -105,7 +109,8 @@ func TestTrickle_SetSeq(t *testing.T) {
 
 	pub, err := NewTricklePublisher(channelURL)
 	require.Nil(err)
-	sub := NewTrickleSubscriber(channelURL)
+	sub, err := NewTrickleSubscriber(subConfig(channelURL))
+	require.Nil(err)
 
 	// give sub preconnect time to latch on
 
@@ -159,7 +164,8 @@ func TestTrickle_Reset(t *testing.T) {
 	pub, err := NewTricklePublisher(channelURL)
 	require.Nil(err)
 
-	sub := NewTrickleSubscriber(channelURL)
+	sub, err := NewTrickleSubscriber(subConfig(channelURL))
+	require.Nil(err)
 	wg := &sync.WaitGroup{}
 
 	// give preconnects time to latch on and autocreate the channel
@@ -235,4 +241,68 @@ func TestTrickle_Reset(t *testing.T) {
 	require.Equal("GoodbyWorld", string(data))
 
 	wg.Wait()
+}
+
+func TestTrickle_IdleSweep(t *testing.T) {
+	require := require.New(t)
+	mux := http.NewServeMux()
+	server := ConfigureServer(TrickleServerConfig{
+		Mux:           mux,
+		IdleTimeout:   1 * time.Millisecond,
+		SweepInterval: 10 * time.Millisecond,
+	})
+	stop := server.Start()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	defer stop()
+
+	channelURL := ts.URL + "/testest"
+	lp := NewLocalPublisher(server, channelURL, "text/plain")
+	lp.CreateChannel()
+
+	sub, err := NewTrickleSubscriber(subConfig(channelURL))
+	require.Nil(err)
+	_, err = sub.Read()
+	require.ErrorIs(err, StreamNotFoundErr)
+}
+
+func TestTrickle_CancelSub(t *testing.T) {
+	require, url := makeServer(t)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	sub, err := NewTrickleSubscriber(TrickleSubscriberConfig{
+		URL: url,
+		Ctx: ctx,
+	})
+	require.Nil(err)
+	// without the cancel, sub.Read() will hang until the channel idles out
+	customErr := errors.New("zuf")
+	go cancel(customErr)
+	_, err = sub.Read()
+	require.ErrorIs(err, customErr)
+}
+
+func makeServer(t *testing.T) (*require.Assertions, string) {
+	// use this function if these defaults work, otherwise copy-paste
+	require := require.New(t)
+	mux := http.NewServeMux()
+	server := ConfigureServer(TrickleServerConfig{
+		Mux: mux,
+	})
+	stop := server.Start()
+	ts := httptest.NewServer(mux)
+	t.Cleanup(func() {
+		stop()
+		ts.Close()
+	})
+
+	// create the channel locally on the server
+	chanName := "testest"
+	lp := NewLocalPublisher(server, chanName, "text/plain")
+	lp.CreateChannel()
+
+	return require, ts.URL + "/" + chanName
+}
+
+func subConfig(url string) TrickleSubscriberConfig {
+	return TrickleSubscriberConfig{URL: url}
 }


### PR DESCRIPTION
If there is a catastrophic issue with the runner and its published channels are not shut down correctly (events and inference output), then it is possible for the trickle subscriber Read() call to hang until the server sweeps idle connections.

Fix this by adding a configuration struct to the subscriber and pass in a context through that, among other fields such as the URL.

This way to pass contexts is a bit unusual, but how we use them within the subscriber is already unusual, so highlight this oddity with a slightly different type of API and some comments.

Also unit tests for context cancellation and server idle sweeps.