### PR TITLE
Add `IgnoreSenderReserveRequirements` param

### DIFF
--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -100,7 +100,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.MaxTotalEV = fs.String("maxTotalEV", *cfg.MaxTotalEV, "The maximum acceptable expected value for one PM payment")
 	// Broadcaster deposit multiplier to determine max acceptable ticket faceValue
 	cfg.DepositMultiplier = fs.Int("depositMultiplier", *cfg.DepositMultiplier, "The deposit multiplier used to determine max acceptable faceValue for PM tickets")
-	cfg.IgnoreSenderReserve = fs.Bool("IgnoreSenderReserve", *cfg.IgnoreSenderReserve, "Skip sender reserve validation and rely solely on broadcaster deposits covering ticket face value (unsafe)")
+	cfg.IgnoreSenderReserve = fs.Bool("ignoreSenderReserve", *cfg.IgnoreSenderReserve, "Ignore sender reserve; lowers gateway reserve needs but allows double-spending risk (unsafe)")
 	// Orchestrator base pricing info
 	cfg.PricePerUnit = fs.String("pricePerUnit", "0", "The price per 'pixelsPerUnit' amount pixels. Can be specified in wei or a custom currency in the format <price><currency> (e.g. 0.50USD). When using a custom currency, a corresponding price feed must be configured with -priceFeedAddr")
 	// Unit of pixels for both O's pricePerUnit and B's maxPricePerUnit

--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -100,6 +100,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.MaxTotalEV = fs.String("maxTotalEV", *cfg.MaxTotalEV, "The maximum acceptable expected value for one PM payment")
 	// Broadcaster deposit multiplier to determine max acceptable ticket faceValue
 	cfg.DepositMultiplier = fs.Int("depositMultiplier", *cfg.DepositMultiplier, "The deposit multiplier used to determine max acceptable faceValue for PM tickets")
+	cfg.IgnoreSenderReserveRequirements = fs.Bool("ignoreSenderReserveRequirements", *cfg.IgnoreSenderReserveRequirements, "Skip sender reserve validation and rely solely on broadcaster deposits covering ticket face value (unsafe)")
 	// Orchestrator base pricing info
 	cfg.PricePerUnit = fs.String("pricePerUnit", "0", "The price per 'pixelsPerUnit' amount pixels. Can be specified in wei or a custom currency in the format <price><currency> (e.g. 0.50USD). When using a custom currency, a corresponding price feed must be configured with -priceFeedAddr")
 	// Unit of pixels for both O's pricePerUnit and B's maxPricePerUnit

--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -100,7 +100,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.MaxTotalEV = fs.String("maxTotalEV", *cfg.MaxTotalEV, "The maximum acceptable expected value for one PM payment")
 	// Broadcaster deposit multiplier to determine max acceptable ticket faceValue
 	cfg.DepositMultiplier = fs.Int("depositMultiplier", *cfg.DepositMultiplier, "The deposit multiplier used to determine max acceptable faceValue for PM tickets")
