### PR TITLE
ai/worker: Migrate scope to proper daydreamlive image

### DIFF
--- a/ai/worker/docker.go
+++ b/ai/worker/docker.go
@@ -81,9 +81,10 @@ var livePipelineToImage = map[string]string{
 	// streamdiffusion-sdxl-faceid is a utility image that uses an SDXL model with a FaceID IP Adapter on the default config of the pipeline. Optimizes startup time.
 	"streamdiffusion-sdxl-faceid": "livepeer/ai-runner:live-app-streamdiffusion-sdxl-faceid",
 	"comfyui":                     "livepeer/ai-runner:live-app-comfyui",
-	"scope":                       "livepeer/ai-runner:live-app-scope",
 	"segment_anything_2":          "livepeer/ai-runner:live-app-segment_anything_2",
 	"noop":                        "livepeer/ai-runner:live-app-noop",
+	// scope image is managed in the daydreamlive org
+	"scope": "daydreamlive/scope-runner",
 }
 
 type ImageOverrides struct {

--- a/ai/worker/docker_test.go
+++ b/ai/worker/docker_test.go
@@ -455,7 +455,7 @@ func TestDockerManager_getContainerImageName(t *testing.T) {
 			},
 			pipeline:      "live-video-to-video",
 			modelID:       "scope",
-			expectedImage: "livepeer/ai-runner:live-app-scope",
+			expectedImage: "daydreamlive/scope-runner",
 			expectError:   false,
 		},
 	}

--- a/box/build-runner.sh
+++ b/box/build-runner.sh
@@ -28,6 +28,7 @@ if [ "${PIPELINE}" = "scope" ]; then
     exit 1
   fi
   USE_LATEST_BASE=1 bash $SCOPE_RUNNER_DIR/build-docker.sh
+  docker stop live-video-to-video_${PIPELINE}_8900 || true
   exit 0
 fi
 

--- a/box/build-runner.sh
+++ b/box/build-runner.sh
@@ -10,15 +10,28 @@ fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 AI_RUNNER_DIR="$SCRIPT_DIR/../../ai-runner"
-cd "$AI_RUNNER_DIR/runner"
 
-VERSION="$(bash print_version.sh)"
 
-# comfyui uses its own external base (livepeer/comfyui-base)
+# Build base image first (needed for all pipelines except comfyui)
 if [ "${PIPELINE}" != "comfyui" ]; then
+  cd "$AI_RUNNER_DIR/runner"
   docker build -t livepeer/ai-runner:live-base -f docker/Dockerfile.live-base .
 fi
 
+# Handle scope pipeline separately - it has its own build script
+if [ "${PIPELINE}" = "scope" ]; then
+  SCOPE_RUNNER_DIR="${SCOPE_RUNNER_DIR:-$SCRIPT_DIR/../../scope-runner}"
+  if [ ! -d "$SCOPE_RUNNER_DIR" ]; then
+    echo "Error: scope-runner directory not found at $SCOPE_RUNNER_DIR" >&2
+    echo "Expected scope-runner to be a sibling directory of go-livepeer" >&2
+    echo "Or set SCOPE_RUNNER_DIR environment variable to override the path" >&2
+    exit 1
+  fi
+  USE_LATEST_BASE=1 bash $SCOPE_RUNNER_DIR/build-docker.sh
+  exit 0
+fi
+
+VERSION="$(bash print_version.sh)"
 
 cd "$AI_RUNNER_DIR"
 DOCKERFILE_PATH="live/${PIPELINE}/Dockerfile"

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -365,13 +365,14 @@ func reportLiveAICapacity(ch chan common.OrchestratorDescriptor, caps common.Cap
 
 	idleContainersByModelAndOrchestrator := make(map[string]map[string]int)
 	for _, od := range allOrchInfo {
-		pricePerUnit := od.RemoteInfo.PriceInfo.PricePerUnit
-		pixelsPerUnit := od.RemoteInfo.PriceInfo.PixelsPerUnit
-		pricePerPixel := big.NewRat(pricePerUnit, pixelsPerUnit)
-		monitor.LiveAIPricePerPixel(od.LocalInfo.URL.String(), pricePerPixel)
-
 		var models map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint
 		if od.RemoteInfo != nil {
+			if od.RemoteInfo.PriceInfo != nil {
+				pricePerUnit := od.RemoteInfo.PriceInfo.PricePerUnit
+				pixelsPerUnit := od.RemoteInfo.PriceInfo.PixelsPerUnit
+				pricePerPixel := big.NewRat(pricePerUnit, pixelsPerUnit)
+				monitor.LiveAIPricePerPixel(od.LocalInfo.URL.String(), pricePerPixel)
+			}
 			models = getModelCaps(od.RemoteInfo.Capabilities)
 		}
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This is to migrate the AI worker logic to use the right scope-runner image,
now published in the daydreamlive org after https://github.com/daydreamlive/scope-runner/pull/2!

**Specific updates (required)**
- Update image in docker.go
- Update build-runner.sh script to use scope-runner repo

**How did you test each of these updates (required)**
`REBUILD=1 PIPELINE=scope make box`

**Does this pull request close any open issues?**
Unblocks scope development.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
