### PR TITLE
worker: Overrule resource hog runner container on startup

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,6 +14,8 @@
 
 #### Orchestrator
 
+* [#3749](https://github.com/livepeer/go-livepeer/pull/3749) worker: Overrule resource-hog AI runner containers on startup (@victorges)
+
 #### Transcoder
 
 ### Bug Fixes 🐞

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -132,7 +132,7 @@ func NewDockerManager(overrides ImageOverrides, verboseLogs bool, gpus []string,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), containerTimeout)
-	if err := RemoveExistingContainers(ctx, client); err != nil {
+	if _, err := RemoveExistingContainers(ctx, client); err != nil {
 		cancel()
 		return nil, err
 	}

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -997,7 +997,7 @@ func TestRemoveExistingContainers(t *testing.T) {
 	mockDockerClient.On("ContainerRemove", mock.Anything, "container1", mock.Anything).Return(nil)
 	mockDockerClient.On("ContainerRemove", mock.Anything, "container2", mock.Anything).Return(nil)
 
-	removeExistingContainers(ctx, mockDockerClient)
+	RemoveExistingContainers(ctx, mockDockerClient)
 	mockDockerClient.AssertExpectations(t)
 }
 

--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -12,8 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-
-	docker "github.com/docker/docker/client"
 )
 
 // EnvValue unmarshals JSON booleans as strings for compatibility with env variables.
@@ -52,12 +50,7 @@ type Worker struct {
 }
 
 func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string) (*Worker, error) {
-	dockerClient, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
-	if err != nil {
-		return nil, fmt.Errorf("error creating docker client: %w", err)
-	}
-
-	manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, dockerClient)
+	manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating docker manager: %w", err)
 	}

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -466,7 +466,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		glog.Exit("both -netint and -nvidia arguments specified, this is not supported")
 	}
 
-	if cfg.AIWorker != nil {
+	if *cfg.AIWorker {
 		// Remove existing worker containers as soon as possible. This needs to be here so it's done before any resources
 		// are allocated by this process. That because we've seen issues where the AI worker containers hoard all the system
 		// resources and the Orchestrator cannot restart because it dies early (e.g. due to no (v)ram available).


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to make sure that `ai-runner` containers that have gone rogue and are consuming
all of the system resources (normally VRAM) are able to get killed by a restarting O.

The problem used to be that the O died out of VRAM when starting and couldnt' get to kill
the runner. This change makes sure that we do it ASAP in the startup so that it frees resources
so the new O can start.

**Specific updates (required)**
- Remove existing containers ASAP in worker startup

**How did you test each of these updates (required)**
Not yet.


**Does this pull request close any open issues?**
Fixes INF-350


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
