### PR TITLE
Add remote signer endpoint for GetOrchestratorInfo

### DIFF
--- a/byoc/job_orchestrator_test.go
+++ b/byoc/job_orchestrator_test.go
@@ -96,6 +96,16 @@ func (r *mockJobOrchestrator) Sign(msg []byte) ([]byte, error) {
 func (r *mockJobOrchestrator) ExtraNodes() int {
 	return r.extraNodes
 }
+func (r *mockJobOrchestrator) OrchInfoSig() []byte {
+	if r.node != nil && len(r.node.InfoSig) > 0 {
+		return r.node.InfoSig
+	}
+	sig, err := r.Sign([]byte(r.Address().Hex()))
+	if err != nil {
+		return nil
+	}
+	return sig
+}
 func (r *mockJobOrchestrator) VerifySig(addr ethcommon.Address, msg string, sig []byte) bool {
 	return r.verifySignature(addr, msg, sig)
 }

--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -138,6 +138,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 
 	// flags
 	cfg.TestOrchAvail = fs.Bool("startupAvailabilityCheck", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
+	cfg.RemoteSigner = fs.Bool("remoteSigner", *cfg.RemoteSigner, "Set to true to run remote signer service")
 
 	// Gateway metrics
 	cfg.KafkaBootstrapServers = fs.String("kafkaBootstrapServers", *cfg.KafkaBootstrapServers, "URL of Kafka Bootstrap Servers")

--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -139,7 +139,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	// flags
 	cfg.TestOrchAvail = fs.Bool("startupAvailabilityCheck", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
 	cfg.RemoteSigner = fs.Bool("remoteSigner", *cfg.RemoteSigner, "Set to true to run remote signer service")
-	cfg.RemoteSignerAddr = fs.String("remoteSignerAddr", *cfg.RemoteSignerAddr, "URL of remote signer service to use (e.g., http://localhost:8935). Gateway only.")
+	cfg.RemoteSignerUrl = fs.String("remoteSignerUrl", *cfg.RemoteSignerUrl, "URL of remote signer service to use (e.g., http://localhost:8935). Gateway only.")
 
 	// Gateway metrics
 	cfg.KafkaBootstrapServers = fs.String("kafkaBootstrapServers", *cfg.KafkaBootstrapServers, "URL of Kafka Bootstrap Servers")

--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -139,6 +139,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	// flags
 	cfg.TestOrchAvail = fs.Bool("startupAvailabilityCheck", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
 	cfg.RemoteSigner = fs.Bool("remoteSigner", *cfg.RemoteSigner, "Set to true to run remote signer service")
+	cfg.RemoteSignerAddr = fs.String("remoteSignerAddr", *cfg.RemoteSignerAddr, "URL of remote signer service to use (e.g., http://localhost:8935). Gateway only.")
 
 	// Gateway metrics
 	cfg.KafkaBootstrapServers = fs.String("kafkaBootstrapServers", *cfg.KafkaBootstrapServers, "URL of Kafka Bootstrap Servers")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1845,6 +1845,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	// Start remote signer server if in remote signer mode
 	if n.NodeType == core.RemoteSignerNode {
 		go func() {
+			*cfg.HttpAddr = defaultAddr(*cfg.HttpAddr, "127.0.0.1", OrchestratorRpcPort)
 			glog.Info("Starting remote signer server on ", *cfg.HttpAddr)
 			err := server.StartRemoteSignerServer(s, *cfg.HttpAddr)
 			if err != nil {

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -168,6 +168,7 @@ type LivepeerConfig struct {
 	OrchMinLivepeerVersion     *string
 	TestOrchAvail              *bool
 	RemoteSigner               *bool
+	RemoteSignerAddr           *string
 	AIRunnerImage              *string
 	AIRunnerImageOverrides     *string
 	AIVerboseLogs              *bool
@@ -304,6 +305,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	// Flags
 	defaultTestOrchAvail := true
 	defaultRemoteSigner := false
+	defaultRemoteSignerAddr := ""
 
 	// Gateway logs
 	defaultKafkaBootstrapServers := ""
@@ -424,8 +426,9 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		OrchMinLivepeerVersion: &defaultMinLivepeerVersion,
 
 		// Flags
-		TestOrchAvail: &defaultTestOrchAvail,
-		RemoteSigner:  &defaultRemoteSigner,
+		TestOrchAvail:    &defaultTestOrchAvail,
+		RemoteSigner:     &defaultRemoteSigner,
+		RemoteSignerAddr: &defaultRemoteSignerAddr,
 
 		// Gateway logs
 		KafkaBootstrapServers: &defaultKafkaBootstrapServers,
@@ -1579,11 +1582,31 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		}
 
 		bcast := core.NewBroadcaster(n)
-		infoSig, err := bcast.Sign([]byte(fmt.Sprintf("%v", bcast.Address().Hex())))
-		if err != nil {
-			glog.Exit("Unable to generate info sig: ", err)
+
+		// Populate infoSig with remote signer if configured
+		if *cfg.RemoteSignerAddr != "" {
+			url, err := url.Parse(*cfg.RemoteSignerAddr)
+			if err != nil {
+				glog.Exit("Invalid remote signer addr: ", err)
+			}
+
+			glog.Info("Retrieving OrchestratorInfo fields from remote signer: ", url)
+			fields, err := server.GetOrchInfoSig(url)
+			if err != nil {
+				glog.Exit("Unable to query remote signer: ", err)
+			}
+			n.RemoteSignerAddr = url
+			n.RemoteEthAddr = ethcommon.BytesToAddress(fields.Address)
+			n.InfoSig = fields.Signature
+			glog.Info("Using Ethereum address from remote signer: ", n.RemoteEthAddr)
+		} else {
+			// Use local signing
+			infoSig, err := bcast.Sign([]byte(fmt.Sprintf("%v", bcast.Address().Hex())))
+			if err != nil {
+				glog.Exit("Unable to generate info sig: ", err)
+			}
+			n.InfoSig = infoSig
 		}
-		n.InfoSig = infoSig
 
 		orchBlacklist := parseOrchBlacklist(cfg.OrchBlacklist)
 		if *cfg.OrchPerfStatsURL != "" && *cfg.Region != "" {

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -167,6 +167,7 @@ type LivepeerConfig struct {
 	OrchBlacklist              *string
 	OrchMinLivepeerVersion     *string
 	TestOrchAvail              *bool
+	RemoteSigner               *bool
 	AIRunnerImage              *string
 	AIRunnerImageOverrides     *string
 	AIVerboseLogs              *bool
@@ -302,6 +303,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 
 	// Flags
 	defaultTestOrchAvail := true
+	defaultRemoteSigner := false
 
 	// Gateway logs
 	defaultKafkaBootstrapServers := ""
@@ -423,6 +425,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 
 		// Flags
 		TestOrchAvail: &defaultTestOrchAvail,
+		RemoteSigner:  &defaultRemoteSigner,
 
 		// Gateway logs
 		KafkaBootstrapServers: &defaultKafkaBootstrapServers,
@@ -679,8 +682,17 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		}
 	}
 
+	// Validate remote signer mode
+	if *cfg.RemoteSigner {
+		if *cfg.Network == "offchain" {
+			exit("Remote signer mode requires on-chain network")
+		}
+	}
+
 	if *cfg.Redeemer {
 		n.NodeType = core.RedeemerNode
+	} else if *cfg.RemoteSigner {
+		n.NodeType = core.RemoteSignerNode
 	} else if *cfg.Orchestrator {
 		n.NodeType = core.OrchestratorNode
 		if !*cfg.Transcoder {
@@ -1790,6 +1802,17 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	if n.NodeType != core.RedeemerNode {
 		go func() {
 			ec <- s.StartMediaServer(msCtx, *cfg.HttpAddr)
+		}()
+	}
+
+	// Start remote signer server if in remote signer mode
+	if n.NodeType == core.RemoteSignerNode {
+		go func() {
+			glog.Info("Starting remote signer server on ", *cfg.HttpAddr)
+			err := server.StartRemoteSignerServer(s, *cfg.HttpAddr)
+			if err != nil {
+				exit("Error starting remote signer server: err=%q", err)
+			}
 		}()
 	}
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1579,6 +1579,12 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		}
 
 		bcast := core.NewBroadcaster(n)
+		infoSig, err := bcast.Sign([]byte(fmt.Sprintf("%v", bcast.Address().Hex())))
+		if err != nil {
+			glog.Exit("Unable to generate info sig: ", err)
+		}
+		n.InfoSig = infoSig
+
 		orchBlacklist := parseOrchBlacklist(cfg.OrchBlacklist)
 		if *cfg.OrchPerfStatsURL != "" && *cfg.Region != "" {
 			glog.Infof("Using Performance Stats, region=%s, URL=%s, minPerfScore=%v", *cfg.Region, *cfg.OrchPerfStatsURL, *cfg.MinPerfScore)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -168,7 +168,7 @@ type LivepeerConfig struct {
 	OrchMinLivepeerVersion     *string
 	TestOrchAvail              *bool
 	RemoteSigner               *bool
-	RemoteSignerAddr           *string
+	RemoteSignerUrl            *string
 	AIRunnerImage              *string
 	AIRunnerImageOverrides     *string
 	AIVerboseLogs              *bool
@@ -305,7 +305,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	// Flags
 	defaultTestOrchAvail := true
 	defaultRemoteSigner := false
-	defaultRemoteSignerAddr := ""
+	defaultRemoteSignerUrl := ""
 
 	// Gateway logs
 	defaultKafkaBootstrapServers := ""
@@ -426,9 +426,9 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		OrchMinLivepeerVersion: &defaultMinLivepeerVersion,
 
 		// Flags
-		TestOrchAvail:    &defaultTestOrchAvail,
-		RemoteSigner:     &defaultRemoteSigner,
-		RemoteSignerAddr: &defaultRemoteSignerAddr,
+		TestOrchAvail:   &defaultTestOrchAvail,
+		RemoteSigner:    &defaultRemoteSigner,
+		RemoteSignerUrl: &defaultRemoteSignerUrl,
 
 		// Gateway logs
 		KafkaBootstrapServers: &defaultKafkaBootstrapServers,
@@ -1584,10 +1584,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		bcast := core.NewBroadcaster(n)
 
 		// Populate infoSig with remote signer if configured
-		if *cfg.RemoteSignerAddr != "" {
-			url, err := url.Parse(*cfg.RemoteSignerAddr)
+		if *cfg.RemoteSignerUrl != "" {
+			url, err := url.Parse(*cfg.RemoteSignerUrl)
 			if err != nil {
-				glog.Exit("Invalid remote signer addr: ", err)
+				glog.Exit("Invalid remote signer URL: ", err)
 			}
 
 			glog.Info("Retrieving OrchestratorInfo fields from remote signer: ", url)
@@ -1595,7 +1595,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			if err != nil {
 				glog.Exit("Unable to query remote signer: ", err)
 			}
-			n.RemoteSignerAddr = url
+			n.RemoteSignerUrl = url
 			n.RemoteEthAddr = ethcommon.BytesToAddress(fields.Address)
 			n.InfoSig = fields.Signature
 			glog.Info("Using Ethereum address from remote signer: ", n.RemoteEthAddr)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1589,6 +1589,14 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			if err != nil {
 				glog.Exit("Invalid remote signer URL: ", err)
 			}
+			if url.Scheme == "" || url.Host == "" {
+				// Usually something like `host:port` or just plain `host`
+				// Prepend https:// for convenience
+				url, err = url.Parse("https://" + *cfg.RemoteSignerUrl)
+				if err != nil {
+					glog.Exit("Adding HTTPS to remote signer URL failed: ", err)
+				}
+			}
 
 			glog.Info("Retrieving OrchestratorInfo fields from remote signer: ", url)
 			fields, err := server.GetOrchInfoSig(url)

--- a/common/types.go
+++ b/common/types.go
@@ -45,6 +45,7 @@ type NodeStatus struct {
 type Broadcaster interface {
 	Address() ethcommon.Address
 	Sign([]byte) ([]byte, error)
+	OrchInfoSig() []byte
 	ExtraNodes() int
 }
 

--- a/core/broadcaster.go
+++ b/core/broadcaster.go
@@ -18,7 +18,13 @@ func (bcast *broadcaster) Sign(msg []byte) ([]byte, error) {
 	return bcast.node.Eth.Sign(crypto.Keccak256(msg))
 }
 func (bcast *broadcaster) Address() ethcommon.Address {
-	if bcast.node == nil || bcast.node.Eth == nil {
+	if bcast.node == nil {
+		return ethcommon.Address{}
+	}
+	if (bcast.node.RemoteEthAddr != ethcommon.Address{}) {
+		return bcast.node.RemoteEthAddr
+	}
+	if bcast.node.Eth == nil {
 		return ethcommon.Address{}
 	}
 	return bcast.node.Eth.Account().Address

--- a/core/broadcaster.go
+++ b/core/broadcaster.go
@@ -23,6 +23,12 @@ func (bcast *broadcaster) Address() ethcommon.Address {
 	}
 	return bcast.node.Eth.Account().Address
 }
+func (bcast *broadcaster) OrchInfoSig() []byte {
+	if bcast == nil || bcast.node == nil {
+		return nil
+	}
+	return bcast.node.InfoSig
+}
 func (bcast *broadcaster) ExtraNodes() int {
 	if bcast == nil || bcast.node == nil {
 		return 0

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -150,8 +150,8 @@ type LivepeerNode struct {
 
 	// Gateway fields for remote signers
 	RemoteSignerUrl *url.URL
-	RemoteEthAddr    ethcommon.Address // eth address of the remote signer
-	InfoSig          []byte            // sig over eth address for the OrchestratorInfo request
+	RemoteEthAddr   ethcommon.Address // eth address of the remote signer
+	InfoSig         []byte            // sig over eth address for the OrchestratorInfo request
 
 	// Thread safety for config fields
 	mu                  sync.RWMutex

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -145,6 +145,7 @@ type LivepeerNode struct {
 	// Broadcaster public fields
 	Sender     pm.Sender
 	ExtraNodes int
+	InfoSig    []byte // sig over eth address for the OrchestratorInfo request
 
 	// Thread safety for config fields
 	mu                  sync.RWMutex

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -149,7 +149,7 @@ type LivepeerNode struct {
 	ExtraNodes int
 
 	// Gateway fields for remote signers
-	RemoteSignerAddr *url.URL
+	RemoteSignerUrl *url.URL
 	RemoteEthAddr    ethcommon.Address // eth address of the remote signer
 	InfoSig          []byte            // sig over eth address for the OrchestratorInfo request
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -26,6 +26,8 @@ import (
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/eth"
 	lpmon "github.com/livepeer/go-livepeer/monitor"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
 )
 
 var ErrTranscoderAvail = errors.New("ErrTranscoderUnavailable")
@@ -145,7 +147,11 @@ type LivepeerNode struct {
 	// Broadcaster public fields
 	Sender     pm.Sender
 	ExtraNodes int
-	InfoSig    []byte // sig over eth address for the OrchestratorInfo request
+
+	// Gateway fields for remote signers
+	RemoteSignerAddr *url.URL
+	RemoteEthAddr    ethcommon.Address // eth address of the remote signer
+	InfoSig          []byte            // sig over eth address for the OrchestratorInfo request
 
 	// Thread safety for config fields
 	mu                  sync.RWMutex

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -48,6 +48,7 @@ const (
 	TranscoderNode
 	RedeemerNode
 	AIWorkerNode
+	RemoteSignerNode
 )
 
 var nodeTypeStrs = map[NodeType]string{
@@ -57,6 +58,7 @@ var nodeTypeStrs = map[NodeType]string{
 	TranscoderNode:   "transcoder",
 	RedeemerNode:     "redeemer",
 	AIWorkerNode:     "aiworker",
+	RemoteSignerNode: "remotesigner",
 }
 
 func (t NodeType) String() string {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -36,6 +36,7 @@ type stubBroadcaster struct{}
 func (s *stubBroadcaster) Sign(msg []byte) ([]byte, error) { return []byte{}, nil }
 func (s *stubBroadcaster) Address() ethcommon.Address      { return ethcommon.Address{} }
 func (s *stubBroadcaster) ExtraNodes() int                 { return 0 }
+func (s *stubBroadcaster) OrchInfoSig() []byte             { return nil }
 
 func TestNewDBOrchestratorPoolCache_NilEthClient_ReturnsError(t *testing.T) {
 	assert := assert.New(t)

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -1,0 +1,108 @@
+# Remote signer
+
+The **remote signer** is a standalone `go-livepeer` node mode that separates **Ethereum key custody + signing** from the gateway’s **untrusted media handling**. It is intended to:
+
+- Improve security posture by removing Ethereum hot keys from the media processing path
+- Enable web3-less gateway implementations natively on additional platforms such as browser, mobile, serverless and embedded backend apps
+- Enable third-party payment operators to manage crypto payments separately from those managing media operations.
+
+## Current implementation status
+
+Remote signing was designed to initially target **Live AI** (`live-video-to-video`).
+
+Support for other workloads may be added in the future.
+
+The on-chain service registry is not used for Live AI workloads right now, so orchestrator discovery is not implemented as part of the remote signer. The gateway can learn about its orchestrators via the orchestrator webhook or the orchAddr list flag.
+
+With these two pieces, a `go-livepeer` gateway can operate in **offchain mode** for production Live AI workloads while interacting with **on-chain orchestrators**.
+
+## Architecture
+
+At a high level, the gateway uses the remote signer to handle Ethereum-related operations such as generating signatures or probabilistic micropayments tickets:
+
+```mermaid
+sequenceDiagram
+  participant RemoteSigner as RemoteSigner
+  participant Gateway as Gateway
+  participant Orchestrator as Orchestrator
+
+  Gateway->>RemoteSigner: POST /sign-orchestrator-info
+  RemoteSigner-->>Gateway: {address, signature}
+  Gateway->>Orchestrator: GetOrchestratorInfo(Address=address,Sig=signature)
+  Orchestrator-->>Gateway: OrchestratorInfo (incl TicketParams)
+
+  Note over Gateway,RemoteSigner: Live AI payments (asynchronous)
+  Gateway->>RemoteSigner: POST /generate-live-payment (orchInfo + signerState)
+  RemoteSigner-->>Gateway: {payment, segCreds, signerState'}
+  Gateway->>Orchestrator: POST /payment (headers: Livepeer-Payment, Livepeer-Segment)
+  Orchestrator-->>Gateway: PaymentResult (incl updated OrchestratorInfo)
+```
+
+## Usage
+
+### Remote signer node
+
+Start a remote signer by enabling the mode flag:
+
+- `-remoteSigner=true`: run the remote signer service
+
+The remote signer is intended to be its own standalone node type. The `-remoteSigner` flag can not be combined with other mode flags such as `-gateway`, `-orchestrator`, `-transcoder`, etc.
+
+**The remote signer requires an on-chain network**. It cannot run with `-network=offchain` - there are no payments and nothing to sign offchain.
+
+The remote signer must have typical Ethereum flags configured (examples: `-network`, `-ethUrl`, `-ethController`, keystore/password flags). See the go-livepeer [devtool](https://github.com/livepeer/go-livepeer/blob/92bdb59f169056e3d1beba9b511554ea5d9eda72/cmd/devtool/devtool.go#L200-L212) for an example of what flags might be required.
+
+The remote signer listens to the standard go-livepeer HTTP port (8935) by default. To change the listening port or interface, use the `-httpAddr` flag.
+
+Example (fill in the placeholders for your environment):
+
+```bash
+./livepeer \
+  -remoteSigner \
+  -network mainnet \
+  -httpAddr 127.0.0.1:7936 \
+  -ethUrl <eth-rpc-url> \
+  -ethController <controller-contract-address> \
+  -ethKeystorePath <keystore-path-or-keyfile> \
+  -ethPassword <password-or-password-file>
+```
+
+### Gateway node
+
+Configure a gateway to use a remote signer with:
+
+- `-remoteSignerUrl <url>`: base URL of the remote signer service (**gateway only**)
+
+If `-remoteSignerUrl` is set, the gateway will query the signer at startup and **fail fast** if it cannot retrieve the signature.
+
+**No Ethereum flags are necessary on the gateway** in this mode. Omit the `-network` flag entirely here; this makes the gateway run in offchain mode, but it will still work on-chain with the `-remoteSignerUrl` flag enabled.
+
+Example:
+
+```bash
+./livepeer \
+  -gateway \
+  -httpAddr :9935 \
+  -remoteSignerUrl localhost:7936 \
+  -orchAddr localhost:7936 \
+  -v 6
+```
+
+## Operational + security guidance
+
+For the moment, remote signers are intended to sit behind infrastructure controls rather than being exposed directly to end-users. For example, run the remote signer on a private network or behind an authenticated proxy. Do not expose the remote signer to unauthenticated end-users.
+
+## Live AI payment protocol notes
+
+Remote signing for Live AI is designed to keep the signer service **stateless** while still supporting stateful PM sessions. It does this by round-tripping an opaque “signer state” blob on every request.
+
+- Remote signer nodes can operate in a redundant configuration due to the statelessness
+- The gateway retains:
+  - the **remote signer state** returned by `/generate-live-payment`
+  - the **orchestrator ticket params** (returned via `GetOrchestratorInfo` and updated after `/payment`)
+- The remote signer **signs** the serialized state with its Ethereum key and **verifies** the signature on subsequent requests to prevent tampering.
+- The gateway should treat the signer state as an **opaque blob** (do not modify it; just store and forward it on the next payment request).
+- If the gateway fails to consistently provide the latest state, it can cause:
+  - invalid tickets (eg, nonce reuse)
+  - excessive ticket generation / overpayment
+- High-frequency or concurrent signing calls for the same session are likely to produce invalid tickets and are not an intended use-case.

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -108,7 +108,7 @@ type OrchInfoSigResponse struct {
 	Signature HexBytes `json:"signature"`
 }
 
-// Calls the remote signer service to get a signature for GetOrchInfo
+// Gateway helper that calls the remote signer service for the GetOrchestratorInfo signature
 func GetOrchInfoSig(remoteSignerHost *url.URL) (*OrchInfoSigResponse, error) {
 
 	url := remoteSignerHost.ResolveReference(&url.URL{Path: "/sign-orchestrator-info"})

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -55,6 +55,12 @@ func StartRemoteSignerServer(ls *LivepeerServer, bind string) error {
 
 	// Start the HTTP server
 	glog.Info("Starting Remote Signer server on ", bind)
+	gw := core.NewBroadcaster(ls.LivepeerNode)
+	sig, err := gw.Sign([]byte(fmt.Sprintf("%v", gw.Address().Hex())))
+	if err != nil {
+		return err
+	}
+	ls.LivepeerNode.InfoSig = sig
 	srv := http.Server{
 		Addr:        bind,
 		Handler:     ls.HTTPMux,

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/clog"
+	"github.com/livepeer/go-livepeer/core"
+)
+
+// SignOrchestratorInfo handles signing GetOrchestratorInfo requests for multiple orchestrators
+func (ls *LivepeerServer) SignOrchestratorInfo(w http.ResponseWriter, r *http.Request) {
+	ctx := clog.AddVal(r.Context(), "request_id", string(core.RandomManifestID()))
+	remoteAddr := getRemoteAddr(r)
+	clog.Info(ctx, "Orch info signature request", "ip", remoteAddr)
+
+	// Get the broadcaster (signer)
+	// In remote signer mode, we may not have an OrchestratorPool, so create a broadcaster directly
+	gw := core.NewBroadcaster(ls.LivepeerNode)
+
+	// Create empty params for signing
+	params := GetOrchestratorInfoParams{}
+
+	// Generate the request (this creates the signature)
+	req, err := genOrchestratorReq(gw, params)
+	if err != nil {
+		clog.Errorf(ctx, "Failed to generate request: err=%q", err)
+		respondJsonError(ctx, w, err, http.StatusInternalServerError)
+		return
+	}
+
+	// Extract signature and format as hex
+	var (
+		signature = "0x" + hex.EncodeToString(req.Sig)
+		address   = gw.Address().String()
+	)
+
+	results := map[string]string{
+		"address":   address,
+		"signature": signature,
+	}
+
+	// Return JSON response
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(results)
+}
+
+// StartRemoteSignerServer starts the HTTP server for remote signer mode
+func StartRemoteSignerServer(ls *LivepeerServer, bind string) error {
+	// Register the remote signer endpoint
+	ls.HTTPMux.Handle("POST /sign-orchestrator-info", http.HandlerFunc(ls.SignOrchestratorInfo))
+
+	// Start the HTTP server
+	glog.Info("Starting Remote Signer server on ", bind)
+	srv := http.Server{
+		Addr:        bind,
+		Handler:     ls.HTTPMux,
+		IdleTimeout: HTTPIdleTimeout,
+	}
+	return srv.ListenAndServe()
+}

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -362,11 +362,7 @@ func startOrchestratorClient(ctx context.Context, uri *url.URL) (net.Orchestrato
 }
 
 func genOrchestratorReq(b common.Broadcaster, params GetOrchestratorInfoParams) (*net.OrchestratorRequest, error) {
-	sig, err := b.Sign([]byte(fmt.Sprintf("%v", b.Address().Hex())))
-	if err != nil {
-		return nil, err
-	}
-	return &net.OrchestratorRequest{Address: b.Address().Bytes(), Sig: sig, Capabilities: params.Caps, IgnoreCapacityCheck: params.IgnoreCapacityCheck}, nil
+	return &net.OrchestratorRequest{Address: b.Address().Bytes(), Sig: b.OrchInfoSig(), Capabilities: params.Caps, IgnoreCapacityCheck: params.IgnoreCapacityCheck}, nil
 }
 
 func genEndSessionRequest(sess *BroadcastSession) (*net.EndTranscodingSessionRequest, error) {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -284,6 +284,10 @@ func (r *stubOrchestrator) GetUrlForCapability(capability string) string {
 func (r *stubOrchestrator) ExtraNodes() int {
 	return 0
 }
+func (r *stubOrchestrator) OrchInfoSig() []byte {
+	b, _ := r.Sign([]byte(r.Address().Hex()))
+	return b
+}
 
 func stubBroadcaster2() *stubOrchestrator {
 	return newStubOrchestrator() // lazy; leverage subtyping for interface commonalities
@@ -323,13 +327,6 @@ func TestRPCTranscoderReq(t *testing.T) {
 		t.Errorf("Expected %v; got %v", o.sessCapErr, err)
 	}
 	o.sessCapErr = nil
-
-	// error signing
-	b.signErr = fmt.Errorf("Signing error")
-	_, err = genOrchestratorReq(b, GetOrchestratorInfoParams{})
-	if err == nil {
-		t.Error("Did not expect to generate a orchestrator request with invalid address")
-	}
 }
 
 func TestRPCSeg(t *testing.T) {

--- a/test_args.sh
+++ b/test_args.sh
@@ -216,6 +216,15 @@ res=0
 $TMPDIR/livepeer -gateway -verifierUrl http\\://host/ || res=$?
 [ $res -ne 0 ]
 
+# Check remote signer URL handling
+$TMPDIR/livepeer -gateway -remoteSignerUrl 127.0.0.1:65535 2>&1 | grep -e "Retrieving OrchestratorInfo fields from remote signer: https://127.0.0.1:65535"
+
+$TMPDIR/livepeer -gateway -remoteSignerUrl http://127.0.0.1:65535 2>&1 | grep -e "Retrieving OrchestratorInfo fields from remote signer: http://127.0.0.1:65535"
+
+$TMPDIR/livepeer -gateway -remoteSignerUrl "http://[::1" 2>&1 | grep -e "Invalid remote signer URL"
+
+$TMPDIR/livepeer -gateway -remoteSignerUrl abc:def 2>&1 | grep -e 'Adding HTTPS to remote signer URL failed: parse "https://acbc:def": invalid port ":def"'
+
 # Check that verifier shared path is required
 $TMPDIR/livepeer -gateway -verifierUrl http://host 2>&1 | grep "Requires a path to the"
 

--- a/test_args.sh
+++ b/test_args.sh
@@ -217,13 +217,13 @@ $TMPDIR/livepeer -gateway -verifierUrl http\\://host/ || res=$?
 [ $res -ne 0 ]
 
 # Check remote signer URL handling
-$TMPDIR/livepeer -gateway -remoteSignerUrl 127.0.0.1:65535 2>&1 | grep -e "Retrieving OrchestratorInfo fields from remote signer: https://127.0.0.1:65535"
+$TMPDIR/livepeer -gateway -remoteSignerUrl abc:65535 2>&1 | grep -e "Retrieving OrchestratorInfo fields from remote signer: https://abc:65535"
 
 $TMPDIR/livepeer -gateway -remoteSignerUrl http://127.0.0.1:65535 2>&1 | grep -e "Retrieving OrchestratorInfo fields from remote signer: http://127.0.0.1:65535"
 
 $TMPDIR/livepeer -gateway -remoteSignerUrl "http://[::1" 2>&1 | grep -e "Invalid remote signer URL"
 
-$TMPDIR/livepeer -gateway -remoteSignerUrl abc:def 2>&1 | grep -e 'Adding HTTPS to remote signer URL failed: parse "https://acbc:def": invalid port ":def"'
+$TMPDIR/livepeer -gateway -remoteSignerUrl abc:def 2>&1 | grep -e 'Adding HTTPS to remote signer URL failed: parse "https://abc:def": invalid port ":def"'
 
 # Check that verifier shared path is required
 $TMPDIR/livepeer -gateway -verifierUrl http://host 2>&1 | grep "Requires a path to the"


### PR DESCRIPTION
This PR is the first part of the remote signing feature, implementing the GetOrchestratorInfo request. See the [design background](https://www.notion.so/livepeer/Remote-Signers-2c00a348568781e59112e88e1f59151a) for additional motivation and design detail around remote signers.

Remote signing support for Live AI (live-video-to-video) consists of two parts:

* GetOrchestratorInfo (this PR)
* PM ticket retrieval (https://github.com/livepeer/go-livepeer/pull/3822)

This PR adds a new mode to go-livepeer: `-remoteSigner`.

The remote signer exposes a HTTP POST endpoint at `/sign-orchestrator-info`. It currently does only does one thing: produces a signature for use in the `OrchestratorInfo` gRPC call. The response includes the signer's Ethereum address as well as the signature itself.

Like the other types of mode flags (gateway, orchestrator, redeemer, etc) the remote signer cannot be combined with other modes.

The gateway adds a new `-remoteSignerAddr` flag which specifies the base address of the remote signer to use (host:port). When configured, the gateway pre-fetches the remote signature for OrchestratorInfo at start-up time and caches it, so subsequent calls to OrchestratorInfo do not have to incur additional remote calls.

One might note that this OrchestratorInfo signing scheme doesn't actually accomplish much at all: the signature effectively static, not scoped to any one orchestrator, and never expires. This is a legacy aspect of the OrchestratorInfo flow that we have to accommodate for now; it is a vestigial corner of the codebase, but one that we've judged internally to be harmless.