-	cfg.IgnoreSenderReserveRequirements = fs.Bool("ignoreSenderReserveRequirements", *cfg.IgnoreSenderReserveRequirements, "Skip sender reserve validation and rely solely on broadcaster deposits covering ticket face value (unsafe)")
+	cfg.IgnoreSenderReserve = fs.Bool("IgnoreSenderReserve", *cfg.IgnoreSenderReserve, "Skip sender reserve validation and rely solely on broadcaster deposits covering ticket face value (unsafe)")
 	// Orchestrator base pricing info
 	cfg.PricePerUnit = fs.String("pricePerUnit", "0", "The price per 'pixelsPerUnit' amount pixels. Can be specified in wei or a custom currency in the format <price><currency> (e.g. 0.50USD). When using a custom currency, a corresponding price feed must be configured with -priceFeedAddr")
 	// Unit of pixels for both O's pricePerUnit and B's maxPricePerUnit

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -80,113 +80,113 @@ const (
 )
 
 type LivepeerConfig struct {
-	Network                         *string
-	RtmpAddr                        *string
-	CliAddr                         *string
-	HttpAddr                        *string
-	ServiceAddr                     *string
-	Nodes                           *string
-	OrchAddr                        *string
-	VerifierURL                     *string
-	EthController                   *string
-	VerifierPath                    *string
-	LocalVerify                     *bool
-	HttpIngest                      *bool
-	Orchestrator                    *bool
-	Transcoder                      *bool
-	AIServiceRegistry               *bool
-	AIWorker                        *bool
-	Gateway                         *bool
-	Broadcaster                     *bool
-	OrchSecret                      *string
-	TranscodingOptions              *string
-	AIModels                        *string
-	MaxAttempts                     *int
-	SelectRandWeight                *float64
-	SelectStakeWeight               *float64
-	SelectPriceWeight               *float64
-	SelectPriceExpFactor            *float64
-	OrchPerfStatsURL                *string
-	Region                          *string
-	MaxPricePerUnit                 *string
-	MaxPricePerCapability           *string
-	IgnoreMaxPriceIfNeeded          *bool
-	MinPerfScore                    *float64
-	DiscoveryTimeout                *time.Duration
-	ExtraNodes                      *int
-	MaxSessions                     *string
-	CurrentManifest                 *bool
-	Nvidia                          *string
-	Netint                          *string
-	HevcDecoding                    *bool
-	TestTranscoder                  *bool
-	GatewayHost                     *string
-	EthAcctAddr                     *string
-	EthPassword                     *string
-	EthKeystorePath                 *string
-	EthOrchAddr                     *string
-	EthUrl                          *string
-	TxTimeout                       *time.Duration
-	MaxTxReplacements               *int
-	GasLimit                        *int
-	MinGasPrice                     *int64
-	MaxGasPrice                     *int
-	InitializeRound                 *bool
-	InitializeRoundMaxDelay         *time.Duration
-	TicketEV                        *string
-	MaxFaceValue                    *string
-	MaxTicketEV                     *string
-	MaxTotalEV                      *string
-	DepositMultiplier               *int
-	IgnoreSenderReserveRequirements *bool
-	PricePerUnit                    *string
-	PixelsPerUnit                   *string
-	PriceFeedAddr                   *string
-	AutoAdjustPrice                 *bool
-	PricePerGateway                 *string
-	PricePerBroadcaster             *string
-	BlockPollingInterval            *int
-	Redeemer                        *bool
-	RedeemerAddr                    *string
-	Reward                          *bool
-	Monitor                         *bool
-	MetricsPerStream                *bool
-	MetricsExposeClientIP           *bool
-	MetadataQueueUri                *string
-	MetadataAmqpExchange            *string
-	MetadataPublishTimeout          *time.Duration
-	Datadir                         *string
-	AIModelsDir                     *string
-	Objectstore                     *string
-	Recordstore                     *string
-	FVfailGsBucket                  *string
-	FVfailGsKey                     *string
-	AuthWebhookURL                  *string
-	LiveAIAuthWebhookURL            *string
-	LiveAITrickleHostForRunner      *string
-	OrchWebhookURL                  *string
-	OrchBlacklist                   *string
-	OrchMinLivepeerVersion          *string
-	TestOrchAvail                   *bool
-	AIRunnerImage                   *string
-	AIRunnerImageOverrides          *string
-	AIVerboseLogs                   *bool
-	AIProcessingRetryTimeout        *time.Duration
-	AIRunnerContainersPerGPU        *int
-	AIMinRunnerVersion              *string
-	KafkaBootstrapServers           *string
-	KafkaUsername                   *string
-	KafkaPassword                   *string
-	KafkaGatewayTopic               *string
-	MediaMTXApiPassword             *string
-	LiveAIAuthApiKey                *string
-	LiveAIHeartbeatURL              *string
-	LiveAIHeartbeatHeaders          *string
-	LiveAIHeartbeatInterval         *time.Duration
-	LivePaymentInterval             *time.Duration
-	LiveOutSegmentTimeout           *time.Duration
-	LiveAICapRefreshModels          *string
-	LiveAISaveNSegments             *int
+	Network                    *string
+	RtmpAddr                   *string
+	CliAddr                    *string
+	HttpAddr                   *string
+	ServiceAddr                *string
+	Nodes                      *string
+	OrchAddr                   *string
+	VerifierURL                *string
+	EthController              *string
+	VerifierPath               *string
+	LocalVerify                *bool
+	HttpIngest                 *bool
+	Orchestrator               *bool
+	Transcoder                 *bool
+	AIServiceRegistry          *bool
+	AIWorker                   *bool
+	Gateway                    *bool
+	Broadcaster                *bool
+	OrchSecret                 *string
+	TranscodingOptions         *string
+	AIModels                   *string
+	MaxAttempts                *int
+	SelectRandWeight           *float64
+	SelectStakeWeight          *float64
+	SelectPriceWeight          *float64
+	SelectPriceExpFactor       *float64
+	OrchPerfStatsURL           *string
+	Region                     *string
+	MaxPricePerUnit            *string
+	MaxPricePerCapability      *string
+	IgnoreMaxPriceIfNeeded     *bool
+	MinPerfScore               *float64
+	DiscoveryTimeout           *time.Duration
+	ExtraNodes                 *int
+	MaxSessions                *string
+	CurrentManifest            *bool
+	Nvidia                     *string
+	Netint                     *string
+	HevcDecoding               *bool
+	TestTranscoder             *bool
+	GatewayHost                *string
+	EthAcctAddr                *string
+	EthPassword                *string
+	EthKeystorePath            *string
+	EthOrchAddr                *string
+	EthUrl                     *string
+	TxTimeout                  *time.Duration
+	MaxTxReplacements          *int
+	GasLimit                   *int
+	MinGasPrice                *int64
+	MaxGasPrice                *int
+	InitializeRound            *bool
+	InitializeRoundMaxDelay    *time.Duration
+	TicketEV                   *string
+	MaxFaceValue               *string
+	MaxTicketEV                *string
+	MaxTotalEV                 *string
+	DepositMultiplier          *int
+	IgnoreSenderReserve        *bool
+	PricePerUnit               *string
+	PixelsPerUnit              *string
+	PriceFeedAddr              *string
+	AutoAdjustPrice            *bool
+	PricePerGateway            *string
+	PricePerBroadcaster        *string
+	BlockPollingInterval       *int
+	Redeemer                   *bool
+	RedeemerAddr               *string
+	Reward                     *bool
+	Monitor                    *bool
+	MetricsPerStream           *bool
+	MetricsExposeClientIP      *bool
+	MetadataQueueUri           *string
+	MetadataAmqpExchange       *string
+	MetadataPublishTimeout     *time.Duration
+	Datadir                    *string
+	AIModelsDir                *string
+	Objectstore                *string
+	Recordstore                *string
+	FVfailGsBucket             *string
+	FVfailGsKey                *string
+	AuthWebhookURL             *string
+	LiveAIAuthWebhookURL       *string
+	LiveAITrickleHostForRunner *string
+	OrchWebhookURL             *string
+	OrchBlacklist              *string
+	OrchMinLivepeerVersion     *string
+	TestOrchAvail              *bool
+	AIRunnerImage              *string
+	AIRunnerImageOverrides     *string
+	AIVerboseLogs              *bool
+	AIProcessingRetryTimeout   *time.Duration
+	AIRunnerContainersPerGPU   *int
+	AIMinRunnerVersion         *string
+	KafkaBootstrapServers      *string
+	KafkaUsername              *string
+	KafkaPassword              *string
+	KafkaGatewayTopic          *string
+	MediaMTXApiPassword        *string
+	LiveAIAuthApiKey           *string
+	LiveAIHeartbeatURL         *string
+	LiveAIHeartbeatHeaders     *string
+	LiveAIHeartbeatInterval    *time.Duration
+	LivePaymentInterval        *time.Duration
+	LiveOutSegmentTimeout      *time.Duration
+	LiveAICapRefreshModels     *string
+	LiveAISaveNSegments        *int
 }
 
 // DefaultLivepeerConfig creates LivepeerConfig exactly the same as when no flags are passed to the livepeer process.
