### PR TITLE
ai/live: Return an error from shouldSwap.

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -47,7 +47,7 @@ func NewOrchestratorSwapper(params aiRequestParams) *orchestratorSwapper {
 	}
 }
 
-func (os *orchestratorSwapper) shouldSwap(ctx context.Context) bool {
+func (os *orchestratorSwapper) shouldSwap(ctx context.Context) error {
 	// Measure how many swaps have been done recently to avoid to many swaps in a short time
 	if time.Since(os.lastSwapped) < recentSwapInterval {
 		os.recentSwapsCount++
@@ -57,11 +57,11 @@ func (os *orchestratorSwapper) shouldSwap(ctx context.Context) bool {
 	// Stop if too many swaps, because there may be something wrong with the input stream
 	if os.recentSwapsCount > maxRecentSwapsCount {
 		clog.Infof(ctx, "Too many swaps, skipping orchestrator swap, recentSwapsCount=%d, maxRecentSwapsCount=%d", os.recentSwapsCount, maxRecentSwapsCount)
-		return false
+		return errors.New("Too many swaps")
 	}
 
 	os.lastSwapped = time.Now()
-	return true
+	return nil
 }
 
 func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestParams, sess *AISession) {

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -47,7 +47,7 @@ func NewOrchestratorSwapper(params aiRequestParams) *orchestratorSwapper {
 	}
 }
 
-func (os *orchestratorSwapper) shouldSwap(ctx context.Context) error {
+func (os *orchestratorSwapper) checkSwap(ctx context.Context) error {
 	// Measure how many swaps have been done recently to avoid to many swaps in a short time
 	if time.Since(os.lastSwapped) < recentSwapInterval {
 		os.recentSwapsCount++

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -705,11 +705,11 @@ func processStream(ctx context.Context, params aiRequestParams, req worker.GenLi
 				clog.Info(ctx, "No input stream, skipping orchestrator swap")
 				break
 			}
-			if !orchSwapper.shouldSwap(ctx) {
-				// TODO return an error from shouldSwap
-				// and wrap the existing error with that?
-				if err == nil {
-					err = errors.New("Not swapping: kicking")
+			if swapErr := orchSwapper.shouldSwap(ctx); swapErr != nil {
+				if err != nil {
+					err = fmt.Errorf("%w: %w", swapErr, err)
+				} else {
+					err = swapErr
 				}
 				break
 			}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -705,7 +705,7 @@ func processStream(ctx context.Context, params aiRequestParams, req worker.GenLi
 				clog.Info(ctx, "No input stream, skipping orchestrator swap")
 				break
 			}
-			if swapErr := orchSwapper.shouldSwap(ctx); swapErr != nil {
+			if swapErr := orchSwapper.checkSwap(ctx); swapErr != nil {
 				if err != nil {
 					err = fmt.Errorf("%w: %w", swapErr, err)
 				} else {


### PR DESCRIPTION
Following up from https://github.com/livepeer/go-livepeer/pull/3671#discussion_r2204681448

Now that I have the diff here, it seems a little silly since there is only one reason we wouldn't swap. [1] But this might be a helpful guardrail anyway for later implementations, if / when we add more reasons to not swap.

[1] Originally we had two reasons, but things were reworked a bit in https://github.com/livepeer/go-livepeer/pull/3663