### PR TITLE
ai/live: Misc orch payments fixes

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -218,6 +218,9 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 		go func() {
 			sub := trickle.NewLocalSubscriber(h.trickleSrv, mid)
 			for {
+				// Set seq to next segment in case the subscriber is outside
+				// the server's retention window
+				sub.SetSeq(-1)
 				segment, err := sub.Read()
 				if err != nil {
 					clog.Infof(ctx, "Error getting local trickle segment err=%v", err)

--- a/trickle/local_subscriber.go
+++ b/trickle/local_subscriber.go
@@ -46,7 +46,10 @@ func (c *TrickleLocalSubscriber) Read() (*TrickleData, error) {
 		}
 		return nil, errors.New("seq not found")
 	}
-	c.seq++
+	seq := segment.idx
+	if seq >= 0 {
+		c.seq = seq + 1
+	}
 	r, w := io.Pipe()
 	go func() {
 		subscriber := &SegmentSubscriber{
@@ -78,4 +81,10 @@ func (c *TrickleLocalSubscriber) Read() (*TrickleData, error) {
 			"Content-Type":      stream.mimeType,
 		}, // TODO take more metadata from http headers
 	}, nil
+}
+
+func (c *TrickleLocalSubscriber) SetSeq(seq int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.seq = seq
 }

--- a/trickle/local_subscriber_test.go
+++ b/trickle/local_subscriber_test.go
@@ -1,0 +1,83 @@
+package trickle
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestLocalSubscriber_OverrunSeq(t *testing.T) {
+	// check local subscriber behavior when the local sequence
+	// falls behind the server's own sequence window
+	require, url, server := makeServerWithServer(t)
+
+	pub, err := NewTricklePublisher(url)
+	require.Nil(err)
+
+	sub := NewLocalSubscriber(server, "testest")
+
+	// Publish more segments
+	for i := 0; i < maxSegmentsPerStream+1; i++ {
+		require.Nil(pub.Write(bytes.NewReader(fmt.Appendf(nil, "write %d", i))))
+	}
+
+	// should fetch the next one by default
+	td, err := sub.Read()
+	require.Nil(err)
+
+	// more segments
+	require.Nil(pub.Write(bytes.NewReader([]byte("abc"))))
+	require.Nil(pub.Write(bytes.NewReader([]byte("def"))))
+
+	// Read just the first segment for now
+	data, err := io.ReadAll(td.Reader)
+	require.Nil(err)
+	require.Equal("abc", string(data))
+
+	td, err = sub.Read()
+	require.Nil(err)
+	data, err = io.ReadAll(td.Reader)
+	require.Equal("def", string(data))
+
+	// Push data beyond the server's buffer
+	for i := 0; i < maxSegmentsPerStream+1; i++ {
+		require.Nil(pub.Write(bytes.NewReader(fmt.Appendf(nil, "next write %d", i))))
+	}
+
+	// sub is out of the server's segment window now
+	td, err = sub.Read()
+	require.Equal("seq not found", err.Error())
+
+	sub.SetSeq(-2)
+	td, err = sub.Read()
+	require.Nil(err)
+	data, err = io.ReadAll(td.Reader)
+	require.Equal("next write 5", string(data))
+
+	require.Nil(pub.Write(bytes.NewReader([]byte("ghi"))))
+
+	td, err = sub.Read()
+	require.Nil(err)
+	data, err = io.ReadAll(td.Reader)
+	require.Nil(err)
+	require.Equal("ghi", string(data))
+
+	sub.SetSeq(-1)
+	td, err = sub.Read()
+	require.Nil(err)
+
+	require.Nil(pub.Write(bytes.NewReader([]byte("jkl"))))
+	require.Nil(pub.Write(bytes.NewReader([]byte("mno"))))
+
+	data, err = io.ReadAll(td.Reader)
+	require.Equal("jkl", string(data))
+	require.Nil(err)
+
+	td, err = sub.Read()
+	require.Nil(err)
+	data, err = io.ReadAll(td.Reader)
+	require.Equal("mno", string(data))
+	require.Nil(err)
+
+}

--- a/trickle/trickle_test.go
+++ b/trickle/trickle_test.go
@@ -93,19 +93,7 @@ func TestTrickle_Close(t *testing.T) {
 }
 
 func TestTrickle_SetSeq(t *testing.T) {
-	require := require.New(t)
-	mux := http.NewServeMux()
-	server := ConfigureServer(TrickleServerConfig{
-		Mux:        mux,
-		Autocreate: true,
-	})
-
-	stop := server.Start()
-	ts := httptest.NewServer(mux)
-	defer ts.Close()
-	defer stop()
-
-	channelURL := ts.URL + "/testest"
+	require, channelURL := makeServer(t)
 
 	pub, err := NewTricklePublisher(channelURL)
 	require.Nil(err)
@@ -391,6 +379,11 @@ func TestTrickle_SetSubStart(t *testing.T) {
 }
 
 func makeServer(t *testing.T) (*require.Assertions, string) {
+	require, url, _ := makeServerWithServer(t)
+	return require, url
+}
+
+func makeServerWithServer(t *testing.T) (*require.Assertions, string, *Server) {
 	// use this function if these defaults work, otherwise copy-paste
 	require := require.New(t)
 	mux := http.NewServeMux()
@@ -409,7 +402,7 @@ func makeServer(t *testing.T) (*require.Assertions, string) {
 	lp := NewLocalPublisher(server, chanName, "text/plain")
 	lp.CreateChannel()
 
-	return require, ts.URL + "/" + chanName
+	return require, ts.URL + "/" + chanName, server
 }
 
 func subConfig(url string) TrickleSubscriberConfig {


### PR DESCRIPTION
This PR fixes a number of small issues with orch payment handling:

* Any error reading the local trickle stream would mean the orch kept processing the stream indefinitely without checking for payments. Fix that by closing the payments session + trickle stream in case of any errors.

* There was a bug in the local trickle subscriber that would error out if the subscriber was too far behind the leading edge - which has happened sometimes, according to logs. 

* The orch payment processor was never shut down in the normal case - the internal loop would hang indefinitely waiting for the next segment. Fix this by passing the parent context into payments, instead of a background context.

* Cancel the payments context in more scenarios, including for any issues with the local trickle stream. Also close the trickle channels preemptively.

* Payment logs did not always capture the session information that we needed.

Mostly found while testing https://github.com/livepeer/go-livepeer/pull/3797

---

[trickle: Fix local subscriptions that start at a non-zero seq.](https://github.com/livepeer/go-livepeer/commit/e172a23f9281caa850927cf545d667f42feee75f) 
Also add a SetSeq helper.

We support subscribing to the next segment (seq -1) or the current
segment (seq -2). The default is -1.

However, if the local subscriber latches onto the server late, then the
current segment will have a nonzero sequence number. The local
calculation of the next segment did not take this into account. Fix this
by always settting the next seq based on the segment's own seq rather
than the local seq.

[ai/live: Update orchestrator logging.](https://github.com/livepeer/go-livepeer/commit/83789963085d8f4cfd7dab2747153ef25b001b9a) 
  - Use the parent context in the payment processor to capture more
    information in the logs. This also allows us to properly cancel
    the processor.

  - Because of the above, don't use the short-lived request context
    as the base for logging; use a fresh background context.

  - Replace some usage of slog with clog to capture session context.

  - Remove some extraneous fields, eg orch_request_id is the same
    as manifest_id. Also rename gateway_request_id to just request_id

  - Add missing timing fields in clog and remove other unnecessary
    fields, eg the request id is already in there.
    
[ai/live: Close trickle channels and cancel context on more errors.](https://github.com/livepeer/go-livepeer/commit/7d0865b7ad8d061a414c8bf2cffddeb150f3cf79) 
This prevents the live payment processor from hanging. It also closes
trickle channels preemptively without waiting for them to idle out.

[ai/live: Start orch local subscriptions on the trickle leading edge.](https://github.com/livepeer/go-livepeer/commit/a586e117ca840caeca5aec74fce86a254b0abaeb) 
There have been instances where the local subscription falls behind the
orchestrator's retention window (whether because of rapid-fire incoming
segments or because accounting for payments took too long) and this
would lead to an early exit of payment processing. (Without the context
/ cancellation changes, the stream would have continued indefinitely
without checking for payment.)

Fix this by always reading from the leading edge after every segment,
rather than relying on the segment's built in seq counter.