### PR TITLE
ai/worker: Add scope pipeline support to worker and build scripts

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,6 +14,8 @@
 
 #### Orchestrator
 
+* [#3814](https://github.com/livepeer/go-livepeer/pull/3814) Sai/worker: Add scope pipeline support to worker and build scripts (@victorges)
+
 #### Transcoder
 
 ### Bug Fixes 🐞

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -77,6 +77,7 @@ var livePipelineToImage = map[string]string{
 	// streamdiffusion-sdxl-faceid is a utility image that uses an SDXL model with a FaceID IP Adapter on the default config of the pipeline. Optimizes startup time.
 	"streamdiffusion-sdxl-faceid": "livepeer/ai-runner:live-app-streamdiffusion-sdxl-faceid",
 	"comfyui":                     "livepeer/ai-runner:live-app-comfyui",
+	"scope":                       "livepeer/ai-runner:live-app-scope",
 	"segment_anything_2":          "livepeer/ai-runner:live-app-segment_anything_2",
 	"noop":                        "livepeer/ai-runner:live-app-noop",
 }

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -433,6 +433,15 @@ func TestDockerManager_getContainerImageName(t *testing.T) {
 			expectedImage: "livepeer/ai-runner:live-app-comfyui",
 			expectError:   false,
 		},
+		{
+			name: "scope live image",
+			setup: func(dockerManager *DockerManager, mockDockerClient *MockDockerClient) {
+			},
+			pipeline:      "live-video-to-video",
+			modelID:       "scope",
+			expectedImage: "livepeer/ai-runner:live-app-scope",
+			expectError:   false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/box/build-runner.sh
+++ b/box/build-runner.sh
@@ -3,8 +3,8 @@ set -ex
 
 PIPELINE=${PIPELINE:-noop}
 
-if [[ "$PIPELINE" != "noop" && "$PIPELINE" != "comfyui" && "$PIPELINE" != "streamdiffusion" && ! "$PIPELINE" =~ ^streamdiffusion- ]]; then
-  echo "Error: PIPELINE must be either 'noop', 'comfyui', 'streamdiffusion' or start with 'streamdiffusion-'"
+if [[ "$PIPELINE" != "noop" && "$PIPELINE" != "comfyui" && "$PIPELINE" != "streamdiffusion" && "$PIPELINE" != "scope" && ! "$PIPELINE" =~ ^streamdiffusion- ]]; then
+  echo "Error: PIPELINE must be either 'noop', 'comfyui', 'streamdiffusion', 'scope' or start with 'streamdiffusion-'"
   exit 1
 fi
 


### PR DESCRIPTION
> Pairs with https://github.com/livepeer/ai-runner/pull/848 to add support for new `scope` pipeline

**What does this pull request do? Explain your changes. (required)**
This commit adds support for the scope pipeline in the go-livepeer worker:

These changes enable the orchestrator to recognize and schedule scope pipeline containers for live-video-to-video requests.

**Specific updates (required)**
Worker Integration:
- Updated ai/worker/docker.go to map scope modelID to livepeer/ai-runner:live-app-scope image in livePipelineToImage map
- Added test case in ai/worker/docker_test.go to verify scope image mapping works correctly

Build Scripts:
- Updated box/build-runner.sh to accept scope as a valid pipeline option alongside streamdiffusion and comfyui

**How did you test each of these updates (required)**
Ran the box, compiled models, ran pipeline at 24FPS (noop haha)

**Does this pull request close any open issues?**
Implements `scope`

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
