### PR TITLE
Remove the session from the pool if the selection failed

### DIFF
--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1493,6 +1493,10 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 		sess, err := params.sessManager.Select(ctx, cap, modelID)
 		if err != nil {
 			clog.Infof(ctx, "Error selecting session modelID=%v err=%v", modelID, err)
+			if cap == core.Capability_LiveVideoToVideo && sess != nil {
+				// for live video, remove the session from the pool to avoid retrying it
+				params.sessManager.Remove(ctx, sess)
+			}
 			continue
 		}
 		if sess == nil {

--- a/server/ai_session.go
+++ b/server/ai_session.go
@@ -556,7 +556,7 @@ func (c *AISessionManager) Select(ctx context.Context, cap core.Capability, mode
 	}
 
 	if err := refreshSessionIfNeeded(ctx, sess.BroadcastSession, false); err != nil {
-		return nil, err
+		return sess, err
 	}
 
 	clog.V(common.DEBUG).Infof(ctx, "selected orchestrator=%s", sess.Transcoder())


### PR DESCRIPTION
Related to this [Discord thread](https://discord.com/channels/423160867534929930/1401729487640465560/1401903113803137095).

**Problem:**
- The Orch session is stored as `inUse`
- But the Orch is busy
- Then, we keep on retrying it instead of making the discovery again

**Solution:**
If the selection failed, then remove the session from the pool (it will anyway be added in the next 6 min, because we make discovery process every 6 min).