### PR TITLE
ai/live: make whip/whep server usable outside live-video-to-video

### DIFF
--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -99,15 +99,17 @@ func startAIMediaServer(ctx context.Context, ls *LivepeerServer) error {
 
 	// Configure WHIP ingest only if an addr is specified.
 	// TODO use a proper cli flag
+	var whipServer *media.WHIPServer
 	if os.Getenv("LIVE_AI_WHIP_ADDR") != "" {
-		whipServer := media.NewWHIPServer()
+		whipServer = media.NewWHIPServer()
 		ls.HTTPMux.Handle("POST /live/video-to-video/{stream}/whip", ls.CreateWhip(whipServer))
 		ls.HTTPMux.Handle("HEAD /live/video-to-video/{stream}/whip", ls.WithCode(http.StatusMethodNotAllowed))
 		ls.HTTPMux.Handle("OPTIONS /live/video-to-video/{stream}/whip", ls.WithCode(http.StatusNoContent))
 	}
 
+	var whepServer *media.WHEPServer
 	if os.Getenv("LIVE_AI_WHEP_ADDR") != "" {
-		whepServer := media.NewWHEPServer()
+		whepServer = media.NewWHEPServer()
 		// path is {stream}-{request}-out but golang router won't match that
 		ls.HTTPMux.Handle("POST /live/video-to-video/{path}/whep", ls.CreateWhep(whepServer))
 		ls.HTTPMux.Handle("HEAD /live/video-to-video/{path}/whep", ls.WithCode(http.StatusMethodNotAllowed))


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Define the whip and whep server outside the if block so BYOC can use same whip and whep server ports.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- define whip and whep variables outside the if blocks.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
