### PR TITLE
GetCapacity metric to support pipeline and modelID filtering

### DIFF
--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -82,7 +82,8 @@ func (w *Worker) HardwareInformation() []HardwareInformation {
 }
 
 func (w *Worker) GetLiveAICapacity() Capacity {
-	return w.manager.GetCapacity()
+	capacity, _ := w.manager.GetCapacity("", "")
+	return capacity
 }
 
 func (w *Worker) Version() []Version {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Fix  `ai_container_in_use` and `ai_container_idle` metrics to report only running pipelines

**Specific updates (required)**
- don't call `monitorInUse()` in `HasCapacity()`
- destroyContainer() to always call monitorInUse()


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
