### PR TITLE
Revert "Move the capacity reporting into db_discovery (#3778)"

### DIFF
--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -75,9 +75,8 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.LiveAIAuthWebhookURL = fs.String("liveAIAuthWebhookUrl", "", "Live AI RTMP authentication webhook URL")
 	cfg.LivePaymentInterval = fs.Duration("livePaymentInterval", *cfg.LivePaymentInterval, "Interval to pay process Gateway <> Orchestrator Payments for Live AI Video")
 	cfg.LiveOutSegmentTimeout = fs.Duration("liveOutSegmentTimeout", *cfg.LiveOutSegmentTimeout, "Timeout duration to wait the output segment to be available in the Live AI pipeline; defaults to no timeout")
+	cfg.LiveAICapRefreshModels = fs.String("liveAICapRefreshModels", "", "Comma separated list of models to periodically fetch capacity for. Leave unset to switch off periodic refresh.")
 	cfg.LiveAISaveNSegments = fs.Int("liveAISaveNSegments", 10, "Set how many segments to save to disk for debugging (both input and output)")
-	cfg.LiveAICapRefreshModels = fs.String("liveAICapRefreshModels", "", "[Deprecated] Capacity is now available for all models, use -liveAICapReportInterval to set the interval for reporting capacity metrics")
-	cfg.LiveAICapReportInterval = fs.Duration("liveAICapReportInterval", *cfg.LiveAICapReportInterval, "Interval to report Live AI container capacity metrics, e.g. 10s, 1m, 1h. defaults to 25 minutes")
 
 	// Onchain:
 	cfg.EthAcctAddr = fs.String("ethAcctAddr", *cfg.EthAcctAddr, "Existing Eth account address. For use when multiple ETH accounts exist in the keystore directory")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -184,7 +184,6 @@ type LivepeerConfig struct {
 	LiveAIHeartbeatInterval    *time.Duration
 	LivePaymentInterval        *time.Duration
 	LiveOutSegmentTimeout      *time.Duration
-	LiveAICapReportInterval    *time.Duration
 	LiveAICapRefreshModels     *string
 	LiveAISaveNSegments        *int
 }
@@ -242,7 +241,6 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultLiveOutSegmentTimeout := 0 * time.Second
 	defaultGatewayHost := ""
 	defaultLiveAIHeartbeatInterval := 5 * time.Second
-	defaultLiveAICapReportInterval := 25 * time.Minute
 
 	// Onchain:
 	defaultEthAcctAddr := ""
@@ -361,7 +359,6 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		LiveOutSegmentTimeout:    &defaultLiveOutSegmentTimeout,
 		GatewayHost:              &defaultGatewayHost,
 		LiveAIHeartbeatInterval:  &defaultLiveAIHeartbeatInterval,
-		LiveAICapReportInterval:  &defaultLiveAICapReportInterval,
 
 		// Onchain:
 		EthAcctAddr:             &defaultEthAcctAddr,
@@ -1594,7 +1591,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		if *cfg.Network != "offchain" {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			dbOrchPoolCache, err := discovery.NewDBOrchestratorPoolCache(ctx, n, timeWatcher, orchBlacklist, *cfg.DiscoveryTimeout, *cfg.LiveAICapReportInterval)
+			dbOrchPoolCache, err := discovery.NewDBOrchestratorPoolCache(ctx, n, timeWatcher, orchBlacklist, *cfg.DiscoveryTimeout)
 			if err != nil {
 				exit("Could not create orchestrator pool with DB cache: %v", err)
 			}
@@ -1760,7 +1757,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		n.LiveAITrickleHostForRunner = *cfg.LiveAITrickleHostForRunner
 	}
 	if cfg.LiveAICapRefreshModels != nil && *cfg.LiveAICapRefreshModels != "" {
-		glog.Warningf("The -liveAICapRefreshModels flag is deprecated, capacity is now available for all models, use -liveAICapReportInterval to set the interval for reporting capacity metrics")
+		n.LiveAICapRefreshModels = strings.Split(*cfg.LiveAICapRefreshModels, ",")
 	}
 	n.LiveAISaveNSegments = cfg.LiveAISaveNSegments
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -169,6 +169,7 @@ type LivepeerNode struct {
 	LiveAIHeartbeatInterval    time.Duration
 	LivePaymentInterval        time.Duration
 	LiveOutSegmentTimeout      time.Duration
+	LiveAICapRefreshModels     []string
 	LiveAISaveNSegments        *int
 
 	// Gateway

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -400,9 +400,6 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchInfos() error {
 }
 
 func reportAICapacityFromNetworkCapabilities(orchNetworkCapabilities []*common.OrchNetworkCapabilities) {
-	if !monitor.Enabled {
-		return
-	}
 	// Build structured capacity data
 	modelCapacities := make(map[string]*monitor.ModelAICapacities)
 

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"math/big"
 	"math/rand"
 	"net/url"
 	"sort"
@@ -250,6 +251,7 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 		}
 		go getOrchInfo(ctx, common.OrchestratorDescriptor{linfos[i], nil}, 0, odCh, errCh, allOrchDescrCh)
 	}
