### PR TITLE
trickle: Simplify server and improve logging.

### DIFF
--- a/trickle/trickle_publisher.go
+++ b/trickle/trickle_publisher.go
@@ -233,6 +233,8 @@ func (p *pendingPost) Write(data io.Reader) (int64, error) {
 
 		// Close the pipe writer to signal end of data for the current POST request
 		closeErr = writer.Close()
+	} else {
+		writer.Close()
 	}
 
 	// check for errors after write, eg >=400 status codes

--- a/trickle/trickle_subscriber.go
+++ b/trickle/trickle_subscriber.go
@@ -135,6 +135,8 @@ func (c *TrickleSubscriber) SetSeq(seq int) {
 	c.cancelCtx()
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// Reset client in case SetSeq is called due to slow reads falling too far behind
+	c.client = httpClient()
 	c.idx = seq
 	c.ctx, c.cancelCtx = context.WithCancel(c.baseCtx)
 	c.pendingGet = nil


### PR DESCRIPTION
Few small tweaks; mostly diagnostic and a couple minor behavioral tweaks which are not likely to change anything in practice.

* Add some server logging to help diagnose stalled subscribes

* Simplify some conflict handling logic on the server. In practice we cannot hit this with the current trickle server configuration, so just remove it for simplicity. Update unit tests to match.

* Reset subscriber client if we reset the sequence numbering. Might help stalled subscribes if the issue is wonky underlying TCP/HTTP.

* Close publisher writer there is IO error copying the segment body