### PR TITLE
cli: Add warning to full unbond as orchestrator

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,10 @@
 
 #### General
 
+#### CLI
+
+- \#3852 Add warning when orchestrator attempts to unbond full stake, requiring confirmation to prevent accidental deactivation (@moudi-network)
+
 #### Broadcaster
 
 #### Orchestrator

--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -286,6 +286,28 @@ func (w *wizard) unbond() {
 		}
 	}
 
+	// Warn if unbonding full amount while being an orchestrator (delegated to self)
+	if amount.Cmp(dInfo.BondedAmount) == 0 && dInfo.DelegateAddress == dInfo.Address {
+		fmt.Printf("\nWARNING: You are about to unbond your entire stake.\n")
+		fmt.Printf("Since you are an orchestrator (delegated to yourself), this will DEACTIVATE your orchestrator.\n")
+		fmt.Printf("Your orchestrator will no longer be eligible to receive work or rewards until you rebond and reactivate.\n")
+		fmt.Printf("Are you sure you want to proceed? (y/n) - ")
+
+		confirm := ""
+		for {
+			confirm = w.readString()
+			if confirm == "y" || confirm == "n" {
+				break
+			}
+			fmt.Printf("Enter (y)es or (n)o \n")
+		}
+
+		if confirm == "n" {
+			fmt.Printf("Unbond cancelled.\n")
+			return
+		}
+	}
+
 	val := url.Values{
 		"amount": {fmt.Sprintf("%v", amount.String())},
 	}


### PR DESCRIPTION
**What does this pull request do? Explain your changes**

This PR adds a CLI warning when an orchestrator attempts to unbond their entire stake. This prevents accidental deactivation of orchestrators by requiring explicit confirmation before proceeding with a full unbond.

**Specific updates (required)**

- Added a check in the unbond() function to detect when an orchestrator (self-delegated) is unbonding their full bonded amount
- Added a warning message explaining that full unbond will deactivate the orchestrator
- Added a y/n confirmation prompt to prevent accidental full unbonds

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully (fails due to pre-existing lpms/ffmpeg dependency issue locally)
- [ ] All tests in `./test.sh` pass ( `FAIL: TestRingbuffer_ConcurrentRW (1.81s)` ) 
- [ ] README and other documentation updated
- [X] [Pending changelog](./CHANGELOG_PENDING.md) updated
