### PR TITLE
AI: add options to /live/video-to-video update and status routes

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -861,7 +861,7 @@ func (ls *LivepeerServer) UpdateLiveVideo() http.Handler {
 			return
 		}
 
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		corsHeaders(w, r.Method)
 		w.WriteHeader(http.StatusOK)
 	})
 }

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -871,8 +871,9 @@ func (ls *LivepeerServer) UpdateLiveVideo() http.Handler {
 // @Router /live/video-to-video/{stream}/status [get]
 func (ls *LivepeerServer) GetLiveVideoToVideoStatus() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodOptions {
-			corsHeaders(w, r.Method)
+
+		corsHeaders(w, r.Method)
+		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -93,6 +93,7 @@ func startAIMediaServer(ctx context.Context, ls *LivepeerServer) error {
 	ls.HTTPMux.Handle("POST /live/video-to-video/{stream}/start", ls.StartLiveVideo())
 	ls.HTTPMux.Handle("POST /live/video-to-video/{prefix}/{stream}/start", ls.StartLiveVideo())
 	ls.HTTPMux.Handle("POST /live/video-to-video/{stream}/update", ls.UpdateLiveVideo())
+	ls.HTTPMux.Handle("OPTIONS /live/video-to-video/{stream}/update", ls.WithCode(http.StatusNoContent))
 	ls.HTTPMux.Handle("/live/video-to-video/smoketest", ls.SmokeTestLiveVideo())
 
 	// Configure WHIP ingest only if an addr is specified.
@@ -859,6 +860,9 @@ func (ls *LivepeerServer) UpdateLiveVideo() http.Handler {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.WriteHeader(http.StatusOK)
 	})
 }
 
@@ -868,6 +872,12 @@ func (ls *LivepeerServer) UpdateLiveVideo() http.Handler {
 // @Router /live/video-to-video/{stream}/status [get]
 func (ls *LivepeerServer) GetLiveVideoToVideoStatus() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodOptions {
+			corsHeaders(w, r.Method)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		streamId := r.PathValue("streamId")
 		if streamId == "" {
 			http.Error(w, "stream id is required", http.StatusBadRequest)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -862,7 +862,6 @@ func (ls *LivepeerServer) UpdateLiveVideo() http.Handler {
 		}
 
 		corsHeaders(w, r.Method)
-		w.WriteHeader(http.StatusOK)
 	})
 }
 

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -1214,7 +1214,7 @@ func corsHeaders(w http.ResponseWriter, reqMethod string) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 	if reqMethod == http.MethodOptions {
-		w.Header().Set("Access-Control-Allow-Methods", "OPTIONS, POST")
+		w.Header().Set("Access-Control-Allow-Methods", "OPTIONS, POST, GET")
 		// Allows us send down a preferred STUN server without ICE restart
 		// https://datatracker.ietf.org/doc/html/draft-ietf-wish-whip-16#section-4.6
 		w.Header()["Link"] = media.GenICELinkHeaders(media.WebrtcConfig.ICEServers)

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -106,6 +106,7 @@ func startAIMediaServer(ctx context.Context, ls *LivepeerServer) error {
 	}
 
 	// Stream status
+	ls.HTTPMux.Handle("OPTIONS /live/video-to-video/{streamId}/status", ls.WithCode(http.StatusNoContent))
 	ls.HTTPMux.Handle("/live/video-to-video/{streamId}/status", ls.GetLiveVideoToVideoStatus())
 
 	//API for dynamic capabilities
@@ -873,10 +874,6 @@ func (ls *LivepeerServer) GetLiveVideoToVideoStatus() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		corsHeaders(w, r.Method)
-		if r.Method == http.MethodOptions {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
 
 		streamId := r.PathValue("streamId")
 		if streamId == "" {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Adds support for OPTIONS header to support cors when testing directly with Gateway from a browser

Similar to /whip endpoints, adds ability to test from a browser locally.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- add OPTIONS /live/video-to-video/{stream}/update
- add cors header and return a ok header from update route
- add OPTIONS method handling to status route

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
