### PR TITLE
ai/live: Measure gateway-to-orchestrator latency

### DIFF
--- a/media/rtp_segmenter.go
+++ b/media/rtp_segmenter.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bluenviron/mediacommon/v2/pkg/formats/mpegts"
@@ -16,6 +17,41 @@ type RTPTrack interface {
 	Codec() webrtc.RTPCodecParameters
 	Kind() webrtc.RTPCodecType
 	SSRC() webrtc.SSRC
+}
+
+type SegmenterTrack interface {
+	RTPTrack
+	LastMpegtsTS() int64
+	SetLastMpegtsTS(ts int64)
+}
+
+type segmenterTrack struct {
+	track  RTPTrack
+	lastTS int64
+}
+
+func NewSegmenterTrack(tr RTPTrack) SegmenterTrack {
+	return &segmenterTrack{track: tr}
+}
+
+func (t *segmenterTrack) Codec() webrtc.RTPCodecParameters {
+	return t.track.Codec()
+}
+
+func (t *segmenterTrack) Kind() webrtc.RTPCodecType {
+	return t.track.Kind()
+}
+
+func (t *segmenterTrack) SSRC() webrtc.SSRC {
+	return t.track.SSRC()
+}
+
+func (t *segmenterTrack) LastMpegtsTS() int64 {
+	return atomic.LoadInt64(&t.lastTS)
+}
+
+func (t *segmenterTrack) SetLastMpegtsTS(ts int64) {
+	atomic.StoreInt64(&t.lastTS, ts)
 }
 
 type MpegtsWriter interface {
@@ -58,13 +94,13 @@ type videoPacket struct {
 }
 
 type trackWriter struct {
-	rtpTrack    RTPTrack
+	rtpTrack    SegmenterTrack
 	mpegtsTrack *mpegts.Track
 	writeAudio  func(pts int64, data [][]byte) error
 	writeVideo  func(pts, dts int64, data [][]byte) error
 }
 
-func NewRTPSegmenter(tracks []RTPTrack, ssr *SwitchableSegmentReader, segDur time.Duration) *RTPSegmenter {
+func NewRTPSegmenter(tracks []SegmenterTrack, ssr *SwitchableSegmentReader, segDur time.Duration) *RTPSegmenter {
 	s := &RTPSegmenter{
 		ssr:          ssr,
 		maxQueueSize: 64,
@@ -120,7 +156,7 @@ func (s *RTPSegmenter) ShouldStartSegment(pts int64, tb uint32) bool {
 	return true
 }
 
-func (s *RTPSegmenter) WriteVideo(source RTPTrack, pts, dts int64, au [][]byte) error {
+func (s *RTPSegmenter) WriteVideo(source SegmenterTrack, pts, dts int64, au [][]byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, t := range s.tracks {
@@ -135,12 +171,14 @@ func (s *RTPSegmenter) WriteVideo(source RTPTrack, pts, dts int64, au [][]byte) 
 			// Add new packet
 			s.videoQueue = append(s.videoQueue, &videoPacket{t, pts, dts, au})
 
+			source.SetLastMpegtsTS(dts)
+
 			return s.interleaveAndWrite()
 		}
 	}
 	return errors.New("no matching video track found")
 }
-func (s *RTPSegmenter) WriteAudio(source RTPTrack, pts int64, au [][]byte) error {
+func (s *RTPSegmenter) WriteAudio(source SegmenterTrack, pts int64, au [][]byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, t := range s.tracks {
@@ -156,6 +194,8 @@ func (s *RTPSegmenter) WriteAudio(source RTPTrack, pts int64, au [][]byte) error
 
 			// Add new packet
 			s.audioQueue = append(s.audioQueue, &audioPacket{t, rescaledPts, au})
+
+			source.SetLastMpegtsTS(rescaledPts)
 
 			return s.interleaveAndWrite()
 		}
@@ -176,7 +216,7 @@ func (s *RTPSegmenter) IsReady() bool {
 	return s.started
 }
 
-func (s *RTPSegmenter) setupTracks(rtpTracks []RTPTrack) []*trackWriter {
+func (s *RTPSegmenter) setupTracks(rtpTracks []SegmenterTrack) []*trackWriter {
 	tracks := []*trackWriter{}
 	for _, t := range rtpTracks {
 		codec := t.Codec()

--- a/media/rtp_segmenter.go
+++ b/media/rtp_segmenter.go
@@ -26,24 +26,12 @@ type SegmenterTrack interface {
 }
 
 type segmenterTrack struct {
-	track  RTPTrack
+	RTPTrack
 	lastTS int64
 }
 
 func NewSegmenterTrack(tr RTPTrack) SegmenterTrack {
-	return &segmenterTrack{track: tr}
-}
-
-func (t *segmenterTrack) Codec() webrtc.RTPCodecParameters {
-	return t.track.Codec()
-}
-
-func (t *segmenterTrack) Kind() webrtc.RTPCodecType {
-	return t.track.Kind()
-}
-
-func (t *segmenterTrack) SSRC() webrtc.SSRC {
-	return t.track.SSRC()
+	return &segmenterTrack{RTPTrack: tr}
 }
 
 func (t *segmenterTrack) LastMpegtsTS() int64 {

--- a/media/stats.go
+++ b/media/stats.go
@@ -1,0 +1,60 @@
+package media
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// OutputStatsData is an opaque struct that holds output statistics for a request.
+// It is concurrency-safe and only ever increases per requestID.
+type OutputStatsData struct {
+	lastMpegTS atomic.Int64
+}
+
+var (
+	outputStatsMu sync.RWMutex
+	outputStats   = make(map[string]*OutputStatsData)
+)
+
+// Returns the output statistics for the given requestID.
+// If no statistics exist, a new one is created and returned.
+// Returns nil if requestID is empty.
+func GetOutputStats(requestID string) *OutputStatsData {
+	if requestID == "" {
+		return nil
+	}
+	outputStatsMu.Lock()
+	defer outputStatsMu.Unlock()
+	entry, ok := outputStats[requestID]
+	if !ok {
+		entry = &OutputStatsData{}
+		outputStats[requestID] = entry
+	}
+	return entry
+}
+
+// Remove any stored output statistics. Safe to call multiple times.
+func ClearOutputStats(requestID string) {
+	if requestID == "" {
+		return
+	}
+	outputStatsMu.Lock()
+	defer outputStatsMu.Unlock()
+	delete(outputStats, requestID)
+}
+
+// Record the latest output timestamp in 90khz MPEG-TS timebase units
+func (o *OutputStatsData) UpdateLastOutputTS(ts int64) {
+	if o == nil {
+		return
+	}
+	o.lastMpegTS.Store(ts)
+}
+
+// Return the latest recorded output timestampin 90khz MPEG-TS timebase units.
+func (o *OutputStatsData) GetLastOutputTS() int64 {
+	if o == nil {
+		return 0
+	}
+	return o.lastMpegTS.Load()
+}

--- a/media/whip_connection.go
+++ b/media/whip_connection.go
@@ -110,6 +110,8 @@ type TrackStats struct {
 	PacketLossPct   float64       `json:"packet_loss_pct"`
 	RTT             time.Duration `json:"rtt"`
 	LastInputTS     float64       `json:"last_input_ts"`
+	LastOutputTS    float64       `json:"last_output_ts"`
+	Latency         float64       `json:"latency"`
 	Warnings        []string      `json:"warnings,omitempty"`
 }
 

--- a/media/whip_connection_test.go
+++ b/media/whip_connection_test.go
@@ -81,18 +81,22 @@ func TestMediaStateStats(t *testing.T) {
 				456: {},
 			},
 		}
-		tracks := []RTPTrack{
-			&mockRTPTrack{ssrc: 123, kind: webrtc.RTPCodecTypeVideo},
-			&mockRTPTrack{ssrc: 999, kind: webrtc.RTPCodecTypeAudio}, // will not be found
-			&mockRTPTrack{ssrc: 456, kind: webrtc.RTPCodecTypeVideo},
+		tracks := []SegmenterTrack{
+			NewSegmenterTrack(&mockRTPTrack{ssrc: 123, kind: webrtc.RTPCodecTypeVideo}),
+			NewSegmenterTrack(&mockRTPTrack{ssrc: 999, kind: webrtc.RTPCodecTypeAudio}), // will not be found
+			NewSegmenterTrack(&mockRTPTrack{ssrc: 456, kind: webrtc.RTPCodecTypeVideo}),
 		}
 		mockState.SetTracks(msGetter, tracks)
+		tracks[0].SetLastMpegtsTS(90_000)
+		tracks[2].SetLastMpegtsTS(180_000)
 
 		statsResult, err := mockState.Stats()
 		require.NoError(t, err)
 		assert.NotNil(t, statsResult)
 		assert.NotNil(t, statsResult.TrackStats, "Expected TrackStats slice to be non-nil")
 		assert.Equal(t, 2, len(statsResult.TrackStats), "Only two tracks should have been found in statsMap")
+		assert.Equal(t, 1.0, statsResult.TrackStats[0].LastInputTS)
+		assert.Equal(t, 2.0, statsResult.TrackStats[1].LastInputTS)
 	})
 
 	t.Run("ReturnsConnectionWarnings", func(t *testing.T) {
@@ -113,9 +117,9 @@ func TestMediaStateStats(t *testing.T) {
 				456: {},
 			},
 		}
-		tracks := []RTPTrack{
-			&mockRTPTrack{ssrc: 123, kind: webrtc.RTPCodecTypeVideo},
-			&mockRTPTrack{ssrc: 456, kind: webrtc.RTPCodecTypeVideo},
+		tracks := []SegmenterTrack{
+			NewSegmenterTrack(&mockRTPTrack{ssrc: 123, kind: webrtc.RTPCodecTypeVideo}),
+			NewSegmenterTrack(&mockRTPTrack{ssrc: 456, kind: webrtc.RTPCodecTypeVideo}),
 		}
 		mockState.SetTracks(msGetter, tracks)
 
@@ -134,8 +138,8 @@ func TestMediaStateStats(t *testing.T) {
 		msGetter := &mockStatsGetter{
 			statsMap: map[uint32]*stats.Stats{},
 		}
-		tracks := []RTPTrack{
-			&mockRTPTrack{ssrc: 111, kind: webrtc.RTPCodecTypeVideo},
+		tracks := []SegmenterTrack{
+			NewSegmenterTrack(&mockRTPTrack{ssrc: 111, kind: webrtc.RTPCodecTypeVideo}),
 		}
 		mockState.SetTracks(msGetter, tracks)
 
@@ -156,9 +160,9 @@ func TestMediaStateStats(t *testing.T) {
 				222: {},
 			},
 		}
-		tracks := []RTPTrack{
-			&mockRTPTrack{ssrc: 111, kind: webrtc.RTPCodecTypeVideo},
-			&mockRTPTrack{ssrc: 222, kind: webrtc.RTPCodecTypeAudio},
+		tracks := []SegmenterTrack{
+			NewSegmenterTrack(&mockRTPTrack{ssrc: 111, kind: webrtc.RTPCodecTypeVideo}),
+			NewSegmenterTrack(&mockRTPTrack{ssrc: 222, kind: webrtc.RTPCodecTypeAudio}),
 		}
 		mockState.SetTracks(msGetter, tracks)
 

--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -233,7 +233,7 @@ func handleRTP(ctx context.Context, segmenter *RTPSegmenter, timeDecoder *rtptim
 	var frame rtp.Depacketizer
 	var tsCorrector *TimestampCorrector
 	codec := track.Codec().MimeType
-	webrtcTrack := track.(*segmenterTrack).track.(*webrtc.TrackRemote)
+	webrtcTrack := track.(*segmenterTrack).RTPTrack.(*webrtc.TrackRemote)
 	incomingTrack := &IncomingTrack{track: webrtcTrack}
 	isAudio := false
 	switch codec {

--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -194,9 +194,9 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 			mediaState.CloseError(errors.New("non-h264 video"))
 			return
 		}
-		tracks := []RTPTrack{videoTrack}
+		tracks := []SegmenterTrack{NewSegmenterTrack(videoTrack)}
 		if audioTrack != nil {
-			tracks = append(tracks, audioTrack)
+			tracks = append(tracks, NewSegmenterTrack(audioTrack))
 		}
 		minSegDur := 1 * time.Second
 		segDurEnv := os.Getenv("LIVE_AI_MIN_SEG_DUR")
@@ -214,7 +214,7 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				handleRTP(ctx, segmenter, timeDecoder, track.(*webrtc.TrackRemote), userAgent)
+				handleRTP(ctx, segmenter, timeDecoder, track, userAgent)
 			}()
 		}
 		gatherDuration := time.Since(gatherStartTime)
@@ -229,11 +229,12 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 	return mediaState
 }
 
-func handleRTP(ctx context.Context, segmenter *RTPSegmenter, timeDecoder *rtptime.GlobalDecoder2, track *webrtc.TrackRemote, userAgent string) {
+func handleRTP(ctx context.Context, segmenter *RTPSegmenter, timeDecoder *rtptime.GlobalDecoder2, track SegmenterTrack, userAgent string) {
 	var frame rtp.Depacketizer
 	var tsCorrector *TimestampCorrector
 	codec := track.Codec().MimeType
-	incomingTrack := &IncomingTrack{track: track}
+	webrtcTrack := track.(*segmenterTrack).track.(*webrtc.TrackRemote)
+	incomingTrack := &IncomingTrack{track: webrtcTrack}
 	isAudio := false
 	switch codec {
 	case webrtc.MimeTypeH264:
@@ -255,7 +256,7 @@ func handleRTP(ctx context.Context, segmenter *RTPSegmenter, timeDecoder *rtptim
 	au := [][]byte{}
 	currentTS := uint32(0)
 	for {
-		pkt, _, err := track.ReadRTP()
+		pkt, _, err := webrtcTrack.ReadRTP()
 		if err != nil {
 			clog.Info(ctx, "Track read complete or error", "track", codec, "err", err)
 			return

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -1201,7 +1201,14 @@ func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID stri
 			}
 			clog.Info(ctx, "whip TransportStats", "ID", stats.PeerConnStats.ID, "bytes_received", stats.PeerConnStats.BytesReceived, "bytes_sent", stats.PeerConnStats.BytesSent)
 			for _, s := range stats.TrackStats {
-				clog.Info(ctx, "whip InboundRTPStreamStats", "kind", s.Type, "jitter", fmt.Sprintf("%.3f", s.Jitter), "packets_lost", s.PacketsLost, "packets_received", s.PacketsReceived, "rtt", s.RTT)
+				clog.Info(ctx, "whip InboundRTPStreamStats",
+					"kind", s.Type,
+					"jitter", fmt.Sprintf("%.3f", s.Jitter),
+					"packets_lost", s.PacketsLost,
+					"packets_received", s.PacketsReceived,
+					"rtt", s.RTT,
+					"last_input_ts", fmt.Sprintf("%.3f", s.LastInputTS),
+				)
 			}
 			GatewayStatus.StoreKey(streamID, "ingest_metrics", map[string]interface{}{
 				"stats": stats,

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -1188,6 +1188,8 @@ func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID stri
 	for {
 		select {
 		case <-ctx.Done():
+			media.ClearOutputStats(requestID + "-video")
+			media.ClearOutputStats(requestID + "-audio")
 			return
 		case <-ticker.C:
 			stats, err := whipConn.Stats()
@@ -1201,6 +1203,9 @@ func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID stri
 			}
 			clog.Info(ctx, "whip TransportStats", "ID", stats.PeerConnStats.ID, "bytes_received", stats.PeerConnStats.BytesReceived, "bytes_sent", stats.PeerConnStats.BytesSent)
 			for _, s := range stats.TrackStats {
+				outputStats := media.GetOutputStats(requestID + "-" + s.Type.String())
+				s.LastOutputTS = float64(outputStats.GetLastOutputTS()) / 90000.0
+				s.Latency = s.LastInputTS - s.LastOutputTS
 				clog.Info(ctx, "whip InboundRTPStreamStats",
 					"kind", s.Type,
 					"jitter", fmt.Sprintf("%.3f", s.Jitter),
@@ -1208,6 +1213,8 @@ func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID stri
 					"packets_received", s.PacketsReceived,
 					"rtt", s.RTT,
 					"last_input_ts", fmt.Sprintf("%.3f", s.LastInputTS),
+					"last_output_ts", fmt.Sprintf("%.3f", s.LastOutputTS),
+					"latency", fmt.Sprintf("%0.3f", s.Latency),
 				)
 			}
 			GatewayStatus.StoreKey(streamID, "ingest_metrics", map[string]interface{}{


### PR DESCRIPTION
Tracks the last input timestamp and the last output timestamp. Subtracting the input
from the output allows for a continuous measurement of gateway-to-orchestrator latency.

For review convenience, the input changes have been committed separately from the output changes.

[ai/live: Track latest input timestamp](https://github.com/livepeer/go-livepeer/commit/569331c8a0dbdfd88cd8401135225b633e7676c9) 
Do this by attaching a timestamp to each MPEG-TS track. Most of the
changes here are a result of changing the segmenter API to use a new
SegmenterTrack struct that can more easily embed and test additional
fields [1] such as the last input timestamp.

This method allows us to cleanly extract the last input TS while
constructing the MediaState object.

The last input timestamp is stored in the original MPEG-TS 90khz
timebase for now, but converted to seconds before logging and Kafka.

[1] webrtc.TrackRemote is nearly impossible to cleanly mock, so
    make the SegmenterTrack take a RTPTrack so we can drop the
    existing TrackRemote in there alongside any additional fields.

[ai/live: Track latest output timestamp](https://github.com/livepeer/go-livepeer/commit/83eb9d1661b1ad5832e5ff6791532899496345ed) 
Use this to measure gateway-to-orchestrator latency continuously.
Surface this in both logs and Kafka metrics.

Introduce a global `media.OutputStats` to track the last seen MPEG-TS
timestamp per track. Spin up a MPEG-TS reader from the trickle
subscriber and publish each track's timestamp to that. For now, the
OutputStats timebase remains at the original 90khz; for logging and
Kafka it is converted to seconds.

When the track stats are calculated, also pull in the OutputStats.
Since we also have the last input timestamp, we can now measure latency.