### PR TITLE
ci: Fix flakiness due to protoc binaries availability

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,6 +76,13 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
+      - name: Install protobuf toolchain
+        run: |
+          apt update
+          apt install -yqq protobuf-compiler
+          GOBIN=/usr/local/bin GOOS=linux GOARCH=amd64 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
+          GOBIN=/usr/local/bin GOOS=linux GOARCH=amd64 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
+
       - name: Set build environment
         run: |
           echo "GOARCH=${{ matrix.target.GOARCH }}" >> $GITHUB_ENV
@@ -185,6 +192,12 @@ jobs:
           echo "GO_BUILD_DIR=lp-builds/" >> $GITHUB_ENV
           echo "LP_BUILD_DIR=livepeer-${{ matrix.target.GOOS }}-${{ matrix.target.GOARCH }}" >> $GITHUB_ENV
           mkdir -p lp-builds/ releases/
+
+      - name: Install protobuf toolchain
+        run: |
+          brew install protobuf
+          env -u GOOS -u GOARCH go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
+          env -u GOOS -u GOARCH go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 
       - name: Cache ffmpeg
         id: cache-ffmpeg

--- a/tools.go
+++ b/tools.go
@@ -6,4 +6,6 @@ package tools
 import (
 	_ "github.com/ethereum/go-ethereum/cmd/abigen"
 	_ "github.com/golang/mock/mockgen"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR resolves a flaky CI build failure where the `protoc-gen-go-grpc` plugin was not found during the `make` process, specifically in the `build.yaml` workflow. The issue occurred when `make` conditionally regenerated `.pb.go` files, but the necessary plugin was not installed or not on the system's PATH for the correct host architecture.

**Specific updates (required)**
- **`build.yaml` (Linux job):** Added explicit installation steps for `protoc-gen-go` and `protoc-gen-go-grpc` for the host (linux/amd64) architecture, ensuring they are placed in `/usr/local/bin` and thus always on PATH.
- **`build.yaml` (macOS job):** Added explicit installation steps for `protoc-gen-go` and `protoc-gen-go-grpc`, using `env -u GOOS -u GOARCH` to ensure they compile for the host macOS toolchain.
- **`tools.go`:** Added `_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"` and `_ "google.golang.org/protobuf/cmd/protoc-gen-go"` as tool imports to ensure these modules are tracked and managed by Go modules.

**How did you test each of these updates (required)**
The changes address a CI build failure. The fix was implemented to ensure that the `protoc-gen-go-grpc` binary is consistently available and executable by `protoc` across all build matrix targets in the `build.yaml` workflow. The primary testing method is the successful execution of the updated GitHub Actions `build.yaml` workflow, which should now complete without the `protoc-gen-go-grpc: program not found` error, regardless of whether proto files need regeneration.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated

---
<a href="https://cursor.com/background-agent?bcId=bc-57be4841-3683-4283-a1a3-126395cd9a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57be4841-3683-4283-a1a3-126395cd9a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

