### PR TITLE
Fix zeroing ai_container_idle metric for non-existing Orchestrators

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -109,7 +109,7 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 		}
 		return caps.CompatibleWith(info.Capabilities)
 	}
-	getOrchInfo := func(ctx context.Context, od common.OrchestratorDescriptor, infoCh chan common.OrchestratorDescriptor, errCh chan error) {
+	getOrchInfo := func(ctx context.Context, od common.OrchestratorDescriptor, infoCh chan common.OrchestratorDescriptor, errCh chan error, allOrchInfoCh chan common.OrchestratorDescriptor) {
 		ctx, cancel := context.WithTimeout(clog.Clone(context.Background(), ctx), maxGetOrchestratorCutoffTimeout)
 		defer cancel()
 
@@ -117,16 +117,17 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 		info, err := serverGetOrchInfo(ctx, o.bcast, od.LocalInfo.URL, server.GetOrchestratorInfoParams{Caps: caps.ToNetCapabilities()})
 		latency := time.Since(start)
 		clog.V(common.DEBUG).Infof(ctx, "Received GetOrchInfo RPC Response from uri=%v, latency=%v", od.LocalInfo.URL, latency)
-		reportLiveAICapacity(info, caps, od.LocalInfo.URL)
+		orchDescr := common.OrchestratorDescriptor{
+			LocalInfo: &common.OrchestratorLocalInfo{
+				URL:     od.LocalInfo.URL,
+				Score:   od.LocalInfo.Score,
+				Latency: &latency,
+			},
+			RemoteInfo: info,
+		}
+		allOrchInfoCh <- orchDescr
 		if err == nil && !isBlacklisted(info) && isCompatible(info) {
-			infoCh <- common.OrchestratorDescriptor{
-				LocalInfo: &common.OrchestratorLocalInfo{
-					URL:     od.LocalInfo.URL,
-					Score:   od.LocalInfo.Score,
-					Latency: &latency,
-				},
-				RemoteInfo: info,
-			}
+			infoCh <- orchDescr
 			return
 		}
 
@@ -144,12 +145,14 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 	timedOut := false
 	nbResp := 0
 	odCh := make(chan common.OrchestratorDescriptor, numAvailableOrchs)
+	allOrchDescrCh := make(chan common.OrchestratorDescriptor, numAvailableOrchs)
 	errCh := make(chan error, numAvailableOrchs)
 
 	// Shuffle and create O descriptor
 	for _, i := range rand.Perm(numAvailableOrchs) {
-		go getOrchInfo(ctx, common.OrchestratorDescriptor{linfos[i], nil}, odCh, errCh)
+		go getOrchInfo(ctx, common.OrchestratorDescriptor{linfos[i], nil}, odCh, errCh, allOrchDescrCh)
 	}
+	go reportLiveAICapacty(ctx, allOrchDescrCh, caps)
 
 	// use a timer to time out the entire get info loop below
 	cutoffTimer := time.NewTimer(maxGetOrchestratorCutoffTimeout)
@@ -213,6 +216,53 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 	return ods, nil
 }
 
+func reportLiveAICapacty(ctx context.Context, ch chan common.OrchestratorDescriptor, caps common.CapabilityComparator) {
+	if !monitor.Enabled {
+		return
+	}
+	modelsReq := getModelCaps(caps.ToNetCapabilities())
+
+	// Just as a safety measure, we will wait for at most 5 minutes
+	// Usually the context will be canceled way before that, but in case
+	maxTimeToWaitForOrchInfo := 5 * time.Minute
+
+	var allOrchInfo []common.OrchestratorDescriptor
+	var done bool
+	for {
+		select {
+		case od := <-ch:
+			allOrchInfo = append(allOrchInfo, od)
+		case <-ctx.Done():
+			done = true
+		case <-time.After(maxTimeToWaitForOrchInfo):
+			done = true
+		}
+		if done {
+			break
+		}
+	}
+
+	res := make(map[string]map[string]int)
+	for _, od := range allOrchInfo {
+		var models map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint
+		if od.RemoteInfo != nil {
+			models = getModelCaps(od.RemoteInfo.Capabilities)
+		}
+
+		for modelID := range modelsReq {
+			idle := 0
+			if models != nil {
+				if model, ok := models[modelID]; ok {
+					idle = int(model.Capacity)
+				}
+			}
+
+			res[modelID] = map[string]int{od.LocalInfo.URL.String(): idle}
+		}
+	}
+	monitor.AIContainersIdleAfterGatewayDiscovery(res)
+}
+
 func getModelCaps(caps *net.Capabilities) map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint {
 	if caps == nil || caps.Constraints == nil || caps.Constraints.PerCapability == nil {
 		return nil
@@ -222,30 +272,6 @@ func getModelCaps(caps *net.Capabilities) map[string]*net.Capabilities_Capabilit
 		return nil
 	}
 	return liveAI.Models
-}
-
-func reportLiveAICapacity(info *net.OrchestratorInfo, capsReq common.CapabilityComparator, orchURL *url.URL) {
-	if !monitor.Enabled {
-		return
-	}
-
-	modelsReq := getModelCaps(capsReq.ToNetCapabilities())
-
-	var models map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint
-	if info != nil {
-		models = getModelCaps(info.Capabilities)
-	}
-
-	for modelID := range modelsReq {
-		idle := 0
-		if models != nil {
-			if model, ok := models[modelID]; ok {
-				idle = int(model.Capacity)
-			}
-		}
-
-		monitor.AIContainersIdle(idle, modelID, orchURL.String())
-	}
 }
 
 func (o *orchestratorPool) Size() int {

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -242,7 +242,7 @@ func reportLiveAICapacty(ctx context.Context, ch chan common.OrchestratorDescrip
 		}
 	}
 
-	res := make(map[string]map[string]int)
+	idleContainersByModelAndOrchestrator := make(map[string]map[string]int)
 	for _, od := range allOrchInfo {
 		var models map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint
 		if od.RemoteInfo != nil {
@@ -257,10 +257,10 @@ func reportLiveAICapacty(ctx context.Context, ch chan common.OrchestratorDescrip
 				}
 			}
 
-			res[modelID] = map[string]int{od.LocalInfo.URL.String(): idle}
+			idleContainersByModelAndOrchestrator[modelID] = map[string]int{od.LocalInfo.URL.String(): idle}
 		}
 	}
