### PR TITLE
BYOC: Longer byoc stream stop timeout

### DIFF
--- a/byoc/stream_gateway.go
+++ b/byoc/stream_gateway.go
@@ -109,7 +109,7 @@ func (bsg *BYOCGatewayServer) sendStopStreamToOrch(ctx context.Context, streamID
 			Req: &JobRequest{
 				Capability: capability,
 				Request:    string(jobReqDetStr),
-				Timeout:    10,
+				Timeout:    60,
 			},
 		},
 		node: bsg.node,

--- a/byoc/stream_test.go
+++ b/byoc/stream_test.go
@@ -441,7 +441,7 @@ func TestRunStream_RunAndCancelStream(t *testing.T) {
 		jobReq := &JobRequest{
 			ID:         "test-stream",
 			Capability: "test-capability",
-			Timeout:    10,
+			Timeout:    60,
 			Request:    "{}",
 		}
 		jobParams := JobParameters{EnableVideoIngress: true, EnableVideoEgress: true, EnableDataOutput: true}
@@ -458,7 +458,7 @@ func TestRunStream_RunAndCancelStream(t *testing.T) {
 		drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 		mockSender := pm.MockSender{}
 		mockSender.On("StartSession", mock.Anything).Return("foo").Times(4)
-		mockSender.On("CreateTicketBatch", "foo", 10).Return(mockTicketBatch(10), nil).Twice() //payment sent on start and stop (only once on stop)
+		mockSender.On("CreateTicketBatch", "foo", 60).Return(mockTicketBatch(60), nil).Twice() //payment sent on start and stop (only once on stop)
 		node.Sender = &mockSender
 		node.Balances = core.NewAddressBalances(10 * time.Second)
 		defer node.Balances.StopCleanup()
@@ -614,7 +614,7 @@ func TestRunStream_OrchestratorFailover(t *testing.T) {
 		jobReq := &JobRequest{
 			ID:         "test-stream",
 			Capability: "test-capability",
-			Timeout:    10,
+			Timeout:    60,
 			Request:    "{}",
 		}
 		jobParams := JobParameters{EnableVideoIngress: true, EnableVideoEgress: true, EnableDataOutput: true}
@@ -835,7 +835,7 @@ func TestStopStreamHandler(t *testing.T) {
 			drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 			mockSender := pm.MockSender{}
 			mockSender.On("StartSession", mock.Anything).Return("foo").Times(4)
-			mockSender.On("CreateTicketBatch", "foo", 10).Return(mockTicketBatch(10), nil).Once()
+			mockSender.On("CreateTicketBatch", "foo", 60).Return(mockTicketBatch(60), nil).Once()
 			node.Sender = &mockSender
 			node.Balances = core.NewAddressBalances(10 * time.Second)
 			defer node.Balances.StopCleanup()
@@ -874,7 +874,7 @@ func TestStopStreamHandler(t *testing.T) {
 				Request:    marshalToString(t, jobDetails),
 				Capability: "test-capability",
 				Parameters: marshalToString(t, jobParams),
-				Timeout:    10,
+				Timeout:    60,
 			}
 			jobReqB, err := json.Marshal(jobReq)
 			assert.NoError(t, err)
@@ -923,7 +923,7 @@ func TestStopStreamHandler(t *testing.T) {
 			drivers.NodeStorage = drivers.NewMemoryDriver(nil)
 			mockSender := pm.MockSender{}
 			mockSender.On("StartSession", mock.Anything).Return("foo").Times(4)
-			mockSender.On("CreateTicketBatch", "foo", 10).Return(mockTicketBatch(10), nil).Once()
+			mockSender.On("CreateTicketBatch", "foo", 60).Return(mockTicketBatch(60), nil).Once()
 			node.Sender = &mockSender
 			node.Balances = core.NewAddressBalances(10 * time.Second)
 			defer node.Balances.StopCleanup()
@@ -956,7 +956,7 @@ func TestStopStreamHandler(t *testing.T) {
 				Request:    marshalToString(t, jobDetails),
 				Capability: "test-capability",
 				Parameters: marshalToString(t, jobParams),
-				Timeout:    10,
+				Timeout:    60,
 			}
 			jobReqB, err := json.Marshal(jobReq)
 			assert.NoError(t, err)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Want to extend default timeout on stop requests to 60 seconds to allow for cleanup.

In my video data app I have a number of LLM calls that would like to be able to have some time to wrap up to get all data.

May want to consider making this configurable in the future but 60 seconds seems reasonable and can always go much faster than that.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- changes stop timeout from 10 seconds to 60 seconds
- updates tests to accomodate

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
