### PR TITLE
Add sdxl and faceid docker containers

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -68,11 +68,11 @@ var pipelineToImage = map[string]string{
 }
 var livePipelineToImage = map[string]string{
 	"streamdiffusion": "livepeer/ai-runner:live-app-streamdiffusion",
-	// streamdiffusion-sd15 is a utility image that uses a SD1.5 model on the default config of the pipeline. Optimizes startup time.
+	// streamdiffusion-sd15 is a utility image that uses an SD1.5 model on the default config of the pipeline. Optimizes startup time.
 	"streamdiffusion-sd15": "livepeer/ai-runner:live-app-streamdiffusion-sd15",
-	// streamdiffusion-sdxl is a utility image that uses a SDXL model on the default config of the pipeline. Optimizes startup time.
+	// streamdiffusion-sdxl is a utility image that uses an SDXL model on the default config of the pipeline. Optimizes startup time.
 	"streamdiffusion-sdxl": "livepeer/ai-runner:live-app-streamdiffusion-sdxl",
-	// streamdiffusion-sdxl-faceid is a utility image that uses a SDXL FaceID model on the default config of the pipeline. Optimizes startup time.
+	// streamdiffusion-sdxl-faceid is a utility image that uses an SDXL model with a FaceID IP Adapter on the default config of the pipeline. Optimizes startup time.
 	"streamdiffusion-sdxl-faceid": "livepeer/ai-runner:live-app-streamdiffusion-sdxl-faceid",
 	"comfyui":              "livepeer/ai-runner:live-app-comfyui",
 	"segment_anything_2":   "livepeer/ai-runner:live-app-segment_anything_2",

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -70,6 +70,10 @@ var livePipelineToImage = map[string]string{
 	"streamdiffusion": "livepeer/ai-runner:live-app-streamdiffusion",
 	// streamdiffusion-sd15 is a utility image that uses a SD1.5 model on the default config of the pipeline. Optimizes startup time.
 	"streamdiffusion-sd15": "livepeer/ai-runner:live-app-streamdiffusion-sd15",
+	// streamdiffusion-sdxl is a utility image that uses a SDXL model on the default config of the pipeline. Optimizes startup time.
+	"streamdiffusion-sdxl": "livepeer/ai-runner:live-app-streamdiffusion-sdxl",
+	// streamdiffusion-sdxl-faceid is a utility image that uses a SDXL FaceID model on the default config of the pipeline. Optimizes startup time.
+	"streamdiffusion-sdxl-faceid": "livepeer/ai-runner:live-app-streamdiffusion-sdxl-faceid",
 	"comfyui":              "livepeer/ai-runner:live-app-comfyui",
 	"segment_anything_2":   "livepeer/ai-runner:live-app-segment_anything_2",
 	"noop":                 "livepeer/ai-runner:live-app-noop",


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This pull request adds support for two new StreamDiffusion variants, `streamdiffusion-sdxl` and `streamdiffusion-sdxl-faceid`, by mapping them to their respective Docker images in the `ai/worker/docker.go` file. This enables the system to correctly identify and launch these new live pipeline containers.

**Specific updates (required)**
- Added `streamdiffusion-sdxl` to the `livePipelineToImage` map, pointing to `livepeer/ai-runner:live-app-streamdiffusion-sdxl`.
- Added `streamdiffusion-sdxl-faceid` to the `livePipelineToImage` map, pointing to `livepeer/ai-runner:live-app-streamdiffusion-sdxl-faceid`.
- Configured the new entries to mirror the existing `streamdiffusion-sd15` pattern, including descriptive comments.

**How did you test each of these updates (required)**
The configuration style for the new entries was verified by inspecting the git commit history that introduced the `streamdiffusion-sd15` variant to ensure consistency. The project was built locally to confirm that the changes compile successfully.

**Does this pull request close any open issues?**


**Checklist:**
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated

---
<a href="https://cursor.com/background-agent?bcId=bc-ae10010c-12ed-4b71-a681-608490bdb60f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae10010c-12ed-4b71-a681-608490bdb60f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

