### PR TITLE
ai/live: Move LiveAIAuthWebhookUrl to LivepeerNode/LivepeerServer

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1550,7 +1550,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			glog.Exit("Error setting live AI auth webhook URL ", err)
 		}
 		glog.Info("Using live AI auth webhook URL ", parsedUrl.Redacted())
-		server.LiveAIAuthWebhookURL = parsedUrl
+		n.LiveAIAuthWebhookURL = parsedUrl
 	}
 
 	httpIngest := true

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -163,6 +163,7 @@ type LivepeerNode struct {
 
 	MediaMTXApiPassword        string
 	LiveAITrickleHostForRunner string
+	LiveAIAuthWebhookURL       *url.URL
 	LiveAIAuthApiKey           string
 	LiveAIHeartbeatURL         string
 	LiveAIHeartbeatHeaders     map[string]string

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -516,8 +516,8 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		mediaMTXClient := media.NewMediaMTXClient(remoteHost, ls.mediaMTXApiPassword, sourceID, sourceType)
 
 		whepURL := generateWhepUrl(streamName, requestID)
-		if LiveAIAuthWebhookURL != nil {
-			authResp, err := authenticateAIStream(LiveAIAuthWebhookURL, ls.liveAIAuthApiKey, AIAuthRequest{
+		if ls.liveAIAuthWebhookURL != nil {
+			authResp, err := authenticateAIStream(ls.liveAIAuthWebhookURL, ls.liveAIAuthApiKey, AIAuthRequest{
 				Stream:      streamName,
 				Type:        sourceTypeStr,
 				QueryParams: queryParams,
@@ -992,8 +992,8 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 
 			ctx = clog.AddVal(ctx, "source_type", sourceTypeStr)
 
-			if LiveAIAuthWebhookURL != nil {
-				authResp, err := authenticateAIStream(LiveAIAuthWebhookURL, ls.liveAIAuthApiKey, AIAuthRequest{
+			if ls.liveAIAuthWebhookURL != nil {
+				authResp, err := authenticateAIStream(ls.liveAIAuthWebhookURL, ls.liveAIAuthApiKey, AIAuthRequest{
 					Stream:      streamName,
 					Type:        sourceTypeStr,
 					QueryParams: queryParams,

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -67,7 +67,6 @@ const AISessionManagerTTL = 10 * time.Minute
 var BroadcastJobVideoProfiles = []ffmpeg.VideoProfile{ffmpeg.P240p30fps4x3, ffmpeg.P360p30fps16x9}
 
 var AuthWebhookURL *url.URL
-var LiveAIAuthWebhookURL *url.URL
 
 func PixelFormatNone() ffmpeg.PixelFormat {
 	return ffmpeg.PixelFormat{RawValue: ffmpeg.PixelFormatNone}
@@ -126,10 +125,11 @@ type LivepeerServer struct {
 	connectionLock    *sync.RWMutex
 	serverLock        *sync.RWMutex
 
-	mediaMTXApiPassword string
-	liveAIAuthApiKey    string
-	livePaymentInterval time.Duration
-	outSegmentTimeout   time.Duration
+	mediaMTXApiPassword  string
+	liveAIAuthWebhookURL *url.URL
+	liveAIAuthApiKey     string
+	livePaymentInterval  time.Duration
+	outSegmentTimeout    time.Duration
 }
 
 func (s *LivepeerServer) SetContextFromUnitTest(c context.Context) {
@@ -196,6 +196,7 @@ func NewLivepeerServer(ctx context.Context, rtmpAddr string, lpNode *core.Livepe
 		recordingsAuthResponses: cache.New(time.Hour, 2*time.Hour),
 		AISessionManager:        NewAISessionManager(lpNode, AISessionManagerTTL),
 		mediaMTXApiPassword:     lpNode.MediaMTXApiPassword,
+		liveAIAuthWebhookURL:    lpNode.LiveAIAuthWebhookURL,
 		liveAIAuthApiKey:        lpNode.LiveAIAuthApiKey,
 		livePaymentInterval:     lpNode.LivePaymentInterval,
 		outSegmentTimeout:       lpNode.LiveOutSegmentTimeout,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Moves the LiveAIAuthWebhookURL to be set to the LivepeerNode\LivepeerServer similar to the LiveAIAuthApiKey.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates to track through setting the LiveAIAuthWebhookURL through the LivepeerNode from starter.go 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