-	monitor.AIContainersIdleAfterGatewayDiscovery(res)
+	monitor.AIContainersIdleAfterGatewayDiscovery(idleContainersByModelAndOrchestrator)
 }
 
 func getModelCaps(caps *net.Capabilities) map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint {

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -2030,12 +2030,12 @@ func AIContainersIdleAfterGatewayDiscovery(idleContainersByPipelinesAndOrchestra
 		}
 	}
 	// Update counts.
-	for k, v := range idleContainersByPipelinesAndOrchestrator {
-		for k2, v2 := range v {
-			if _, exists := census.aiContainersIdleByPipelineByOrchestrator[k]; !exists {
-				census.aiContainersIdleByPipelineByOrchestrator[k] = make(map[string]int)
+	for pipeline, v := range idleContainersByPipelinesAndOrchestrator {
+		for orchestrator, count := range v {
+			if _, exists := census.aiContainersIdleByPipelineByOrchestrator[pipeline]; !exists {
+				census.aiContainersIdleByPipelineByOrchestrator[pipeline] = make(map[string]int)
 			}
-			census.aiContainersIdleByPipelineByOrchestrator[k][k2] = v2
+			census.aiContainersIdleByPipelineByOrchestrator[pipeline][orchestrator] = count
 		}
 	}
 
@@ -2058,7 +2058,6 @@ func AIContainersIdleAfterGatewayDiscovery(idleContainersByPipelinesAndOrchestra
 		}
 	}
 }
-
 
 func AIContainersIdle(currentContainersIdle int, pipeline, modelID, uri string) {
 	if err := stats.RecordWithTags(census.ctx,


### PR DESCRIPTION
Currently, when an Orchestrator is removed from the pool, then we don't make the metrics `0`. That leads to the wrong capacity being reported.

Related [Discord Thread](https://discord.com/channels/423160867534929930/1397141878654107790/1400782365932126228).


-------

To address this issue, we adopt a similar approach to the one used for the `ai_current_live_pipelines metric` in [this PR](https://github.com/livepeer/go-livepeer/pull/3686). Specifically, we maintain an in-memory record of the current metric values. The updated flow is as follows:
1. Instead of reporting metrics immediately after receiving each OrchInfo response, we first collect all OrchInfo data from all orchestrators.
2. Once the discovery process completes, we:
    - Report metrics for all received OrchInfo responses.
    - Reset metrics for any orchestrators previously stored in memory but not present in the current discovery cycle.

While an alternative approach could involve a loop with a timeout for each entry (like a cache with a timeout), the solution implemented here provides more consistency and aligns better with the current metric reporting logic.