@@ -264,7 +264,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultMaxPricePerUnit := "0"
 	defaultMaxPricePerCapability := ""
 	defaultIgnoreMaxPriceIfNeeded := false
-	defaultIgnoreSenderReserveRequirements := false
+	defaultIgnoreSenderReserve := false
 	defaultPixelsPerUnit := "1"
 	defaultPriceFeedAddr := "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612" // ETH / USD price feed address on Arbitrum Mainnet
 	defaultAutoAdjustPrice := true
@@ -363,41 +363,41 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		LiveAIHeartbeatInterval:  &defaultLiveAIHeartbeatInterval,
 
 		// Onchain:
-		EthAcctAddr:                     &defaultEthAcctAddr,
-		EthPassword:                     &defaultEthPassword,
-		EthKeystorePath:                 &defaultEthKeystorePath,
-		EthOrchAddr:                     &defaultEthOrchAddr,
-		EthUrl:                          &defaultEthUrl,
-		TxTimeout:                       &defaultTxTimeout,
-		MaxTxReplacements:               &defaultMaxTxReplacements,
-		GasLimit:                        &defaultGasLimit,
-		MaxGasPrice:                     &defaultMaxGasPrice,
-		EthController:                   &defaultEthController,
-		InitializeRound:                 &defaultInitializeRound,
-		InitializeRoundMaxDelay:         &defaultInitializeRoundMaxDelay,
-		TicketEV:                        &defaultTicketEV,
-		MaxFaceValue:                    &defaultMaxFaceValue,
-		MaxTicketEV:                     &defaultMaxTicketEV,
-		MaxTotalEV:                      &defaultMaxTotalEV,
-		DepositMultiplier:               &defaultDepositMultiplier,
-		IgnoreSenderReserveRequirements: &defaultIgnoreSenderReserveRequirements,
-		MaxPricePerUnit:                 &defaultMaxPricePerUnit,
-		MaxPricePerCapability:           &defaultMaxPricePerCapability,
-		IgnoreMaxPriceIfNeeded:          &defaultIgnoreMaxPriceIfNeeded,
-		PixelsPerUnit:                   &defaultPixelsPerUnit,
-		PriceFeedAddr:                   &defaultPriceFeedAddr,
-		AutoAdjustPrice:                 &defaultAutoAdjustPrice,
-		PricePerGateway:                 &defaultPricePerGateway,
-		PricePerBroadcaster:             &defaultPricePerBroadcaster,
-		BlockPollingInterval:            &defaultBlockPollingInterval,
-		Redeemer:                        &defaultRedeemer,
-		RedeemerAddr:                    &defaultRedeemerAddr,
-		Monitor:                         &defaultMonitor,
-		MetricsPerStream:                &defaultMetricsPerStream,
-		MetricsExposeClientIP:           &defaultMetricsExposeClientIP,
-		MetadataQueueUri:                &defaultMetadataQueueUri,
-		MetadataAmqpExchange:            &defaultMetadataAmqpExchange,
-		MetadataPublishTimeout:          &defaultMetadataPublishTimeout,
+		EthAcctAddr:             &defaultEthAcctAddr,
+		EthPassword:             &defaultEthPassword,
+		EthKeystorePath:         &defaultEthKeystorePath,
+		EthOrchAddr:             &defaultEthOrchAddr,
+		EthUrl:                  &defaultEthUrl,
+		TxTimeout:               &defaultTxTimeout,
+		MaxTxReplacements:       &defaultMaxTxReplacements,
+		GasLimit:                &defaultGasLimit,
+		MaxGasPrice:             &defaultMaxGasPrice,
+		EthController:           &defaultEthController,
+		InitializeRound:         &defaultInitializeRound,
+		InitializeRoundMaxDelay: &defaultInitializeRoundMaxDelay,
+		TicketEV:                &defaultTicketEV,
+		MaxFaceValue:            &defaultMaxFaceValue,
+		MaxTicketEV:             &defaultMaxTicketEV,
+		MaxTotalEV:              &defaultMaxTotalEV,
+		DepositMultiplier:       &defaultDepositMultiplier,
+		IgnoreSenderReserve:     &defaultIgnoreSenderReserve,
+		MaxPricePerUnit:         &defaultMaxPricePerUnit,
+		MaxPricePerCapability:   &defaultMaxPricePerCapability,
+		IgnoreMaxPriceIfNeeded:  &defaultIgnoreMaxPriceIfNeeded,
+		PixelsPerUnit:           &defaultPixelsPerUnit,
+		PriceFeedAddr:           &defaultPriceFeedAddr,
+		AutoAdjustPrice:         &defaultAutoAdjustPrice,
+		PricePerGateway:         &defaultPricePerGateway,
+		PricePerBroadcaster:     &defaultPricePerBroadcaster,
+		BlockPollingInterval:    &defaultBlockPollingInterval,
+		Redeemer:                &defaultRedeemer,
+		RedeemerAddr:            &defaultRedeemerAddr,
+		Monitor:                 &defaultMonitor,
+		MetricsPerStream:        &defaultMetricsPerStream,
+		MetricsExposeClientIP:   &defaultMetricsExposeClientIP,
+		MetadataQueueUri:        &defaultMetadataQueueUri,
+		MetadataAmqpExchange:    &defaultMetadataAmqpExchange,
+		MetadataPublishTimeout:  &defaultMetadataPublishTimeout,
 
 		// Ingest:
 		HttpIngest: &defaultHttpIngest,
