### PR TITLE
ai/live: Exclude Safari 18.6 from the iOS timestamp fix.

### DIFF
--- a/media/timestamp_corrector.go
+++ b/media/timestamp_corrector.go
@@ -3,6 +3,7 @@ package media
 import (
 	"context"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/livepeer/go-livepeer/clog"
@@ -133,6 +134,10 @@ var uaRegex = regexp.MustCompile(`iPhone|iPad|Version/18`)
 func shouldFix(s string) bool {
 	if s == "" {
 		return true
+	}
+	// Explicitly exclude Safari 18.6 user agents from the fix
+	if strings.Contains(s, "Version/18.6") {
+		return false
 	}
 	return uaRegex.MatchString(s)
 }

--- a/media/timestamp_corrector_test.go
+++ b/media/timestamp_corrector_test.go
@@ -218,6 +218,14 @@ func TestTimestampCorrector_UAFilter(t *testing.T) {
 			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
 		},
 		{
+			name: "Safari 18.6 on MacOS",
+			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15",
+		},
+		{
+			name: "Safari 18.6 on iPhone",
+			ua:   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1",
+		},
+		{
 			name: "Headless Chrome on MacOS",
 			ua:   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/137.0.0.0 Safari/537.36",
 		},


### PR DESCRIPTION
The RTP timestamp bug was finally fixed in Safari 18.6 but still sometimes triggers false positives in our timestamp corrector, so explicitly ignore it.

<img width="908" height="762" alt="image" src="https://github.com/user-attachments/assets/dfd8cc57-ce28-4b0c-8c68-59053b20e3f0" />