### PR TITLE
test: Fix more discovery race conditions

### DIFF
--- a/common/testutil.go
+++ b/common/testutil.go
@@ -89,15 +89,23 @@ func IgnoreRoutines() []goleak.Option {
 		"github.com/livepeer/go-livepeer/server.(*LivepeerServer).StartMediaServer", "github.com/livepeer/go-livepeer/core.(*RemoteTranscoderManager).Manage.func1",
 		"github.com/livepeer/go-livepeer/server.(*LivepeerServer).HandlePush.func1", "github.com/rjeczalik/notify.(*nonrecursiveTree).dispatch",
 		"github.com/rjeczalik/notify.(*nonrecursiveTree).internal", "github.com/livepeer/lpms/stream.NewBasicRTMPVideoStream.func1", "github.com/patrickmn/go-cache.(*janitor).Run",
-		"github.com/golang/glog.(*fileSink).flushDaemon", "github.com/livepeer/go-livepeer/core.(*LivepeerNode).transcodeFrames.func2", "github.com/ipfs/go-log/writer.(*MirrorWriter).logRoutine",
+		"github.com/livepeer/go-livepeer/core.(*LivepeerNode).transcodeFrames.func2", "github.com/ipfs/go-log/writer.(*MirrorWriter).logRoutine",
 		"github.com/livepeer/go-livepeer/core.(*Balances).StartCleanup",
 		"internal/synctest.Run",
 		"testing/synctest.testingSynctestTest",
 	}
+	ignoreAnywhereFuncs := []string{
+		// glog’s file flusher often has syscall/os.* on top
+		"github.com/golang/glog.(*fileSink).flushDaemon",
+	}
 
-	res := make([]goleak.Option, 0, len(funcs2ignore))
+	res := make([]goleak.Option, 0, len(funcs2ignore)+len(ignoreAnywhereFuncs))
 	for _, f := range funcs2ignore {
 		res = append(res, goleak.IgnoreTopFunction(f))
+	}
+	for _, f := range ignoreAnywhereFuncs {
+		// ignore if these function signatures appear anywhere in the call stack
+		res = append(res, goleak.IgnoreAnyFunction(f))
 	}
 	return res
 }

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -244,6 +244,10 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 
 	// Shuffle and create O descriptor
 	for _, i := range rand.Perm(numAvailableOrchs) {
+		if i >= maxOrchNodes {
+			// prevents channel deadlocks when maxOrchNodes < numAvailableOrchs
+			break
+		}
 		go getOrchInfo(ctx, common.OrchestratorDescriptor{linfos[i], nil}, 0, odCh, errCh, allOrchDescrCh)
 	}
 	go reportLiveAICapacity(allOrchDescrCh, caps)

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -585,8 +585,11 @@ func TestNewOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *
 }
 
 func TestNewOrchestratorPoolWithPred_TestPredicate(t *testing.T) {
+	cfg := server.NewBroadcastConfig()
 	pred := func(info *net.OrchestratorInfo) bool {
-		price := server.BroadcastCfg.MaxPrice()
+		// create a new one for each call -for some reason the price auto-converts
+		// to zero and messes up if we reuse it
+		price := cfg.MaxPrice()
 		if price == nil {
 			return true
 		}
@@ -612,15 +615,15 @@ func TestNewOrchestratorPoolWithPred_TestPredicate(t *testing.T) {
 		},
 	}
 
-	// server.BroadcastCfg.maxPrice not yet set, predicate should return true
+	// cfg.maxPrice not yet set, predicate should return true
 	assert.True(t, pool.pred(oInfo))
 
-	// Set server.BroadcastCfg.maxPrice higher than PriceInfo , should return true
-	server.BroadcastCfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(10, 1)))
+	// Set cfg.maxPrice higher than PriceInfo , should return true
+	cfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(10, 1)))
 	assert.True(t, pool.pred(oInfo))
 