@@ -1018,10 +1018,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			defer sm.Stop()
 
 			tcfg := pm.TicketParamsConfig{
-				EV:                              ev,
-				RedeemGas:                       redeemGas,
-				TxCostMultiplier:                txCostMultiplier,
-				IgnoreSenderReserveRequirements: *cfg.IgnoreSenderReserveRequirements,
+				EV:                  ev,
+				RedeemGas:           redeemGas,
+				TxCostMultiplier:    txCostMultiplier,
+				IgnoreSenderReserve: *cfg.IgnoreSenderReserve,
 			}
 			n.Recipient, err = pm.NewRecipient(
 				recipientAddr,
@@ -1036,7 +1036,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				glog.Errorf("Error setting up PM recipient: %v", err)
 				return
 			}
-			if *cfg.IgnoreSenderReserveRequirements {
+			if *cfg.IgnoreSenderReserve {
 				glog.Warning("Sender reserve requirements disabled; relying on broadcaster deposit to cover ticket face value. Double-spend protection is reduced.")
 			}
 			mfv, _ := new(big.Int).SetString(*cfg.MaxFaceValue, 10)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -80,112 +80,113 @@ const (
 )
 
 type LivepeerConfig struct {
-	Network                    *string
-	RtmpAddr                   *string
-	CliAddr                    *string
-	HttpAddr                   *string
-	ServiceAddr                *string
-	Nodes                      *string
-	OrchAddr                   *string
-	VerifierURL                *string
-	EthController              *string
-	VerifierPath               *string
-	LocalVerify                *bool
-	HttpIngest                 *bool
-	Orchestrator               *bool
-	Transcoder                 *bool
-	AIServiceRegistry          *bool
-	AIWorker                   *bool
-	Gateway                    *bool
-	Broadcaster                *bool
-	OrchSecret                 *string
-	TranscodingOptions         *string
-	AIModels                   *string
-	MaxAttempts                *int
-	SelectRandWeight           *float64
-	SelectStakeWeight          *float64
-	SelectPriceWeight          *float64
-	SelectPriceExpFactor       *float64
-	OrchPerfStatsURL           *string
-	Region                     *string
-	MaxPricePerUnit            *string
-	MaxPricePerCapability      *string
-	IgnoreMaxPriceIfNeeded     *bool
-	MinPerfScore               *float64
-	DiscoveryTimeout           *time.Duration
-	ExtraNodes                 *int
-	MaxSessions                *string
-	CurrentManifest            *bool
-	Nvidia                     *string
-	Netint                     *string
-	HevcDecoding               *bool
-	TestTranscoder             *bool
-	GatewayHost                *string
-	EthAcctAddr                *string
-	EthPassword                *string
-	EthKeystorePath            *string
-	EthOrchAddr                *string
-	EthUrl                     *string
-	TxTimeout                  *time.Duration
-	MaxTxReplacements          *int
-	GasLimit                   *int
-	MinGasPrice                *int64
-	MaxGasPrice                *int
-	InitializeRound            *bool
-	InitializeRoundMaxDelay    *time.Duration
-	TicketEV                   *string
-	MaxFaceValue               *string
-	MaxTicketEV                *string
-	MaxTotalEV                 *string
-	DepositMultiplier          *int
-	PricePerUnit               *string
-	PixelsPerUnit              *string
-	PriceFeedAddr              *string
-	AutoAdjustPrice            *bool
-	PricePerGateway            *string
-	PricePerBroadcaster        *string
-	BlockPollingInterval       *int
-	Redeemer                   *bool
-	RedeemerAddr               *string
-	Reward                     *bool
-	Monitor                    *bool
-	MetricsPerStream           *bool
-	MetricsExposeClientIP      *bool
-	MetadataQueueUri           *string
-	MetadataAmqpExchange       *string
-	MetadataPublishTimeout     *time.Duration
-	Datadir                    *string
-	AIModelsDir                *string
-	Objectstore                *string
-	Recordstore                *string
-	FVfailGsBucket             *string
-	FVfailGsKey                *string
-	AuthWebhookURL             *string
-	LiveAIAuthWebhookURL       *string
-	LiveAITrickleHostForRunner *string
-	OrchWebhookURL             *string
-	OrchBlacklist              *string
-	OrchMinLivepeerVersion     *string
-	TestOrchAvail              *bool
-	AIRunnerImage              *string
-	AIRunnerImageOverrides     *string
-	AIVerboseLogs              *bool
-	AIProcessingRetryTimeout   *time.Duration
-	AIRunnerContainersPerGPU   *int
-	AIMinRunnerVersion         *string
-	KafkaBootstrapServers      *string
-	KafkaUsername              *string
-	KafkaPassword              *string
-	KafkaGatewayTopic          *string
-	MediaMTXApiPassword        *string
-	LiveAIAuthApiKey           *string
-	LiveAIHeartbeatURL         *string
-	LiveAIHeartbeatHeaders     *string
-	LiveAIHeartbeatInterval    *time.Duration
-	LivePaymentInterval        *time.Duration
-	LiveOutSegmentTimeout      *time.Duration
-	LiveAICapRefreshModels     *string
-	LiveAISaveNSegments        *int
+	Network                         *string
+	RtmpAddr                        *string
+	CliAddr                         *string
+	HttpAddr                        *string
+	ServiceAddr                     *string
+	Nodes                           *string
+	OrchAddr                        *string
+	VerifierURL                     *string
+	EthController                   *string
+	VerifierPath                    *string
+	LocalVerify                     *bool
+	HttpIngest                      *bool
+	Orchestrator                    *bool
+	Transcoder                      *bool
+	AIServiceRegistry               *bool
+	AIWorker                        *bool
+	Gateway                         *bool
+	Broadcaster                     *bool
+	OrchSecret                      *string
+	TranscodingOptions              *string
+	AIModels                        *string
+	MaxAttempts                     *int
+	SelectRandWeight                *float64
+	SelectStakeWeight               *float64
+	SelectPriceWeight               *float64
+	SelectPriceExpFactor            *float64
+	OrchPerfStatsURL                *string
+	Region                          *string
+	MaxPricePerUnit                 *string
+	MaxPricePerCapability           *string
+	IgnoreMaxPriceIfNeeded          *bool
+	MinPerfScore                    *float64
+	DiscoveryTimeout                *time.Duration
+	ExtraNodes                      *int
+	MaxSessions                     *string
+	CurrentManifest                 *bool
+	Nvidia                          *string
+	Netint                          *string
+	HevcDecoding                    *bool
+	TestTranscoder                  *bool
+	GatewayHost                     *string
+	EthAcctAddr                     *string
+	EthPassword                     *string
+	EthKeystorePath                 *string
+	EthOrchAddr                     *string
+	EthUrl                          *string
+	TxTimeout                       *time.Duration
+	MaxTxReplacements               *int
+	GasLimit                        *int
+	MinGasPrice                     *int64
+	MaxGasPrice                     *int
+	InitializeRound                 *bool
+	InitializeRoundMaxDelay         *time.Duration
+	TicketEV                        *string
+	MaxFaceValue                    *string
+	MaxTicketEV                     *string
+	MaxTotalEV                      *string
+	DepositMultiplier               *int
+	IgnoreSenderReserveRequirements *bool
+	PricePerUnit                    *string
+	PixelsPerUnit                   *string
+	PriceFeedAddr                   *string
+	AutoAdjustPrice                 *bool
+	PricePerGateway                 *string
+	PricePerBroadcaster             *string
+	BlockPollingInterval            *int
+	Redeemer                        *bool
+	RedeemerAddr                    *string
+	Reward                          *bool
+	Monitor                         *bool
+	MetricsPerStream                *bool
+	MetricsExposeClientIP           *bool
+	MetadataQueueUri                *string
+	MetadataAmqpExchange            *string
+	MetadataPublishTimeout          *time.Duration
+	Datadir                         *string
+	AIModelsDir                     *string
+	Objectstore                     *string
+	Recordstore                     *string
+	FVfailGsBucket                  *string
+	FVfailGsKey                     *string
+	AuthWebhookURL                  *string
+	LiveAIAuthWebhookURL            *string
+	LiveAITrickleHostForRunner      *string
+	OrchWebhookURL                  *string
+	OrchBlacklist                   *string
+	OrchMinLivepeerVersion          *string
+	TestOrchAvail                   *bool
+	AIRunnerImage                   *string
+	AIRunnerImageOverrides          *string
+	AIVerboseLogs                   *bool
+	AIProcessingRetryTimeout        *time.Duration
+	AIRunnerContainersPerGPU        *int
+	AIMinRunnerVersion              *string
+	KafkaBootstrapServers           *string
+	KafkaUsername                   *string
+	KafkaPassword                   *string
+	KafkaGatewayTopic               *string
+	MediaMTXApiPassword             *string
+	LiveAIAuthApiKey                *string
+	LiveAIHeartbeatURL              *string
+	LiveAIHeartbeatHeaders          *string
+	LiveAIHeartbeatInterval         *time.Duration
+	LivePaymentInterval             *time.Duration
+	LiveOutSegmentTimeout           *time.Duration
+	LiveAICapRefreshModels          *string
+	LiveAISaveNSegments             *int
 }
 
 // DefaultLivepeerConfig creates LivepeerConfig exactly the same as when no flags are passed to the livepeer process.
@@ -263,6 +264,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultMaxPricePerUnit := "0"
 	defaultMaxPricePerCapability := ""
 	defaultIgnoreMaxPriceIfNeeded := false
+	defaultIgnoreSenderReserveRequirements := false
 	defaultPixelsPerUnit := "1"
 	defaultPriceFeedAddr := "0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612" // ETH / USD price feed address on Arbitrum Mainnet
 	defaultAutoAdjustPrice := true
@@ -361,40 +363,41 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		LiveAIHeartbeatInterval:  &defaultLiveAIHeartbeatInterval,
 
 		// Onchain:
-		EthAcctAddr:             &defaultEthAcctAddr,
-		EthPassword:             &defaultEthPassword,
-		EthKeystorePath:         &defaultEthKeystorePath,
-		EthOrchAddr:             &defaultEthOrchAddr,
-		EthUrl:                  &defaultEthUrl,
-		TxTimeout:               &defaultTxTimeout,
-		MaxTxReplacements:       &defaultMaxTxReplacements,
-		GasLimit:                &defaultGasLimit,
-		MaxGasPrice:             &defaultMaxGasPrice,
-		EthController:           &defaultEthController,
-		InitializeRound:         &defaultInitializeRound,
-		InitializeRoundMaxDelay: &defaultInitializeRoundMaxDelay,
-		TicketEV:                &defaultTicketEV,
-		MaxFaceValue:            &defaultMaxFaceValue,
-		MaxTicketEV:             &defaultMaxTicketEV,
-		MaxTotalEV:              &defaultMaxTotalEV,
-		DepositMultiplier:       &defaultDepositMultiplier,
-		MaxPricePerUnit:         &defaultMaxPricePerUnit,
-		MaxPricePerCapability:   &defaultMaxPricePerCapability,
-		IgnoreMaxPriceIfNeeded:  &defaultIgnoreMaxPriceIfNeeded,
-		PixelsPerUnit:           &defaultPixelsPerUnit,
-		PriceFeedAddr:           &defaultPriceFeedAddr,
-		AutoAdjustPrice:         &defaultAutoAdjustPrice,
-		PricePerGateway:         &defaultPricePerGateway,
-		PricePerBroadcaster:     &defaultPricePerBroadcaster,
-		BlockPollingInterval:    &defaultBlockPollingInterval,
-		Redeemer:                &defaultRedeemer,
-		RedeemerAddr:            &defaultRedeemerAddr,
-		Monitor:                 &defaultMonitor,
-		MetricsPerStream:        &defaultMetricsPerStream,
-		MetricsExposeClientIP:   &defaultMetricsExposeClientIP,
-		MetadataQueueUri:        &defaultMetadataQueueUri,
-		MetadataAmqpExchange:    &defaultMetadataAmqpExchange,
-		MetadataPublishTimeout:  &defaultMetadataPublishTimeout,
+		EthAcctAddr:                     &defaultEthAcctAddr,
+		EthPassword:                     &defaultEthPassword,
+		EthKeystorePath:                 &defaultEthKeystorePath,
+		EthOrchAddr:                     &defaultEthOrchAddr,
+		EthUrl:                          &defaultEthUrl,
+		TxTimeout:                       &defaultTxTimeout,
+		MaxTxReplacements:               &defaultMaxTxReplacements,
+		GasLimit:                        &defaultGasLimit,
+		MaxGasPrice:                     &defaultMaxGasPrice,
+		EthController:                   &defaultEthController,
+		InitializeRound:                 &defaultInitializeRound,
+		InitializeRoundMaxDelay:         &defaultInitializeRoundMaxDelay,
+		TicketEV:                        &defaultTicketEV,
+		MaxFaceValue:                    &defaultMaxFaceValue,
+		MaxTicketEV:                     &defaultMaxTicketEV,
+		MaxTotalEV:                      &defaultMaxTotalEV,
+		DepositMultiplier:               &defaultDepositMultiplier,
+		IgnoreSenderReserveRequirements: &defaultIgnoreSenderReserveRequirements,
+		MaxPricePerUnit:                 &defaultMaxPricePerUnit,
+		MaxPricePerCapability:           &defaultMaxPricePerCapability,
+		IgnoreMaxPriceIfNeeded:          &defaultIgnoreMaxPriceIfNeeded,
+		PixelsPerUnit:                   &defaultPixelsPerUnit,
+		PriceFeedAddr:                   &defaultPriceFeedAddr,
+		AutoAdjustPrice:                 &defaultAutoAdjustPrice,
+		PricePerGateway:                 &defaultPricePerGateway,
+		PricePerBroadcaster:             &defaultPricePerBroadcaster,
+		BlockPollingInterval:            &defaultBlockPollingInterval,
+		Redeemer:                        &defaultRedeemer,
+		RedeemerAddr:                    &defaultRedeemerAddr,
+		Monitor:                         &defaultMonitor,
+		MetricsPerStream:                &defaultMetricsPerStream,
+		MetricsExposeClientIP:           &defaultMetricsExposeClientIP,
+		MetadataQueueUri:                &defaultMetadataQueueUri,
+		MetadataAmqpExchange:            &defaultMetadataAmqpExchange,
+		MetadataPublishTimeout:          &defaultMetadataPublishTimeout,
 
 		// Ingest:
 		HttpIngest: &defaultHttpIngest,
@@ -1015,9 +1018,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			defer sm.Stop()
 
 			tcfg := pm.TicketParamsConfig{
-				EV:               ev,
-				RedeemGas:        redeemGas,
-				TxCostMultiplier: txCostMultiplier,
+				EV:                              ev,
+				RedeemGas:                       redeemGas,
+				TxCostMultiplier:                txCostMultiplier,
+				IgnoreSenderReserveRequirements: *cfg.IgnoreSenderReserveRequirements,
 			}
 			n.Recipient, err = pm.NewRecipient(
 				recipientAddr,
@@ -1031,6 +1035,9 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			if err != nil {
 				glog.Errorf("Error setting up PM recipient: %v", err)
 				return
+			}
+			if *cfg.IgnoreSenderReserveRequirements {
+				glog.Warning("Sender reserve requirements disabled; relying on broadcaster deposit to cover ticket face value. Double-spend protection is reduced.")
 			}
 			mfv, _ := new(big.Int).SetString(*cfg.MaxFaceValue, 10)
 			if mfv == nil {

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -289,11 +289,11 @@ func (r *recipient) faceValue(sender ethcommon.Address) (*big.Int, error) {
 			faceValue = maxFloat
 		}
 	} else {
-		deposit, err := r.sm.SenderDeposit(sender)
+		available, err := r.sm.SenderFunds(sender)
 		if err != nil {
 			return nil, err
 		}
-		if deposit.Cmp(faceValue) < 0 {
+		if available.Cmp(faceValue) < 0 {
 			return nil, errInsufficientSenderReserve
 		}
 	}
@@ -305,7 +305,7 @@ func (r *recipient) faceValue(sender ethcommon.Address) (*big.Int, error) {
 	}
 	if monitor.Enabled {
 		monitor.TicketFaceValue(sender.Hex(), faceValue)
-		if maxFloat != nil {
+		if !r.cfg.IgnoreSenderReserve && maxFloat != nil {
 			monitor.MaxFloat(sender.Hex(), maxFloat)
 		}
 	}

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -70,8 +70,8 @@ type TicketParamsConfig struct {
 	// cost for redemption
 	TxCostMultiplier int
 
-	// IgnoreSenderReserveRequirements instructs the recipient to skip sender reserve checks and accept tickets as long as the computed face value meets EV requirements
-	IgnoreSenderReserveRequirements bool
+	// IgnoreSenderReserve instructs the recipient to skip sender reserve checks and accept tickets as long as the computed face value meets EV requirements
+	IgnoreSenderReserve bool
 }
 
 // GasPriceMonitor defines methods for monitoring gas prices
@@ -275,7 +275,7 @@ func (r *recipient) faceValue(sender ethcommon.Address) (*big.Int, error) {
 	}
 
 	var maxFloat *big.Int
-	if !r.cfg.IgnoreSenderReserveRequirements {
+	if !r.cfg.IgnoreSenderReserve {
 		// Fetch current max float for sender
 		var err error
 		maxFloat, err = r.sm.MaxFloat(sender)

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -530,6 +530,21 @@ func TestTicketParams(t *testing.T) {
 	_, err = r.TicketParams(sender, big.NewRat(1, 1))
 	assert.EqualError(err, errInsufficientSenderReserve.Error())
 
+	// Test ignoring sender reserve requirements bypasses maxFloat enforcement
+	cfg.IgnoreSenderReserveRequirements = true
+	sm.maxFloat = big.NewInt(100)
+	sm.deposit = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
+	rIgnore := NewRecipientWithSecret(recipient, b, v, gm, sm, tm, secret, cfg)
+	paramsIgnore, err := rIgnore.TicketParams(sender, big.NewRat(1, 1))
+	require.Nil(err)
+	assert.True(paramsIgnore.FaceValue.Cmp(sm.maxFloat) > 0)
+
+	// Test ignoring sender reserve requirements errors if deposit < faceValue
+	sm.deposit = new(big.Int).Sub(paramsIgnore.FaceValue, big.NewInt(1))
+	_, err = rIgnore.TicketParams(sender, big.NewRat(1, 1))
+	assert.EqualError(err, errInsufficientSenderReserve.Error())
+	cfg.IgnoreSenderReserveRequirements = false
+
 	// Test faceValue < txCostWithGasPrice(current gasPrice) and faceValue > txCostWithGasPrice(avg gasPrice)
 	// Set current gasPrice higher than avg gasPrice
 	gm.gasPrice = new(big.Int).Add(avgGasPrice, big.NewInt(1))

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -531,7 +531,7 @@ func TestTicketParams(t *testing.T) {
 	assert.EqualError(err, errInsufficientSenderReserve.Error())
 
 	// Test ignoring sender reserve requirements bypasses maxFloat enforcement
-	cfg.IgnoreSenderReserveRequirements = true
+	cfg.IgnoreSenderReserve = true
 	sm.maxFloat = big.NewInt(100)
 	sm.deposit = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
 	rIgnore := NewRecipientWithSecret(recipient, b, v, gm, sm, tm, secret, cfg)
@@ -543,7 +543,7 @@ func TestTicketParams(t *testing.T) {
 	sm.deposit = new(big.Int).Sub(paramsIgnore.FaceValue, big.NewInt(1))
 	_, err = rIgnore.TicketParams(sender, big.NewRat(1, 1))
 	assert.EqualError(err, errInsufficientSenderReserve.Error())
-	cfg.IgnoreSenderReserveRequirements = false
+	cfg.IgnoreSenderReserve = false
 
 	// Test faceValue < txCostWithGasPrice(current gasPrice) and faceValue > txCostWithGasPrice(avg gasPrice)
 	// Set current gasPrice higher than avg gasPrice

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -388,12 +388,14 @@ type stubSenderMonitor struct {
 	maxFloatErr       error
 	validateSenderErr error
 	shouldFail        error
+	deposit           *big.Int
 }
 
 func newStubSenderMonitor() *stubSenderMonitor {
 	return &stubSenderMonitor{
 		maxFloat:   big.NewInt(0),
 		redeemable: make(chan *redemption),
+		deposit:    big.NewInt(0),
 	}
 }
 
@@ -431,6 +433,10 @@ func (s *stubSenderMonitor) MaxFloat(_ ethcommon.Address) (*big.Int, error) {
 	}
 
 	return s.maxFloat, nil
+}
+
+func (s *stubSenderMonitor) SenderDeposit(_ ethcommon.Address) (*big.Int, error) {
+	return s.deposit, nil
 }
 
 func (s *stubSenderMonitor) ValidateSender(_ ethcommon.Address) error { return s.validateSenderErr }

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -381,6 +381,7 @@ func (s *stubGasPriceMonitor) GasPrice() *big.Int {
 
 type stubSenderMonitor struct {
 	maxFloat          *big.Int
+	funds             *big.Int
 	redeemable        chan *redemption
 	queued            []*SignedTicket
 	acceptable        bool
@@ -435,7 +436,10 @@ func (s *stubSenderMonitor) MaxFloat(_ ethcommon.Address) (*big.Int, error) {
 	return s.maxFloat, nil
 }
 
-func (s *stubSenderMonitor) SenderDeposit(_ ethcommon.Address) (*big.Int, error) {
+func (s *stubSenderMonitor) SenderFunds(_ ethcommon.Address) (*big.Int, error) {
+	if s.funds != nil {
+		return new(big.Int).Set(s.funds), nil
+	}
 	return s.deposit, nil
 }
 

--- a/server/redeemer.go
+++ b/server/redeemer.go
@@ -272,6 +272,18 @@ func (r *RedeemerClient) MaxFloat(sender ethcommon.Address) (*big.Int, error) {
 	return mf, nil
 }
 
+// SenderDeposit retrieves the sender's deposit directly from the local sender manager cache
+func (r *RedeemerClient) SenderDeposit(sender ethcommon.Address) (*big.Int, error) {
+	info, err := r.sm.GetSenderInfo(sender)
+	if err != nil {
+		return nil, err
+	}
+	if info.Deposit == nil {
+		return big.NewInt(0), nil
+	}
+	return new(big.Int).Set(info.Deposit), nil
+}
+
 // ValidateSender checks whether a sender has not recently unlocked its deposit and reserve
 func (r *RedeemerClient) ValidateSender(sender ethcommon.Address) error {
 	info, err := r.sm.GetSenderInfo(sender)

--- a/server/redeemer.go
+++ b/server/redeemer.go
@@ -272,16 +272,27 @@ func (r *RedeemerClient) MaxFloat(sender ethcommon.Address) (*big.Int, error) {
 	return mf, nil
 }
 
-// SenderDeposit retrieves the sender's deposit directly from the local sender manager cache
-func (r *RedeemerClient) SenderDeposit(sender ethcommon.Address) (*big.Int, error) {
+// SenderFunds retrieves the sender's spendable balance directly from the local sender manager cache
+func (r *RedeemerClient) SenderFunds(sender ethcommon.Address) (*big.Int, error) {
 	info, err := r.sm.GetSenderInfo(sender)
 	if err != nil {
 		return nil, err
 	}
-	if info.Deposit == nil {
-		return big.NewInt(0), nil
+
+	totalReserve := new(big.Int).Set(info.Reserve.FundsRemaining)
+	if info.Reserve.ClaimedInCurrentRound != nil {
+		totalReserve.Add(totalReserve, info.Reserve.ClaimedInCurrentRound)
 	}
-	return new(big.Int).Set(info.Deposit), nil
+
+	available := new(big.Int).Set(totalReserve)
+	if info.Deposit != nil {
+		available.Add(available, info.Deposit)
+	}
+
+	if available.Sign() < 0 {
+		available = big.NewInt(0)
+	}
+	return available, nil
 }
 
 // ValidateSender checks whether a sender has not recently unlocked its deposit and reserve


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Adds a parameter which, instead of doing the full check to prevent double spending (split reserve + deposit across orch pool + subtract pending tickets), does a simple check: does the current deposit cover the ticket payout?

**Specific updates (required)**
- Added new param
- Added new function to the SenderMonitor (and it's Redeemer equivalent) to retrieve only the (cached) deposit
- Modified reserve checks to use the new or old approach
- Added simple test cases

**How did you test each of these updates (required)**
Not tested yet.


**Does this pull request close any open issues?**
Related to #3746 and #3744, but a PR with the proper fix (monitor avg gas price) will also be put up as a proper solution.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
