### PR TITLE
worker: Fix orphaned containers on node shutdown

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,4 +16,8 @@
 
 ### Bug Fixes 🐞
 
+#### General
+
+* [#3779](https://github.com/livepeer/go-livepeer/pull/3779) worker: Fix orphaned containers on node shutdown (@victorges)
+
 #### CLI

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -411,11 +411,11 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 	}
 
 	restartPolicy := container.RestartPolicy{
-		Name:              "on-failure",
+		Name:              container.RestartPolicyOnFailure,
 		MaximumRetryCount: 3,
 	}
 	if keepWarm {
-		restartPolicy = container.RestartPolicy{Name: "always"}
+		restartPolicy = container.RestartPolicy{Name: container.RestartPolicyUnlessStopped}
 	}
 
 	hostConfig := &container.HostConfig{

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -414,9 +414,6 @@ func (m *DockerManager) createContainer(ctx context.Context, pipeline string, mo
 		Name:              container.RestartPolicyOnFailure,
 		MaximumRetryCount: 3,
 	}
-	if keepWarm {
-		restartPolicy = container.RestartPolicy{Name: container.RestartPolicyUnlessStopped}
-	}
 
 	hostConfig := &container.HostConfig{
 		Resources: container.Resources{

--- a/box/box.sh
+++ b/box/box.sh
@@ -3,6 +3,19 @@ set -e
 
 FRONTEND=${FRONTEND:-false}
 
+# Ensure backgrounded services are stopped gracefully when this script is
+# interrupted or exits.
+cleanup() {
+  if [ "$DOCKER" = "true" ]; then
+    echo "Stopping services..."
+    # Stop dockerized services if present; ignore errors if not running
+    docker stop orchestrator --timeout 15 >/dev/null 2>&1 || true
+    docker stop gateway --timeout 15 >/dev/null 2>&1 || true
+    docker stop mediamtx --timeout 15 >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup INT TERM HUP EXIT
+
 # Start multiple processes and output their logs to the console
 gateway() {
   echo "Starting Gateway..."

--- a/box/box.sh
+++ b/box/box.sh
@@ -3,19 +3,6 @@ set -e
 
 FRONTEND=${FRONTEND:-false}
 
-# Ensure backgrounded services are stopped gracefully when this script is
-# interrupted or exits.
-cleanup() {
-  if [ "$DOCKER" = "true" ]; then
-    echo "Stopping services..."
-    # Stop dockerized services if present; ignore errors if not running
-    docker stop orchestrator --timeout 15 >/dev/null 2>&1 || true
-    docker stop gateway --timeout 15 >/dev/null 2>&1 || true
-    docker stop mediamtx --timeout 15 >/dev/null 2>&1 || true
-  fi
-}
-trap cleanup INT TERM HUP EXIT
-
 # Start multiple processes and output their logs to the console
 gateway() {
   echo "Starting Gateway..."

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -21,6 +21,8 @@ import (
 	"github.com/livepeer/go-livepeer/core"
 )
 
+const shutdownTimeout = 10 * time.Second
+
 func main() {
 	// Override the default flag set since there are dependencies that
 	// incorrectly add their own flags (specifically, due to the 'testing'
@@ -94,7 +96,7 @@ func main() {
 	select {
 	case <-lc:
 		glog.Infof("Graceful shutdown complete")
-	case <-time.After(time.Second * 2):
+	case <-time.After(shutdownTimeout):
 		glog.Infof("Shutdown timed out, forcing exit")
 		os.Exit(1)
 	}

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"syscall"
 	"time"
 
 	"github.com/livepeer/go-livepeer/cmd/livepeer/starter"
@@ -76,17 +77,25 @@ func main() {
 	lc := make(chan struct{})
 
 	go func() {
+		defer close(lc)
 		starter.StartLivepeer(ctx, cfg)
-		lc <- struct{}{}
 	}()
 
-	c := make(chan os.Signal)
-	signal.Notify(c, os.Interrupt)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
 	select {
 	case sig := <-c:
 		glog.Infof("Exiting Livepeer: %v", sig)
 		cancel()
-		time.Sleep(time.Second * 2) //Give time for other processes to shut down completely
 	case <-lc:
+		// fallthrough to normal shutdown below
+	}
+	select {
+	case <-lc:
+		glog.Infof("Graceful shutdown complete")
+	case <-time.After(time.Second * 2):
+		glog.Infof("Shutdown timed out, forcing exit")
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This fixes the shutdown process to actually wait for the `StartLivepeer` function to exit,
while increasing the timeout of doing so to up to 10s. We are frequently leaving orphaned
containers behind because 2s is not enough to both stop+remove them on ai-worker logic.

This ensure we give enough time for the `dockerRemoveContainer` functions to run before
we exit the process.

Also, removed the `RestartPolicy: always` from the warm containers. This can also cause orphaned
containers in case of OS reboot, since docker will automatically restart the containers on reboot.
We already have a watchdog logic to make sure containers are healthy and restart them if not,
so the restart policy is redundant rn. Simplify it to just use up to 3 restarts `on-failure` for everyone.

**Specific updates (required)**
- Actually wait for node logic to exit before quitting
- Increase shutdown timeout
- Fix restart policy of containers

**How did you test each of these updates (required)**
Kill O and make sure no containers are left behind

**Does this pull request close any open issues?**
Fixes https://github.com/livepeer/go-livepeer/issues/3776

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
