### PR TITLE
ai/live: Fix panic during RTMP ingest cleanup.

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -508,7 +508,11 @@ func setOutWriter(ctx context.Context, writer *media.RingBuffer, params aiReques
 	stream, requestID := params.liveParams.stream, params.liveParams.requestID
 	sess, exists := params.node.LivePipelines[stream]
 	if !exists || sess.RequestID != requestID {
-		clog.Info(ctx, "Did not set output writer due to nonexistent stream or mismatched request ID", "exists", exists, "requestID", requestID, "session-requestID", sess.RequestID)
+		sessRID := "nonexistent"
+		if sess != nil {
+			sessRID = sess.RequestID
+		}
+		clog.Info(ctx, "Did not set output writer due to nonexistent stream or mismatched request ID", "exists", exists, "requestID", requestID, "session-requestID", sessRID)
 		return
 	}
 	sess.OutWriter = writer
@@ -882,7 +886,7 @@ func (a aiRequestParams) inputStreamExists() bool {
 	a.node.LiveMu.RLock()
 	defer a.node.LiveMu.RUnlock()
 	p, ok := a.node.LivePipelines[a.liveParams.stream]
-	return ok && p.RequestID == a.liveParams.requestID
+	return ok && p.RequestID == a.liveParams.requestID && !p.Closed
 }
 
 func stopProcessing(ctx context.Context, params aiRequestParams, err error) {

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -670,9 +670,9 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 					"url":     "",
 				},
 			})
-			ssr.Close()
 			<-orchSelection // wait for selection to complete
 			cleanupControl(ctx, params)
+			ssr.Close()
 			orchCancel()
 		}()
 


### PR DESCRIPTION
We are seeing panics in prod during RTMP ingest cleanup. The general sequence seems to be:

1. RTMP ingest closes
2. Close segmenter and trickle reader (via ssr.Close())
3. Orchestrator swap initiates due to trickle closing
4. Clean up session from map via cleanupControl
5. Trickle publish initializes on a new orchestrator.
6. Trickle publish checks for session liveness before each segment
7. Trickle publish sets output stream for playback.
8. Crashes due to accessing a nonexistent session ... for logging :(

There are three issues here:

* Step 3 is obviously wrong; we should not be swapping after ingest close.

* Step 6 does not correctly see the stream as disconnected.

* Step 8 does not correctly handle nonexistent sessions.

There is most likely a race condition between steps 6 and 8 where step 4 hasn't fully completed; we should also account for that.

Fix Step 3 by only closing the segmenter (and then the trickle reader) after the session is cleaned via cleanupControl. This matches the [WHIP ingest](https://github.com/livepeer/go-livepeer/blob/864dabc11f1ff78f333584391e3023b62c676417/server/ai_mediaserver.go#L1149-L1151) behavior

Fix Step 6 by checking the `Closed` field in `inputStreamExists` method

Fix Step 8 by checking for a nil session before using its accessor.