### PR TITLE
Add param for block batch size

### DIFF
--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -209,6 +209,8 @@ func parseLivepeerConfig() starter.LivepeerConfig {
 	cfg.PricePerBroadcaster = flag.String("pricePerBroadcaster", *cfg.PricePerBroadcaster, `json list of price per broadcaster or path to json config file. Example: {"broadcasters":[{"ethaddress":"address1","priceperunit":0.5,"currency":"USD","pixelsperunit":1000000000000},{"ethaddress":"address2","priceperunit":0.3,"currency":"USD","pixelsperunit":1000000000000}]}`)
 	// Interval to poll for blocks
 	cfg.BlockPollingInterval = flag.Int("blockPollingInterval", *cfg.BlockPollingInterval, "Interval in seconds at which different blockchain event services poll for blocks")
+	// Max blocks to fetch in a single getLogs query
+	cfg.BlockBatchSize = flag.Int("blockBatchSize", *cfg.BlockBatchSize, "Maximum number of blocks to fetch logs for in a single eth_getLogs query (default 1000)")
 	// Redemption service
 	cfg.Redeemer = flag.Bool("redeemer", *cfg.Redeemer, "Set to true to run a ticket redemption service")
 	cfg.RedeemerAddr = flag.String("redeemerAddr", *cfg.RedeemerAddr, "URL of the ticket redemption service to use")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -141,6 +141,7 @@ type LivepeerConfig struct {
 	PricePerGateway            *string
 	PricePerBroadcaster        *string
 	BlockPollingInterval       *int
+	BlockBatchSize             *int
 	Redeemer                   *bool
 	RedeemerAddr               *string
 	Reward                     *bool
@@ -258,6 +259,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultPricePerGateway := ""
 	defaultPricePerBroadcaster := ""
 	defaultBlockPollingInterval := 5
+	defaultBlockBatchSize := 1000
 	defaultRedeemer := false
 	defaultRedeemerAddr := ""
 	defaultMonitor := false
@@ -373,6 +375,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		PricePerGateway:         &defaultPricePerGateway,
 		PricePerBroadcaster:     &defaultPricePerBroadcaster,
 		BlockPollingInterval:    &defaultBlockPollingInterval,
+		BlockBatchSize:          &defaultBlockBatchSize,
 		Redeemer:                &defaultRedeemer,
 		RedeemerAddr:            &defaultRedeemerAddr,
 		Monitor:                 &defaultMonitor,
@@ -800,6 +803,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			PollingInterval:     blockPollingTime,
 			StartBlockDepth:     rpc.LatestBlockNumber,
 			BlockRetentionLimit: blockWatcherRetentionLimit,
+			BlockBatchSize:      *cfg.BlockBatchSize,
 			WithLogs:            true,
 			Topics:              topics,
 			Client:              blockWatcherClient,

--- a/eth/blockwatch/block_watcher_test.go
+++ b/eth/blockwatch/block_watcher_test.go
@@ -19,6 +19,7 @@ var config = Config{
 	PollingInterval:     1 * time.Second,
 	BlockRetentionLimit: 10,
 	StartBlockDepth:     rpc.LatestBlockNumber,
+	BlockBatchSize:      1000,
 	WithLogs:            false,
 	Topics:              []common.Hash{},
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Some RPC providers have reduced their batch limit to 500. This PR allows node operators to modify the batch size.

**Specific updates (required)**
Added a new `blockBatchSize` param to override the default of 1000 blocks for a `getLogs` call.
The block watcher no longer uses a hardcoded value, instead uses the drilled parameter.

**How did you test each of these updates (required)**
Not yet, will update the PR ...

**Does this pull request close any open issues?**
No.


**Checklist:**
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
