### PR TITLE
ai/live: Treat whep mpegts init errors as 404

### DIFF
--- a/media/whep_server.go
+++ b/media/whep_server.go
@@ -64,8 +64,12 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 		R: mediaReader,
 	}
 	if err := mpegtsReader.Initialize(); err != nil {
+		// Usually happens if O swaps before any output is produced.
+		// The best error code is tricky: technically this is a 500-class (internal)
+		// code but we don't want to produce on-call alerts, so use a 404 instead
+		// to mirror the MediaMTX behavior if a stream is not ready
 		clog.InfofErr(ctx, "Failed to initialize mpegts reader", err)
-		http.Error(w, "Failed to initialize mpegts reader", http.StatusInternalServerError)
+		http.Error(w, "Failed to initialize mpegts reader", http.StatusNotFound)
 		peerConnection.Close()
 		return
 	}


### PR DESCRIPTION
This usually happens if the O swaps before producing any output and should be benign. In this case the player should re-try the playback and should eventually latch onto the next O.

However, the most appropriate error code to use here is tricky, since technically this is a 500-class internal server error. However, 500s produce alerts in our monitoring system, and alerting on benign errors is poor on-call hygiene.

Use a 404 instead, simply because this is what existing clients using MediaMTX are conditioned to expect if a attempting to connect to a stream that is not yet ready