### PR TITLE
Monitor avg gas price

### DIFF
--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -25,7 +25,7 @@ func newRecipientFixtureOrFatal(_ *testing.T) (ethcommon.Address, *stubBroker, *
 	v := &stubValidator{}
 	v.SetIsValidTicket(true)
 
-	gm := &stubGasPriceMonitor{gasPrice: big.NewInt(100)}
+	gm := &stubGasPriceMonitor{gasPrice: big.NewInt(100), avgPrice: big.NewInt(100)}
 	sm := newStubSenderMonitor()
 	sm.maxFloat = big.NewInt(10000000000)
 	tm := &stubTimeManager{lastSeenBlock: big.NewInt(1), round: big.NewInt(1), blkHash: RandHash(), preBlkHash: RandHash()}
@@ -532,9 +532,11 @@ func TestTicketParams(t *testing.T) {
 
 	// Test faceValue < txCostWithGasPrice(current gasPrice) and faceValue > txCostWithGasPrice(avg gasPrice)
 	// Set current gasPrice higher than avg gasPrice
+	avgGasPrice := big.NewInt(200)
+	gm.avgPrice = new(big.Int).Set(avgGasPrice)
 	gm.gasPrice = new(big.Int).Add(avgGasPrice, big.NewInt(1))
 	txCost := new(big.Int).Mul(big.NewInt(int64(cfg.RedeemGas)), gm.gasPrice)
-	txCostAvgGasPrice := new(big.Int).Mul(big.NewInt(int64(cfg.RedeemGas)), avgGasPrice)
+	txCostAvgGasPrice := new(big.Int).Mul(big.NewInt(int64(cfg.RedeemGas)), gm.avgPrice)
 	sm.maxFloat = new(big.Int).Sub(txCost, big.NewInt(1))
 	require.True(sm.maxFloat.Cmp(txCost) < 0)
 	require.True(sm.maxFloat.Cmp(txCostAvgGasPrice) > 0)

--- a/pm/stub.go
+++ b/pm/stub.go
@@ -373,10 +373,18 @@ func (s *stubSenderManager) SubscribeReserveChange(sink chan<- ethcommon.Address
 
 type stubGasPriceMonitor struct {
 	gasPrice *big.Int
+	avgPrice *big.Int
 }
 
 func (s *stubGasPriceMonitor) GasPrice() *big.Int {
 	return s.gasPrice
+}
+
+func (s *stubGasPriceMonitor) AvgGasPrice() *big.Int {
+	if s.avgPrice == nil {
+		return nil
+	}
+	return new(big.Int).Set(s.avgPrice)
 }
 
 type stubSenderMonitor struct {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Removes the hardcoded avg gas price, rather track an actual moving average in the GasPriceMonitor

**Specific updates (required)**
- Remove hardcoded default
- Calculate moving average over gas price samples to expose an average gas price
- Pass actual avg gas price in FaceValue function

**How did you test each of these updates (required)**
Not yet

**Does this pull request close any open issues?**
Related to #3746 and #3744

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
