### PR TITLE
BYOC: fix orchestrator stream setup when fails

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,6 +19,7 @@
 * [#3814](https://github.com/livepeer/go-livepeer/pull/3814) ai/worker: Add scope pipeline support to worker and build scripts (@victorges)
 * [#3823](https://github.com/livepeer/go-livepeer/pull/3823) ai/worker: Add sd15-v2v image support (@victorges)
 * [#3843](https://github.com/livepeer/go-livepeer/pull/3843) ai/worker: Add sdxl-v2v image support (@victorges)
+* [#3849](https://github.com/livepeer/go-livepeer/pull/3849) byoc: fix orchestrator stream setup when fails (@ad-astra-video)
 
 #### Transcoder
 

--- a/byoc/stream_orchestrator.go
+++ b/byoc/stream_orchestrator.go
@@ -160,6 +160,24 @@ func (bso *BYOCOrchestratorServer) StartStream() http.Handler {
 			//return error response from the worker
 			w.WriteHeader(resp.StatusCode)
 			w.Write(respBody)
+
+			//free capacity if not fatal (500 error)
+			if resp.StatusCode != http.StatusInternalServerError {
+				bso.orch.FreeExternalCapabilityCapacity(orchJob.Req.Capability)
+			}
+			//close the trickle channels
+			if pubCh != nil {
+				pubCh.Close()
+			}
+			if subCh != nil {
+				subCh.Close()
+			}
+			if dataCh != nil {
+				dataCh.Close()
+			}
+			controlPubCh.Close()
+			eventsCh.Close()
+
 			return
 		}
 

--- a/byoc/stream_test.go
+++ b/byoc/stream_test.go
@@ -1836,12 +1836,209 @@ func TestStartStreamWorkerErrorResponse(t *testing.T) {
 			assert.Contains(t, w.Body.String(), "invalid request parameters")
 
 			// Verify freeCapacity was called for non-500 errors
-			assert.False(t, freeCapacityCalled, "FreeExternalCapabilityCapacity should NOT have been called")
+			assert.True(t, freeCapacityCalled, "FreeExternalCapabilityCapacity should have been called")
 
 			server.CloseClientConnections()
 
 			// no stream created
 			assert.Zero(t, len(mockOrch.node.ExternalCapabilities.Streams))
+		})
+	})
+}
+
+// TestStartStreamError_OtherScenarios tests the other failedToStartStream = true scenarios
+// from StartStream in stream_orchestrator.go (lines 138, 149, 173, 201)
+// Excludes line 165 (worker request timeout)
+func TestStartStreamError_OtherScenarios(t *testing.T) {
+	// Mock worker that returns 200 OK
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/stream/start" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"result": "success"}`))
+			return
+		}
+	}))
+	defer server.Close()
+
+	mockVerifySig := func(addr ethcommon.Address, msg string, sig []byte) bool {
+		return true
+	}
+	mockGetUrlForCapability := func(capability string) string {
+		return server.URL
+	}
+	mockJobPriceInfo := func(addr ethcommon.Address, cap string) (*net.PriceInfo, error) {
+		return &net.PriceInfo{
+			PricePerUnit:  0,
+			PixelsPerUnit: 1,
+		}, nil
+	}
+
+	var freeCapacityCalled bool
+	mockFreeExternalCapabilityCapacity := func(string) error {
+		freeCapacityCalled = true
+		return nil
+	}
+
+	mockOrch := newMockJobOrchestrator()
+	mockOrch.verifySignature = mockVerifySig
+	mockOrch.getUrlForCapability = mockGetUrlForCapability
+	mockOrch.jobPriceInfo = mockJobPriceInfo
+	mockOrch.freeCapacity = mockFreeExternalCapabilityCapacity
+
+	bso := &BYOCOrchestratorServer{
+		orch:    mockOrch,
+		httpMux: http.NewServeMux(),
+		node:    mockOrch.node,
+		trickleSrv: trickle.ConfigureServer(trickle.TrickleServerConfig{
+			Mux:      http.NewServeMux(),
+			BasePath: "/ai/trickle/",
+		}),
+	}
+
+	// Set up mock sender
+	mockSender := pm.MockSender{}
+	mockSender.On("StartSession", mock.Anything).Return("foo")
+	mockSender.On("CreateTicketBatch", mock.Anything, mock.Anything).Return(mockTicketBatch(70), nil)
+	mockOrch.node.Sender = &mockSender
+	mockOrch.node.Balances = core.NewAddressBalances(10 * time.Second)
+	defer mockOrch.node.Balances.StopCleanup()
+
+	// Prepare job request
+	jobParams := JobParameters{EnableVideoIngress: true, EnableVideoEgress: true, EnableDataOutput: true}
+	paramsStr := marshalToString(t, jobParams)
+	jobReq := &JobRequest{
+		ID:         "test-stream",
+		Capability: "test-capability",
+		Parameters: paramsStr,
+		Timeout:    70,
+		Request:    "{}",
+	}
+
+	orchJob := &orchJob{Req: jobReq, Params: &jobParams}
+	gatewayJob := &gatewayJob{Job: orchJob, node: mockOrch.node}
+
+	// Setup signing
+	mockOrch.node.OrchestratorPool = newStubOrchestratorPool(mockOrch.node, []string{server.URL})
+	gatewayJob.sign()
+	mockOrch.node.OrchestratorPool = nil
+
+	// Prepare stream start request
+	startReq := StartRequest{
+		Stream:   "teststream",
+		StreamId: "test-stream",
+		Params:   "{}",
+	}
+	body, _ := json.Marshal(startReq)
+
+	t.Run("InvalidJSONBody", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			freeCapacityCalled = false
+
+			// Invalid JSON body - trickle channels ARE created before JSON parsing
+			invalidBody := []byte("notjson")
+			req := httptest.NewRequest(http.MethodPost, "/process/stream/start", bytes.NewReader(invalidBody))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(jobRequestHdr, gatewayJob.SignedJobReq)
+
+			w := httptest.NewRecorder()
+			handler := bso.StartStream()
+			handler.ServeHTTP(w, req)
+
+			// Verify 400 Bad Request response
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+
+			// Verify freeCapacity WAS called (trickle channels were created)
+			assert.True(t, freeCapacityCalled, "FreeExternalCapabilityCapacity should have been called")
+
+			// no stream created
+			assert.Zero(t, len(mockOrch.node.ExternalCapabilities.Streams))
+		})
+	})
+
+	t.Run("WorkerReturnsErrorStatus", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			freeCapacityCalled = false
+
+			// Create a server that returns error status
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/stream/start" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusBadRequest)
+					w.Write([]byte(`{"error": "invalid request"}`))
+					return
+				}
+			}))
+			defer server.Close()
+
+			// Update capability URL to use this server
+			mockGetUrlForCapability = func(capability string) string {
+				return server.URL
+			}
+			mockOrch.getUrlForCapability = mockGetUrlForCapability
+
+			req := httptest.NewRequest(http.MethodPost, "/process/stream/start", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(jobRequestHdr, gatewayJob.SignedJobReq)
+
+			w := httptest.NewRecorder()
+			handler := bso.StartStream()
+			handler.ServeHTTP(w, req)
+
+			// Verify error response is forwarded
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+			assert.Contains(t, w.Body.String(), "invalid request")
+
+			// Verify freeCapacity was called (non-500 error)
+			assert.True(t, freeCapacityCalled, "FreeExternalCapabilityCapacity should have been called")
+
+			// no stream created
+			assert.Zero(t, len(mockOrch.node.ExternalCapabilities.Streams))
+		})
+	})
+
+	t.Run("AddStreamToExternalCapabilitiesFails", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			freeCapacityCalled = false
+
+			// Create a server that returns 200 OK
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/stream/start" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{"result": "success"}`))
+					return
+				}
+			}))
+			defer server.Close()
+
+			// Update capability URL to use this server
+			mockGetUrlForCapability = func(capability string) string {
+				return server.URL
+			}
+			mockOrch.getUrlForCapability = mockGetUrlForCapability
+
+			// Pre-create a stream with the same ID to cause AddStream to fail
+			_, err := mockOrch.node.ExternalCapabilities.AddStream(jobReq.ID, jobReq.Capability, []byte("{}"))
+			assert.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/process/stream/start", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set(jobRequestHdr, gatewayJob.SignedJobReq)
+
+			w := httptest.NewRecorder()
+			handler := bso.StartStream()
+			handler.ServeHTTP(w, req)
+
+			// Verify 500 Internal Server Error response
+			assert.Equal(t, http.StatusInternalServerError, w.Code)
+			assert.Contains(t, w.Body.String(), "Error adding stream to external capabilities")
+
+			// Verify freeCapacity was called
+			assert.True(t, freeCapacityCalled, "FreeExternalCapabilityCapacity should have been called")
+
+			// Clean up pre-created stream
+			mockOrch.node.ExternalCapabilities.RemoveStream(jobReq.ID)
 		})
 	})
 }

