### PR TITLE
ai/worker: Add sd15-v2v image support

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,7 +14,8 @@
 
 #### Orchestrator
 
-* [#3814](https://github.com/livepeer/go-livepeer/pull/3814) Sai/worker: Add scope pipeline support to worker and build scripts (@victorges)
+* [#3814](https://github.com/livepeer/go-livepeer/pull/3814) ai/worker: Add scope pipeline support to worker and build scripts (@victorges)
+* [#3823](https://github.com/livepeer/go-livepeer/pull/3823) ai/worker: Add sd15-v2v image support (@victorges)
 
 #### Transcoder
 

--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -72,6 +72,8 @@ var livePipelineToImage = map[string]string{
 	"streamdiffusion": "livepeer/ai-runner:live-app-streamdiffusion",
 	// streamdiffusion-sd15 is a utility image that uses an SD1.5 model on the default config of the pipeline. Optimizes startup time.
 	"streamdiffusion-sd15": "livepeer/ai-runner:live-app-streamdiffusion-sd15",
+	// streamdiffusion-sd15-v2v is a utility image that uses an SD1.5 model with cached attention enabled by default. Optimizes startup time for cached-attention inference.
+	"streamdiffusion-sd15-v2v": "livepeer/ai-runner:live-app-streamdiffusion-sd15-v2v",
 	// streamdiffusion-sdxl is a utility image that uses an SDXL model on the default config of the pipeline. Optimizes startup time.
 	"streamdiffusion-sdxl": "livepeer/ai-runner:live-app-streamdiffusion-sdxl",
 	// streamdiffusion-sdxl-faceid is a utility image that uses an SDXL model with a FaceID IP Adapter on the default config of the pipeline. Optimizes startup time.

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -335,6 +335,14 @@ func TestDockerManager_getContainerImageName(t *testing.T) {
 			expectError:   false,
 		},
 		{
+			name:          "live-video-to-video with cached attention sd15 modelID",
+			setup:         func(dockerManager *DockerManager, mockDockerClient *MockDockerClient) {},
+			pipeline:      "live-video-to-video",
+			modelID:       "streamdiffusion-sd15-v2v",
+			expectedImage: "livepeer/ai-runner:live-app-streamdiffusion-sd15-v2v",
+			expectError:   false,
+		},
+		{
 			name:        "live-video-to-video with invalid modelID",
 			setup:       func(dockerManager *DockerManager, mockDockerClient *MockDockerClient) {},
 			pipeline:    "live-video-to-video",


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This adds support for the `live-video-to-video:streamdiffusion-sd15-v2v` image for
having warmed up node pools with `streamv2v` enabled (cached attention)

**Specific updates (required)**
- add image config

**How did you test each of these updates (required)**
`go test ./ai/worker`

**Does this pull request close any open issues?**
Implements streamv2v support

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