-	// Set MaxBroadcastPrice lower than PriceInfo, should return false
-	server.BroadcastCfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(1, 1)))
+	// Set cfg.MaxBroadcastPrice lower than PriceInfo, should return false
+	cfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(1, 1)))
 	assert.False(t, pool.pred(oInfo))
 
 	// PixelsPerUnit is 0 , return false

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1709,6 +1709,7 @@ func TestGetOrchestrator_Nodes_Simple(t *testing.T) {
 }
 
 func TestGetOrchestrators_Nodes_ExtraNodes(t *testing.T) {
+	defer goleak.VerifyNone(t, common.IgnoreRoutines()...)
 	initial := "https://127.0.0.1:8200"
 	uris := stringsToURIs([]string{initial})
 

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1650,7 +1650,9 @@ func TestSetGetOrchestratorTimeout(t *testing.T) {
 	}
 
 	//set timeout to 1000ms
-	poolCache, err := NewDBOrchestratorPoolCache(context.TODO(), node, &stubRoundsManager{}, []string{}, 1000*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	poolCache, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 1000*time.Millisecond)
 	assert.Nil(err)
 	//confirm the timeout is now 1000ms
 	assert.Equal(poolCache.discoveryTimeout, 1000*time.Millisecond)

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1636,7 +1636,9 @@ func TestOrchestratorPool_Capabilities(t *testing.T) {
 
 func TestSetGetOrchestratorTimeout(t *testing.T) {
 	assert := assert.New(t)
-	dbh, _, err := common.TempDB(t)
+	dbh, dbraw, err := common.TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
 	require := require.New(t)
 	require.Nil(err)
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -41,7 +41,7 @@ var maxRefreshSessionsThreshold = 8.0
 var recordSegmentsMaxTimeout = 1 * time.Minute
 
 var Policy *verification.Policy
-var BroadcastCfg = newBroadcastConfig()
+var BroadcastCfg = NewBroadcastConfig()
 var MaxAttempts = 3
 
 var MetadataQueue event.SimpleProducer
@@ -60,7 +60,7 @@ type BroadcastConfig struct {
 	mu                    sync.RWMutex
 }
 
-func newBroadcastConfig() *BroadcastConfig {
+func NewBroadcastConfig() *BroadcastConfig {
 	maxPrices := make(map[core.Capability]map[string]*core.AutoConvertedPrice)
 	models := make(map[string]*core.AutoConvertedPrice)
 	maxPrices[core.Capability_Unused] = models

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -1826,7 +1826,7 @@ func TestVerifcationRunsBasedOnVerificationFrequency(t *testing.T) {
 }
 
 func TestMaxPrice(t *testing.T) {
-	cfg := newBroadcastConfig()
+	cfg := NewBroadcastConfig()
 
 	// Should return nil if max price is not set.
 	assert.Nil(t, cfg.MaxPrice())
@@ -1847,7 +1847,7 @@ func TestMaxPrice(t *testing.T) {
 }
 
 func TestCapabilityMaxPrice(t *testing.T) {
-	cfg := newBroadcastConfig()
+	cfg := NewBroadcastConfig()
 
 	// Should return nil if no price is set for the capability.
 	assert.Nil(t, cfg.getCapabilityMaxPrice(core.Capability(1), "model1"))
@@ -1885,7 +1885,7 @@ func TestCapabilityMaxPrice(t *testing.T) {
 }
 
 func TestGetCapabilitiesMaxPrice(t *testing.T) {
-	cfg := newBroadcastConfig()
+	cfg := NewBroadcastConfig()
 
 	// Should return nil if no max price is set and no capabilities are provided.
 	assert.Nil(t, cfg.GetCapabilitiesMaxPrice(nil))


### PR DESCRIPTION
This should hopefully clear up some of the sporadic errors we get from CI around discovery since we switched to golang 1.25. We had (and still have) a number of tests that unintentionally share state, usually via modifying globals, and that causes them to stomp over one another sometimes. In other places we had blocked goroutines that weren't being terminated and running tests multiple times `-count 2` triggered the goleak detector in *other* tests - those were fun to track down.

Also see https://github.com/livepeer/go-livepeer/pull/3745

[test: Add glog.FlushDaemon to goleak ignore list.](https://github.com/livepeer/go-livepeer/commit/eb6d6a52a380fdc322ca9879026f1dcb6147aaba)
Since the move to golang 1.25 sometimes we get a failure
where unit tests exit while glog is in the middle of flushing via
glog.FlushDaemon. This puts the function in the middle of the call
stack, usually with some other OS functions on top.

Fix this by matching this specific function anywhere in the call stack,
(goleak.IgnoreAnyFunction) rather than just on top of the call stack
(goleak.IgnoreTopFunction).

We may encounter more of these in which case it might be justified to
stick everything under IgnoreAnyFunction but for now let's be cautious.

[discovery: Prevent blocked discovery requests.](https://github.com/livepeer/go-livepeer/commit/ab4d1129388f723f00493a81fceb0ee59111b750)

[discovery/test: Prevent race condition with custom getOrchInfo](https://github.com/livepeer/go-livepeer/commit/559c172770f8d4f4cafac143652fb6a2bdc04e35)

[discovery/test: Close hanging DB handle.](https://github.com/livepeer/go-livepeer/commit/5b4fbe4896a79cd17d52af850986ad7b1009cd9a)

[Close DB orch pool context to tear down polling loop.](https://github.com/livepeer/go-livepeer/commit/d2ae41d215cfaa27e73da42967020334bfcf7214)

[server: Export NewBroadcastConfig() for tests.](https://github.com/livepeer/go-livepeer/commit/52162153e026fdc20d09e728ad535a4cfdcef74b)
Some unit tests were stomping over one another by using this global.

The struct does not allow us to set individual fields (and even so the
internals are a bit complex) so just do the lazy thing and export a
constructor function for tests to use.