### PR TITLE
BYOC: prepare core for byoc streaming

### DIFF
--- a/core/ai_orchestrator.go
+++ b/core/ai_orchestrator.go
@@ -1163,8 +1163,8 @@ func (orch *orchestrator) CheckExternalCapabilityCapacity(extCapability string) 
 func (orch *orchestrator) ReserveExternalCapabilityCapacity(extCapability string) error {
 	cap, ok := orch.node.ExternalCapabilities.Capabilities[extCapability]
 	if ok {
-		cap.mu.Lock()
-		defer cap.mu.Unlock()
+		cap.Mu.Lock()
+		defer cap.Mu.Unlock()
 
 		cap.Load++
 		return nil
@@ -1176,8 +1176,8 @@ func (orch *orchestrator) ReserveExternalCapabilityCapacity(extCapability string
 func (orch *orchestrator) FreeExternalCapabilityCapacity(extCapability string) error {
 	cap, ok := orch.node.ExternalCapabilities.Capabilities[extCapability]
 	if ok {
-		cap.mu.Lock()
-		defer cap.mu.Unlock()
+		cap.Mu.Lock()
+		defer cap.Mu.Unlock()
 
 		cap.Load--
 		return nil
@@ -1198,6 +1198,12 @@ func (orch *orchestrator) JobPriceInfo(sender ethcommon.Address, jobCapability s
 	jobPrice, err := orch.jobPriceInfo(sender, jobCapability)
 	if err != nil {
 		return nil, err
+	}
+
+	//ensure price numerator and denominator can be int64
+	jobPrice, err = common.PriceToInt64(jobPrice)
+	if err != nil {
+		return nil, fmt.Errorf("invalid job price: %w", err)
 	}
 
 	return &net.PriceInfo{

--- a/core/external_capabilities.go
+++ b/core/external_capabilities.go
@@ -1,13 +1,17 @@
 package core
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"time"
 
 	"sync"
 
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang/glog"
+	"github.com/livepeer/go-livepeer/trickle"
 )
 
 type ExternalCapability struct {
@@ -21,17 +25,167 @@ type ExternalCapability struct {
 
 	price *AutoConvertedPrice
 
-	mu   sync.RWMutex
+	Mu   sync.RWMutex
 	Load int
+}
+
+type StreamInfo struct {
+	StreamID   string
+	Capability string
+
+	//Orchestrator fields
+	Sender         ethcommon.Address
+	StreamRequest  []byte
+	pubChannel     *trickle.TrickleLocalPublisher
+	subChannel     *trickle.TrickleLocalPublisher
+	controlChannel *trickle.TrickleLocalPublisher
+	eventsChannel  *trickle.TrickleLocalPublisher
+	dataChannel    *trickle.TrickleLocalPublisher
+	//Stream fields
+	JobParams    string
+	StreamCtx    context.Context
+	CancelStream context.CancelFunc
+
+	cleanupOnce sync.Once
+	sdm         sync.Mutex
+}
+
+func (sd *StreamInfo) IsActive() bool {
+	sd.sdm.Lock()
+	defer sd.sdm.Unlock()
+	if sd.StreamCtx.Err() != nil {
+		return false
+	}
+
+	if sd.controlChannel == nil {
+		return false
+	}
+
+	return true
+}
+
+func (sd *StreamInfo) UpdateParams(params string) {
+	sd.sdm.Lock()
+	defer sd.sdm.Unlock()
+	sd.JobParams = params
+}
+
+func (sd *StreamInfo) SetChannels(pub, sub, control, events, data *trickle.TrickleLocalPublisher) {
+	sd.sdm.Lock()
+	defer sd.sdm.Unlock()
+	sd.pubChannel = pub
+	sd.subChannel = sub
+	sd.controlChannel = control
+	sd.eventsChannel = events
+	sd.dataChannel = data
+}
+
+func (sd *StreamInfo) cleanup() {
+	sd.cleanupOnce.Do(func() {
+		// Close all channels exactly once
+		if sd.pubChannel != nil {
+			sd.pubChannel.Close()
+		}
+		if sd.subChannel != nil {
+			sd.subChannel.Close()
+		}
+		if sd.controlChannel != nil {
+			sd.controlChannel.Close()
+		}
+		if sd.eventsChannel != nil {
+			sd.eventsChannel.Close()
+		}
+		if sd.dataChannel != nil {
+			sd.dataChannel.Close()
+		}
+	})
 }
 
 type ExternalCapabilities struct {
 	capm         sync.Mutex
 	Capabilities map[string]*ExternalCapability
+	Streams      map[string]*StreamInfo
 }
 
 func NewExternalCapabilities() *ExternalCapabilities {
-	return &ExternalCapabilities{Capabilities: make(map[string]*ExternalCapability)}
+	return &ExternalCapabilities{
+		Capabilities: make(map[string]*ExternalCapability),
+		Streams:      make(map[string]*StreamInfo)}
+}
+
+func (extCaps *ExternalCapabilities) AddStream(streamID string, capability string, streamReq []byte) (*StreamInfo, error) {
+	extCaps.capm.Lock()
+	defer extCaps.capm.Unlock()
+	_, ok := extCaps.Streams[streamID]
+	if ok {
+		return nil, fmt.Errorf("stream already exists: %s", streamID)
+	}
+
+	//add to streams
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := StreamInfo{
+		StreamID:      streamID,
+		Capability:    capability,
+		StreamRequest: streamReq,
+		StreamCtx:     ctx,
+		CancelStream:  cancel,
+	}
+	extCaps.Streams[streamID] = &stream
+
+	//clean up when stream ends
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		defer stream.cleanup()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				// Periodically check if stream still exists in map
+				extCaps.capm.Lock()
+				_, exists := extCaps.Streams[streamID]
+				extCaps.capm.Unlock()
+				if !exists {
+					return
+				}
+			}
+		}
+	}()
+
+	return &stream, nil
+}
+
+func (extCaps *ExternalCapabilities) RemoveStream(streamID string) {
+	extCaps.capm.Lock()
+	defer extCaps.capm.Unlock()
+
+	streamInfo, ok := extCaps.Streams[streamID]
+	if ok {
+		//confirm stream context is canceled before deleting
+		if streamInfo.StreamCtx.Err() == nil {
+			streamInfo.CancelStream()
+		}
+	}
+
+	delete(extCaps.Streams, streamID)
+}
+
+func (extCaps *ExternalCapabilities) GetStream(streamID string) (*StreamInfo, bool) {
+	extCaps.capm.Lock()
+	defer extCaps.capm.Unlock()
+
+	streamInfo, ok := extCaps.Streams[streamID]
+	return streamInfo, ok
+}
+
+func (extCaps *ExternalCapabilities) StreamExists(streamID string) bool {
+	extCaps.capm.Lock()
+	defer extCaps.capm.Unlock()
+
+	_, ok := extCaps.Streams[streamID]
+	return ok
 }
 
 func (extCaps *ExternalCapabilities) RemoveCapability(extCap string) {
@@ -76,7 +230,7 @@ func (extCaps *ExternalCapabilities) RegisterCapability(extCapability string) (*
 }
 
 func (extCap *ExternalCapability) GetPrice() *big.Rat {
-	extCap.mu.RLock()
-	defer extCap.mu.RUnlock()
+	extCap.Mu.RLock()
+	defer extCap.Mu.RUnlock()
 	return extCap.price.Value()
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Pulled out changes to `core` package to separate PR to bring in streaming for BYOC capabilities.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Updates a `Mu`  in ExternalCapability to export to be usable in `byoc` package
- Adds `StreamInfo` tracking for Orchestrator to manage running streams.
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Built docker container and ran tests locally.  The changes here are in preparation for BYOC streaming which I have run continuously on mainnet gateway/orchestrator setup.

**Does this pull request close any open issues?**
<!-- Fixes # -->
No

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
