### PR TITLE
Fix crash in broadcaster max price calculation.

### DIFF
--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -102,6 +102,9 @@ func (cfg *BroadcastConfig) GetCapabilitiesMaxPrice(caps common.CapabilityCompar
 		return cfg.MaxPrice()
 	}
 	netCaps := caps.ToNetCapabilities()
+	if netCaps == nil || netCaps.Constraints == nil {
+		return cfg.MaxPrice()
+	}
 	price := big.NewRat(0, 1)
 	for capabilityInt, constraints := range netCaps.Constraints.PerCapability {
 		for modelID := range constraints.Models {

--- a/server/broadcast_test.go
+++ b/server/broadcast_test.go
@@ -1895,6 +1895,14 @@ func TestGetCapabilitiesMaxPrice(t *testing.T) {
 	cfg.SetMaxPrice(price)
 	assert.Equal(t, big.NewRat(10, 1), cfg.GetCapabilitiesMaxPrice(nil))
 
+	// Should return the max price if net capabilities are nil.
+	capabilitiesNilNet := &StubCapabilityComparator{NetCaps: nil}
+	assert.Equal(t, big.NewRat(10, 1), cfg.GetCapabilitiesMaxPrice(capabilitiesNilNet))
+
+	// Should return the max price if constraints are nil.
+	capabilitiesNilConstraints := &StubCapabilityComparator{NetCaps: &net.Capabilities{}}
+	assert.Equal(t, big.NewRat(10, 1), cfg.GetCapabilitiesMaxPrice(capabilitiesNilConstraints))
+
 	// Create capabilities object.
 	capability1 := core.Capability(1)
 	modelID1 := "model1"


### PR DESCRIPTION
Usually there are constraints in place alongside the capabilities in order to set a per-capability price. However, if no constraints are set, there are no per-capability prices, so return the global max price instead.

This hasn't come up in prod (and fixes a crash) so shouldn't be a breaking change.