### PR TITLE
docker: Re-apply creator-id flag with additional migration logic

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -37,6 +37,7 @@ const optFlagsContainerTimeout = 5 * time.Minute
 const containerRemoveTimeout = 30 * time.Second
 const containerCreatorLabel = "creator"
 const containerCreator = "ai-worker"
+const containerCreatorIDLabel = "creator_id"
 
 var containerTimeout = 3 * time.Minute
 var containerWatchInterval = 5 * time.Second
@@ -109,10 +110,11 @@ func NewDefaultDockerClient() (DockerClient, error) {
 }
 
 type DockerManager struct {
-	gpus        []string
-	modelDir    string
-	overrides   ImageOverrides
-	verboseLogs bool
+	gpus               []string
+	modelDir           string
+	overrides          ImageOverrides
+	verboseLogs        bool
+	containerCreatorID string
 
 	dockerClient DockerClient
 	// gpu ID => container
@@ -122,7 +124,7 @@ type DockerManager struct {
 	mu         *sync.Mutex
 }
 
-func NewDockerManager(overrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string, client DockerClient) (*DockerManager, error) {
+func NewDockerManager(overrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string, client DockerClient, containerCreatorID string) (*DockerManager, error) {
 	if client == nil {
 		var err error
 		client, err = NewDefaultDockerClient()
@@ -132,21 +134,22 @@ func NewDockerManager(overrides ImageOverrides, verboseLogs bool, gpus []string,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), containerTimeout)
-	if _, err := RemoveExistingContainers(ctx, client); err != nil {
+	if _, err := RemoveExistingContainers(ctx, client, containerCreatorID); err != nil {
 		cancel()
 		return nil, err
 	}
 	cancel()
 
 	manager := &DockerManager{
-		gpus:          gpus,
-		modelDir:      modelDir,
-		overrides:     overrides,
-		verboseLogs:   verboseLogs,
-		dockerClient:  client,
-		gpuContainers: make(map[string]*RunnerContainer),
-		containers:    make(map[string]*RunnerContainer),
-		mu:            &sync.Mutex{},
+		gpus:               gpus,
+		modelDir:           modelDir,
+		overrides:          overrides,
+		verboseLogs:        verboseLogs,
+		dockerClient:       client,
+		containerCreatorID: containerCreatorID,
+		gpuContainers:      make(map[string]*RunnerContainer),
+		containers:         make(map[string]*RunnerContainer),
+		mu:                 &sync.Mutex{},
 	}
 
 	return manager, nil
@@ -399,6 +402,9 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 		Labels: map[string]string{
 			containerCreatorLabel: containerCreator,
 		},
+	}
+	if m.containerCreatorID != "" {
+		containerConfig.Labels[containerCreatorIDLabel] = m.containerCreatorID
 	}
 
 	gpuOpts := opts.GpuOpts{}
@@ -686,7 +692,7 @@ func (m *DockerManager) watchContainer(rc *RunnerContainer) {
 	}
 }
 
-func RemoveExistingContainers(ctx context.Context, client DockerClient) (int, error) {
+func RemoveExistingContainers(ctx context.Context, client DockerClient, containerCreatorID string) (int, error) {
 	if client == nil {
 		var err error
 		client, err = NewDefaultDockerClient()
@@ -696,6 +702,9 @@ func RemoveExistingContainers(ctx context.Context, client DockerClient) (int, er
 	}
 
 	filters := filters.NewArgs(filters.Arg("label", containerCreatorLabel+"="+containerCreator))
+	if containerCreatorID != "" {
+		filters.Add("label", containerCreatorIDLabel+"="+containerCreatorID)
+	}
 	containers, err := client.ContainerList(ctx, container.ListOptions{All: true, Filters: filters})
 	if err != nil {
 		return 0, fmt.Errorf("failed to list containers: %w", err)

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -707,7 +707,7 @@ func RemoveExistingContainers(ctx context.Context, client DockerClient, containe
 
 	removed := 0
 	for _, c := range containers {
-		hasCreatorID, creatorID := c.Labels[containerCreatorIDLabel]
+		creatorID, hasCreatorID := c.Labels[containerCreatorIDLabel]
 		// We also remove containers without creator-id label as a migration from previous versions that didn't have it.
 		shouldRemove := !hasCreatorID || creatorID == containerCreatorID
 		if !shouldRemove {

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -400,7 +400,7 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 			containerPort: struct{}{},
 		},
 		Labels: map[string]string{
-			containerCreatorLabel: containerCreator,
+			containerCreatorLabel:   containerCreator,
 			containerCreatorIDLabel: m.containerCreatorID,
 		},
 	}

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -1032,6 +1032,7 @@ func TestRemoveExistingContainers_InMemoryFilterLegacyAndOwnerID(t *testing.T) {
 		Return([]types.Container{
 			{ID: "legacy-1", Names: []string{"/legacy-1"}, Labels: map[string]string{containerCreatorLabel: containerCreator}},                           // no creator_id -> remove
 			{ID: "other-1", Names: []string{"/other-1"}, Labels: map[string]string{containerCreatorLabel: containerCreator, containerCreatorIDLabel: "owner-B"}}, // mismatched -> keep
+			{ID: "other-2-empty", Names: []string{"/other-2"}, Labels: map[string]string{containerCreatorLabel: containerCreator, containerCreatorIDLabel: ""}}, // empty -> keep (new version but empty label)
 			{ID: "mine-1", Names: []string{"/mine-1"}, Labels: map[string]string{containerCreatorLabel: containerCreator, containerCreatorIDLabel: "owner-A"}},   // match -> remove
 		}, nil).
 		Once()

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -1030,9 +1030,9 @@ func TestRemoveExistingContainers_InMemoryFilterLegacyAndOwnerID(t *testing.T) {
 			return hasCreator
 		})).
 		Return([]types.Container{
-			{ID: "legacy-1", Names: []string{"/legacy-1"}, Labels: map[string]string{containerCreatorLabel: containerCreator}},                           // no creator_id -> remove
+			{ID: "legacy-1", Names: []string{"/legacy-1"}, Labels: map[string]string{containerCreatorLabel: containerCreator}},                                   // no creator_id -> remove
 			{ID: "other-1", Names: []string{"/other-1"}, Labels: map[string]string{containerCreatorLabel: containerCreator, containerCreatorIDLabel: "owner-B"}}, // mismatched -> keep
-			{ID: "other-2-empty", Names: []string{"/other-2"}, Labels: map[string]string{containerCreatorLabel: containerCreator, containerCreatorIDLabel: ""}}, // empty -> keep (new version but empty label)
+			{ID: "other-2-empty", Names: []string{"/other-2"}, Labels: map[string]string{containerCreatorLabel: containerCreator, containerCreatorIDLabel: ""}},  // empty -> keep (new version but empty label)
 			{ID: "mine-1", Names: []string{"/mine-1"}, Labels: map[string]string{containerCreatorLabel: containerCreator, containerCreatorIDLabel: "owner-A"}},   // match -> remove
 		}, nil).
 		Once()

--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -49,8 +49,8 @@ type Worker struct {
 	mu                 *sync.Mutex
 }
 
-func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string) (*Worker, error) {
-	manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil)
+func NewWorker(imageOverrides ImageOverrides, verboseLogs bool, gpus []string, modelDir string, containerCreatorID string) (*Worker, error) {
+	manager, err := NewDockerManager(imageOverrides, verboseLogs, gpus, modelDir, nil, containerCreatorID)
 	if err != nil {
 		return nil, fmt.Errorf("error creating docker manager: %w", err)
 	}

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -481,11 +481,17 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		glog.Exit("both -netint and -nvidia arguments specified, this is not supported")
 	}
 
+	// Identify this instance using service address (preferred) or Ethereum address if available.
+	containerCreatorID := *cfg.ServiceAddr
+	if containerCreatorID == "" && *cfg.EthAcctAddr != "" {
+		containerCreatorID = *cfg.EthAcctAddr
+	}
+
 	if *cfg.AIWorker {
 		// Remove existing worker containers as soon as possible. This needs to be here so it's done before any resources
 		// are allocated by this process. That because we've seen issues where the AI worker containers hoard all the system
 		// resources and the Orchestrator cannot restart because it dies early (e.g. due to no (v)ram available).
-		removed, err := worker.RemoveExistingContainers(context.Background(), nil)
+		removed, err := worker.RemoveExistingContainers(context.Background(), nil, containerCreatorID)
 		if err != nil {
 			glog.Errorf("Error removing existing AI worker containers: %v", err)
 		}
@@ -1336,7 +1342,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 		}
 
-		n.AIWorker, err = worker.NewWorker(imageOverrides, *cfg.AIVerboseLogs, gpus, modelsDir)
+		n.AIWorker, err = worker.NewWorker(imageOverrides, *cfg.AIVerboseLogs, gpus, modelsDir, containerCreatorID)
 		if err != nil {
 			glog.Errorf("Error starting AI worker: %v", err)
 			return


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This reapplies #3755 with an additional logic to remove containers that have
no `creator-id` label. This is needed to support a seamless migration from Os
that did not add the `creator-id` label.

**Specific updates (required)**
- Reapply
- Remove containers with no creator-id label

**How did you test each of these updates (required)**
Start O and check removed containers

**Does this pull request close any open issues?**
Un-reverts #3755 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
