### PR TITLE
BYOC: Fix byoc whip ingest test

### DIFF
--- a/byoc/stream_test.go
+++ b/byoc/stream_test.go
@@ -1061,7 +1061,6 @@ func TestStartStreamWhipIngestHandler(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, newParams.liveParams.kickInput)
 
-		bsg.updateStreamPipelineParams(stream.StreamID, newParams)
 		newParams.liveParams.kickInput(errors.New("test complete"))
 	})
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Fixes data race in TestStartStreamWhipIngestHandler

In the stack trace below, the `updateStreamPipelineParams` was doing a write when `stream.streamParams.liveParams.segmentReader.Close()` was being called.  The `updateStreamPipelineParams` call in the test is not needed and not expected in regular code execution.

Removing this line and running five consecutive 200 count runs on the test showed no data race.

```
==================
WARNING: DATA RACE
Write at 0x00c0004f8350 by goroutine 319:
  github.com/livepeer/go-livepeer/byoc.(*BYOCGatewayServer).updateStreamPipelineParams()
      /home/runner/work/go-livepeer/go-livepeer/byoc/byoc.go:139 +0x184
  github.com/livepeer/go-livepeer/byoc.TestStartStreamWhipIngestHandler.func1()
      /home/runner/work/go-livepeer/go-livepeer/byoc/stream_test.go:1064 +0x11b9
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.0/x64/src/testing/testing.go:1934 +0x21c
  testing.testingSynctestTest.gowrap1()
      /opt/hostedtoolcache/go/1.25.0/x64/src/testing/testing.go:2046 +0x44

Previous read at 0x00c0004f8350 by goroutine 321:
  github.com/livepeer/go-livepeer/byoc.TestStartStreamWhipIngestHandler.func1.(*BYOCGatewayServer).StartStreamWhipIngest.1.2()
      /home/runner/work/go-livepeer/go-livepeer/byoc/stream_gateway.go:808 +0x464

Goroutine 319 (running) created at:
  testing/synctest.testingSynctestTest()
      /opt/hostedtoolcache/go/1.25.0/x64/src/testing/testing.go:2046 +0x5e7
  testing/synctest.Test.func1()
      /opt/hostedtoolcache/go/1.25.0/x64/src/testing/synctest/synctest.go:283 +0x44

Goroutine 321 (running) created at:
  github.com/livepeer/go-livepeer/byoc.TestStartStreamWhipIngestHandler.func1.(*BYOCGatewayServer).StartStreamWhipIngest.1()
      /home/runner/work/go-livepeer/go-livepeer/byoc/stream_gateway.go:797 +0x53d
  net/http.HandlerFunc.ServeHTTP()
      /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0xff0
  github.com/livepeer/go-livepeer/byoc.TestStartStreamWhipIngestHandler.func1()
      /home/runner/work/go-livepeer/go-livepeer/byoc/stream_test.go:1054 +0xfd4
  testing.tRunner()
      /opt/hostedtoolcache/go/1.25.0/x64/src/testing/testing.go:1934 +0x21c
  testing.testingSynctestTest.gowrap1()
      /opt/hostedtoolcache/go/1.25.0/x64/src/testing/testing.go:2046 +0x44
==================
```
**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- 
- 
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
