### PR TITLE
docker: Forcefully SIGKILL runners after timeout

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,5 +19,6 @@
 #### General
 
 * [#3779](https://github.com/livepeer/go-livepeer/pull/3779) worker: Fix orphaned containers on node shutdown (@victorges)
+* [#3777](https://github.com/livepeer/go-livepeer/pull/3777) docker: Forcefully SIGKILL runners after timeout (@pwilczynskiclearcode)
 
 #### CLI

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -34,6 +34,7 @@ const containerPort = "8000/tcp"
 const pollingInterval = 500 * time.Millisecond
 const externalContainerTimeout = 2 * time.Minute
 const optFlagsContainerTimeout = 5 * time.Minute
+const containerStopTimeout = 8 * time.Second
 const containerRemoveTimeout = 30 * time.Second
 const containerCreatorLabel = "creator"
 const containerCreator = "ai-worker"
@@ -733,8 +734,8 @@ func dockerRemoveContainer(client DockerClient, containerID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), containerRemoveTimeout)
 	defer cancel()
 
-	killTimeout := 1 // 1s timeout to give SIGTERM a chance then SIGKILL forcefully
-	err := client.ContainerStop(ctx, containerID, container.StopOptions{Signal: "SIGKILL", Timeout: &killTimeout})
+	timeoutSec := int(containerStopTimeout.Seconds())
+	err := client.ContainerStop(ctx, containerID, container.StopOptions{Timeout: &timeoutSec})
 	// Ignore "not found" or "already stopped" errors
 	if err != nil && !docker.IsErrNotFound(err) && !errdefs.IsNotModified(err) {
 		return err

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -733,7 +733,8 @@ func dockerRemoveContainer(client DockerClient, containerID string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), containerRemoveTimeout)
 	defer cancel()
 
-	err := client.ContainerStop(ctx, containerID, container.StopOptions{})
+	killTimeout := 1 // 1s timeout to give SIGTERM a chance then SIGKILL forcefully
+	err := client.ContainerStop(ctx, containerID, container.StopOptions{Signal: "SIGKILL", Timeout: &killTimeout})
 	// Ignore "not found" or "already stopped" errors
 	if err != nil && !docker.IsErrNotFound(err) && !errdefs.IsNotModified(err) {
 		return err

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -236,7 +236,8 @@ func TestDockerManager_Stop(t *testing.T) {
 		},
 	}
 
-	MockDockerClient.On("ContainerStop", mock.Anything, containerID, container.StopOptions{Timeout: nil}).Return(nil)
+	timeout := 1
+	MockDockerClient.On("ContainerStop", mock.Anything, containerID, container.StopOptions{Signal: "SIGKILL", Timeout: &timeout}).Return(nil)
 	MockDockerClient.On("ContainerRemove", mock.Anything, containerID, container.RemoveOptions{}).Return(nil)
 	err := dockerManager.Stop(ctx)
 	require.NoError(t, err)
@@ -650,7 +651,8 @@ func TestDockerManager_allocGPU(t *testing.T) {
 				dockerManager.gpuContainers[rc.GPU] = rc
 				dockerManager.containers[rc.Name] = rc
 				// Mock client methods to simulate the removal of the warm container.
-				mockDockerClient.On("ContainerStop", mock.Anything, "container1", container.StopOptions{}).Return(nil)
+				timeout := 1
+				mockDockerClient.On("ContainerStop", mock.Anything, "container1", container.StopOptions{Signal: "SIGKILL", Timeout: &timeout}).Return(nil)
 				mockDockerClient.On("ContainerRemove", mock.Anything, "container1", container.RemoveOptions{}).Return(nil)
 			},
 			expectedAllocatedGPU: "gpu0",
@@ -694,7 +696,8 @@ func TestDockerManager_destroyContainer(t *testing.T) {
 	dockerManager.gpuContainers[gpu] = rc
 	dockerManager.containers[containerID] = rc
 
-	mockDockerClient.On("ContainerStop", mock.Anything, containerID, container.StopOptions{}).Return(nil)
+	timeout := 1
+	mockDockerClient.On("ContainerStop", mock.Anything, containerID, container.StopOptions{Signal: "SIGKILL", Timeout: &timeout}).Return(nil)
 	mockDockerClient.On("ContainerRemove", mock.Anything, containerID, container.RemoveOptions{}).Return(nil)
 
 	err := dockerManager.destroyContainer(rc, true)
@@ -1095,7 +1098,8 @@ func TestDockerContainerName(t *testing.T) {
 func TestDockerRemoveContainer(t *testing.T) {
 	mockDockerClient := new(MockDockerClient)
 
-	mockDockerClient.On("ContainerStop", mock.Anything, "container1", container.StopOptions{}).Return(nil)
+	timeout := 1
+	mockDockerClient.On("ContainerStop", mock.Anything, "container1", container.StopOptions{Signal: "SIGKILL", Timeout: &timeout}).Return(nil)
 	mockDockerClient.On("ContainerRemove", mock.Anything, "container1", container.RemoveOptions{}).Return(nil)
 
 	err := dockerRemoveContainer(mockDockerClient, "container1")

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -20,6 +20,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var stopTimeout = 8
+var expectedContainerStopOptions = container.StopOptions{Timeout: &stopTimeout}
+
 type MockDockerClient struct {
 	mock.Mock
 }
@@ -136,15 +139,15 @@ func TestNewDockerManager(t *testing.T) {
 			{ID: "container2", Names: []string{"/container2"}, Labels: map[string]string{containerCreatorLabel: containerCreator}},
 		}
 		mockDockerClient.On("ContainerList", mock.Anything, mock.Anything).Return(existingContainers, nil)
-		mockDockerClient.On("ContainerStop", mock.Anything, "container1", mock.Anything).Return(nil)
-		mockDockerClient.On("ContainerStop", mock.Anything, "container2", mock.Anything).Return(nil)
+		mockDockerClient.On("ContainerStop", mock.Anything, "container1", expectedContainerStopOptions).Return(nil)
+		mockDockerClient.On("ContainerStop", mock.Anything, "container2", expectedContainerStopOptions).Return(nil)
 		mockDockerClient.On("ContainerRemove", mock.Anything, "container1", mock.Anything).Return(nil)
 		mockDockerClient.On("ContainerRemove", mock.Anything, "container2", mock.Anything).Return(nil)
 
 		// Verify that existing containers were stopped and removed.
 		createAndVerifyManager()
-		mockDockerClient.AssertCalled(t, "ContainerStop", mock.Anything, "container1", mock.Anything)
-		mockDockerClient.AssertCalled(t, "ContainerStop", mock.Anything, "container2", mock.Anything)
+		mockDockerClient.AssertCalled(t, "ContainerStop", mock.Anything, "container1", expectedContainerStopOptions)
+		mockDockerClient.AssertCalled(t, "ContainerStop", mock.Anything, "container2", expectedContainerStopOptions)
 		mockDockerClient.AssertCalled(t, "ContainerRemove", mock.Anything, "container1", mock.Anything)
 		mockDockerClient.AssertCalled(t, "ContainerRemove", mock.Anything, "container2", mock.Anything)
 		mockDockerClient.AssertExpectations(t)
@@ -236,8 +239,7 @@ func TestDockerManager_Stop(t *testing.T) {
 		},
 	}
 
-	timeout := 1
-	MockDockerClient.On("ContainerStop", mock.Anything, containerID, container.StopOptions{Signal: "SIGKILL", Timeout: &timeout}).Return(nil)
+	MockDockerClient.On("ContainerStop", mock.Anything, containerID, expectedContainerStopOptions).Return(nil)
 	MockDockerClient.On("ContainerRemove", mock.Anything, containerID, container.RemoveOptions{}).Return(nil)
 	err := dockerManager.Stop(ctx)
 	require.NoError(t, err)
@@ -651,8 +653,7 @@ func TestDockerManager_allocGPU(t *testing.T) {
 				dockerManager.gpuContainers[rc.GPU] = rc
 				dockerManager.containers[rc.Name] = rc
 				// Mock client methods to simulate the removal of the warm container.
-				timeout := 1
-				mockDockerClient.On("ContainerStop", mock.Anything, "container1", container.StopOptions{Signal: "SIGKILL", Timeout: &timeout}).Return(nil)
+				mockDockerClient.On("ContainerStop", mock.Anything, "container1", expectedContainerStopOptions).Return(nil)
 				mockDockerClient.On("ContainerRemove", mock.Anything, "container1", container.RemoveOptions{}).Return(nil)
 			},
 			expectedAllocatedGPU: "gpu0",
@@ -696,8 +697,7 @@ func TestDockerManager_destroyContainer(t *testing.T) {
 	dockerManager.gpuContainers[gpu] = rc
 	dockerManager.containers[containerID] = rc
 
-	timeout := 1
-	mockDockerClient.On("ContainerStop", mock.Anything, containerID, container.StopOptions{Signal: "SIGKILL", Timeout: &timeout}).Return(nil)
+	mockDockerClient.On("ContainerStop", mock.Anything, containerID, expectedContainerStopOptions).Return(nil)
 	mockDockerClient.On("ContainerRemove", mock.Anything, containerID, container.RemoveOptions{}).Return(nil)
 
 	err := dockerManager.destroyContainer(rc, true)
@@ -847,7 +847,7 @@ func TestDockerManager_watchContainer(t *testing.T) {
 			tt.mockServerSetup(mockServer)
 
 			// Mock destroyContainer to verify it is called.
-			mockDockerClient.On("ContainerStop", mock.Anything, rc.Name, mock.Anything).Return(nil).Once()
+			mockDockerClient.On("ContainerStop", mock.Anything, rc.Name, expectedContainerStopOptions).Return(nil).Once()
 			mockDockerClient.On("ContainerRemove", mock.Anything, rc.Name, mock.Anything).Return(nil).Once()
 
 			done := make(chan struct{})
@@ -909,7 +909,7 @@ func TestDockerManager_watchContainer(t *testing.T) {
 		mockDockerClient.AssertNotCalled(t, "ContainerRemove", mock.Anything, rc.Name, mock.Anything)
 
 		// Mock destroyContainer to verify it is called.
-		mockDockerClient.On("ContainerStop", mock.Anything, rc.Name, mock.Anything).Return(nil).Once()
+		mockDockerClient.On("ContainerStop", mock.Anything, rc.Name, expectedContainerStopOptions).Return(nil).Once()
 		mockDockerClient.On("ContainerRemove", mock.Anything, rc.Name, mock.Anything).Return(nil).Once()
 
 		// after the first failure, there should only 1 more healthcheck for the container to be stopped
@@ -996,8 +996,8 @@ func TestRemoveExistingContainers(t *testing.T) {
 		{ID: "container2", Names: []string{"/container2"}, Labels: map[string]string{containerCreatorLabel: containerCreator}},
 	}
 	mockDockerClient.On("ContainerList", mock.Anything, mock.Anything).Return(existingContainers, nil)
-	mockDockerClient.On("ContainerStop", mock.Anything, "container1", mock.Anything).Return(nil)
-	mockDockerClient.On("ContainerStop", mock.Anything, "container2", mock.Anything).Return(nil)
+	mockDockerClient.On("ContainerStop", mock.Anything, "container1", expectedContainerStopOptions).Return(nil)
+	mockDockerClient.On("ContainerStop", mock.Anything, "container2", expectedContainerStopOptions).Return(nil)
 	mockDockerClient.On("ContainerRemove", mock.Anything, "container1", mock.Anything).Return(nil)
 	mockDockerClient.On("ContainerRemove", mock.Anything, "container2", mock.Anything).Return(nil)
 
@@ -1039,9 +1039,9 @@ func TestRemoveExistingContainers_InMemoryFilterLegacyAndOwnerID(t *testing.T) {
 			{ID: "mine-1", Names: []string{"/mine-1"}, Labels: map[string]string{containerCreatorLabel: containerCreator, containerCreatorIDLabel: "owner-A"}},   // match -> remove
 		}, nil).
 		Once()
-	mockDockerClient.On("ContainerStop", mock.Anything, "legacy-1", mock.Anything).Return(nil).Once()
+	mockDockerClient.On("ContainerStop", mock.Anything, "legacy-1", expectedContainerStopOptions).Return(nil).Once()
 	mockDockerClient.On("ContainerRemove", mock.Anything, "legacy-1", mock.Anything).Return(nil).Once()
-	mockDockerClient.On("ContainerStop", mock.Anything, "mine-1", mock.Anything).Return(nil).Once()
+	mockDockerClient.On("ContainerStop", mock.Anything, "mine-1", expectedContainerStopOptions).Return(nil).Once()
 	mockDockerClient.On("ContainerRemove", mock.Anything, "mine-1", mock.Anything).Return(nil).Once()
 
 	removed, err := RemoveExistingContainers(ctx, mockDockerClient, "owner-A")
@@ -1098,8 +1098,7 @@ func TestDockerContainerName(t *testing.T) {
 func TestDockerRemoveContainer(t *testing.T) {
 	mockDockerClient := new(MockDockerClient)
 
-	timeout := 1
-	mockDockerClient.On("ContainerStop", mock.Anything, "container1", container.StopOptions{Signal: "SIGKILL", Timeout: &timeout}).Return(nil)
+	mockDockerClient.On("ContainerStop", mock.Anything, "container1", expectedContainerStopOptions).Return(nil)
 	mockDockerClient.On("ContainerRemove", mock.Anything, "container1", container.RemoveOptions{}).Return(nil)
 
 	err := dockerRemoveContainer(mockDockerClient, "container1")


### PR DESCRIPTION
**What does this pull request do? Explain your changes.**
Forcefully (SIGKILL) kill runners on orchestrator exit.

**Specific updates (required)**
- In case graceful `SIGTERM` fails after 1 second use `SIGKILL` to forcefully stop runner containers.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
It should fix most of cased from https://github.com/livepeer/go-livepeer/issues/3776 but not all

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