+	go reportLiveAICapacity(allOrchDescrCh, caps)
 
 	// use a timer to time out the entire get info loop below
 	cutoffTimer := time.NewTimer(maxGetOrchestratorCutoffTimeout)
@@ -327,6 +329,67 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 	clog.Infof(ctx, "Done fetching orch info orchs=%d/%d responses=%d/%d timedOut=%t",
 		len(ods), numOrchestrators, nbResp, maxOrchNodes, timedOut)
 	return ods, nil
+}
+
+func getModelCaps(caps *net.Capabilities) map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint {
+	if caps == nil || caps.Constraints == nil || caps.Constraints.PerCapability == nil {
+		return nil
+	}
+	liveAI, ok := caps.Constraints.PerCapability[uint32(core.Capability_LiveVideoToVideo)]
+	if !ok {
+		return nil
+	}
+
+	return liveAI.Models
+}
+
+func reportLiveAICapacity(ch chan common.OrchestratorDescriptor, caps common.CapabilityComparator) {
+	if !monitor.Enabled {
+		return
+	}
+	modelsReq := getModelCaps(caps.ToNetCapabilities())
+
+	var allOrchInfo []common.OrchestratorDescriptor
+	var done bool
+	for {
+		select {
+		case od := <-ch:
+			allOrchInfo = append(allOrchInfo, od)
+		case <-time.After(maxGetOrchestratorCutoffTimeout):
+			done = true
+		}
+		if done {
+			break
+		}
+	}
+
+	idleContainersByModelAndOrchestrator := make(map[string]map[string]int)
+	for _, od := range allOrchInfo {
+		pricePerUnit := od.RemoteInfo.PriceInfo.PricePerUnit
+		pixelsPerUnit := od.RemoteInfo.PriceInfo.PixelsPerUnit
+		pricePerPixel := big.NewRat(pricePerUnit, pixelsPerUnit)
+		monitor.LiveAIPricePerPixel(od.LocalInfo.URL.String(), pricePerPixel)
+
+		var models map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint
+		if od.RemoteInfo != nil {
+			models = getModelCaps(od.RemoteInfo.Capabilities)
+		}
+
+		for modelID := range modelsReq {
+			idle := 0
+			if models != nil {
+				if model, ok := models[modelID]; ok {
+					idle = int(model.Capacity)
+				}
+			}
+
+			if _, exists := idleContainersByModelAndOrchestrator[modelID]; !exists {
+				idleContainersByModelAndOrchestrator[modelID] = make(map[string]int)
+			}
+			idleContainersByModelAndOrchestrator[modelID][od.LocalInfo.URL.String()] = idle
+		}
+	}
+	monitor.AIContainersIdleAfterGatewayDiscovery(idleContainersByModelAndOrchestrator)
 }
 
 func (o *orchestratorPool) Size() int {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -51,7 +51,7 @@ func TestNewDBOrchestratorPoolCache_NilEthClient_ReturnsError(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond)
 	assert.Nil(pool)
 	assert.EqualError(err, "could not create DBOrchestratorPoolCache: LivepeerEthClient is nil")
 }
