### PR TITLE
ai/live: Send param updates to Kafka from the control handler.

### DIFF
--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -169,11 +169,12 @@ type LivepeerNode struct {
 }
 
 type LivePipeline struct {
-	RequestID   string
-	Params      string
-	Pipeline    string
-	ControlPub  *trickle.TricklePublisher
-	StopControl func()
+	RequestID    string
+	Params       []byte
+	Pipeline     string
+	ControlPub   *trickle.TricklePublisher
+	StopControl  func()
+	ReportUpdate func([]byte)
 }
 
 // NewLivepeerNode creates a new Livepeer Node. Eth can be nil.

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -533,14 +533,18 @@ func startControlPublish(ctx context.Context, control *url.URL, params aiRequest
 
 	reportUpdate := func(data []byte) {
 		// send the param update to kafka
-		event := make(map[string]interface{})
-		event["type"] = "params_update"
-		event["stream_id"] = params.liveParams.streamID
-		event["request_id"] = params.liveParams.requestID
-		event["pipeline"] = params.liveParams.pipeline
-		event["pipeline_id"] = params.liveParams.pipelineID
-		event["params"] = json.RawMessage(data)
-		monitor.SendQueueEventAsync("ai_stream_events", event)
+		monitor.SendQueueEventAsync("ai_stream_events", map[string]interface{}{
+			"type":        "params_update",
+			"stream_id":   params.liveParams.streamID,
+			"request_id":  params.liveParams.requestID,
+			"pipeline":    params.liveParams.pipeline,
+			"pipeline_id": params.liveParams.pipelineID,
+			"params":      json.RawMessage(data),
+			"orchestrator_info": map[string]interface{}{
+				"address": params.liveParams.sess.Address(),
+				"url":     params.liveParams.sess.Transcoder(),
+			},
+		})
 	}
 
 	sess, exists := params.node.LivePipelines[stream]

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -845,7 +845,8 @@ func (ls *LivepeerServer) UpdateLiveVideo() http.Handler {
 
 		params := string(data)
 		ls.LivepeerNode.LiveMu.Lock()
-		p.Params = params
+		p.Params = data
+		reportUpdate := p.ReportUpdate
 		controlPub := p.ControlPub
 		ls.LivepeerNode.LiveMu.Unlock()
 
@@ -855,10 +856,12 @@ func (ls *LivepeerServer) UpdateLiveVideo() http.Handler {
 		}
 
 		clog.V(6).Infof(ctx, "Sending Live Video Update Control API stream=%s, params=%s", stream, params)
-		if err := controlPub.Write(strings.NewReader(params)); err != nil {
+		if err := controlPub.Write(bytes.NewReader(data)); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
+		reportUpdate(data)
 
 		corsHeaders(w, r.Method)
 	})


### PR DESCRIPTION
This mitigates some observability issues with param updates not being reported to Kafka since they were removed in [1].

[1] https://github.com/livepeer/ai-runner/pull/723

The event fields were based on:

https://github.com/livepeer/ai-runner/blob/acff3a3be0c9235473ca69ed5fdc241e2af4a3b0/runner/app/live/streamer/process_guardian.py#L121-L132

and

https://github.com/livepeer/go-livepeer/blob/1b6298d42aef6e82b75d0860a278d8ea037492de/server/ai_live_video.go#L689-L691