### PR TITLE
Fix: Potential Goroutine Leak Due to Un-buffered Channel

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1690,9 +1690,9 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		exit("Error creating Livepeer server: err=%q", err)
 	}
 
-	ec := make(chan error)
-	tc := make(chan struct{})
-	wc := make(chan struct{})
+	ec := make(chan error, 1)
+	tc := make(chan struct{}, 1)
+	wc := make(chan struct{}, 1)
 	msCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/server/router.go
+++ b/server/router.go
@@ -111,7 +111,7 @@ func getOrchestratorInfo(ctx context.Context, uris []*url.URL, req *net.Orchestr
 		return nil, errNoOrchestrators
 	}
 
-	infoCh := make(chan *net.OrchestratorInfo)
+	infoCh := make(chan *net.OrchestratorInfo, 1)
 	errCh := make(chan error, len(uris))
 
 	cctx, cancel := context.WithTimeout(ctx, getOrchestratorTimeout)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR is intended to fix the potential goroutine leak issue. In the `StartLivepeer` function, there is a potential goroutine leak caused by sending to an un-buffered channel. The channels `ec`, `tc`, and `wc` are un-buffered, which can lead to a situation where the goroutine blocks indefinitely if the `ctx.Done()` branch wins the race. This results in leaked resources as the goroutine is never able to complete its execution.
```go
func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
    //...
	ec := make(chan error)
	tc := make(chan struct{})
	wc := make(chan struct{})
	//...
	select {
		case err := <-ec:
			glog.Infof("Error from media server: %v", err)
			return
		case <-tc:
			glog.Infof("Orchestrator server shut down")
		case <-wc:
			glog.Infof("CLI webserver shut down")
			return
		case <-ctx.Done():
			srv.Shutdown(ctx)
			return
	}
}
```
The same issue exists in the `getOrchestratorInfo` function from `server/router.go`, where an un-buffered channel `infoCh` is used to receive orchestrator information

**Specific updates (required)**
To prevent the potential goroutine leak, this PR make the channels buffered by specifying a buffer size of 1.
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
No


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
