### PR TITLE
ai/live: Prevent panic on concurrent map writes.

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"net/url"
@@ -920,6 +921,9 @@ func (ls *LivepeerServer) GetLiveVideoToVideoStatus() http.Handler {
 		if gatewayExists {
 			if status == nil {
 				status = make(map[string]any)
+			} else {
+				// Clone so we can safely update the object (shallow)
+				status = maps.Clone(status)
 			}
 			status["gateway_status"] = gatewayStatus
 		}

--- a/server/ai_pipeline_status.go
+++ b/server/ai_pipeline_status.go
@@ -27,6 +27,7 @@ func (s *streamStatusStore) Clear(streamID string) {
 }
 
 // GetStreamStatus returns the current status for a stream
+// NB: Do not mutate the returned object without first (deep-)copying it
 func (s *streamStatusStore) Get(streamID string) (map[string]interface{}, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
We return a `status` map in the LiveVideoStatus HTTP handler then mutate it to add the gateway status. This causes a panic if we happen to have simultaneous accesses to this HTTP handler for the same stream.

At some point we might want to think about merging the gateway and status maps since they seem to carry similar per-stream data. This would both make the bookkeeping simpler and avoid the need for this (potentially expensive) copy on each request.