### PR TITLE
Add LiveSelectionAlgorithm

### DIFF
--- a/server/ai_session.go
+++ b/server/ai_session.go
@@ -222,10 +222,10 @@ func NewAISessionSelector(ctx context.Context, cap core.Capability, modelID stri
 	var warmSel, coldSel BroadcastSessionsSelector
 	var autoClear bool
 	if cap == core.Capability_LiveVideoToVideo {
-		// For Realtime Video AI, we don't use any features of MinLSSelector (preferring known sessions, etc.),
-		// We always select a fresh session which has the lowest initial latency
-		warmSel = NewSelector(stakeRdr, node.SelectionAlgorithm, node.OrchPerfScore, warmCaps)
-		coldSel = NewSelector(stakeRdr, node.SelectionAlgorithm, node.OrchPerfScore, coldCaps)
+		// For Realtime Video AI, we use a dedicated selection algorithm
+		selAlg := LiveSelectionAlgorithm{}
+		warmSel = NewSelector(stakeRdr, selAlg, node.OrchPerfScore, warmCaps)
+		coldSel = NewSelector(stakeRdr, selAlg, node.OrchPerfScore, coldCaps)
 		// we don't use penalties for not in Realtime Video AI
 		penalty = 0
 		// Automatically clear the session pool from old sessions during the discovery


### PR DESCRIPTION
Add LiveSelectionAlgorithm, which for now only takes into consideration the maxPrice (the Orchestrator's price needs to be below the `maxPrice` value set by Gateway). Then, it takes the first Orchestrators in the list (which is sorted by the initial latency).

This new selection algorithm ignores other factors like:
- Stake
- Performance Score
- Price

Fix https://linear.app/livepeer/issue/INF-239/public-os-selected-regardless-of-latency