### PR TITLE
ai/live: Store and forward parameter updates.

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -170,6 +170,7 @@ type LivepeerNode struct {
 
 type LivePipeline struct {
 	RequestID   string
+	Params      string
 	ControlPub  *trickle.TricklePublisher
 	StopControl func()
 }

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -723,6 +723,10 @@ func processStream(ctx context.Context, params aiRequestParams, req worker.GenLi
 			}
 			params.liveParams.sendErrorEvent(err)
 		}
+		if isFirst {
+			// failed before selecting an orchestrator
+			firstProcessed <- struct{}{}
+		}
 		params.liveParams.kickInput(err)
 	}()
 	<-firstProcessed

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -633,6 +633,8 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 			},
 		}
 
+		registerControl(ctx, params)
+
 		// Create a special parent context for orchestrator cancellation
 		orchCtx, orchCancel := context.WithCancel(ctx)
 
@@ -820,22 +822,36 @@ func (ls *LivepeerServer) UpdateLiveVideo() http.Handler {
 			return
 		}
 		ls.LivepeerNode.LiveMu.RLock()
-		defer ls.LivepeerNode.LiveMu.RUnlock()
+		// NB: LiveMu is a global lock, avoid holding it
+		// during blocking network actions ... can't defer
 		p, ok := ls.LivepeerNode.LivePipelines[stream]
+		ls.LivepeerNode.LiveMu.RUnlock()
 		if !ok {
 			// Stream not found
 			http.Error(w, "Stream not found", http.StatusNotFound)
 			return
 		}
-		defer r.Body.Close()
-		params, err := io.ReadAll(r.Body)
+		reader := http.MaxBytesReader(w, r.Body, 1*1024*104) // 1 MB
+		defer reader.Close()
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 
-		clog.V(6).Infof(ctx, "Sending Live Video Update Control API stream=%s, params=%s", stream, string(params))
-		if err := p.ControlPub.Write(strings.NewReader(string(params))); err != nil {
+		params := string(data)
+		ls.LivepeerNode.LiveMu.Lock()
+		p.Params = params
+		controlPub := p.ControlPub
+		ls.LivepeerNode.LiveMu.Unlock()
+
+		if controlPub == nil {
+			clog.Info(ctx, "No orchestrator available, caching params", "stream", stream, "params", params)
+			return
+		}
+
+		clog.V(6).Infof(ctx, "Sending Live Video Update Control API stream=%s, params=%s", stream, params)
+		if err := controlPub.Write(strings.NewReader(params)); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -1068,6 +1084,8 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 					orchestrator:           orchestrator,
 				},
 			}
+
+			registerControl(ctx, params)
 
 			req := worker.GenLiveVideoToVideoJSONRequestBody{
 				ModelId:          &pipeline,


### PR DESCRIPTION
This allows us to correctly handle cases where:

* We haven't selected an orchestrator yet but the client sent a control API update.

* We've swapped orchestrators.

* We're mid-swap without an orchestrator.

In all these cases, the newly selected orchestrator will receive the most recent parameter update as soon as it's selected.

Also add a 1 MB limit for reading parameters.