### PR TITLE
box: Only run frontend on demand and fix shutdown

### DIFF
--- a/box/box.sh
+++ b/box/box.sh
@@ -9,6 +9,17 @@ if [ "$FRONTEND" = "true" && "$DOCKER" = "false" ]; then
   exit 1
 fi
 
+# Ensure backgrounded services are stopped gracefully when this script is interrupted or exits.
+cleanup() {
+  if [ "$DOCKER" = "true" ]; then
+    echo "Stopping dockerized services..."
+    docker stop orchestrator --time 15 >/dev/null 2>&1 || true
+    docker stop gateway --time 15 >/dev/null 2>&1 || true
+    docker stop mediamtx --time 15 >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup INT TERM HUP EXIT
+
 # Start multiple processes and output their logs to the console
 gateway() {
   echo "Starting Gateway..."

--- a/box/box.sh
+++ b/box/box.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -e
 
+DOCKER=${DOCKER:-false}
 FRONTEND=${FRONTEND:-false}
+
+if [ "$FRONTEND" = "true" && "$DOCKER" = "false" ]; then
+  echo "Running the box with FRONTEND=true requires DOCKER=true"
+  exit 1
+fi
 
 # Start multiple processes and output their logs to the console
 gateway() {
@@ -34,9 +40,9 @@ gateway &
 orchestrator &
 mediamtx &
 
-if [ "$DOCKER" = "true" ]; then
+if [ "$FRONTEND" = "true" ]; then
   supabase &
-  mediamtx &
+  frontend &
 fi
 
 # Wait for all background processes to finish


### PR DESCRIPTION
This makes 2 fixes to the box:
- Doesn't run frontend automatically. It's super verbose so should be opt-in
- Makes sure we wait for services to gracefully shutdown on interrupt