### PR TITLE
Make debug segment count configurable

### DIFF
--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -71,6 +71,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.LivePaymentInterval = fs.Duration("livePaymentInterval", *cfg.LivePaymentInterval, "Interval to pay process Gateway <> Orchestrator Payments for Live AI Video")
 	cfg.LiveOutSegmentTimeout = fs.Duration("liveOutSegmentTimeout", *cfg.LiveOutSegmentTimeout, "Timeout duration to wait the output segment to be available in the Live AI pipeline; defaults to no timeout")
 	cfg.LiveAICapRefreshModels = fs.String("liveAICapRefreshModels", "", "Comma separated list of models to periodically fetch capacity for. Leave unset to switch off periodic refresh.")
+	cfg.LiveAISaveNSegments = fs.Int("liveAISaveNSegments", 10, "Set how many segments to save to disk for debugging (both input and output)")
 
 	// Onchain:
 	cfg.EthAcctAddr = fs.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in the keystore directory")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1682,7 +1682,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	if cfg.LiveAICapRefreshModels != nil && *cfg.LiveAICapRefreshModels != "" {
 		n.LiveAICapRefreshModels = strings.Split(*cfg.LiveAICapRefreshModels, ",")
 	}
-	n.LiveAISaveNSegments = *cfg.LiveAISaveNSegments
+	n.LiveAISaveNSegments = cfg.LiveAISaveNSegments
 
 	//Create Livepeer Node
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -180,6 +180,7 @@ type LivepeerConfig struct {
 	LivePaymentInterval        *time.Duration
 	LiveOutSegmentTimeout      *time.Duration
 	LiveAICapRefreshModels     *string
+	LiveAISaveNSegments        *int
 }
 
 // DefaultLivepeerConfig creates LivepeerConfig exactly the same as when no flags are passed to the livepeer process.
@@ -1681,6 +1682,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	if cfg.LiveAICapRefreshModels != nil && *cfg.LiveAICapRefreshModels != "" {
 		n.LiveAICapRefreshModels = strings.Split(*cfg.LiveAICapRefreshModels, ",")
 	}
+	n.LiveAISaveNSegments = *cfg.LiveAISaveNSegments
 
 	//Create Livepeer Node
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -163,7 +163,7 @@ type LivepeerNode struct {
 	LivePaymentInterval        time.Duration
 	LiveOutSegmentTimeout      time.Duration
 	LiveAICapRefreshModels     []string
-	LiveAISaveNSegments        int
+	LiveAISaveNSegments        *int
 
 	// Gateway
 	GatewayHost string

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -163,6 +163,7 @@ type LivepeerNode struct {
 	LivePaymentInterval        time.Duration
 	LiveOutSegmentTimeout      time.Duration
 	LiveAICapRefreshModels     []string
+	LiveAISaveNSegments        int
 
 	// Gateway
 	GatewayHost string

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -32,6 +32,10 @@ const (
 	maxRecentSwapsCount = 2
 )
 
+var (
+	liveAISaveNSegments = 10
+)
+
 type orchestratorSwapper struct {
 	params           aiRequestParams
 	cap              core.Capability
@@ -452,7 +456,7 @@ func ffmpegOutput(ctx context.Context, outputUrl string, outWriter *media.RingBu
 func copySegment(ctx context.Context, segment *http.Response, w io.Writer, seq int, params aiRequestParams) (int64, error) {
 	defer segment.Body.Close()
 	var reader io.Reader = segment.Body
-	if seq < 10 {
+	if seq < liveAISaveNSegments {
 		p := filepath.Join(params.node.WorkDir, fmt.Sprintf("%s-out-%d.ts", params.liveParams.requestID, seq))
 		outFile, err := os.Create(p)
 		if err != nil {
@@ -835,7 +839,7 @@ func LiveErrorEventSender(ctx context.Context, streamID string, event map[string
 
 func logToDisk(ctx context.Context, r media.CloneableReader, workdir string, requestID string, seq int) {
 	// NB these segments are cleaned up periodically by the temp file sweeper in rtmp2segment
-	if seq > 10 {
+	if seq > liveAISaveNSegments {
 		return
 	}
 	go func() {

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -203,7 +203,9 @@ func NewLivepeerServer(ctx context.Context, rtmpAddr string, lpNode *core.Livepe
 	if lpNode.NodeType == core.BroadcasterNode && httpIngest {
 		opts.HttpMux.HandleFunc("/live/", ls.HandlePush)
 
-		liveAISaveNSegments = lpNode.LiveAISaveNSegments
+		if lpNode.LiveAISaveNSegments != nil {
+			liveAISaveNSegments = *lpNode.LiveAISaveNSegments
+		}
 		if err := startAIMediaServer(ctx, ls); err != nil {
 			return nil, fmt.Errorf("failed to start AI media server: %w", err)
 		}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -203,6 +203,7 @@ func NewLivepeerServer(ctx context.Context, rtmpAddr string, lpNode *core.Livepe
 	if lpNode.NodeType == core.BroadcasterNode && httpIngest {
 		opts.HttpMux.HandleFunc("/live/", ls.HandlePush)
 
+		liveAISaveNSegments = lpNode.LiveAISaveNSegments
 		if err := startAIMediaServer(ctx, ls); err != nil {
 			return nil, fmt.Errorf("failed to start AI media server: %w", err)
 		}


### PR DESCRIPTION
I've been finding it necessary to save more than the first 10 segments to be able to debug the different input modes we have in the app. Make it configurable so we can easily adjust it temporarily.