### PR TITLE
box: Update build-runner.sh for nexus refactor support

### DIFF
--- a/box/build-runner.sh
+++ b/box/build-runner.sh
@@ -8,42 +8,41 @@ if [[ "$PIPELINE" != "noop" && "$PIPELINE" != "comfyui" && "$PIPELINE" != "strea
   exit 1
 fi
 
-# Switch to neighbour ai-runner directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd "$SCRIPT_DIR/../../ai-runner/runner"
+AI_RUNNER_DIR="$SCRIPT_DIR/../../ai-runner"
+cd "$AI_RUNNER_DIR/runner"
 
 VERSION="$(bash print_version.sh)"
 
-docker build -t livepeer/ai-runner:live-base -f docker/Dockerfile.live-base .
-if [ "${PIPELINE}" = "noop" ]; then
-    docker build -t livepeer/ai-runner:live-app-noop -f docker/Dockerfile.live-app-noop --build-arg VERSION=${VERSION} .
-else
-    BASE_PIPELINE=${PIPELINE}
-    PARAM_NAME=""
-    if [[ "$PIPELINE" == "streamdiffusion" ]]; then
-        PARAM_NAME="sdturbo"
-    elif [[ "$PIPELINE" =~ ^streamdiffusion- ]]; then
-        BASE_PIPELINE="streamdiffusion"
-        PARAM_NAME="$(echo "${PIPELINE#streamdiffusion-}" | tr '-' '_')"
-    fi
-
-    INFERPY_INITIAL_PARAMS=""
-    if [[ -n "$PARAM_NAME" ]]; then
-        JSON_FILE=./app/live/pipelines/streamdiffusion/${PARAM_NAME}_default_params.json
-        if [ ! -f "$JSON_FILE" ]; then
-            echo "Params file missing: $JSON_FILE" >&2
-            exit 1
-        fi
-        INFERPY_INITIAL_PARAMS=$(tr -d '\n' < "$JSON_FILE")
-    fi
-    docker build -t livepeer/ai-runner:live-base-${BASE_PIPELINE} -f docker/Dockerfile.live-base-${BASE_PIPELINE} .
-    docker build \
-      -f docker/Dockerfile.live-app__PIPELINE__ \
-      -t livepeer/ai-runner:live-app-${PIPELINE} \
-      --build-arg PIPELINE=${BASE_PIPELINE} \
-      --build-arg VERSION=${VERSION} \
-      --build-arg INFERPY_INITIAL_PARAMS="$INFERPY_INITIAL_PARAMS" \
-      .
+# comfyui uses its own external base (livepeer/comfyui-base)
+if [ "${PIPELINE}" != "comfyui" ]; then
+  docker build -t livepeer/ai-runner:live-base -f docker/Dockerfile.live-base .
 fi
+
+
+cd "$AI_RUNNER_DIR"
+DOCKERFILE_PATH="live/${PIPELINE}/Dockerfile"
+EXTRA_ARGS=""
+
+if [ "${PIPELINE}" = "noop" ]; then
+  # noop is built from the runner directory
+  cd "$AI_RUNNER_DIR/runner"
+  DOCKERFILE_PATH="docker/Dockerfile.live-app-noop"
+elif [[ "${PIPELINE}" == "streamdiffusion" || "${PIPELINE}" =~ ^streamdiffusion- ]]; then
+  DOCKERFILE_PATH="live/streamdiffusion/Dockerfile"
+
+  SUBVARIANT="sdturbo"
+  if [[ "$PIPELINE" =~ ^streamdiffusion- ]]; then
+    SUBVARIANT="${PIPELINE#streamdiffusion-}"
+  fi
+  EXTRA_ARGS="--build-arg SUBVARIANT=$SUBVARIANT"
+fi
+
+docker build \
+  -f ${DOCKERFILE_PATH} \
+  -t livepeer/ai-runner:live-app-${PIPELINE} \
+  --build-arg VERSION=${VERSION} \
+  $EXTRA_ARGS \
+  .
 
 docker stop live-video-to-video_${PIPELINE}_8900 || true


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This updates the `build-runner.sh` script from the box to support the new build
logic from ai-runner after the "nexus" refactor: https://github.com/livepeer/ai-runner/pull/866

**Specific updates (required)**
- Use new dockerfile paths
- Simplify pipeline handling logic

**How did you test each of these updates (required)**
Build all the pipelines `PIPELINE=x make box-runner`

**Does this pull request close any open issues?**
N/A

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
