### PR TITLE
ai: add support for local kafka with no auth

### DIFF
--- a/cmd/livepeer/starter/kafka.go
+++ b/cmd/livepeer/starter/kafka.go
@@ -6,7 +6,7 @@ import (
 )
 
 func startKafkaProducer(cfg LivepeerConfig) error {
-	if *cfg.KafkaBootstrapServers == "" || *cfg.KafkaUsername == "" || *cfg.KafkaPassword == "" || *cfg.KafkaGatewayTopic == "" {
+	if *cfg.KafkaBootstrapServers == "" || *cfg.KafkaGatewayTopic == "" {
 		glog.Warning("not starting Kafka producer as producer config values aren't present")
 		return nil
 	}

--- a/monitor/kafka.go
+++ b/monitor/kafka.go
@@ -66,15 +66,20 @@ func InitKafkaProducer(bootstrapServers, user, password, topic, gatewayAddress s
 
 func newKafkaProducer(bootstrapServers, user, password, topic, gatewayAddress string) (*KafkaProducer, error) {
 	dialer := &kafka.Dialer{
-		Timeout: KafkaRequestTimeout,
-		SASLMechanism: plain.Mechanism{
+		Timeout:   KafkaRequestTimeout,
+		DualStack: true,
+	}
+
+	if user != "" && password != "" {
+		tls := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
+		sasl := &plain.Mechanism{
 			Username: user,
 			Password: password,
-		},
-		DualStack: true,
-		TLS: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		},
+		}
+		dialer.SASLMechanism = sasl
+		dialer.TLS = tls
 	}
 
 	writer := kafka.NewWriter(kafka.WriterConfig{


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Add option to run Kafak with no auth and without SSL for local deployments.

Helps be able to see events running locally up through kafka without having to setup SSL certs.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- update starter.go to not require `-kafkaUser` and `-kafkaPassword`
- update connection setup in `monitor/kafka.go` to include SASL_PLAINTEXT and TLS config if user and password are set.
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
