### PR TITLE
INF-314 AI prometheus metrics to set correct "pipeline" and "model_name" labels

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -221,6 +221,7 @@ func getModelCaps(caps *net.Capabilities) map[string]*net.Capabilities_Capabilit
 	if !ok {
 		return nil
 	}
+
 	return liveAI.Models
 }
 
@@ -244,7 +245,7 @@ func reportLiveAICapacity(info *net.OrchestratorInfo, capsReq common.CapabilityC
 			}
 		}
 
-		monitor.AIContainersIdle(idle, modelID, orchURL.String())
+		monitor.AIContainersIdle(idle, "", modelID, orchURL.String())
 	}
 }
 

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -1017,14 +1017,14 @@ func InitCensus(nodeType NodeType, version string) {
 			Name:        "ai_container_in_use",
 			Measure:     census.mAIContainersInUse,
 			Description: "Number of containers currently used for AI processing",
-			TagKeys:     append([]tag.Key{census.kOrchestratorURI, census.kPipeline, census.kModelName}, baseTags...),
+			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTags...),
 			Aggregation: view.LastValue(),
 		},
 		{
 			Name:        "ai_container_idle",
 			Measure:     census.mAIContainersIdle,
 			Description: "Number of containers currently available for AI processing",
-			TagKeys:     append([]tag.Key{census.kOrchestratorURI, census.kPipeline, census.kModelName}, baseTags...),
+			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName, census.kOrchestratorURI}, baseTags...),
 			Aggregation: view.LastValue(),
 		},
 		{
@@ -1038,7 +1038,7 @@ func InitCensus(nodeType NodeType, version string) {
 			Name:        "ai_current_live_pipelines",
 			Measure:     census.mAICurrentLivePipelines,
 			Description: "Number of live AI pipelines currently running",
-			TagKeys:     append([]tag.Key{census.kOrchestratorURI, census.kPipeline, census.kModelName}, baseTags...),
+			TagKeys:     append([]tag.Key{census.kPipeline}, baseTags...),
 			Aggregation: view.LastValue(),
 		},
 		{
@@ -1052,7 +1052,7 @@ func InitCensus(nodeType NodeType, version string) {
 			Name:        "ai_live_attempt",
 			Measure:     census.mAILiveAttempts,
 			Description: "AI Live stream attempted",
-			TagKeys:     baseTags,
+			TagKeys:     append([]tag.Key{census.kModelName}, baseTags...),
 			Aggregation: view.Count(),
 		},
 		{
@@ -1109,8 +1109,6 @@ func InitCensus(nodeType NodeType, version string) {
 	stats.Record(census.ctx, census.mWinningTicketsRecv.M(int64(0)))
 	stats.Record(census.ctx, census.mCurrentSessions.M(int64(0)))
 	stats.Record(census.ctx, census.mValueRedeemed.M(float64(0)))
-	stats.Record(census.ctx, census.mAIContainersInUse.M(int64(0)))
-	stats.Record(census.ctx, census.mAICurrentLivePipelines.M(int64(0)))
 }
 
 /*
@@ -2010,24 +2008,28 @@ func AIRequestError(code string, pipeline string, model string, orchInfo *lpnet.
 	}
 }
 
-func AIContainersInUse(currentContainersInUse int, model, uri string) {
+func AIContainersInUse(currentContainersInUse int, pipeline, modelID string) {
 	if err := stats.RecordWithTags(census.ctx,
-		[]tag.Mutator{tag.Insert(census.kModelName, model), tag.Insert(census.kOrchestratorURI, uri)},
+		[]tag.Mutator{tag.Insert(census.kPipeline, pipeline), tag.Insert(census.kModelName, modelID)},
 		census.mAIContainersInUse.M(int64(currentContainersInUse))); err != nil {
 		glog.Errorf("Error recording metrics err=%q", err)
 	}
 }
 
-func AIContainersIdle(currentContainersIdle int, model, uri string) {
+func AIContainersIdle(currentContainersIdle int, pipeline, modelID, uri string) {
 	if err := stats.RecordWithTags(census.ctx,
-		[]tag.Mutator{tag.Insert(census.kModelName, model), tag.Insert(census.kOrchestratorURI, uri)},
+		[]tag.Mutator{tag.Insert(census.kPipeline, pipeline), tag.Insert(census.kModelName, modelID), tag.Insert(census.kOrchestratorURI, uri)},
 		census.mAIContainersIdle.M(int64(currentContainersIdle))); err != nil {
 		glog.Errorf("Error recording metrics err=%q", err)
 	}
 }
 
-func AIGPUsIdle(currentGPUsIdle int) {
-	stats.Record(census.ctx, census.mAIGPUsIdle.M(int64(currentGPUsIdle)))
+func AIGPUsIdle(currentGPUsIdle int, pipeline, modelID string) {
+	if err := stats.RecordWithTags(census.ctx,
+		[]tag.Mutator{tag.Insert(census.kPipeline, pipeline), tag.Insert(census.kModelName, modelID)},
+		census.mAIGPUsIdle.M(int64(currentGPUsIdle))); err != nil {
+		glog.Errorf("Error recording metrics err=%q", err)
+	}
 }
 
 func AICurrentLiveSessions(sessionsByPipeline map[string]int) {
@@ -2144,8 +2146,15 @@ func AIFirstSegmentDelay(delayMs int64, orchInfo *lpnet.OrchestratorInfo) {
 	}
 }
 
-func AILiveVideoAttempt() {
-	stats.Record(census.ctx, census.mAILiveAttempts.M(1))
+func AILiveVideoAttempt(modelID string) {
+	if !Enabled {
+		return
+	}
+	if err := stats.RecordWithTags(census.ctx,
+		[]tag.Mutator{tag.Insert(census.kModelName, modelID)},
+		census.mAILiveAttempts.M(1)); err != nil {
+		glog.Errorf("Error recording %s metric err=%q", census.mAILiveAttempts.Name(), err)
+	}
 }
 
 func AINumOrchestrators(count int, modelName string) {

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -583,9 +583,7 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 
 		// Count `ai_live_attempts` after successful parameters validation
 		clog.V(common.VERBOSE).Infof(ctx, "AI Live video attempt")
-		if monitor.Enabled {
-			monitor.AILiveVideoAttempt()
-		}
+		monitor.AILiveVideoAttempt(pipeline) // this `pipeline` is actually modelID
 
 		sendErrorEvent := LiveErrorEventSender(ctx, streamID, map[string]string{
 			"type":        "error",
@@ -1037,6 +1035,10 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 					"url":     "",
 				},
 			})
+
+			clog.V(common.VERBOSE).Infof(ctx, "AI Live video attempt")
+			monitor.AILiveVideoAttempt(pipeline) // this `pipeline` is actually modelID
+
 			go func() {
 				defer func() {
 					if r := recover(); r != nil {
@@ -1061,10 +1063,6 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 					},
 				})
 			}()
-
-			if monitor.Enabled {
-				monitor.AILiveVideoAttempt()
-			}
 
 			if outputURL != "" {
 				rtmpOutputs = append(rtmpOutputs, outputURL)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Normalising AI metrics to have correct `pipeline`, `model_name` and `orchestratorUri` tags.

**Specific updates (required)**
* `ai_container_in_use` to set correct `mode_name` label (`orchestratorUri` got removed)
* `ai_container_idle` to set correct `mode_name` label 
* `ai_gpus_idle` to set `mode_name` label (`orchestratorUri` got removed)
* `ai_current_live_pipelines ` to set `model_name` label (`orchestratorUri` got removed)
* `ai_live_attempt` to introduce `model_name` label

**How did you test each of these updates (required)**
...


**Does this pull request close any open issues?**
no

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
