### PR TITLE
Pass full URLs to the app for whep, status and update

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -500,13 +500,14 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 
 		mediaMTXClient := media.NewMediaMTXClient(remoteHost, ls.mediaMTXApiPassword, sourceID, sourceType)
 
+		whepURL := generateWhepUrl(streamName, requestID)
 		if LiveAIAuthWebhookURL != nil {
 			authResp, err := authenticateAIStream(LiveAIAuthWebhookURL, ls.liveAIAuthApiKey, AIAuthRequest{
 				Stream:      streamName,
 				Type:        sourceTypeStr,
 				QueryParams: queryParams,
 				GatewayHost: ls.LivepeerNode.GatewayHost,
-				WhepURL:     generateWhepUrl(streamName, requestID),
+				WhepURL:     whepURL,
 				UpdateURL:   generateGatewayLiveURL(ls.LivepeerNode.GatewayHost, streamName, "/status"),
 				StatusURL:   generateGatewayLiveURL(ls.LivepeerNode.GatewayHost, streamID, "/update"),
 			})
@@ -564,6 +565,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 
 		// Clear any previous gateway status
 		GatewayStatus.Clear(streamID)
+		GatewayStatus.StoreKey(streamID, "whep_url", whepURL)
 
 		monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
 			"type":        "gateway_receive_stream_request",
@@ -976,6 +978,7 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 
 			// Clear any previous gateway status
 			GatewayStatus.Clear(streamID)
+			GatewayStatus.StoreKey(streamID, "whep_url", whepURL)
 
 			monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
 				"type":        "gateway_receive_stream_request",

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -508,8 +508,8 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 				QueryParams: queryParams,
 				GatewayHost: ls.LivepeerNode.GatewayHost,
 				WhepURL:     whepURL,
-				UpdateURL:   generateGatewayLiveURL(ls.LivepeerNode.GatewayHost, streamName, "/status"),
-				StatusURL:   generateGatewayLiveURL(ls.LivepeerNode.GatewayHost, streamID, "/update"),
+				UpdateURL:   generateGatewayLiveURL(ls.LivepeerNode.GatewayHost, streamName, "/update"),
+				StatusURL:   generateGatewayLiveURL(ls.LivepeerNode.GatewayHost, streamID, "/status"),
 			})
 			if err != nil {
 				kickErr := mediaMTXClient.KickInputConnection(ctx)
@@ -924,8 +924,9 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 					QueryParams: queryParams,
 					GatewayHost: ls.LivepeerNode.GatewayHost,
 					WhepURL:     whepURL,
-					UpdateURL:   generateGatewayLiveURL(ls.LivepeerNode.GatewayHost, streamName, "/status"),
-					StatusURL:   generateGatewayLiveURL(ls.LivepeerNode.GatewayHost, streamID, "/update")})
+					UpdateURL:   generateGatewayLiveURL(ls.LivepeerNode.GatewayHost, streamName, "/update"),
+					StatusURL:   generateGatewayLiveURL(ls.LivepeerNode.GatewayHost, streamID, "/status"),
+				})
 				if err != nil {
 					whipConn.Close()
 					clog.Errorf(ctx, "Live AI auth failed: %s", err.Error())

--- a/server/ai_pipeline_status.go
+++ b/server/ai_pipeline_status.go
@@ -35,7 +35,7 @@ func (s *streamStatusStore) Get(streamID string) (map[string]interface{}, bool) 
 }
 
 // StoreIfNotExists stores a status only if the streamID doesn't already exist or keyToCheck does not exist on the status
-func (s *streamStatusStore) StoreIfNotExists(streamID string, key string, status map[string]interface{}) {
+func (s *streamStatusStore) StoreIfNotExists(streamID string, key string, status interface{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	existing, exists := s.store[streamID]
@@ -48,13 +48,13 @@ func (s *streamStatusStore) StoreIfNotExists(streamID string, key string, status
 	}
 }
 
-func (s *streamStatusStore) StoreKey(streamID, key string, status map[string]interface{}) {
+func (s *streamStatusStore) StoreKey(streamID, key string, status interface{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.storeKey(streamID, key, status)
 }
 
-func (s *streamStatusStore) storeKey(streamID, key string, status map[string]interface{}) {
+func (s *streamStatusStore) storeKey(streamID, key string, status interface{}) {
 	if _, ok := s.store[streamID]; !ok {
 		s.store[streamID] = make(map[string]interface{})
 	}

--- a/server/auth.go
+++ b/server/auth.go
@@ -109,6 +109,9 @@ type AIAuthRequest struct {
 
 	// Gateway host
 	GatewayHost string `json:"gateway_host"`
+	WhepURL     string `json:"whep_url"`
+	StatusURL   string `json:"status_url"`
+	UpdateURL   string `json:"update_url"`
 }
 
 // Contains the configuration parameters for this AI job


### PR DESCRIPTION
This means that the app will no longer have to form these URLs itself based on the gatewayHost, which is prone to error if we ever changed URL format in the gateway.

