### PR TITLE
worker: Allow runner to go back to LOADING post-start

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -644,7 +644,7 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer) {
 				failures, loadingStartTime = 0, time.Time{}
 				continue
 			case LOADING:
-				if startedLoading := loadingStartTime.IsZero(); startedLoading {
+				if loadingStartTime.IsZero() {
 					failures, loadingStartTime = 0, time.Now()
 
 					if !isBorrowed {

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -570,8 +570,8 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer) {
 	defer ticker.Stop()
 
 	slog.Info("Watching container", slog.String("container", rc.Name))
+	var loadingStartTime time.Time
 	failures := 0
-	loadingStartTime := 0.0
 	for {
 		if failures >= maxHealthCheckFailures {
 			slog.Error("Container health check failed too many times", slog.String("container", rc.Name))
@@ -641,20 +641,19 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer) {
 				}
 				fallthrough
 			case OK:
-				failures, loadingStartTime = 0, 0
+				failures, loadingStartTime = 0, time.Time{}
 				continue
-			case "LOADING": // TODO: Use enum when ai-runner SDK is updated
-				if !isBorrowed {
-					slog.Info("Container is loading, removing from pool", slog.String("container", rc.Name))
-					failures = 0
+			case LOADING:
+				if startedLoading := loadingStartTime.IsZero(); startedLoading {
+					failures, loadingStartTime = 0, time.Now()
 
-					m.mu.Lock()
-					m.borrowContainerLocked(context.Background(), rc)
-					m.mu.Unlock()
-				}
+					if !isBorrowed {
+						slog.Info("Container is loading, removing from pool", slog.String("container", rc.Name))
 
-				if loadingStartTime == 0 {
-					loadingStartTime = time.Now()
+						m.mu.Lock()
+						m.borrowContainerLocked(context.Background(), rc)
+						m.mu.Unlock()
+					}
 				}
 				if loadingTime := time.Since(loadingStartTime); loadingTime > containerTimeout {
 					failures++


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is a change required by https://github.com/livepeer/ai-runner/pull/798
so that the runner containers are "allowed" to go back to the LOADING state
after startup. This will be used to avoid sending streams to a container that
is still returning to the default params after handling a stream.

**Specific updates (required)**
- Reset the `loadingStartTime` every time we see the LOADING state
- thats all lol

**How did you test each of these updates (required)**
Ran the box and tested multiple loading scenarios, during stream, after stream, etc.


**Does this pull request close any open issues?**
Part of INF-297

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
