### PR TITLE
ai/live: Remove segment probing from payments

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -214,7 +214,7 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 		go func() {
 			sub := trickle.NewLocalSubscriber(h.trickleSrv, mid)
 			for {
-				_, err := sub.Read()
+				segment, err := sub.Read()
 				if err != nil {
 					clog.Infof(ctx, "Error getting local trickle segment err=%v", err)
 					return
@@ -222,6 +222,9 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 				if paymentProcessor != nil {
 					paymentProcessor.process(ctx)
 				}
+				// read the segment so we know when it is complete, otherwise sub.Read()
+				// would rapidly request follow-on segments that do not yet exist
+				io.Copy(io.Discard, segment.Reader)
 			}
 		}()
 

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -210,20 +210,18 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 			clog.Warningf(ctx, "No price info found for model %v, Orchestrator will not charge for video processing", modelID)
 		}
 
-		// Subscribe to the publishUrl for payments monitoring and payment processing
+		// For every segment, check payments
 		go func() {
 			sub := trickle.NewLocalSubscriber(h.trickleSrv, mid)
 			for {
-				segment, err := sub.Read()
+				_, err := sub.Read()
 				if err != nil {
 					clog.Infof(ctx, "Error getting local trickle segment err=%v", err)
 					return
 				}
-				reader := segment.Reader
 				if paymentProcessor != nil {
-					reader = paymentProcessor.process(ctx, segment.Reader)
+					paymentProcessor.process(ctx)
 				}
-				io.Copy(io.Discard, reader)
 			}
 		}()
 

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -121,7 +121,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 			defer slowOrchChecker.EndSegment()
 			var r io.Reader = reader
 			if paymentProcessor != nil {
-				r = paymentProcessor.process(ctx, reader)
+				paymentProcessor.process(ctx)
 			}
 
 			clog.V(8).Infof(ctx, "trickle publish writing data seq=%d", seq)


### PR DESCRIPTION
Since we now do time based payments rather than resolution based payments, segment probing is no longer needed.

However, we still send handle payments roughly once per segment to roughly synchronize the frequency of payment transmissions and checks between gateways and orchestrators. In theory having the G / O handle payments at different rates should be OK as long as the G has some balance with the O, but for now we can try to keep the cadence similar to the current setup that is known to work well.

---

- [x] Tested with local devnet
- [x] Tested on a single staging region
- [x] Found a number of smaller but unrelated issues while testing this: https://github.com/livepeer/go-livepeer/pull/3802 