### PR TITLE
ai/live: Add delayed teardowns to trickle server

### DIFF
--- a/trickle/trickle_server.go
+++ b/trickle/trickle_server.go
@@ -18,6 +18,9 @@ import (
 
 const CHANGEFEED = "_changes"
 
+// Stream exists but segment doesn't
+const StatusNoSegment = 470
+
 type TrickleServerConfig struct {
 	// Base HTTP path for the server
 	BasePath string
@@ -518,7 +521,7 @@ func (s *Stream) handleGet(w http.ResponseWriter, r *http.Request, idx int) {
 			w.Header().Set("Lp-Trickle-Closed", "terminated")
 		} else {
 			// Special status to indicate "stream exists but segment doesn't"
-			w.WriteHeader(470)
+			w.WriteHeader(StatusNoSegment)
 		}
 		w.Write([]byte("Entry not found"))
 		return
@@ -577,7 +580,7 @@ func (s *Stream) handleGet(w http.ResponseWriter, r *http.Request, idx int) {
 						// other times, the subscriber is slow and the segment falls out of the live window
 						// send over latest seq so slow clients can grab leading edge
 						w.Header().Set("Lp-Trickle-Latest", strconv.Itoa(latestSeq))
-						w.WriteHeader(470)
+						w.WriteHeader(StatusNoSegment)
 					}
 				}
 				return totalWrites, nil

--- a/trickle/trickle_subscriber.go
+++ b/trickle/trickle_subscriber.go
@@ -158,7 +158,7 @@ func (c *TrickleSubscriber) connect(ctx context.Context) (*http.Response, error)
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close() // Ensure we close the body to avoid leaking connections
-		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == 470 {
+		if resp.StatusCode == http.StatusNotFound || resp.StatusCode == StatusNoSegment {
 			return resp, nil
 		}
 		return nil, fmt.Errorf("failed GET segment, status code: %d, msg: %s", resp.StatusCode, string(body))
@@ -247,7 +247,7 @@ func (c *TrickleSubscriber) Read() (*http.Response, error) {
 		return nil, StreamNotFoundErr
 	}
 
-	if conn.StatusCode == 470 {
+	if conn.StatusCode == StatusNoSegment {
 		// stream exists but segment dosn't
 		return nil, &SequenceNonexistent{Seq: GetSeq(conn), Latest: GetLatest(conn)}
 	}

--- a/trickle/trickle_test.go
+++ b/trickle/trickle_test.go
@@ -92,6 +92,87 @@ func TestTrickle_Close(t *testing.T) {
 	require.Error(StreamNotFoundErr, pub2.Write(bytes.NewReader([]byte("bad post"))))
 }
 
+func TestTrickle_DelayedClose(t *testing.T) {
+	require := require.New(t)
+	mux := http.NewServeMux()
+	clock := MockClock{}
+	server := ConfigureServer(TrickleServerConfig{
+		Mux:           mux,
+		DelayCleanup:  true,
+		Now:           clock.Now,
+		SweepInterval: 5 * time.Millisecond,
+	})
+
+	// Check:
+	// 1. reading after close
+	// 2. writing after close
+
+	stop := server.Start()
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	defer stop()
+	lp := NewLocalPublisher(server, "testest", "text/plain")
+	lp.CreateChannel()
+
+	// Write to a channel and close it
+	channelURL := ts.URL + "/testest"
+	segs := []string{"012", "345", "678", "901"}
+	pub, err := NewTricklePublisher(channelURL)
+	require.Nil(err)
+	for _, c := range segs {
+		require.Nil(pub.Write(bytes.NewReader([]byte(c))), "pub.Write")
+	}
+
+	// Now close the stream
+	pub.Close()
+
+	//
+	// NB: we set the "Connection: close" header on the server after close
+	// If the client is under load and slow this could lead to premature
+	// termination of the preconnect before the response is finished reading.
+	// Easily triggered with eg, `go test -race -count 100`
+	//
+	// Check repeatedly to run out preconnects, and allow for a couple of
+	// preconnect failures, but most re-connect attempts should succeed.
+	gotEOS := 0
+	for i := 0; i < 10; i++ {
+		err = pub.Write(bytes.NewReader([]byte("234")))
+		if errors.Is(err, EOS) {
+			gotEOS++
+		}
+	}
+	require.GreaterOrEqual(gotEOS, 8, "did not have enough EOS writes")
+
+	// Check reads
+	sub, err := NewTrickleSubscriber(subConfig(channelURL))
+	require.Nil(err)
+	sub.SetSeq(0)
+	for _, s := range segs {
+		resp, err := sub.Read()
+		require.Nil(err, "sub.Read")
+		buf, err := io.ReadAll(resp.Body)
+		require.Nil(err)
+		require.Equal(s, string(buf))
+		resp.Body.Close()
+	}
+	// check for EOS multiple times to flush out read preconnects
+	for i := 0; i < 5; i++ {
+		_, err = sub.Read()
+		require.ErrorIs(err, EOS)
+	}
+
+	// check for sweep
+	clock.Set(time.Now())
+	time.Sleep(20 * time.Millisecond)
+	pub, err = NewTricklePublisher(channelURL)
+	require.Nil(err)
+	require.ErrorIs(pub.Write(bytes.NewReader([]byte("invalid"))), StreamNotFoundErr)
+	sub, err = NewTrickleSubscriber(subConfig(channelURL))
+	require.Nil(err)
+	_, err = sub.Read()
+	require.ErrorIs(err, StreamNotFoundErr)
+}
+
 func TestTrickle_SetSeq(t *testing.T) {
 	require := require.New(t)
 	mux := http.NewServeMux()
@@ -414,4 +495,20 @@ func makeServer(t *testing.T) (*require.Assertions, string) {
 
 func subConfig(url string) TrickleSubscriberConfig {
 	return TrickleSubscriberConfig{URL: url}
+}
+
+type MockClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (mc *MockClock) Now() time.Time {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	return mc.now
+}
+func (mc *MockClock) Set(now time.Time) {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	mc.now = now
 }


### PR DESCRIPTION
Draft for now as I'm doing a final round of e2e testing locally.

### Commits

[ai/live: Add delayed teardowns to trickle server.](https://github.com/livepeer/go-livepeer/commit/874c2bcaa3c56dc3aede41ad2c050a6260112c19)

This allows for reads to a channel after closing, but not writes.

Closed channels are swept after the idle timeout period.

[ai/live: Add unit tests for trickle delayed teardowns.](https://github.com/livepeer/go-livepeer/commit/3ec80f65fd1120945446ee5f1e1a39032b90971f) 
Add a mock for the time.Now function for testing.

[ai/live: Const-ify status code 470 to StatusNoSegment](https://github.com/livepeer/go-livepeer/commit/1affd533e1f9411bd908548b8a4e68e0d50832cc)