--- a/byoc/stream_test.go
+++ b/byoc/stream_test.go
@@ -1760,6 +1760,7 @@ func TestStartStreamWorkerErrorResponse(t *testing.T) {
 			// running in synctest confirms that no trickle channels remain open
 
 			statusCodeReturned = http.StatusBadRequest
+			freeCapacityCalled = false
 
 			req := httptest.NewRequest(http.MethodPost, "/process/stream/start", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
@@ -1789,6 +1790,7 @@ func TestStartStreamWorkerErrorResponse(t *testing.T) {
 	t.Run("WorkerReturns503_Unavailable", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			statusCodeReturned = http.StatusServiceUnavailable
+			freeCapacityCalled = false
 
 			req := httptest.NewRequest(http.MethodPost, "/process/stream/start", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
@@ -1817,6 +1819,7 @@ func TestStartStreamWorkerErrorResponse(t *testing.T) {
 	t.Run("WorkerReturns500_FatalError", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			statusCodeReturned = http.StatusInternalServerError
+			freeCapacityCalled = false
 
 			req := httptest.NewRequest(http.MethodPost, "/process/stream/start", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Fixes a bug where if the worker returns error code (e.g. 503) the Orchestrator should reset state to no stream running.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- closes trickle channels immediately
- restores capacity if is non fatal error (500 status code from runner)

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass        ------`byoc` package tests ran locally
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