@@ -173,7 +173,7 @@ func sync_TestDBOrchestratorPoolCacheSize(t *testing.T) {
 		goleak.VerifyNone(t, common.IgnoreRoutines()...)
 	}()
 
-	emptyPool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	emptyPool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond)
 	require.NoError(err)
 	require.NotNil(emptyPool)
 	assert.Equal(0, emptyPool.Size())
@@ -184,7 +184,7 @@ func sync_TestDBOrchestratorPoolCacheSize(t *testing.T) {
 		dbh.UpdateOrch(ethOrchToDBOrch(o))
 	}
 
-	nonEmptyPool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	nonEmptyPool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond)
 	require.NoError(err)
 	require.NotNil(nonEmptyPool)
 	assert.Equal(len(addresses), nonEmptyPool.Size())
@@ -232,7 +232,7 @@ func TestNewDBOrchestorPoolCache_NoEthAddress(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, rm, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, rm, []string{}, 500*time.Millisecond)
 	require.Nil(err)
 
 	// Check that serverGetOrchInfo returns early and the orchestrator isn't updated
@@ -282,7 +282,7 @@ func TestNewDBOrchestratorPoolCache_InvalidPrices(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, rm, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, rm, []string{}, 500*time.Millisecond)
 	require.Nil(err)
 
 	// priceInfo.PixelsPerUnit = 0
@@ -346,7 +346,7 @@ func sync_TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrec
 
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil).Times(3)
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond)
 	dbOrchs, err := dbh.SelectOrchs(nil)
 	require.NoError(err)
 	assert.Equal(pool.Size(), 3)
@@ -422,7 +422,7 @@ func TestNewDBOrchestratorPoolCache_TestURLs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond)
 	require.NoError(err)
 	// bad URLs are inserted in the database but are not included in the working set, as there is no returnable query for getting their priceInfo
 	// And if URL is updated it won't be picked up until next cache update
@@ -455,7 +455,7 @@ func TestNewDBOrchestratorPoolCache_TestURLs_Empty(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond)
 	require.NoError(err)
 	assert.Equal(0, pool.Size())
 	infos := pool.GetInfos()
@@ -527,7 +527,10 @@ func sync_TestNewDBOrchestorPoolCache_PollOrchestratorInfo(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 700*time.Millisecond, 200*time.Millisecond)
+	origCacheRefreshInterval := cacheRefreshInterval
+	cacheRefreshInterval = 200 * time.Millisecond
+	defer func() { cacheRefreshInterval = origCacheRefreshInterval }()
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 700*time.Millisecond)
 	require.NoError(err)
 
 	// Ensure orchestrators exist in DB
@@ -686,7 +689,7 @@ func sync_TestCachedPool_AllOrchestratorsTooExpensive_ReturnsAllOrchestrators(t 
 
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond)
 	require.NoError(err)
 
 	// ensuring orchs exist in DB
@@ -775,7 +778,7 @@ func sync_TestCachedPool_GetOrchestrators_MaxBroadcastPriceNotSet(t *testing.T) 
 
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond)
 	require.NoError(err)
 
 	// ensuring orchs exist in DB
@@ -881,7 +884,7 @@ func sync_TestCachedPool_N_OrchestratorsGoodPricing_ReturnsNOrchestrators(t *tes
 
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond)
 	require.NoError(err)
 
 	// ensuring orchs exist in DB
@@ -976,7 +979,7 @@ func TestCachedPool_GetOrchestrators_TicketParamsValidation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 500*time.Millisecond)
 	require.NoError(err)
 
 	// Test 25 out of 50 orchs pass ticket params validation
@@ -1065,7 +1068,7 @@ func sync_TestCachedPool_GetOrchestrators_OnlyActiveOrchestrators(t *testing.T) 
 
 	sender.On("ValidateTicketParams", mock.Anything).Return(nil)
 
-	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{round: big.NewInt(24)}, []string{}, 500*time.Millisecond, 1*time.Minute)
+	pool, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{round: big.NewInt(24)}, []string{}, 500*time.Millisecond)
 	require.NoError(err)
 
 	// ensuring orchs exist in DB
