### PR TITLE
Fix latency reporting, remove RequestID

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -272,7 +272,6 @@ func (h *lphttp) StartLiveVideoToVideo() http.Handler {
 			SubscribeUrl: subUrl,
 			ControlUrl:   &controlUrl,
 			EventsUrl:    &eventsUrl,
-			RequestId:    &requestID,
 			ManifestId:   &mid,
 		})
 		if err != nil {

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -1205,7 +1205,8 @@ func runStats(ctx context.Context, whipConn *media.WHIPConnection, streamID stri
 				monitor.AIWhipTransportBytesSent(int64(stats.PeerConnStats.BytesSent))
 			}
 			clog.Info(ctx, "whip TransportStats", "ID", stats.PeerConnStats.ID, "bytes_received", stats.PeerConnStats.BytesReceived, "bytes_sent", stats.PeerConnStats.BytesSent)
-			for _, s := range stats.TrackStats {
+			for i := range stats.TrackStats {
+				s := &stats.TrackStats[i] // pointer because underlying object is being updated
 				outputStats := media.GetOutputStats(requestID + "-" + s.Type.String())
 				s.LastOutputTS = float64(outputStats.GetLastOutputTS()) / 90000.0
 				s.Latency = s.LastInputTS - s.LastOutputTS


### PR DESCRIPTION
Combining two separate (but tiny!) changes for ease of review.

[ai/live: Iterate over TrackStats with a pointer](https://github.com/livepeer/go-livepeer/commit/7814faebf25ceef046c60335963800ec6e566780) 
With the `for range` loop, a copy of each struct is created due
to the definition of `TrackStats: []TrackStats`. This results in
losing modifications that are done to each track stat within loops,
and those modifications are not sent to Kafka.

Fix this by retrieving a pointer to each object and updating that.

While we could also modify the definition to `TrackStats: []*TrackStats`
opt for the smallest structural change (for now).

[ai/live: Exclude requestID from the orchestrator's LiveToLive response](https://github.com/livepeer/go-livepeer/commit/0b319f7313ac6568877f92e168959585d5c5da32) 
Tightens things up:

* The "RequestID" that was being returned here matches the ManifestID,
  rather than request ID that was supplied in the original request.

* There is a ManifestID field that is field that that is returned
  already. So the RequestID in the response is reundant in addition to
  being semantically incorrect.

* The RequestID in the response isn't actually used within go-livepeer
  so remove it before anyone else starts to depend on it, eg as part of
  a local SDK.