### PR TITLE
selection: Prevent crash on nonexistent price.

### DIFF
--- a/server/selection_algorithm.go
+++ b/server/selection_algorithm.go
@@ -83,7 +83,7 @@ func filterByMaxPrice(ctx context.Context, addrs []ethcommon.Address, maxPrice *
 			if price == nil {
 				price = big.NewRat(-1, 1)
 			}
-			clog.Warningf(ctx, "Orchestrator %s is above max price %v, price=%v", addr, maxPrice, price.FloatString(3))
+			clog.Warningf(ctx, "Orchestrator %s is above max price %v, price=%v", addr, maxPrice.FloatString(3), price.FloatString(3))
 		}
 	}
 	return res

--- a/server/selection_algorithm.go
+++ b/server/selection_algorithm.go
@@ -80,6 +80,9 @@ func filterByMaxPrice(ctx context.Context, addrs []ethcommon.Address, maxPrice *
 		if price != nil && price.Cmp(maxPrice) <= 0 {
 			res = append(res, addr)
 		} else {
+			if price == nil {
+				price = big.NewRat(-1, 1)
+			}
 			clog.Warningf(ctx, "Orchestrator %s is above max price %v, price=%v", addr, maxPrice, price.FloatString(3))
 		}
 	}


### PR DESCRIPTION
This seems to just be logging, so set to a nonsense price of -1.

Unit tests started breaking after this revert: https://github.com/livepeer/go-livepeer/pull/3833 which actually added a FloatString call to a potentially nil price