### PR TITLE
fix(remote_signer): fix ticket value calculation for capability-constraint pricing

### DIFF
--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -89,6 +89,7 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 				inPixels:  inPixels,
 				priceInfo: priceInfo,
 				mid:       params.liveParams.manifestID,
+				modelID:   sess.ModelID,
 			})
 		}
 		paymentProcessor = NewLivePaymentProcessor(ctx, params.liveParams.paymentProcessInterval, sendPaymentFunc)

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -89,7 +89,6 @@ func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestPara
 				inPixels:  inPixels,
 				priceInfo: priceInfo,
 				mid:       params.liveParams.manifestID,
-				modelID:   sess.ModelID,
 			})
 		}
 		paymentProcessor = NewLivePaymentProcessor(ctx, params.liveParams.paymentProcessInterval, sendPaymentFunc)

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1059,8 +1059,8 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 			return nil, errors.New("remote sender was not the correct type")
 		}
 		res, err := rpp.RequestPayment(ctx, &SegmentInfoSender{
-			sess:    sess.BroadcastSession,
-			modelID: sess.ModelID,
+			sess:      sess.BroadcastSession,
+			priceInfo: sess.OrchestratorInfo.PriceInfo,
 		})
 		if err != nil {
 			return nil, err

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1059,7 +1059,8 @@ func submitLiveVideoToVideo(ctx context.Context, params aiRequestParams, sess *A
 			return nil, errors.New("remote sender was not the correct type")
 		}
 		res, err := rpp.RequestPayment(ctx, &SegmentInfoSender{
-			sess: sess.BroadcastSession,
+			sess:    sess.BroadcastSession,
+			modelID: sess.ModelID,
 		})
 		if err != nil {
 			return nil, err

--- a/server/live_payment.go
+++ b/server/live_payment.go
@@ -216,13 +216,20 @@ func (r *remotePaymentSender) RequestPayment(ctx context.Context, segmentInfo *S
 	state := r.state
 	r.mu.Unlock()
 
+	priceInfo := segmentInfo.priceInfo
+	if priceInfo != nil && priceInfo.Capability == 0 && sess.OrchestratorInfo.PriceInfo != nil {
+		priceInfo.Capability = sess.OrchestratorInfo.PriceInfo.Capability
+	}
+	if priceInfo != nil && priceInfo.Capability == uint32(core.Capability_LiveVideoToVideo) && priceInfo.Constraint == "" {
+		priceInfo.Constraint = segmentInfo.modelID
+	}
+
 	// Build remote payment request
 	reqPayload := RemotePaymentRequest{
 		ManifestID:   segmentInfo.mid,
 		Orchestrator: oInfoBytes,
 		State:        state,
-		Type:         RemoteType_LiveVideoToVideo,
-		ModelID:      segmentInfo.modelID,
+		PriceInfo:    priceInfo,
 	}
 
 	body, err := json.Marshal(reqPayload)

--- a/server/live_payment.go
+++ b/server/live_payment.go
@@ -30,6 +30,7 @@ type SegmentInfoSender struct {
 	inPixels  int64
 	priceInfo *net.PriceInfo
 	mid       string
+	modelID   string
 	callCount int
 }
 
@@ -221,6 +222,7 @@ func (r *remotePaymentSender) RequestPayment(ctx context.Context, segmentInfo *S
 		Orchestrator: oInfoBytes,
 		State:        state,
 		Type:         RemoteType_LiveVideoToVideo,
+		ModelID:      segmentInfo.modelID,
 	}
 
 	body, err := json.Marshal(reqPayload)

--- a/server/live_payment.go
+++ b/server/live_payment.go
@@ -30,7 +30,6 @@ type SegmentInfoSender struct {
 	inPixels  int64
 	priceInfo *net.PriceInfo
 	mid       string
-	modelID   string
 	callCount int
 }
 
@@ -217,12 +216,6 @@ func (r *remotePaymentSender) RequestPayment(ctx context.Context, segmentInfo *S
 	r.mu.Unlock()
 
 	priceInfo := segmentInfo.priceInfo
-	if priceInfo != nil && priceInfo.Capability == 0 && sess.OrchestratorInfo.PriceInfo != nil {
-		priceInfo.Capability = sess.OrchestratorInfo.PriceInfo.Capability
-	}
-	if priceInfo != nil && priceInfo.Capability == uint32(core.Capability_LiveVideoToVideo) && priceInfo.Constraint == "" {
-		priceInfo.Constraint = segmentInfo.modelID
-	}
 
 	// Build remote payment request
 	reqPayload := RemotePaymentRequest{

--- a/server/live_payment_test.go
+++ b/server/live_payment_test.go
@@ -29,10 +29,17 @@ func TestSendPayment(t *testing.T) {
 	defer ts.Close()
 	tr := &net.PaymentResult{
 		Info: &net.OrchestratorInfo{
-			Transcoder:   ts.URL,
-			PriceInfo:    &net.PriceInfo{PricePerUnit: 7, PixelsPerUnit: 7},
-			TicketParams: &net.TicketParams{ExpirationBlock: big.NewInt(100).Bytes()},
-			AuthToken:    stubAuthToken,
+			Transcoder: ts.URL,
+			PriceInfo:  &net.PriceInfo{PricePerUnit: 7, PixelsPerUnit: 7},
+			TicketParams: &net.TicketParams{
+				Recipient:         ethcommon.HexToAddress("0x1111111111111111111111111111111111111111").Bytes(),
+				FaceValue:         big.NewInt(1_000_000_000_000_000_000).Bytes(), // 1 ETH
+				WinProb:           big.NewInt(1).Bytes(),
+				RecipientRandHash: ethcommon.HexToHash("0x2222222222222222222222222222222222222222").Bytes(),
+				Seed:              big.NewInt(1234).Bytes(),
+				ExpirationBlock:   big.NewInt(100).Bytes(),
+			},
+			AuthToken: stubAuthToken,
 		},
 	}
 	buf, err := proto.Marshal(tr)
@@ -155,10 +162,17 @@ func TestRemoteLivePaymentSender_BasicFlow(t *testing.T) {
 	defer ts.Close()
 	tr := &net.PaymentResult{
 		Info: &net.OrchestratorInfo{
-			Transcoder:   ts.URL,
-			PriceInfo:    &net.PriceInfo{PricePerUnit: 7, PixelsPerUnit: 7},
-			TicketParams: &net.TicketParams{ExpirationBlock: big.NewInt(100).Bytes()},
-			AuthToken:    stubAuthToken,
+			Transcoder: ts.URL,
+			PriceInfo:  &net.PriceInfo{PricePerUnit: 7, PixelsPerUnit: 7},
+			TicketParams: &net.TicketParams{
+				Recipient:         ethcommon.HexToAddress("0x3333333333333333333333333333333333333333").Bytes(),
+				FaceValue:         big.NewInt(1_000_000_000_000_000_000).Bytes(), // 1 ETH
+				WinProb:           big.NewInt(1).Bytes(),
+				RecipientRandHash: ethcommon.HexToHash("0x4444444444444444444444444444444444444444").Bytes(),
+				Seed:              big.NewInt(5678).Bytes(),
+				ExpirationBlock:   big.NewInt(100).Bytes(),
+			},
+			AuthToken: stubAuthToken,
 		},
 	}
 	buf, err := proto.Marshal(tr)

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -1,43 +1,7 @@
 package server
 
-import (
-	"context"
-	"net/url"
-	"testing"
+import "testing"
 
-	"github.com/livepeer/go-livepeer/common"
-	"github.com/livepeer/go-livepeer/core"
-	"github.com/livepeer/go-livepeer/net"
-	"github.com/stretchr/testify/require"
-)
-
-func TestLV2VCapabilities(t *testing.T) {
-	caps := lv2vCapabilities("modelA")
-	require.NotNil(t, caps)
-	require.Equal(t, uint32(1), caps.Capacities[uint32(core.Capability_LiveVideoToVideo)])
-
-	models := caps.Constraints.PerCapability[uint32(core.Capability_LiveVideoToVideo)].Models
-	_, ok := models["modelA"]
-	require.True(t, ok)
-}
-
-func TestRefreshOrchInfoForLV2V(t *testing.T) {
-	defer func(prev func(context.Context, common.Broadcaster, *url.URL, GetOrchestratorInfoParams) (*net.OrchestratorInfo, error)) {
-		remoteGetOrchInfo = prev
-	}(remoteGetOrchInfo)
-
-	expected := &net.OrchestratorInfo{
-		PriceInfo: &net.PriceInfo{PricePerUnit: 5, PixelsPerUnit: 10},
-		TicketParams: &net.TicketParams{
-			Recipient: []byte{0x01},
-		},
-	}
-
-	remoteGetOrchInfo = func(ctx context.Context, b common.Broadcaster, uri *url.URL, params GetOrchestratorInfoParams) (*net.OrchestratorInfo, error) {
-		return expected, nil
-	}
-
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	info := refreshOrchInfoForLV2V(context.Background(), node, "https://example.com", "modelA")
-	require.Equal(t, expected, info)
+func TestPlaceholder(t *testing.T) {
+	// Remote signer tests removed with capability-driven pricing refactor.
 }

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/net"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLV2VCapabilities(t *testing.T) {
+	caps := lv2vCapabilities("modelA")
+	require.NotNil(t, caps)
+	require.Equal(t, uint32(1), caps.Capacities[uint32(core.Capability_LiveVideoToVideo)])
+
+	models := caps.Constraints.PerCapability[uint32(core.Capability_LiveVideoToVideo)].Models
+	_, ok := models["modelA"]
+	require.True(t, ok)
+}
+
+func TestRefreshOrchInfoForLV2V(t *testing.T) {
+	defer func(prev func(context.Context, common.Broadcaster, *url.URL, GetOrchestratorInfoParams) (*net.OrchestratorInfo, error)) {
+		remoteGetOrchInfo = prev
+	}(remoteGetOrchInfo)
+
+	expected := &net.OrchestratorInfo{
+		PriceInfo: &net.PriceInfo{PricePerUnit: 5, PixelsPerUnit: 10},
+		TicketParams: &net.TicketParams{
+			Recipient: []byte{0x01},
+		},
+	}
+
+	remoteGetOrchInfo = func(ctx context.Context, b common.Broadcaster, uri *url.URL, params GetOrchestratorInfoParams) (*net.OrchestratorInfo, error) {
+		return expected, nil
+	}
+
+	node, _ := core.NewLivepeerNode(nil, "", nil)
+	info := refreshOrchInfoForLV2V(context.Background(), node, "https://example.com", "modelA")
+	require.Equal(t, expected, info)
+}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
This PR updates the remote signer's ticket value calculation to use capability/model-specific pricing from the gateway, so that accurate price info can be provided to the signer. 

The change removes the `Type` field in favor of `PriceInfo.Capability` for capability and sets `model_id` to `PriceInfo.Constraint` which matches how orchestrators advertise pricing for `live-video-to-video`

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->

Removes the `Type` field in favor of `PriceInfo.Capability` for capability and sets `model_id` to `PriceInfo.Constraint` which matches how orchestrators advertise pricing for `live-video-to-video` 

- Gateway now fetches capability/model–scoped `OrchestratorInfo` (including matching `TicketParams`) before requesting payments, and sends that alongside the selected PriceInfo to the signer.
- Remote signer trusts the provided `OrchestratorInfo/PriceInfo`, no longer performs its own `GetOrchestratorInfo` refresh, and normalizes defaults for capability/constraint.
- Updated `RemotePaymentRequest` to replace the `Type` field with `PriceInfo` which contains pricing for all capabilities. `OrchestratorInfo.Capability` and `PriceInfo.Constraint` are used for ticket valuation on lv2v requests, matching how orchestrators advertise pricing for `live-video-to-video` 
- Added a safeguard to always issue at least one ticket in the first payment to avoid zero-balance rejections, and updated Python client helpers to request scoped orchestrator info via capabilities.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
- Tested with on-chain remote signer and orchestrator (excluding `-pricePerPixel` and `-pricePerUnit` flag along with this models config:
```
[
    {
      "currency": "USD",
      "model_id": "noop",
      "pipeline": "live-video-to-video",
      "pixels_per_unit": 995328000000,
      "price_per_unit": 5,
      "warm": true,
      "capacity": 1
    }
]
```

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes how remote signer calculates ticket value, by ensuring it uses the correct capability/constraint price
Removes unintended requirement that orchestrator have `-pricePerPixel` and `-pricePerPixel` flags set

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
