### PR TITLE
[WIP] docker: Fix docker image build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,8 @@ ENV	GOARCH="$TARGETARCH" \
 	CGO_LDFLAGS="-L/usr/local/cuda_${TARGETARCH}/lib64"
 
 RUN	apt update \
-	&& apt install -yqq software-properties-common curl apt-transport-https lsb-release nasm \
+	&& apt install -yqq software-properties-common curl apt-transport-https lsb-release nasm=2.14.02-1 \
+	&& apt-mark hold nasm \
 	&& curl -fsSL https://dl.google.com/go/go1.21.5.linux-${BUILDARCH}.tar.gz | tar -C /usr/local -xz \
 	&& curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
 	&& add-apt-repository "deb [arch=${BUILDARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,7 @@ ENV	GOARCH="$TARGETARCH" \
 	CGO_LDFLAGS="-L/usr/local/cuda_${TARGETARCH}/lib64"
 
 RUN	apt update \
-	&& apt install -yqq software-properties-common curl apt-transport-https lsb-release nasm=2.14.02-1 \
-	&& apt-mark hold nasm \
+	&& apt install -yqq software-properties-common curl apt-transport-https lsb-release yasm \
 	&& curl -fsSL https://dl.google.com/go/go1.21.5.linux-${BUILDARCH}.tar.gz | tar -C /usr/local -xz \
 	&& curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
 	&& add-apt-repository "deb [arch=${BUILDARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
@@ -34,7 +33,9 @@ RUN	GRPC_HEALTH_PROBE_VERSION=v0.3.6 \
 RUN FFMPEG_SHA=b76053d8bf322b197a9d07bd27bbdad14fd5bc15 git clone --depth 1 https://git.ffmpeg.org/ffmpeg.git /ffmpeg \
 	&& cd /ffmpeg && git fetch --depth 1 origin ${FFMPEG_SHA} \
 	&& git checkout ${FFMPEG_SHA} \
-	&& ./configure --enable-gpl --enable-libx264 --enable-libfdk-aac --enable-nonfree --prefix=build && make -j"$(nproc)" && make install
+	&& ./configure --enable-gpl --enable-libx264 --enable-libfdk-aac --enable-nonfree --x86asmexe=yasm --prefix=build \
+	&& make -j"$(nproc)" \
+	&& make install
 
 ENV	GOPATH=/go \
 	GO_BUILD_DIR=/build/ \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,8 @@ ENV	GOARCH="$TARGETARCH" \
 	CGO_LDFLAGS="-L/usr/local/cuda_${TARGETARCH}/lib64"
 
 RUN	apt update \
-	&& apt install -yqq software-properties-common curl apt-transport-https lsb-release yasm \
+	&& apt install -yqq software-properties-common curl apt-transport-https lsb-release nasm=2.14.02-1 \
+	&& apt-mark hold nasm \
 	&& curl -fsSL https://dl.google.com/go/go1.21.5.linux-${BUILDARCH}.tar.gz | tar -C /usr/local -xz \
 	&& curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
 	&& add-apt-repository "deb [arch=${BUILDARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
@@ -33,9 +34,7 @@ RUN	GRPC_HEALTH_PROBE_VERSION=v0.3.6 \
 RUN FFMPEG_SHA=b76053d8bf322b197a9d07bd27bbdad14fd5bc15 git clone --depth 1 https://git.ffmpeg.org/ffmpeg.git /ffmpeg \
 	&& cd /ffmpeg && git fetch --depth 1 origin ${FFMPEG_SHA} \
 	&& git checkout ${FFMPEG_SHA} \
-	&& ./configure --enable-gpl --enable-libx264 --enable-libfdk-aac --enable-nonfree --x86asmexe=yasm --prefix=build \
-	&& make -j"$(nproc)" \
-	&& make install
+	&& ./configure --enable-gpl --enable-libx264 --enable-libfdk-aac --enable-nonfree --prefix=build && make -j"$(nproc)" && make install
 
 ENV	GOPATH=/go \
 	GO_BUILD_DIR=/build/ \


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The `nasm` version was recently upgraded in the indexes, which broke
our ffmpeg build. Apparently ffmpeg has trouble with versions 2.16+ of `nasm`.

The exact version was determined by running a couple commands on my latest
`go-livepeer` image build to determine what version of `nasm` we used to have
before:
```
cd /home/user/workspace && docker run --rm --entrypoint nasm glp-buildcached -v
NASM version 2.14.02
```
```
cd /home/user/workspace && docker run --rm --entrypoint bash glp-buildcached -lc "apt-cache policy nasm | head"
nasm:
  Installed: 2.14.02-1
  Candidate: 2.14.02-1
  Version table:
 *** 2.14.02-1 500
        500 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages
        100 /var/lib/dpkg/status
```

We could also fix this by switching to `yasm` instead of `nasm`, but I don't even know what
that package does so let's just do the safest thing and stick to the version that worked lol

**Specific updates (required)**
- Pin `nasm` version on install
- Mark it as non-upgradable so the rest of the docker build doesn't change it

**How did you test each of these updates (required)**
Build

**Does this pull request close any open issues?**
https://discord.com/channels/423160867534929930/1447457162736570461

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
