### PR TITLE
worker/docker: Implement creator ID label to support O node-sharing

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -110,11 +110,11 @@ func NewDefaultDockerClient() (DockerClient, error) {
 }
 
 type DockerManager struct {
-	gpus        []string
-	modelDir    string
-	overrides   ImageOverrides
-	verboseLogs bool
-	containerCreatorID  string
+	gpus               []string
+	modelDir           string
+	overrides          ImageOverrides
+	verboseLogs        bool
+	containerCreatorID string
 
 	dockerClient DockerClient
 	// gpu ID => container
@@ -141,15 +141,15 @@ func NewDockerManager(overrides ImageOverrides, verboseLogs bool, gpus []string,
 	cancel()
 
 	manager := &DockerManager{
-		gpus:          gpus,
-		modelDir:      modelDir,
-		overrides:     overrides,
-		verboseLogs:   verboseLogs,
-		dockerClient:  client,
-		containerCreatorID:    containerCreatorID,
-		gpuContainers: make(map[string]*RunnerContainer),
-		containers:    make(map[string]*RunnerContainer),
-		mu:            &sync.Mutex{},
+		gpus:               gpus,
+		modelDir:           modelDir,
+		overrides:          overrides,
+		verboseLogs:        verboseLogs,
+		dockerClient:       client,
+		containerCreatorID: containerCreatorID,
+		gpuContainers:      make(map[string]*RunnerContainer),
+		containers:         make(map[string]*RunnerContainer),
+		mu:                 &sync.Mutex{},
 	}
 
 	return manager, nil
@@ -701,10 +701,10 @@ func RemoveExistingContainers(ctx context.Context, client DockerClient, containe
 		}
 	}
 
-    filters := filters.NewArgs(filters.Arg("label", containerCreatorLabel+"="+containerCreator))
-    if containerCreatorID != "" {
-        filters.Add("label", containerCreatorIDLabel+"="+containerCreatorID)
-    }
+	filters := filters.NewArgs(filters.Arg("label", containerCreatorLabel+"="+containerCreator))
+	if containerCreatorID != "" {
+		filters.Add("label", containerCreatorIDLabel+"="+containerCreatorID)
+	}
 	containers, err := client.ContainerList(ctx, container.ListOptions{All: true, Filters: filters})
 	if err != nil {
 		return 0, fmt.Errorf("failed to list containers: %w", err)

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -96,14 +96,14 @@ func NewMockServer() *MockServer {
 // createDockerManager creates a DockerManager with a mock DockerClient.
 func createDockerManager(mockDockerClient *MockDockerClient) *DockerManager {
 	return &DockerManager{
-		gpus:          []string{"gpu0"},
-		modelDir:      "/models",
-		overrides:     ImageOverrides{Default: "default-image"},
-		dockerClient:  mockDockerClient,
-        containerCreatorID:    "instance-1",
-		gpuContainers: make(map[string]*RunnerContainer),
-		containers:    make(map[string]*RunnerContainer),
-		mu:            &sync.Mutex{},
+		gpus:               []string{"gpu0"},
+		modelDir:           "/models",
+		overrides:          ImageOverrides{Default: "default-image"},
+		dockerClient:       mockDockerClient,
+		containerCreatorID: "instance-1",
+		gpuContainers:      make(map[string]*RunnerContainer),
+		containers:         make(map[string]*RunnerContainer),
+		mu:                 &sync.Mutex{},
 	}
 }
 
@@ -111,7 +111,7 @@ func TestNewDockerManager(t *testing.T) {
 	mockDockerClient := new(MockDockerClient)
 
 	createAndVerifyManager := func() *DockerManager {
-        manager, err := NewDockerManager(ImageOverrides{Default: "default-image"}, false, []string{"gpu0"}, "/models", mockDockerClient, "instance-1")
+		manager, err := NewDockerManager(ImageOverrides{Default: "default-image"}, false, []string{"gpu0"}, "/models", mockDockerClient, "instance-1")
 		require.NoError(t, err)
 		require.NotNil(t, manager)
 		require.Equal(t, "default-image", manager.overrides.Default)
@@ -135,7 +135,7 @@ func TestNewDockerManager(t *testing.T) {
 			{ID: "container1", Names: []string{"/container1"}},
 			{ID: "container2", Names: []string{"/container2"}},
 		}
-    mockDockerClient.On("ContainerList", mock.Anything, mock.Anything).Return(existingContainers, nil)
+		mockDockerClient.On("ContainerList", mock.Anything, mock.Anything).Return(existingContainers, nil)
 		mockDockerClient.On("ContainerStop", mock.Anything, "container1", mock.Anything).Return(nil)
 		mockDockerClient.On("ContainerStop", mock.Anything, "container2", mock.Anything).Return(nil)
 		mockDockerClient.On("ContainerRemove", mock.Anything, "container1", mock.Anything).Return(nil)
@@ -988,56 +988,56 @@ func TestRemoveExistingContainers(t *testing.T) {
 	ctx := context.Background()
 
 	// Mock client methods to simulate the removal of existing containers.
-    existingContainers := []types.Container{
-        {ID: "container1", Names: []string{"/container1"}},
-        {ID: "container2", Names: []string{"/container2"}},
-    }
-    mockDockerClient.On("ContainerList", mock.Anything, mock.Anything).Return(existingContainers, nil)
-    mockDockerClient.On("ContainerStop", mock.Anything, "container1", mock.Anything).Return(nil)
-    mockDockerClient.On("ContainerStop", mock.Anything, "container2", mock.Anything).Return(nil)
-    mockDockerClient.On("ContainerRemove", mock.Anything, "container1", mock.Anything).Return(nil)
-    mockDockerClient.On("ContainerRemove", mock.Anything, "container2", mock.Anything).Return(nil)
+	existingContainers := []types.Container{
+		{ID: "container1", Names: []string{"/container1"}},
+		{ID: "container2", Names: []string{"/container2"}},
+	}
+	mockDockerClient.On("ContainerList", mock.Anything, mock.Anything).Return(existingContainers, nil)
+	mockDockerClient.On("ContainerStop", mock.Anything, "container1", mock.Anything).Return(nil)
+	mockDockerClient.On("ContainerStop", mock.Anything, "container2", mock.Anything).Return(nil)
+	mockDockerClient.On("ContainerRemove", mock.Anything, "container1", mock.Anything).Return(nil)
+	mockDockerClient.On("ContainerRemove", mock.Anything, "container2", mock.Anything).Return(nil)
 
-    RemoveExistingContainers(ctx, mockDockerClient, "instance-1")
-    mockDockerClient.AssertExpectations(t)
+	RemoveExistingContainers(ctx, mockDockerClient, "instance-1")
+	mockDockerClient.AssertExpectations(t)
 }
 
 func TestRemoveExistingContainers_FiltersByContainerOwnerID(t *testing.T) {
-    mockDockerClient := new(MockDockerClient)
+	mockDockerClient := new(MockDockerClient)
 
-    ctx := context.Background()
+	ctx := context.Background()
 
-    // Simulate Docker filtering by ensuring the call contains both labels and only returning our container
-    mockDockerClient.
-        On("ContainerList", mock.Anything, mock.MatchedBy(func(opts container.ListOptions) bool {
-            if !opts.All {
-                return false
-            }
-            labels := opts.Filters.Get("label")
-            hasCreator := false
-            hasOwner := false
-            for _, l := range labels {
-                if l == containerCreatorLabel+"="+containerCreator {
-                    hasCreator = true
-                }
-                if l == containerCreatorIDLabel+"="+"owner-A" {
-                    hasOwner = true
-                }
-            }
-            return hasCreator && hasOwner
-        })).
-        Return([]types.Container{{ID: "mine-1", Names: []string{"/mine-1"}}}, nil).
-        Once()
-    mockDockerClient.On("ContainerStop", mock.Anything, "mine-1", mock.Anything).Return(nil).Once()
-    mockDockerClient.On("ContainerRemove", mock.Anything, "mine-1", mock.Anything).Return(nil).Once()
+	// Simulate Docker filtering by ensuring the call contains both labels and only returning our container
+	mockDockerClient.
+		On("ContainerList", mock.Anything, mock.MatchedBy(func(opts container.ListOptions) bool {
+			if !opts.All {
+				return false
+			}
+			labels := opts.Filters.Get("label")
+			hasCreator := false
+			hasOwner := false
+			for _, l := range labels {
+				if l == containerCreatorLabel+"="+containerCreator {
+					hasCreator = true
+				}
+				if l == containerCreatorIDLabel+"="+"owner-A" {
+					hasOwner = true
+				}
+			}
+			return hasCreator && hasOwner
+		})).
+		Return([]types.Container{{ID: "mine-1", Names: []string{"/mine-1"}}}, nil).
+		Once()
+	mockDockerClient.On("ContainerStop", mock.Anything, "mine-1", mock.Anything).Return(nil).Once()
+	mockDockerClient.On("ContainerRemove", mock.Anything, "mine-1", mock.Anything).Return(nil).Once()
 
-    removed, err := RemoveExistingContainers(ctx, mockDockerClient, "owner-A")
-    require.NoError(t, err)
-    // We cannot verify the server-side filter here (Docker handles it); we verify we only attempted
-    // to remove a single container, the one we consider ours from this test's perspective.
-    require.Equal(t, 1, removed)
+	removed, err := RemoveExistingContainers(ctx, mockDockerClient, "owner-A")
+	require.NoError(t, err)
+	// We cannot verify the server-side filter here (Docker handles it); we verify we only attempted
+	// to remove a single container, the one we consider ours from this test's perspective.
+	require.Equal(t, 1, removed)
 
-    mockDockerClient.AssertExpectations(t)
+	mockDockerClient.AssertExpectations(t)
 }
 
 func TestDockerContainerName(t *testing.T) {

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -100,6 +100,7 @@ func createDockerManager(mockDockerClient *MockDockerClient) *DockerManager {
 		modelDir:      "/models",
 		overrides:     ImageOverrides{Default: "default-image"},
 		dockerClient:  mockDockerClient,
+        instanceID:    "instance-1",
 		gpuContainers: make(map[string]*RunnerContainer),
 		containers:    make(map[string]*RunnerContainer),
 		mu:            &sync.Mutex{},
@@ -110,7 +111,7 @@ func TestNewDockerManager(t *testing.T) {
 	mockDockerClient := new(MockDockerClient)
 
 	createAndVerifyManager := func() *DockerManager {
-		manager, err := NewDockerManager(ImageOverrides{Default: "default-image"}, false, []string{"gpu0"}, "/models", mockDockerClient)
+        manager, err := NewDockerManager(ImageOverrides{Default: "default-image"}, false, []string{"gpu0"}, "/models", mockDockerClient, "instance-1")
 		require.NoError(t, err)
 		require.NotNil(t, manager)
 		require.Equal(t, "default-image", manager.overrides.Default)
@@ -134,7 +135,7 @@ func TestNewDockerManager(t *testing.T) {
 			{ID: "container1", Names: []string{"/container1"}},
 			{ID: "container2", Names: []string{"/container2"}},
 		}
-		mockDockerClient.On("ContainerList", mock.Anything, mock.Anything).Return(existingContainers, nil)
+    mockDockerClient.On("ContainerList", mock.Anything, mock.Anything).Return(existingContainers, nil)
 		mockDockerClient.On("ContainerStop", mock.Anything, "container1", mock.Anything).Return(nil)
 		mockDockerClient.On("ContainerStop", mock.Anything, "container2", mock.Anything).Return(nil)
 		mockDockerClient.On("ContainerRemove", mock.Anything, "container1", mock.Anything).Return(nil)
@@ -997,7 +998,7 @@ func TestRemoveExistingContainers(t *testing.T) {
 	mockDockerClient.On("ContainerRemove", mock.Anything, "container1", mock.Anything).Return(nil)
 	mockDockerClient.On("ContainerRemove", mock.Anything, "container2", mock.Anything).Return(nil)
 
-	RemoveExistingContainers(ctx, mockDockerClient)
+    RemoveExistingContainers(ctx, mockDockerClient, "instance-1")
 	mockDockerClient.AssertExpectations(t)
 }
 

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -100,7 +100,7 @@ func createDockerManager(mockDockerClient *MockDockerClient) *DockerManager {
 		modelDir:      "/models",
 		overrides:     ImageOverrides{Default: "default-image"},
 		dockerClient:  mockDockerClient,
-        containerOwnerID:    "instance-1",
+        containerCreatorID:    "instance-1",
 		gpuContainers: make(map[string]*RunnerContainer),
 		containers:    make(map[string]*RunnerContainer),
 		mu:            &sync.Mutex{},
@@ -1020,7 +1020,7 @@ func TestRemoveExistingContainers_FiltersByContainerOwnerID(t *testing.T) {
                 if l == containerCreatorLabel+"="+containerCreator {
                     hasCreator = true
                 }
-                if l == containerInstanceLabel+"="+"owner-A" {
+                if l == containerCreatorIDLabel+"="+"owner-A" {
                     hasOwner = true
                 }
             }

--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -49,8 +49,8 @@ type Worker struct {
 	mu                 *sync.Mutex
 }
 
-func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string, instanceID string) (*Worker, error) {
-    manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil, instanceID)
+func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string, containerOwnerID string) (*Worker, error) {
+    manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil, containerOwnerID)
 	if err != nil {
 		return nil, fmt.Errorf("error creating docker manager: %w", err)
 	}

--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -49,8 +49,8 @@ type Worker struct {
 	mu                 *sync.Mutex
 }
 
-func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string) (*Worker, error) {
-	manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil)
+func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string, instanceID string) (*Worker, error) {
+    manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil, instanceID)
 	if err != nil {
 		return nil, fmt.Errorf("error creating docker manager: %w", err)
 	}

--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -50,7 +50,7 @@ type Worker struct {
 }
 
 func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string, containerCreatorID string) (*Worker, error) {
-    manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil, containerCreatorID)
+	manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil, containerCreatorID)
 	if err != nil {
 		return nil, fmt.Errorf("error creating docker manager: %w", err)
 	}

--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -49,8 +49,8 @@ type Worker struct {
 	mu                 *sync.Mutex
 }
 
-func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string, containerOwnerID string) (*Worker, error) {
-    manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil, containerOwnerID)
+func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string, containerCreatorID string) (*Worker, error) {
+    manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil, containerCreatorID)
 	if err != nil {
 		return nil, fmt.Errorf("error creating docker manager: %w", err)
 	}

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -470,7 +470,14 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		// Remove existing worker containers as soon as possible. This needs to be here so it's done before any resources
 		// are allocated by this process. That because we've seen issues where the AI worker containers hoard all the system
 		// resources and the Orchestrator cannot restart because it dies early (e.g. due to no (v)ram available).
-		removed, err := worker.RemoveExistingContainers(context.Background(), nil)
+		// Identify this instance using service address (preferred) or Ethereum address if available.
+		instanceID := ""
+		if *cfg.ServiceAddr != "" {
+			instanceID = *cfg.ServiceAddr
+		} else if *cfg.EthAcctAddr != "" {
+			instanceID = *cfg.EthAcctAddr
+		}
+		removed, err := worker.RemoveExistingContainers(context.Background(), nil, instanceID)
 		if err != nil {
 			glog.Errorf("Error removing existing AI worker containers: %v", err)
 		}
@@ -1321,7 +1328,14 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 		}
 
-		n.AIWorker, err = worker.NewWorker(imageOverrides, *cfg.AIVerboseLogs, gpus, modelsDir)
+		// Identify this instance using service address (preferred) or Ethereum address if available.
+		instanceID := ""
+		if *cfg.ServiceAddr != "" {
+			instanceID = *cfg.ServiceAddr
+		} else if *cfg.EthAcctAddr != "" {
+			instanceID = *cfg.EthAcctAddr
+		}
+		n.AIWorker, err = worker.NewWorker(imageOverrides, *cfg.AIVerboseLogs, gpus, modelsDir, instanceID)
 		if err != nil {
 			glog.Errorf("Error starting AI worker: %v", err)
 			return

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -466,17 +466,17 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		glog.Exit("both -netint and -nvidia arguments specified, this is not supported")
 	}
 
-    // Identify this instance using service address (preferred) or Ethereum address if available.
-    containerCreatorID := *cfg.ServiceAddr
-    if containerCreatorID == "" && *cfg.EthAcctAddr != "" {
-        containerCreatorID = *cfg.EthAcctAddr
-    }
+	// Identify this instance using service address (preferred) or Ethereum address if available.
+	containerCreatorID := *cfg.ServiceAddr
+	if containerCreatorID == "" && *cfg.EthAcctAddr != "" {
+		containerCreatorID = *cfg.EthAcctAddr
+	}
 
-    if *cfg.AIWorker {
+	if *cfg.AIWorker {
 		// Remove existing worker containers as soon as possible. This needs to be here so it's done before any resources
 		// are allocated by this process. That because we've seen issues where the AI worker containers hoard all the system
 		// resources and the Orchestrator cannot restart because it dies early (e.g. due to no (v)ram available).
-        removed, err := worker.RemoveExistingContainers(context.Background(), nil, containerCreatorID)
+		removed, err := worker.RemoveExistingContainers(context.Background(), nil, containerCreatorID)
 		if err != nil {
 			glog.Errorf("Error removing existing AI worker containers: %v", err)
 		}
@@ -1327,7 +1327,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 		}
 
-        n.AIWorker, err = worker.NewWorker(imageOverrides, *cfg.AIVerboseLogs, gpus, modelsDir, containerCreatorID)
+		n.AIWorker, err = worker.NewWorker(imageOverrides, *cfg.AIVerboseLogs, gpus, modelsDir, containerCreatorID)
 		if err != nil {
 			glog.Errorf("Error starting AI worker: %v", err)
 			return

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -467,16 +467,16 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	}
 
     // Identify this instance using service address (preferred) or Ethereum address if available.
-    containerOwnerID := *cfg.ServiceAddr
-    if containerOwnerID == "" && *cfg.EthAcctAddr != "" {
-        containerOwnerID = *cfg.EthAcctAddr
+    containerCreatorID := *cfg.ServiceAddr
+    if containerCreatorID == "" && *cfg.EthAcctAddr != "" {
+        containerCreatorID = *cfg.EthAcctAddr
     }
 
     if *cfg.AIWorker {
 		// Remove existing worker containers as soon as possible. This needs to be here so it's done before any resources
 		// are allocated by this process. That because we've seen issues where the AI worker containers hoard all the system
 		// resources and the Orchestrator cannot restart because it dies early (e.g. due to no (v)ram available).
-        removed, err := worker.RemoveExistingContainers(context.Background(), nil, containerOwnerID)
+        removed, err := worker.RemoveExistingContainers(context.Background(), nil, containerCreatorID)
 		if err != nil {
 			glog.Errorf("Error removing existing AI worker containers: %v", err)
 		}
@@ -1327,7 +1327,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 		}
 
-        n.AIWorker, err = worker.NewWorker(imageOverrides, *cfg.AIVerboseLogs, gpus, modelsDir, containerOwnerID)
+        n.AIWorker, err = worker.NewWorker(imageOverrides, *cfg.AIVerboseLogs, gpus, modelsDir, containerCreatorID)
 		if err != nil {
 			glog.Errorf("Error starting AI worker: %v", err)
 			return


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This pull request implements per-instance scoping for AI worker Docker containers. It prevents unintended cleanup of containers belonging to other Livepeer instances that might be running on the same host by uniquely identifying containers per instance.

**Specific updates (required)**
- Added a `creator_instance` label to AI worker Docker containers, using the orchestrator's service address (preferred) or Ethereum address as the unique instance ID.
- Modified `RemoveExistingContainers` to filter containers by both the `creator=ai-worker` label and the new `creator_instance` label, ensuring only containers from the current instance are removed.
- Wired the instance ID from `cmd/livepeer/starter/starter.go` through `ai/worker/worker.go` to `ai/worker/docker.go` for both initial cleanup and new container creation.
- Updated `ai/worker/docker_test.go` to reflect the changes in `NewDockerManager` and `RemoveExistingContainers` that now accept an `instanceID`.

**How did you test each of these updates (required)**
- **Unit Tests**: Existing unit tests in `ai/worker/docker_test.go` were updated to pass an `instanceID` to `NewDockerManager` and `RemoveExistingContainers`. These tests verify that the Docker manager is initialized correctly and that container removal logic respects the new instance ID filtering.
- **Manual Verification (Conceptual)**: The logic for deriving the `instanceID` from `-serviceAddr` or `-ethAcctAddr` in `starter.go` was reviewed to ensure it correctly prioritizes the service address and falls back to the Ethereum address as specified. The labeling and filtering logic in `docker.go` was reviewed to confirm that containers are tagged correctly and that cleanup operations will only target containers with a matching `creator_instance` label.

**Does this pull request close any open issues?**
Fixes #3754

**Checklist:**
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated

---
<a href="https://cursor.com/background-agent?bcId=bc-f64eee7f-79c4-40e0-9bdb-8eb18c32d653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f64eee7f-79c4-40e0-9bdb-8eb18c32d653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

