### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/ai/worker/worker.go
+++ b/ai/worker/worker.go
@@ -396,7 +396,7 @@ func (w *Worker) AudioToText(ctx context.Context, req GenAudioToTextMultipartReq
 	return resp.JSON200, nil
 }
 
-func (w *Worker) LLM(ctx context.Context, req GenLLMJSONRequestBody) (interface{}, error) {
+func (w *Worker) LLM(ctx context.Context, req GenLLMJSONRequestBody) (any, error) {
 	isStreaming := req.Stream != nil && *req.Stream
 	ctx, cancel := context.WithCancel(ctx)
 	c, err := w.borrowContainer(ctx, "llm", *req.Model)

--- a/clog/clog.go
+++ b/clog/clog.go
@@ -137,7 +137,7 @@ func GetVal(ctx context.Context, key string) string {
 	return val
 }
 
-func Warningf(ctx context.Context, format string, args ...interface{}) {
+func Warningf(ctx context.Context, format string, args ...any) {
 	if !glog.V(2) {
 		return
 	}
@@ -145,7 +145,7 @@ func Warningf(ctx context.Context, format string, args ...interface{}) {
 	glog.WarningDepth(1, msg)
 }
 
-func Errorf(ctx context.Context, format string, args ...interface{}) {
+func Errorf(ctx context.Context, format string, args ...any) {
 	if !glog.V(1) {
 		return
 	}
@@ -153,12 +153,12 @@ func Errorf(ctx context.Context, format string, args ...interface{}) {
 	glog.ErrorDepth(1, msg)
 }
 
-func Infof(ctx context.Context, format string, args ...interface{}) {
+func Infof(ctx context.Context, format string, args ...any) {
 	infof(ctx, false, false, format, args...)
 }
 
 // InfofErr if last argument is not nil it will be printed as " err=%q"
-func InfofErr(ctx context.Context, format string, args ...interface{}) {
+func InfofErr(ctx context.Context, format string, args ...any) {
 	infof(ctx, true, false, format, args...)
 }
 
@@ -168,14 +168,14 @@ func V(level glog.Level) Verbose {
 
 // Infof is equivalent to the global Infof function, guarded by the value of v.
 // See the documentation of V for usage.
-func (v Verbose) Infof(ctx context.Context, format string, args ...interface{}) {
+func (v Verbose) Infof(ctx context.Context, format string, args ...any) {
 	if v {
 		infof(ctx, false, false, format, args...)
 	}
 }
 
-func (v Verbose) InfofErr(ctx context.Context, format string, args ...interface{}) {
-	var err interface{}
+func (v Verbose) InfofErr(ctx context.Context, format string, args ...any) {
+	var err any
 	if len(args) > 0 {
 		err = args[len(args)-1]
 	}
@@ -184,7 +184,7 @@ func (v Verbose) InfofErr(ctx context.Context, format string, args ...interface{
 	}
 }
 
-func infof(ctx context.Context, lastErr bool, publicLog bool, format string, args ...interface{}) {
+func infof(ctx context.Context, lastErr bool, publicLog bool, format string, args ...any) {
 	msg, isErr := formatMessage(ctx, lastErr, publicLog, format, args...)
 	if bool(glog.V(2)) && isErr {
 		glog.ErrorDepth(2, msg)
@@ -196,7 +196,7 @@ func infof(ctx context.Context, lastErr bool, publicLog bool, format string, arg
 // Info logs a message with key-value pairs in a slog-like style.
 // Example: Info(ctx, "hello", "key1", value1, "key2", value2)
 // This will log: "hello key1=value1 key2=value2"
-func Info(ctx context.Context, msg string, keyvals ...interface{}) {
+func Info(ctx context.Context, msg string, keyvals ...any) {
 	if len(keyvals)%2 != 0 {
 		keyvals = append(keyvals[:len(keyvals)-1], "MISSING", keyvals[len(keyvals)-1])
 	}
@@ -229,7 +229,7 @@ func Info(ctx context.Context, msg string, keyvals ...interface{}) {
 }
 
 // V returns a Verbose instance for conditional logging at the specified level
-func (v Verbose) Info(ctx context.Context, msg string, keyvals ...interface{}) {
+func (v Verbose) Info(ctx context.Context, msg string, keyvals ...any) {
 	if v {
 		Info(ctx, msg, keyvals...)
 	}
@@ -263,13 +263,13 @@ func messageFromContext(ctx context.Context, sb *strings.Builder) {
 	cmap.mu.RUnlock()
 }
 
-func formatMessage(ctx context.Context, lastErr bool, publicLog bool, format string, args ...interface{}) (string, bool) {
+func formatMessage(ctx context.Context, lastErr bool, publicLog bool, format string, args ...any) (string, bool) {
 	var sb strings.Builder
 	if publicLog {
 		sb.WriteString(publicLogTag)
 	}
 	messageFromContext(ctx, &sb)
-	var err interface{}
+	var err any
 	if lastErr && len(args) > 0 {
 		err = args[len(args)-1]
 		args = args[:len(args)-1]
@@ -281,7 +281,7 @@ func formatMessage(ctx context.Context, lastErr bool, publicLog bool, format str
 	return sb.String(), err != nil
 }
 
-func PublicInfof(ctx context.Context, format string, args ...interface{}) {
+func PublicInfof(ctx context.Context, format string, args ...any) {
 	publicCtx := context.Background()
 
 	publicCtx = PublicCloneCtx(ctx, publicCtx, publicLogKeys)

--- a/eth/blockwatch/client.go
+++ b/eth/blockwatch/client.go
@@ -71,7 +71,7 @@ func (rc *RPCClient) HeaderByHash(hash common.Hash) (*MiniHeader, error) {
 	return rc.callEth("eth_getBlockByHash", hash)
 }
 
-func (rc *RPCClient) callEth(method string, arg interface{}) (*MiniHeader, error) {
+func (rc *RPCClient) callEth(method string, arg any) (*MiniHeader, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), rc.requestTimeout)
 	defer cancel()
 

--- a/monitor/kafka.go
+++ b/monitor/kafka.go
@@ -28,28 +28,28 @@ type KafkaProducer struct {
 }
 
 type GatewayEvent struct {
-	ID        *string     `json:"id,omitempty"`
-	Type      *string     `json:"type"`
-	Timestamp *string     `json:"timestamp"`
-	Gateway   *string     `json:"gateway,omitempty"`
-	Data      interface{} `json:"data"`
+	ID        *string `json:"id,omitempty"`
+	Type      *string `json:"type"`
+	Timestamp *string `json:"timestamp"`
+	Gateway   *string `json:"gateway,omitempty"`
+	Data      any     `json:"data"`
 }
 
 type PipelineStatus struct {
-	Pipeline             string      `json:"pipeline"`
-	StartTime            float64     `json:"start_time"`
-	LastParamsUpdateTime float64     `json:"last_params_update_time"`
-	LastParams           interface{} `json:"last_params"`
-	LastParamsHash       string      `json:"last_params_hash"`
-	InputFPS             float64     `json:"input_fps"`
-	OutputFPS            float64     `json:"output_fps"`
-	LastInputTime        float64     `json:"last_input_time"`
-	LastOutputTime       float64     `json:"last_output_time"`
-	RestartCount         int         `json:"restart_count"`
-	LastRestartTime      float64     `json:"last_restart_time"`
-	LastRestartLogs      []string    `json:"last_restart_logs"`
-	LastError            *string     `json:"last_error"`
-	StreamID             *string     `json:"stream_id"`
+	Pipeline             string   `json:"pipeline"`
+	StartTime            float64  `json:"start_time"`
+	LastParamsUpdateTime float64  `json:"last_params_update_time"`
+	LastParams           any      `json:"last_params"`
+	LastParamsHash       string   `json:"last_params_hash"`
+	InputFPS             float64  `json:"input_fps"`
+	OutputFPS            float64  `json:"output_fps"`
+	LastInputTime        float64  `json:"last_input_time"`
+	LastOutputTime       float64  `json:"last_output_time"`
+	RestartCount         int      `json:"restart_count"`
+	LastRestartTime      float64  `json:"last_restart_time"`
+	LastRestartLogs      []string `json:"last_restart_logs"`
+	LastError            *string  `json:"last_error"`
+	StreamID             *string  `json:"stream_id"`
 }
 
 var kafkaProducer *KafkaProducer
@@ -149,7 +149,7 @@ func (p *KafkaProducer) sendBatch(eventsBatch []kafka.Message) {
 	}
 }
 
-func SendQueueEventAsync(eventType string, data interface{}) {
+func SendQueueEventAsync(eventType string, data any) {
 	if kafkaProducer == nil {
 		return
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->



This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.
 
As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.


**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
