### PR TITLE
ai/live: Fix race on publish close, advance trickle seq on empty writes

### DIFF
--- a/trickle/local_subscriber_test.go
+++ b/trickle/local_subscriber_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"strconv"
 	"testing"
 )
 
@@ -81,4 +82,47 @@ func TestLocalSubscriber_OverrunSeq(t *testing.T) {
 	require.Equal("mno", string(data))
 	require.Nil(err)
 
+}
+
+func TestLocalSubscriber_PreconnectOnEmpty(t *testing.T) {
+	// Checks that the channel seq still increments even on zero-byte writes
+	require, url, server := makeServerWithServer(t)
+
+	pub, err := NewTricklePublisher(url)
+	require.Nil(err)
+	defer pub.Close()
+
+	sub := NewLocalSubscriber(server, "testest")
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		require.Nil(pub.Write(bytes.NewReader([]byte("hello"))))
+		require.Nil(pub.Close())
+	}()
+
+	setSeqCount := 0
+
+	for i := 0; ; i++ {
+		sub.SetSeq(-1)
+		td, err := sub.Read()
+		if err != nil {
+			break
+		}
+		require.Equal(strconv.Itoa(setSeqCount), td.Metadata["Lp-Trickle-Seq"])
+
+		n, err := io.Copy(io.Discard, td.Reader)
+		require.Nil(err)
+		if i == 0 {
+			require.Equal(5, int(n)) // first write - "hello"
+		} else {
+			// second write latches on after first completes, but cancelled
+			// third write (preconnect after second) also cancelled
+			require.Equal(0, int(n))
+		}
+		setSeqCount++
+	}
+
+	<-done
+	require.Equal(2, setSeqCount)
 }

--- a/trickle/trickle_publisher.go
+++ b/trickle/trickle_publisher.go
@@ -127,14 +127,6 @@ func (c *TricklePublisher) preconnect() (*pendingPost, error) {
 
 func (c *TricklePublisher) Close() error {
 
-	// Close any pending writers
-	c.writeLock.Lock()
-	pp := c.pendingPost
-	if pp != nil {
-		pp.writer.Close()
-	}
-	c.writeLock.Unlock()
-
 	req, err := http.NewRequest("DELETE", c.baseURL, nil)
 	if err != nil {
 		return err
@@ -149,6 +141,15 @@ func (c *TricklePublisher) Close() error {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("Failed to delete stream: %v - %s", resp.Status, string(body))
 	}
+
+	// Close any pending writers
+	c.writeLock.Lock()
+	pp := c.pendingPost
+	if pp != nil {
+		pp.writer.Close()
+	}
+	c.writeLock.Unlock()
+
 	return nil
 }
 

--- a/trickle/trickle_server.go
+++ b/trickle/trickle_server.go
@@ -415,6 +415,9 @@ func (s *Stream) handlePost(w http.ResponseWriter, r *http.Request, idx int) {
 				if totalRead <= 0 {
 					s.mutex.Lock()
 					isClosed := s.closed
+					// increment seq anyway: avoids clients erroring out on next seq
+					s.nextWrite = idx + 1
+					s.writeTime = time.Now()
 					s.mutex.Unlock()
 					if isClosed {
 						w.Header().Set("Lp-Trickle-Closed", "terminated")

--- a/trickle/trickle_server.go
+++ b/trickle/trickle_server.go
@@ -470,8 +470,8 @@ func (s *Stream) getForWrite(idx int) (*Segment, bool) {
 }
 
 func (s *Stream) getForRead(idx int) (*Segment, int, bool, bool) {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
+	s.mutex.Lock() // Lock instead of RLock since we may precreate the segment
+	defer s.mutex.Unlock()
 	exists := func(seg *Segment, i int) bool {
 		return seg != nil && seg.idx == i
 	}


### PR DESCRIPTION
The change in [1] introduced a bit of a race condition and uncovered a separate issue that would lead to dozens of rapid-fire GET calls from the orchestrator's local subscriber to the same nonexistent segment.

The race condition was this: on deleting a channel, the publisher [first closes the preconnect](https://github.com/livepeer/go-livepeer/blob/83ea085f96c0313c4a13bba6cb54941b1937e857/trickle/trickle_publisher.go#L130-L136) to clean up its own state, which triggers a segment close on the server with zero bytes written. Then the publisher DELETEs the channel itself.

However, on closing zero-byte segments, the server did [not increment the sequence number](https://github.com/livepeer/go-livepeer/blob/83ea085f96c0313c4a13bba6cb54941b1937e857/trickle/trickle_server.go#L394-L399) for the next expected segment. This would cause two problems:

* Subscribers that set the seq to the "next" segment (-1) would keep getting the same zero-byte segment back until the channel was deleted.

  This is what happened to us: the orch runs a trickle local subscriber that [continuously fetches the leading edge segment](https://github.com/livepeer/go-livepeer/blob/83ea085f96c0313c4a13bba6cb54941b1937e857/server/ai_http.go#L217-L237), but it would immediately return with zero bytes just before the channel is deleted. Because this is a local subscriber, it would be repeating this dozens of times until the DELETE got through.

* Subscribers that handle their own sequence numbering (eg, incrementing it after a successful read; there is nothing inherently wrong with a zero-byte segment) would see an error if it fetched the next segment in the sequence, since the server does not allow for preconnects more than one segment ahead.

Address this in two ways:

* Have the publisher delete the channel then close its own preconnect, rather than the other way around. This addresses the immediate issue of repeated retries: because the channel is marked as deleted first, any later retries see a nonexistent channel.

* Treat zero-byte segments as valid on the server and increment the expected sequence number once a zero-byte segment closes. This would also have prevented this issue even without the publisher fix (at the expense of one more preconnect) and allows us to gracefully handle non-updated publishers or scenarios that raise similar behaviors.

[1] https://github.com/livepeer/go-livepeer/pull/3802