### PR TITLE
Take model into account for O to gateway capacity reporting

### DIFF
--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -74,8 +74,8 @@ func (w *Worker) HardwareInformation() []HardwareInformation {
 	return append(hardware, w.manager.HardwareInformation()...)
 }
 
-func (w *Worker) GetLiveAICapacity() Capacity {
-	capacity, _ := w.manager.GetCapacity("", "")
+func (w *Worker) GetLiveAICapacity(pipeline, modelID string) Capacity {
+	capacity, _ := w.manager.GetCapacity(pipeline, modelID)
 	return capacity
 }
 

--- a/core/ai.go
+++ b/core/ai.go
@@ -33,7 +33,7 @@ type AI interface {
 	HasCapacity(string, string) bool
 	EnsureImageAvailable(context.Context, string, string) error
 	HardwareInformation() []worker.HardwareInformation
-	GetLiveAICapacity() worker.Capacity
+	GetLiveAICapacity(pipeline, modelID string) worker.Capacity
 	Version() []worker.Version
 }
 

--- a/core/ai_orchestrator.go
+++ b/core/ai_orchestrator.go
@@ -440,8 +440,8 @@ func (orch *orchestrator) CheckAICapacity(pipeline, modelID string) (bool, chan<
 
 }
 
-func (orch *orchestrator) GetLiveAICapacity() worker.Capacity {
-	return orch.node.AIWorker.GetLiveAICapacity()
+func (orch *orchestrator) GetLiveAICapacity(pipeline, modelID string) worker.Capacity {
+	return orch.node.AIWorker.GetLiveAICapacity(pipeline, modelID)
 }
 
 func (orch *orchestrator) WorkerHardware() []worker.HardwareInformation {

--- a/core/ai_test.go
+++ b/core/ai_test.go
@@ -648,7 +648,7 @@ func createAIWorkerCapabilities() *Capabilities {
 
 type stubAIWorker struct{}
 
-func (a *stubAIWorker) GetLiveAICapacity() worker.Capacity {
+func (a *stubAIWorker) GetLiveAICapacity(pipeline, modelID string) worker.Capacity {
 	return worker.Capacity{}
 }
 

--- a/server/ai_worker_test.go
+++ b/server/ai_worker_test.go
@@ -474,7 +474,7 @@ type stubAIWorker struct {
 	Err    error
 }
 
-func (a *stubAIWorker) GetLiveAICapacity() worker.Capacity {
+func (a *stubAIWorker) GetLiveAICapacity(pipeline, modelID string) worker.Capacity {
 	return worker.Capacity{}
 }
 

--- a/server/job_rpc_test.go
+++ b/server/job_rpc_test.go
@@ -222,7 +222,7 @@ func (r *mockJobOrchestrator) WorkerHardware() []worker.HardwareInformation {
 }
 func (r *mockJobOrchestrator) ServeAIWorker(stream net.AIWorker_RegisterAIWorkerServer, capabilities *net.Capabilities, hardware []*net.HardwareInformation) {
 }
-func (r *mockJobOrchestrator) GetLiveAICapacity() worker.Capacity {
+func (r *mockJobOrchestrator) GetLiveAICapacity(pipeline, modelID string) worker.Capacity {
 	return worker.Capacity{}
 }
 func (r *mockJobOrchestrator) RegisterExternalCapability(extCapabilitySettings string) (*core.ExternalCapability, error) {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -515,12 +515,12 @@ func setLiveAICapacity(orch Orchestrator, capabilities *net.Capabilities) {
 		return
 	}
 
-	for modelID, model := range liveAI.Models {
+	for _, model := range liveAI.Models {
 		if model == nil {
 			glog.Warning("Model was nil when setting Live AI capacity")
 			continue
 		}
-		aiCapacity := orch.GetLiveAICapacity("live-video-to-video", modelID)
+		aiCapacity := orch.GetLiveAICapacity("live-video-to-video", "foo")
 		model.Capacity = uint32(aiCapacity.ContainersIdle)
 		model.CapacityInUse = uint32(aiCapacity.ContainersInUse)
 	}

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -515,12 +515,12 @@ func setLiveAICapacity(orch Orchestrator, capabilities *net.Capabilities) {
 		return
 	}
 
-	for _, model := range liveAI.Models {
+	for modelID, model := range liveAI.Models {
 		if model == nil {
 			glog.Warning("Model was nil when setting Live AI capacity")
 			continue
 		}
-		aiCapacity := orch.GetLiveAICapacity("live-video-to-video", "foo")
+		aiCapacity := orch.GetLiveAICapacity("live-video-to-video", modelID)
 		model.Capacity = uint32(aiCapacity.ContainersIdle)
 		model.CapacityInUse = uint32(aiCapacity.ContainersInUse)
 	}

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -1729,17 +1729,18 @@ func Test_setLiveAICapacity(t *testing.T) {
 					},
 				},
 			},
-			expectedSet: false,
+			expectedSet: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setLiveAICapacity(orch, tt.capabilities)
 			if tt.expectedSet {
-				model := tt.capabilities.Constraints.PerCapability[uint32(core.Capability_LiveVideoToVideo)].Models["foo"]
-				require.NotNil(t, model)
-				require.Equal(t, uint32(123), model.Capacity)
-				require.Equal(t, uint32(123), model.CapacityInUse)
+				for _, model := range tt.capabilities.Constraints.PerCapability[uint32(core.Capability_LiveVideoToVideo)].Models {
+					require.NotNil(t, model)
+					require.Equal(t, uint32(123), model.Capacity)
+					require.Equal(t, uint32(123), model.CapacityInUse)
+				}
 			}
 		})
 	}

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -83,7 +83,7 @@ type stubOrchestrator struct {
 	jobPriceInfo *net.PriceInfo
 }
 
-func (r *stubOrchestrator) GetLiveAICapacity() worker.Capacity {
+func (r *stubOrchestrator) GetLiveAICapacity(pipeline, modelID string) worker.Capacity {
 	return worker.Capacity{}
 }
 
@@ -1462,7 +1462,7 @@ type mockOrchestrator struct {
 	mock.Mock
 }
 
-func (o *mockOrchestrator) GetLiveAICapacity() worker.Capacity {
+func (o *mockOrchestrator) GetLiveAICapacity(pipeline, modelID string) worker.Capacity {
 	args := o.Called()
 	return args.Get(0).(worker.Capacity)
 }


### PR DESCRIPTION
* Brad noticed the `Setting Live AI capacity is only supported in a single model setup` log line on his O. He's tested this branch build on his O and seems to be working nicely.
* We're currently missing capacity reporting for multi model Os, this will fix it.
* Live AI capacity doesn't assume all containers serving the same model like [it was](https://github.com/livepeer/go-livepeer/pull/3557#issuecomment-2854896041)