### PR TITLE
box/build-runner: Fix build for default streamdiffusion

### DIFF
--- a/box/build-runner.sh
+++ b/box/build-runner.sh
@@ -31,7 +31,7 @@ if [ "${PIPELINE}" = "noop" ]; then
 elif [[ "${PIPELINE}" == "streamdiffusion" || "${PIPELINE}" =~ ^streamdiffusion- ]]; then
   DOCKERFILE_PATH="live/streamdiffusion/Dockerfile"
 
-  SUBVARIANT="sdturbo"
+  SUBVARIANT=""
   if [[ "$PIPELINE" =~ ^streamdiffusion- ]]; then
     SUBVARIANT="${PIPELINE#streamdiffusion-}"
   fi


### PR DESCRIPTION
It should not have SUBVARIANT=sdturbo anymore

This changes the box development environment only (which shouldn't be in this repo), so merging this without approval.