### PR TITLE
ai/live: WHEP negotiation improvements

### DIFF
--- a/media/whep_server.go
+++ b/media/whep_server.go
@@ -60,6 +60,29 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 			mediaReader.Close()
 		}
 	})
+
+	if err := peerConnection.SetRemoteDescription(offer); err != nil {
+		clog.InfofErr(ctx, "SetRemoteDescription failed", err)
+		http.Error(w, "SetRemoteDescription failed", http.StatusBadRequest)
+		peerConnection.Close()
+		return
+	}
+
+	// gather up the tracks the client is expecting
+	expectsVideo, expectsAudio := false, false
+	for _, t := range peerConnection.GetTransceivers() {
+		if t.Kind() == webrtc.RTPCodecTypeVideo {
+			expectsVideo = true
+		} else if t.Kind() == webrtc.RTPCodecTypeAudio {
+			expectsAudio = true
+		}
+	}
+	if !expectsVideo && !expectsAudio {
+		err := errors.New("SDP did not expect any media")
+		clog.InfofErr(ctx, "SDP did not expect any media", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+
 	mpegtsReader := mpegts.Reader{
 		R: mediaReader,
 	}
@@ -74,11 +97,15 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 		return
 	}
 	tracks := mpegtsReader.Tracks()
-	hasAudio, hasVideo, hasIDR := false, false, false
+	hasAudio, hasVideo, hasIDR, trackAdded := false, false, false, false
 	trackCodecs := make([]string, 0, len(tracks))
 	for _, track := range tracks {
 		switch track.Codec.(type) {
 		case *mpegts.CodecH264:
+			hasVideo = true
+			if !expectsVideo {
+				break
+			}
 			// TODO this track can probably be reused for multiple viewers
 			webrtcTrack, err := NewLocalTrack(
 				webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypeH264},
@@ -109,9 +136,13 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 				return webrtcTrack.WriteSample(au, pts)
 			})
 			trackCodecs = append(trackCodecs, "h264")
-			hasVideo = true
+			trackAdded = true
 
 		case *mpegts.CodecOpus:
+			hasAudio = true
+			if !expectsAudio {
+				break
+			}
 			webrtcTrack, err := NewLocalTrack(
 				// NB: Don't signal sample rate or channel count here. Leave empty to use defaults.
 				// Opus RTP RFC 7587 requires opus/48000/2 regardless of the actual content
@@ -128,6 +159,7 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 			if _, err := peerConnection.AddTrack(webrtcTrack); err != nil {
 				clog.InfofErr(ctx, "Error adding track for audio", err)
 				http.Error(w, "Error adding track for audio", http.StatusInternalServerError)
+
 				peerConnection.Close()
 				return
 			}
@@ -136,7 +168,7 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 				return webrtcTrack.WriteSample(packets, pts)
 			})
 			trackCodecs = append(trackCodecs, "opus")
-			hasAudio = true
+			trackAdded = true
 		}
 	}
 
@@ -146,13 +178,36 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 		peerConnection.Close()
 		return
 	}
-	clog.Info(ctx, "Outputs", "hasVideo", hasVideo, "hasAudio", hasAudio, "tracks", trackCodecs)
 
-	if err := peerConnection.SetRemoteDescription(offer); err != nil {
-		clog.InfofErr(ctx, "SetRemoteDescription failed", err)
-		http.Error(w, "SetRemoteDescription failed", http.StatusBadRequest)
+	if !trackAdded {
+		clog.InfofErr(ctx, "No compatible tracks found", errors.New("no compatible tracks found"))
+		http.Error(w, "No compatible tracks found", http.StatusBadRequest)
 		peerConnection.Close()
 		return
+	}
+
+	clog.Info(ctx, "Outputs", "hasVideo", hasVideo, "hasAudio", hasAudio, "expectsVideo", expectsVideo, "expectsAudio", expectsAudio, "tracks", trackCodecs)
+
+	// Disable media if offered but won't exist in answer
+	disableMedia := func(has bool, kind webrtc.RTPCodecType, t *webrtc.RTPTransceiver) bool {
+		if !has && t.Kind() == kind {
+			if err := t.Stop(); err != nil {
+				clog.InfofErr(ctx, "error stopping transceiver kind=%s", kind, err)
+				http.Error(w, "Error stopping transceiver", http.StatusBadRequest)
+				return false
+			}
+			clog.Info(ctx, "Stopped transceiver", "kind", kind)
+		}
+		return true
+	}
+
+	for _, t := range peerConnection.GetTransceivers() {
+		if !disableMedia(hasAudio, webrtc.RTPCodecTypeAudio, t) {
+			return
+		}
+		if !disableMedia(hasVideo, webrtc.RTPCodecTypeVideo, t) {
+			return
+		}
 	}
 
 	// Create and set local answer

--- a/media/whep_server.go
+++ b/media/whep_server.go
@@ -158,7 +158,6 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 			if _, err := peerConnection.AddTrack(webrtcTrack); err != nil {
 				clog.InfofErr(ctx, "Error adding track for audio", err)
 				http.Error(w, "Error adding track for audio", http.StatusInternalServerError)
-
 				peerConnection.Close()
 				return
 			}

--- a/media/whep_server.go
+++ b/media/whep_server.go
@@ -97,7 +97,7 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 		return
 	}
 	tracks := mpegtsReader.Tracks()
-	hasAudio, hasVideo, hasIDR, trackAdded := false, false, false, false
+	hasAudio, hasVideo, hasIDR := false, false, false
 	trackCodecs := make([]string, 0, len(tracks))
 	for _, track := range tracks {
 		switch track.Codec.(type) {
@@ -136,7 +136,6 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 				return webrtcTrack.WriteSample(au, pts)
 			})
 			trackCodecs = append(trackCodecs, "h264")
-			trackAdded = true
 
 		case *mpegts.CodecOpus:
 			hasAudio = true
@@ -168,7 +167,6 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 				return webrtcTrack.WriteSample(packets, pts)
 			})
 			trackCodecs = append(trackCodecs, "opus")
-			trackAdded = true
 		}
 	}
 
@@ -179,6 +177,7 @@ func (s *WHEPServer) CreateWHEP(ctx context.Context, w http.ResponseWriter, r *h
 		return
 	}
 
+	trackAdded := len(trackCodecs) > 0
 	if !trackAdded {
 		clog.InfofErr(ctx, "No compatible tracks found", errors.New("no compatible tracks found"))
 		http.Error(w, "No compatible tracks found", http.StatusBadRequest)


### PR DESCRIPTION
Small correctness improvements, although these haven't
caused issues in practice as far as I can tell.

* Disable the offered track if it doesn't exist in the output
  (eg, client requests audio track but there isn't one)

* Don't add a track that the client didn't request
  (eg, output has audio but client only asked for video)

* Fail preemptively if no tracks match