### PR TITLE
ai/live: Retry ffmpeg more often.

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -236,7 +236,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 	}
 	// Launch ffmpeg for each configured RTMP output
 	for _, outURL := range params.liveParams.rtmpOutputs {
-		go ffmpegOutput(ctx, outURL, outWriter.MakeReader(), params)
+		go ffmpegOutput(ctx, outURL, outWriter, params)
 	}
 
 	// read segments from trickle subscription
@@ -357,7 +357,7 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 	}()
 }
 
-func ffmpegOutput(ctx context.Context, outputUrl string, r io.Reader, params aiRequestParams) {
+func ffmpegOutput(ctx context.Context, outputUrl string, outWriter *media.RingBuffer, params aiRequestParams) {
 	// Clone the context since we can call this function multiple times
 	// Adding rtmpOut val multiple times to the same context will just stomp over old ones
 	ctx = clog.Clone(ctx, ctx)
@@ -399,13 +399,18 @@ func ffmpegOutput(ctx context.Context, outputUrl string, r io.Reader, params aiR
 			return cmd.Process.Signal(syscall.SIGTERM)
 		}
 		cmd.WaitDelay = 5 * time.Second
-		cmd.Stdin = r
+		cmd.Stdin = outWriter.MakeReader() // start at leading edge of output for each retry
 		output, err := cmd.CombinedOutput()
-		clog.Infof(ctx, "Process output: %s", output)
-		if err != nil {
-			clog.Errorf(ctx, "Error sending RTMP out: %v", err)
-			return
+		clog.Infof(ctx, "Process err=%v output: %s", err, output)
+
+		select {
+		case <-ctx.Done():
+			clog.Info(ctx, "Context done, stopping rtmp output")
+			return // Returns context.Canceled or context.DeadlineExceeded
+		default:
+			// Context is still active, continue with normal processing
 		}
+
 		time.Sleep(5 * time.Second)
 	}
 }


### PR DESCRIPTION
Instead of quitting on error, retry. Clean exits are rare; we almost always get an error.

Check for context cancellation which indicates a swap or disconnect. Quit on those. We already
check for disconnected input after the sleep.

This helps fix the case where the output disconnects but the rest of the processing keeps going.

Also lazily instantiate the output reader per retry, so we aren't blasting out 5+ seconds worth of
buffered data after each retry.