### PR TITLE
BYOC: Fix Orchestrator streaming reserve capacity

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,8 @@
 
 #### Orchestrator
 
+* [#3857](https://github.com/livepeer/go-livepeer/pull/3857) byoc: fix orchestrator streaming reserve capacity (@ad-astra-video)
+
 #### Transcoder
 
 ### Bug Fixes 🐞

--- a/byoc/job_gateway.go
+++ b/byoc/job_gateway.go
@@ -260,7 +260,7 @@ func (bsg *BYOCGatewayServer) setupGatewayJob(ctx context.Context, jobReqHdr str
 	var orchs []JobToken
 
 	clog.Infof(ctx, "processing job request req=%v", jobReqHdr)
-	jobReq, err := bsg.verifyJobCreds(ctx, jobReqHdr, true)
+	jobReq, err := bsg.verifyJobCreds(jobReqHdr)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Unable to parse job request, err=%v", err))
 	}
@@ -321,7 +321,7 @@ func getOrchSearchTimeouts(ctx context.Context, searchTimeoutHdr, respTimeoutHdr
 	return timeout, respTimeout
 }
 
-func (bsg *BYOCGatewayServer) verifyJobCreds(ctx context.Context, jobCreds string, reserveCapacity bool) (*JobRequest, error) {
+func (bsg *BYOCGatewayServer) verifyJobCreds(jobCreds string) (*JobRequest, error) {
 	//Gateway needs JobRequest parsed and verification of required fields
 	jobData, err := parseJobRequest(jobCreds)
 	if err != nil {

--- a/byoc/job_gateway.go
+++ b/byoc/job_gateway.go
@@ -418,7 +418,9 @@ func getJobOrchestrators(ctx context.Context, node *core.LivepeerNode, capabilit
 	for nbResp < numAvailableOrchs && len(jobTokens) < numAvailableOrchs && !timedOut {
 		select {
 		case token := <-tokenCh:
-			jobTokens = append(jobTokens, token)
+			if token.AvailableCapacity > 0 {
+				jobTokens = append(jobTokens, token)
+			}
 			nbResp++
 		case <-errCh:
 			nbResp++

--- a/byoc/stream_orchestrator.go
+++ b/byoc/stream_orchestrator.go
@@ -19,14 +19,13 @@ import (
 
 var getNewTokenTimeout = 3 * time.Second
 
-// StartStream handles the POST /stream/start endpoint for the Orchestrator
 func (bso *BYOCOrchestratorServer) StartStream() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		orch := bso.orch
 		remoteAddr := getRemoteAddr(r)
 		ctx := clog.AddVal(r.Context(), clog.ClientIP, remoteAddr)
 
-		orchJob, err := bso.setupOrchJob(ctx, r, false)
+		orchJob, err := bso.setupOrchJob(ctx, r, true)
 		if err != nil {
 			code := http.StatusBadRequest
 			if err == errInsufficientBalance {

--- a/byoc/types.go
+++ b/byoc/types.go
@@ -55,7 +55,7 @@ type Orchestrator interface {
 	JobPriceInfo(sender ethcommon.Address, capability string) (*net.PriceInfo, error)
 	TicketParams(sender ethcommon.Address, priceInfo *net.PriceInfo) (*net.TicketParams, error)
 	Balance(sender ethcommon.Address, manifestID core.ManifestID) *big.Rat
-	CheckExternalCapabilityCapacity(capability string) bool
+	CheckExternalCapabilityCapacity(capability string) int64
 	RemoveExternalCapability(extCapName string) error
 	RegisterExternalCapability(extCapSettings string) (*core.ExternalCapability, error)
 	FreeExternalCapabilityCapacity(capability string) error
@@ -132,11 +132,12 @@ type JobOrchestratorsFilter struct {
 }
 
 type JobToken struct {
-	SenderAddress *JobSender        `json:"sender_address,omitempty"`
-	TicketParams  *net.TicketParams `json:"ticket_params,omitempty"`
-	Balance       int64             `json:"balance,omitempty"`
-	Price         *net.PriceInfo    `json:"price,omitempty"`
-	ServiceAddr   string            `json:"service_addr,omitempty"`
+	SenderAddress     *JobSender        `json:"sender_address,omitempty"`
+	TicketParams      *net.TicketParams `json:"ticket_params,omitempty"`
+	Balance           int64             `json:"balance,omitempty"`
+	Price             *net.PriceInfo    `json:"price,omitempty"`
+	ServiceAddr       string            `json:"service_addr,omitempty"`
+	AvailableCapacity int64             `json:"available_capacity,omitempty"`
 
 	LastNonce uint32
 }

--- a/core/ai_orchestrator.go
+++ b/core/ai_orchestrator.go
@@ -1148,14 +1148,14 @@ func (orch *orchestrator) GetUrlForCapability(extCapability string) string {
 	return ""
 }
 
-func (orch *orchestrator) CheckExternalCapabilityCapacity(extCapability string) bool {
+func (orch *orchestrator) CheckExternalCapabilityCapacity(extCapability string) int64 {
 	if cap, ok := orch.node.ExternalCapabilities.Capabilities[extCapability]; !ok {
-		return false
+		return 0
 	} else {
 		if cap.Load < cap.Capacity {
-			return true
+			return int64(cap.Capacity - cap.Load)
 		} else {
-			return false
+			return 0
 		}
 	}
 }

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -87,7 +87,7 @@ type Orchestrator interface {
 	RegisterExternalCapability(extCapability string) (*core.ExternalCapability, error)
 	RemoveExternalCapability(extCapability string) error
 	GetUrlForCapability(extCapability string) string
-	CheckExternalCapabilityCapacity(extCapability string) bool
+	CheckExternalCapabilityCapacity(extCapability string) int64
 	ReserveExternalCapabilityCapacity(extCapability string) error
 	FreeExternalCapabilityCapacity(extCapability string) error
 	JobPriceInfo(sender ethcommon.Address, jobCapabiliy string) (*net.PriceInfo, error)

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -266,8 +266,8 @@ func (r *stubOrchestrator) RegisterExternalCapability(extCapabilitySettings stri
 func (r *stubOrchestrator) RemoveExternalCapability(extCapability string) error {
 	return nil
 }
-func (r *stubOrchestrator) CheckExternalCapabilityCapacity(extCap string) bool {
-	return true
+func (r *stubOrchestrator) CheckExternalCapabilityCapacity(extCap string) int64 {
+	return 1
 }
 func (r *stubOrchestrator) ReserveExternalCapabilityCapacity(extCap string) error {
 	return nil
@@ -1623,8 +1623,8 @@ func (o *mockOrchestrator) RegisterExternalCapability(extCapabilitySettings stri
 func (o *mockOrchestrator) RemoveExternalCapability(extCapability string) error {
 	return nil
 }
-func (o *mockOrchestrator) CheckExternalCapabilityCapacity(extCap string) bool {
-	return true
+func (o *mockOrchestrator) CheckExternalCapabilityCapacity(extCap string) int64 {
+	return 1
 }
 func (o *mockOrchestrator) ReserveExternalCapabilityCapacity(extCap string) error {
 	return nil


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Fixes bug introduces when spliting BYOC to separate gateway and orchestrator streaming files.

Part of the fix is also returning a JobToken even when there is no capacity.  This enables reporting capacity available when job token sent

No net new features added, just bug fix and refactor.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Fixed `verifyJobCreds` function in BYOCOrchestratorServer and simplified same function for Gateway to only parse the request.
- Added test to check that reserve capacity function is called
- Updated `CheckExternalCapabilityCapacity` to return net capacity available
- Updated `GetToken` to return JobToken even if no capacity.  No major change on this one but removing the if block makes the diff kind of ugly.
- Updated `getJobOrchestrators` to use `token.AvailableCapacity` to determine if Orchestrator should be in working set (0 = excluded)

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Added test and built and ran local docker containers for Gateway and Orchestrator to test full stack.

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