@@ -1652,7 +1655,7 @@ func TestSetGetOrchestratorTimeout(t *testing.T) {
 	//set timeout to 1000ms
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	poolCache, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 1000*time.Millisecond, 1*time.Minute)
+	poolCache, err := NewDBOrchestratorPoolCache(ctx, node, &stubRoundsManager{}, []string{}, 1000*time.Millisecond)
 	assert.Nil(err)
 	//confirm the timeout is now 1000ms
 	assert.Equal(poolCache.discoveryTimeout, 1000*time.Millisecond)

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -73,18 +73,6 @@ const (
 	segTypeRec     = "recorded" // segment in the stream for which recording is enabled
 )
 
-// AIContainerCapacity holds capacity information for AI containers
-type AIContainerCapacity struct {
-	Idle  int
-	InUse int
-}
-
-// ModelAICapacities holds all orchestrator capacities for a specific model
-type ModelAICapacities struct {
-	ModelID       string
-	Orchestrators map[string]AIContainerCapacity // orchURI -> capacity
-}
-
 const (
 	//mpeg7-sign comparison fail of fast verification
 	FVType1Error = 1
@@ -209,25 +197,25 @@ type (
 		mSceneClassification *stats.Int64Measure
 
 		// Metrics for AI jobs
-		mAIModelsRequested          *stats.Int64Measure
-		mAIRequestLatencyScore      *stats.Float64Measure
-		mAIRequestPrice             *stats.Float64Measure
-		mAIRequestError             *stats.Int64Measure
-		mAIResultDownloaded         *stats.Int64Measure
-		mAIResultDownloadTime       *stats.Float64Measure
-		mAIResultUploaded           *stats.Int64Measure
-		mAIResultUploadTime         *stats.Float64Measure
-		mAIResultSaveFailed         *stats.Int64Measure
-		mAIContainersInUse          *stats.Int64Measure
-		mAIContainersIdle           *stats.Int64Measure
-		mLiveAIPricePerPixel        *stats.Float64Measure
-		aiContainersCapacityByModel map[string]*ModelAICapacities
-		mAIGPUsIdle                 *stats.Int64Measure
-		mAICurrentLivePipelines     *stats.Int64Measure
-		aiLiveSessionsByPipeline    map[string]int
-		mAIFirstSegmentDelay        *stats.Int64Measure
-		mAILiveAttempts             *stats.Int64Measure
-		mAINumOrchs                 *stats.Int64Measure
+		mAIModelsRequested                       *stats.Int64Measure
+		mAIRequestLatencyScore                   *stats.Float64Measure
+		mAIRequestPrice                          *stats.Float64Measure
+		mAIRequestError                          *stats.Int64Measure
+		mAIResultDownloaded                      *stats.Int64Measure
+		mAIResultDownloadTime                    *stats.Float64Measure
+		mAIResultUploaded                        *stats.Int64Measure
+		mAIResultUploadTime                      *stats.Float64Measure
+		mAIResultSaveFailed                      *stats.Int64Measure
+		mAIContainersInUse                       *stats.Int64Measure
+		mAIContainersIdle                        *stats.Int64Measure
+		mLiveAIPricePerPixel                     *stats.Float64Measure
+		aiContainersIdleByPipelineByOrchestrator map[string]map[string]int
+		mAIGPUsIdle                              *stats.Int64Measure
+		mAICurrentLivePipelines                  *stats.Int64Measure
+		aiLiveSessionsByPipeline                 map[string]int
+		mAIFirstSegmentDelay                     *stats.Int64Measure
+		mAILiveAttempts                          *stats.Int64Measure
+		mAINumOrchs                              *stats.Int64Measure
 
 		mAIWhipTransportBytesReceived *stats.Int64Measure
 		mAIWhipTransportBytesSent     *stats.Int64Measure
@@ -405,7 +393,7 @@ func InitCensus(nodeType NodeType, version string) {
 	census.mAIContainersInUse = stats.Int64("ai_container_in_use", "Number of containers currently used for AI processing", "tot")
 	census.mAIContainersIdle = stats.Int64("ai_container_idle", "Number of containers currently available for AI processing", "tot")
 	census.mLiveAIPricePerPixel = stats.Float64("live_ai_price_per_pixel", "Live AI price per pixel", "wei/pixel")
-	census.aiContainersCapacityByModel = make(map[string]*ModelAICapacities)
+	census.aiContainersIdleByPipelineByOrchestrator = make(map[string]map[string]int)
 	census.mAIGPUsIdle = stats.Int64("ai_gpus_idle", "Number of idle GPUs (with no configured container)", "tot")
 	census.mAICurrentLivePipelines = stats.Int64("ai_current_live_pipelines", "Number of live AI pipelines currently running", "tot")
 	census.aiLiveSessionsByPipeline = make(map[string]int)
@@ -1033,7 +1021,7 @@ func InitCensus(nodeType NodeType, version string) {
 			Name:        "ai_container_in_use",
 			Measure:     census.mAIContainersInUse,
 			Description: "Number of containers currently used for AI processing",
-			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName, census.kOrchestratorURI}, baseTags...),
+			TagKeys:     append([]tag.Key{census.kPipeline, census.kModelName}, baseTags...),
 			Aggregation: view.LastValue(),
 		},
 		{
@@ -2039,56 +2027,43 @@ func AIContainersInUse(currentContainersInUse int, pipeline, modelID string) {
 	}
 }
 
-func ReportAIContainerCapacity(modelCapacities map[string]*ModelAICapacities) {
+func AIContainersIdleAfterGatewayDiscovery(idleContainersByPipelinesAndOrchestrator map[string]map[string]int) {
 	census.lock.Lock()
 	defer census.lock.Unlock()
 
-	// Reset all existing model container counts to zero first.
+	// Reset all existing pipeline idleContainers to zero first.
 	// This ensures we don't have any stale counts.
-	for _, modelCap := range census.aiContainersCapacityByModel {
-		for orchURI := range modelCap.Orchestrators {
-			modelCap.Orchestrators[orchURI] = AIContainerCapacity{Idle: 0, InUse: 0}
+	for k, v := range census.aiContainersIdleByPipelineByOrchestrator {
+		for k2 := range v {
+			census.aiContainersIdleByPipelineByOrchestrator[k][k2] = 0
+		}
+	}
+	// Update counts.
+	for pipeline, v := range idleContainersByPipelinesAndOrchestrator {
+		for orchestrator, count := range v {
+			if _, exists := census.aiContainersIdleByPipelineByOrchestrator[pipeline]; !exists {
+				census.aiContainersIdleByPipelineByOrchestrator[pipeline] = make(map[string]int)
+			}
+			census.aiContainersIdleByPipelineByOrchestrator[pipeline][orchestrator] = count
 		}
 	}
 
-	// Update counts with new data
-	for modelID, newModelCap := range modelCapacities {
-		if _, exists := census.aiContainersCapacityByModel[modelID]; !exists {
-			census.aiContainersCapacityByModel[modelID] = &ModelAICapacities{
-				ModelID:       modelID,
-				Orchestrators: make(map[string]AIContainerCapacity),
-			}
-		}
-		for orchURI, capacity := range newModelCap.Orchestrators {
-			census.aiContainersCapacityByModel[modelID].Orchestrators[orchURI] = capacity
-		}
-	}
-
-	// Record metrics for all models for all orchestrators
-	for modelID, modelCap := range census.aiContainersCapacityByModel {
-		for orchURI, capacity := range modelCap.Orchestrators {
-			// Record idle containers metric
+	// Record metrics for all pipelines for all orchestrators
+	for model, v := range census.aiContainersIdleByPipelineByOrchestrator {
+		for orchURL, v2 := range v {
 			if err := stats.RecordWithTags(census.ctx,
-				[]tag.Mutator{tag.Insert(census.kModelName, modelID), tag.Insert(census.kOrchestratorURI, orchURI)},
-				census.mAIContainersIdle.M(int64(capacity.Idle))); err != nil {
-				glog.Errorf("Error recording idle containers metric err=%q", err)
+				[]tag.Mutator{tag.Insert(census.kModelName, model), tag.Insert(census.kOrchestratorURI, orchURL)},
+				census.mAIContainersIdle.M(int64(v2))); err != nil {
+				glog.Errorf("Error recording metrics err=%q", err)
 			}
-
-			// Record in-use containers metric
-			if err := stats.RecordWithTags(census.ctx,
-				[]tag.Mutator{tag.Insert(census.kModelName, modelID), tag.Insert(census.kOrchestratorURI, orchURI)},
-				census.mAIContainersInUse.M(int64(capacity.InUse))); err != nil {
-				glog.Errorf("Error recording in-use containers metric err=%q", err)
-			}
-
-			if capacity.Idle == 0 && capacity.InUse == 0 {
+			if v2 == 0 {
 				// Remove zero counts, no need to report it again
-				delete(census.aiContainersCapacityByModel[modelID].Orchestrators, orchURI)
+				delete(census.aiContainersIdleByPipelineByOrchestrator[model], orchURL)
 			}
 		}
-		if len(census.aiContainersCapacityByModel[modelID].Orchestrators) == 0 {
-			// If there are no more orchestrators for this model, remove it from the map
-			delete(census.aiContainersCapacityByModel, modelID)
+		if len(census.aiContainersIdleByPipelineByOrchestrator[model]) == 0 {
+			// If there are no more pipelines for this model, remove it from the map
+			delete(census.aiContainersIdleByPipelineByOrchestrator, model)
 		}
 	}
 }

--- a/server/ai_session.go
+++ b/server/ai_session.go
@@ -478,6 +478,53 @@ func (sel *AISessionSelector) getSessions(ctx context.Context) ([]*BroadcastSess
 	return selectOrchestrator(ctx, sel.node, streamParams, numOrchs, sel.suspender, common.ScoreAtLeast(0), func(sessionID string) {})
 }
 
+type noopSus struct{}
+
+func (n noopSus) Suspended(orch string) int {
+	return 0
+}
+
+func (c *AISessionManager) refreshOrchCapacity(modelIDs []string) {
+	if len(modelIDs) < 1 {
+		return
+	}
+
+	pool := c.node.OrchestratorPool
+	if pool == nil {
+		return
+	}
+	clog.Infof(context.Background(), "Starting periodic orchestrator refresh for capacity reporting")
+
+	modelsReq := make(map[string]*core.ModelConstraint)
+	for _, modelID := range modelIDs {
+		modelsReq[modelID] = &core.ModelConstraint{
+			Warm:          false,
+			RunnerVersion: c.node.Capabilities.MinRunnerVersionConstraint(core.Capability_LiveVideoToVideo, modelID),
+		}
+	}
+	go func() {
+		refreshInterval := 10 * time.Second
+		ticker := time.NewTicker(refreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				ctx, cancel := context.WithTimeout(context.Background(), refreshInterval)
+				capabilityConstraints := core.PerCapabilityConstraints{
+					core.Capability_LiveVideoToVideo: {Models: modelsReq},
+				}
+				caps := core.NewCapabilities(append(core.DefaultCapabilities(), core.Capability_LiveVideoToVideo), nil)
+				caps.SetPerCapabilityConstraints(capabilityConstraints)
+				caps.SetMinVersionConstraint(c.node.Capabilities.MinVersionConstraint())
+
+				pool.GetOrchestrators(ctx, pool.Size(), noopSus{}, caps, common.ScoreAtLeast(0))
+
+				cancel()
+			}
+		}
+	}()
+}
+
 type AISessionManager struct {
 	node      *core.LivepeerNode
 	selectors map[string]*AISessionSelector
@@ -492,6 +539,7 @@ func NewAISessionManager(node *core.LivepeerNode, ttl time.Duration) *AISessionM
 		mu:        sync.Mutex{},
 		ttl:       ttl,
 	}
+	sessionManager.refreshOrchCapacity(node.LiveAICapRefreshModels)
 	return sessionManager
 }
 


### PR DESCRIPTION
Reverting this for now because I've realised that the pool of Os for `db_discovery` is different to what we're using for live AI streams. I believe `db_discovery` is using the automated discovery whereas for live AI we're using the hardcoded list from `orchWebhookUrl`