### PR TITLE
BYOC: add orch swap reporting same as lv2v

### DIFF
--- a/byoc/stream_gateway.go
+++ b/byoc/stream_gateway.go
@@ -262,10 +262,21 @@ func (bsg *BYOCGatewayServer) runStream(gatewayJob *gatewayJob) {
 		if err == nil {
 			err = errors.New("unknown swap reason")
 		}
+		// report the swap
+		monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
+			"type":        "orchestrator_swap",
+			"stream_id":   params.liveParams.streamID,
+			"request_id":  params.liveParams.requestID,
+			"pipeline":    params.liveParams.pipeline,
+			"pipeline_id": params.liveParams.pipelineID,
+			"message":     err.Error(),
+			"orchestrator_info": map[string]interface{}{
+				"address": params.liveParams.orchToken.Address(),
+				"url":     params.liveParams.orchToken.URL(),
+			},
+		})
 
 		clog.Infof(ctx, "Retrying stream with a different orchestrator err=%v", err.Error())
-
-		params.liveParams.sendErrorEvent(err)
 	}
 
 	//if there is ingress input then force off


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
Removes generic error reporting in favor of more specific `stream_trace` event similar to how lv2v pipeline reports orchestrator swaps.

lv2v orchestrator swap event reporting
https://github.com/livepeer/go-livepeer/blob/ab55f826503f9829ecd18bf6a08ee039e783bd1f/server/ai_mediaserver.go#L742-L753
**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- remove `sendErrorEvent` generic error reporting
- replace with `stream` trace event `orchestrator_swap` type
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->


**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated
