### PR TITLE
ai/live: Remote signer discovery

### DIFF
--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -140,7 +140,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.TestOrchAvail = fs.Bool("startupAvailabilityCheck", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
 	cfg.RemoteSigner = fs.Bool("remoteSigner", *cfg.RemoteSigner, "Set to true to run remote signer service")
 	cfg.RemoteSignerUrl = fs.String("remoteSignerUrl", *cfg.RemoteSignerUrl, "URL of remote signer service to use (e.g., http://localhost:8935). Gateway only.")
-	cfg.RemoteOrchDiscovery = fs.Bool("remoteOrchDiscovery", *cfg.RemoteOrchDiscovery, "Enable orchestrator discovery on remote signers")
+	cfg.RemoteDiscovery = fs.Bool("remoteDiscovery", *cfg.RemoteDiscovery, "Enable orchestrator discovery on remote signers")
 
 	// Gateway metrics
 	cfg.KafkaBootstrapServers = fs.String("kafkaBootstrapServers", *cfg.KafkaBootstrapServers, "URL of Kafka Bootstrap Servers")

--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -140,6 +140,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.TestOrchAvail = fs.Bool("startupAvailabilityCheck", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
 	cfg.RemoteSigner = fs.Bool("remoteSigner", *cfg.RemoteSigner, "Set to true to run remote signer service")
 	cfg.RemoteSignerUrl = fs.String("remoteSignerUrl", *cfg.RemoteSignerUrl, "URL of remote signer service to use (e.g., http://localhost:8935). Gateway only.")
+	cfg.RemoteOrchDiscovery = fs.Bool("remoteOrchDiscovery", *cfg.RemoteOrchDiscovery, "Enable orchestrator discovery on remote signers")
 
 	// Gateway metrics
 	cfg.KafkaBootstrapServers = fs.String("kafkaBootstrapServers", *cfg.KafkaBootstrapServers, "URL of Kafka Bootstrap Servers")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1803,6 +1803,9 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	if cfg.LiveAICapReportInterval != nil {
 		n.LiveAICapReportInterval = *cfg.LiveAICapReportInterval
 	}
+	if cfg.RemoteDiscovery != nil {
+		n.RemoteDiscovery = *cfg.RemoteDiscovery
+	}
 	if cfg.LiveAIHeartbeatHeaders != nil {
 		n.LiveAIHeartbeatHeaders = make(map[string]string)
 		headers := strings.Split(*cfg.LiveAIHeartbeatHeaders, ",")
@@ -1910,7 +1913,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 		}
 
-		if *cfg.RemoteDiscovery && n.OrchestratorPool == nil {
+		if n.RemoteDiscovery && n.OrchestratorPool == nil {
 			exit("RemoteDiscovery is set but no orchestrator pool could be configured")
 		}
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -428,9 +428,9 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		OrchMinLivepeerVersion: &defaultMinLivepeerVersion,
 
 		// Flags
-		TestOrchAvail:       &defaultTestOrchAvail,
-		RemoteSigner:        &defaultRemoteSigner,
-		RemoteSignerUrl:     &defaultRemoteSignerUrl,
+		TestOrchAvail:   &defaultTestOrchAvail,
+		RemoteSigner:    &defaultRemoteSigner,
+		RemoteSignerUrl: &defaultRemoteSignerUrl,
 		RemoteDiscovery: &defaultRemoteDiscovery,
 
 		// Gateway logs
@@ -1862,16 +1862,41 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				glog.Exit("Error setting orch webhook URL ", err)
 			}
 			glog.Info("Using orchestrator webhook URL ", whurl)
-			n.OrchestratorPool = discovery.NewWebhookPool(bcast, whurl, *cfg.DiscoveryTimeout)
+			n.OrchestratorPool = discovery.WebhookPoolConfig{
+				Broadcaster:         bcast,
+				Callback:            whurl,
+				DiscoveryTimeout:    *cfg.DiscoveryTimeout,
+				IgnoreCapacityCheck: true,
+			}.New()
 		} else if len(orchURLs) > 0 {
-			n.OrchestratorPool = discovery.NewOrchestratorPool(bcast, orchURLs, common.Score_Trusted, orchBlacklist, *cfg.DiscoveryTimeout)
+			pool, err := discovery.NewOrchestratorPoolWithConfig(discovery.OrchestratorPoolConfig{
+				Broadcaster:         bcast,
+				URIs:                orchURLs,
+				Score:               common.Score_Trusted,
+				OrchBlacklist:       orchBlacklist,
+				DiscoveryTimeout:    *cfg.DiscoveryTimeout,
+				IgnoreCapacityCheck: true,
+				ExtraNodes:          *cfg.ExtraNodes,
+			})
+			if err != nil {
+				glog.Exit("Error initializing orchestrator pool ", err)
+			}
+			n.OrchestratorPool = pool
 		}
 
 		// When the node is on-chain mode always cache the on-chain orchestrators and poll for updates
 		if *cfg.Network != "offchain" && *cfg.RemoteDiscovery {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			dbOrchPoolCache, err := discovery.NewDBOrchestratorPoolCache(ctx, n, timeWatcher, orchBlacklist, *cfg.DiscoveryTimeout, *cfg.LiveAICapReportInterval)
+			dbOrchPoolCache, err := discovery.DBOrchestratorPoolCacheConfig{
+				Ctx:                     ctx,
+				Node:                    n,
+				RoundsManager:           timeWatcher,
+				OrchBlacklist:           orchBlacklist,
+				DiscoveryTimeout:        *cfg.DiscoveryTimeout,
+				LiveAICapReportInterval: *cfg.LiveAICapReportInterval,
+				IgnoreCapacityCheck:     true,
+			}.New()
 			if err != nil {
 				exit("Could not create orchestrator pool with DB cache: %v", err)
 			}

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1800,6 +1800,9 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	if cfg.LiveAIHeartbeatInterval != nil {
 		n.LiveAIHeartbeatInterval = *cfg.LiveAIHeartbeatInterval
 	}
+	if cfg.LiveAICapReportInterval != nil {
+		n.LiveAICapReportInterval = *cfg.LiveAICapReportInterval
+	}
 	if cfg.LiveAIHeartbeatHeaders != nil {
 		n.LiveAIHeartbeatHeaders = make(map[string]string)
 		headers := strings.Split(*cfg.LiveAIHeartbeatHeaders, ",")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -169,6 +169,7 @@ type LivepeerConfig struct {
 	TestOrchAvail              *bool
 	RemoteSigner               *bool
 	RemoteSignerUrl            *string
+	RemoteOrchDiscovery        *bool
 	AIRunnerImage              *string
 	AIRunnerImageOverrides     *string
 	AIVerboseLogs              *bool
@@ -306,6 +307,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultTestOrchAvail := true
 	defaultRemoteSigner := false
 	defaultRemoteSignerUrl := ""
+	defaultRemoteOrchDiscovery := false
 
 	// Gateway logs
 	defaultKafkaBootstrapServers := ""
@@ -426,9 +428,10 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		OrchMinLivepeerVersion: &defaultMinLivepeerVersion,
 
 		// Flags
-		TestOrchAvail:   &defaultTestOrchAvail,
-		RemoteSigner:    &defaultRemoteSigner,
-		RemoteSignerUrl: &defaultRemoteSignerUrl,
+		TestOrchAvail:       &defaultTestOrchAvail,
+		RemoteSigner:        &defaultRemoteSigner,
+		RemoteSignerUrl:     &defaultRemoteSignerUrl,
+		RemoteOrchDiscovery: &defaultRemoteOrchDiscovery,
 
 		// Gateway logs
 		KafkaBootstrapServers: &defaultKafkaBootstrapServers,
@@ -1635,6 +1638,10 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			n.OrchestratorPool = discovery.NewWebhookPool(bcast, whurl, *cfg.DiscoveryTimeout)
 		} else if len(orchURLs) > 0 {
 			n.OrchestratorPool = discovery.NewOrchestratorPool(bcast, orchURLs, common.Score_Trusted, orchBlacklist, *cfg.DiscoveryTimeout)
+		} else if n.RemoteSignerUrl != nil {
+			orchDiscoveryURL := n.RemoteSignerUrl.ResolveReference(&url.URL{Path: "/discover-orchestrators"})
+			glog.Info("Using remote signer orchestrator discovery endpoint ", orchDiscoveryURL)
+			n.OrchestratorPool = discovery.NewWebhookPool(bcast, orchDiscoveryURL, *cfg.DiscoveryTimeout)
 		}
 
 		// When the node is on-chain mode always cache the on-chain orchestrators and poll for updates
@@ -1648,7 +1655,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				exit("Could not create orchestrator pool with DB cache: %v", err)
 			}
 
-			//if orchURLs is empty and webhook pool not used, use the DB orchestrator pool cache as orchestrator pool
+			// If orchURLs is empty and webhook pool not used, use the DB orchestrator pool cache.
 			if *cfg.OrchWebhookURL == "" && len(orchURLs) == 0 {
 				n.OrchestratorPool = dbOrchPoolCache
 			}
@@ -1842,8 +1849,44 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		}()
 	}
 
-	// Start remote signer server if in remote signer mode
+	// Set up orchestrator pool for remote signer mode and start server
 	if n.NodeType == core.RemoteSignerNode {
+		bcast := core.NewBroadcaster(n)
+		orchBlacklist := parseOrchBlacklist(cfg.OrchBlacklist)
+		n.ExtraNodes = *cfg.ExtraNodes
+
+		// Set up orchestrator discovery - same logic as BroadcasterNode
+		if *cfg.OrchWebhookURL != "" {
+			whurl, err := validateURL(*cfg.OrchWebhookURL)
+			if err != nil {
+				glog.Exit("Error setting orch webhook URL ", err)
+			}
+			glog.Info("Using orchestrator webhook URL ", whurl)
+			n.OrchestratorPool = discovery.NewWebhookPool(bcast, whurl, *cfg.DiscoveryTimeout)
+		} else if len(orchURLs) > 0 {
+			n.OrchestratorPool = discovery.NewOrchestratorPool(bcast, orchURLs, common.Score_Trusted, orchBlacklist, *cfg.DiscoveryTimeout)
+		}
+
+		// When the node is on-chain mode always cache the on-chain orchestrators and poll for updates
+		if *cfg.Network != "offchain" && *cfg.RemoteOrchDiscovery {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			dbOrchPoolCache, err := discovery.NewDBOrchestratorPoolCache(ctx, n, timeWatcher, orchBlacklist, *cfg.DiscoveryTimeout, *cfg.LiveAICapReportInterval)
+			if err != nil {
+				exit("Could not create orchestrator pool with DB cache: %v", err)
+			}
+
+			// If orchURLs is empty and webhook pool not used, use the DB orchestrator pool cache
+			if *cfg.OrchWebhookURL == "" && len(orchURLs) == 0 {
+				n.OrchestratorPool = dbOrchPoolCache
+			}
+		}
+
+		if *cfg.RemoteOrchDiscovery && n.OrchestratorPool == nil {
+			exit("RemoteOrchDiscovery is set but no orchestrator pool could be configured")
+		}
+
+		// Start remote signer server
 		go func() {
 			*cfg.HttpAddr = defaultAddr(*cfg.HttpAddr, "127.0.0.1", OrchestratorRpcPort)
 			glog.Info("Starting remote signer server on ", *cfg.HttpAddr)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -169,7 +169,7 @@ type LivepeerConfig struct {
 	TestOrchAvail              *bool
 	RemoteSigner               *bool
 	RemoteSignerUrl            *string
-	RemoteOrchDiscovery        *bool
+	RemoteDiscovery            *bool
 	AIRunnerImage              *string
 	AIRunnerImageOverrides     *string
 	AIVerboseLogs              *bool
@@ -307,7 +307,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultTestOrchAvail := true
 	defaultRemoteSigner := false
 	defaultRemoteSignerUrl := ""
-	defaultRemoteOrchDiscovery := false
+	defaultRemoteDiscovery := false
 
 	// Gateway logs
 	defaultKafkaBootstrapServers := ""
@@ -431,7 +431,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		TestOrchAvail:       &defaultTestOrchAvail,
 		RemoteSigner:        &defaultRemoteSigner,
 		RemoteSignerUrl:     &defaultRemoteSignerUrl,
-		RemoteOrchDiscovery: &defaultRemoteOrchDiscovery,
+		RemoteDiscovery: &defaultRemoteDiscovery,
 
 		// Gateway logs
 		KafkaBootstrapServers: &defaultKafkaBootstrapServers,
@@ -1868,7 +1868,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		}
 
 		// When the node is on-chain mode always cache the on-chain orchestrators and poll for updates
-		if *cfg.Network != "offchain" && *cfg.RemoteOrchDiscovery {
+		if *cfg.Network != "offchain" && *cfg.RemoteDiscovery {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			dbOrchPoolCache, err := discovery.NewDBOrchestratorPoolCache(ctx, n, timeWatcher, orchBlacklist, *cfg.DiscoveryTimeout, *cfg.LiveAICapReportInterval)
@@ -1882,8 +1882,8 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 		}
 
-		if *cfg.RemoteOrchDiscovery && n.OrchestratorPool == nil {
-			exit("RemoteOrchDiscovery is set but no orchestrator pool could be configured")
+		if *cfg.RemoteDiscovery && n.OrchestratorPool == nil {
+			exit("RemoteDiscovery is set but no orchestrator pool could be configured")
 		}
 
 		// Start remote signer server

--- a/common/types.go
+++ b/common/types.go
@@ -174,6 +174,7 @@ type OrchNetworkCapabilities struct {
 	LocalAddress       string                     `json:"local_address"`
 	OrchURI            string                     `json:"orch_uri"`
 	Capabilities       *net.Capabilities          `json:"capabilities"`
+	PriceInfo          *net.PriceInfo             `json:"price_info"`
 	CapabilitiesPrices []*net.PriceInfo           `json:"capabilities_prices"`
 	Hardware           []*net.HardwareInformation `json:"hardware"`
 }

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -152,6 +152,7 @@ type LivepeerNode struct {
 	RemoteSignerUrl *url.URL
 	RemoteEthAddr   ethcommon.Address // eth address of the remote signer
 	InfoSig         []byte            // sig over eth address for the OrchestratorInfo request
+	RemoteDiscovery bool              // expose remote discovery endpoint when enabled
 
 	// Thread safety for config fields
 	mu                  sync.RWMutex

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -177,6 +177,7 @@ type LivepeerNode struct {
 	LiveAIHeartbeatURL         string
 	LiveAIHeartbeatHeaders     map[string]string
 	LiveAIHeartbeatInterval    time.Duration
+	LiveAICapReportInterval    time.Duration
 	LivePaymentInterval        time.Duration
 	LiveOutSegmentTimeout      time.Duration
 	LiveAISaveNSegments        *int

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -34,10 +34,33 @@ type DBOrchestratorPoolCache struct {
 	bcast                 common.Broadcaster
 	orchBlacklist         []string
 	discoveryTimeout      time.Duration
+	ignoreCapacityCheck   bool
 	node                  *core.LivepeerNode
 }
 
 func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm common.RoundsManager, orchBlacklist []string, discoveryTimeout time.Duration, liveAICapReportInterval time.Duration) (*DBOrchestratorPoolCache, error) {
+	return DBOrchestratorPoolCacheConfig{
+		Ctx:                     ctx,
+		Node:                    node,
+		RoundsManager:           rm,
+		OrchBlacklist:           orchBlacklist,
+		DiscoveryTimeout:        discoveryTimeout,
+		LiveAICapReportInterval: liveAICapReportInterval,
+	}.New()
+}
+
+type DBOrchestratorPoolCacheConfig struct {
+	Ctx                     context.Context
+	Node                    *core.LivepeerNode
+	RoundsManager           common.RoundsManager
+	OrchBlacklist           []string
+	DiscoveryTimeout        time.Duration
+	LiveAICapReportInterval time.Duration
+	IgnoreCapacityCheck     bool
+}
+
+func (cfg DBOrchestratorPoolCacheConfig) New() (*DBOrchestratorPoolCache, error) {
+	node := cfg.Node
 	if node.Eth == nil {
 		return nil, fmt.Errorf("could not create DBOrchestratorPoolCache: LivepeerEthClient is nil")
 	}
@@ -46,10 +69,11 @@ func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm
 		store:                 node.Database,
 		lpEth:                 node.Eth,
 		ticketParamsValidator: node.Sender,
-		rm:                    rm,
+		rm:                    cfg.RoundsManager,
 		bcast:                 core.NewBroadcaster(node),
-		orchBlacklist:         orchBlacklist,
-		discoveryTimeout:      discoveryTimeout,
+		orchBlacklist:         cfg.OrchBlacklist,
+		discoveryTimeout:      cfg.DiscoveryTimeout,
+		ignoreCapacityCheck:   cfg.IgnoreCapacityCheck,
 		node:                  node,
 	}
 
@@ -62,7 +86,7 @@ func NewDBOrchestratorPoolCache(ctx context.Context, node *core.LivepeerNode, rm
 			return err
 		}
 
-		if err := dbo.pollOrchestratorInfo(ctx, liveAICapReportInterval); err != nil {
+		if err := dbo.pollOrchestratorInfo(cfg.Ctx, cfg.LiveAICapReportInterval); err != nil {
 			return err
 		}
 		return nil
@@ -152,7 +176,19 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(ctx context.Context, numOrc
 		return true
 	}
 
-	orchPool := NewOrchestratorPoolWithPred(dbo.bcast, uris, pred, common.Score_Untrusted, dbo.orchBlacklist, dbo.discoveryTimeout)
+	orchPool, err := NewOrchestratorPoolWithConfig(OrchestratorPoolConfig{
+		Broadcaster:         dbo.bcast,
+		URIs:                uris,
+		Pred:                pred,
+		Score:               common.Score_Untrusted,
+		OrchBlacklist:       dbo.orchBlacklist,
+		DiscoveryTimeout:    dbo.discoveryTimeout,
+		IgnoreCapacityCheck: dbo.ignoreCapacityCheck,
+		ExtraNodes:          dbo.bcast.ExtraNodes(),
+	})
+	if err != nil {
+		return nil, err
+	}
 	orchInfos, err := orchPool.GetOrchestrators(ctx, numOrchestrators, suspender, caps, scorePred)
 	if err != nil || len(orchInfos) <= 0 {
 		return nil, err
@@ -323,7 +359,9 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchInfos() error {
 			errc <- fmt.Errorf("skipping orch=%v, URI not set", orch.URL.String())
 			return
 		}
-		info, err := serverGetOrchInfo(ctx, dbo.bcast, uri, server.GetOrchestratorInfoParams{})
+		info, err := serverGetOrchInfo(ctx, dbo.bcast, uri, server.GetOrchestratorInfoParams{
+			IgnoreCapacityCheck: dbo.ignoreCapacityCheck,
+		})
 		if err != nil {
 			errc <- err
 			return

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -339,16 +339,24 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchInfos() error {
 	}
 
 	type orchPollingInfo struct {
+		level    int
 		orchInfo *net.OrchestratorInfo
 		dbOrch   *common.DBOrch
 	}
 
-	resc, errc := make(chan orchPollingInfo, len(orchs)), make(chan error, len(orchs))
+	nodesPerOrch := dbo.bcast.ExtraNodes()
+	// Each base orchestrator can contribute itself plus up to nodesPerOrch first-level advertised nodes.
+	maxOrchs := len(orchs) * (nodesPerOrch + 1)
+	resc, errc := make(chan orchPollingInfo, maxOrchs), make(chan error, maxOrchs)
 	timeout := getOrchestratorTimeoutLoop // Needs to be same or longer than GRPCConnectTimeout in server/rpc.go
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	getOrchInfoRPC := serverGetOrchInfo
+	if pool, ok := dbo.node.OrchestratorPool.(*orchestratorPool); ok && pool.getOrchInfo != nil {
+		getOrchInfoRPC = pool.getOrchInfo
+	}
 
-	getOrchInfo := func(orch common.OrchestratorLocalInfo) {
+	getOrchInfo := func(orch common.OrchestratorLocalInfo, level int) {
 		uri, err := parseURI(orch.URL.String())
 		if err != nil {
 			errc <- err
@@ -359,7 +367,7 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchInfos() error {
 			errc <- fmt.Errorf("skipping orch=%v, URI not set", orch.URL.String())
 			return
 		}
-		info, err := serverGetOrchInfo(ctx, dbo.bcast, uri, server.GetOrchestratorInfoParams{
+		info, err := getOrchInfoRPC(ctx, dbo.bcast, uri, server.GetOrchestratorInfoParams{
 			IgnoreCapacityCheck: dbo.ignoreCapacityCheck,
 		})
 		if err != nil {
@@ -399,13 +407,30 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchInfos() error {
 			}
 		}
 
-		resc <- orchPollingInfo{orchInfo: info, dbOrch: dbOrch}
+		resc <- orchPollingInfo{
+			level:    level,
+			orchInfo: info,
+			dbOrch:   dbOrch,
+		}
 	}
 
+	seen := make(map[string]bool, maxOrchs)
 	numOrchs := 0
-	for _, orch := range orchs {
+	startOrchLookup := func(orch common.OrchestratorLocalInfo, level int) {
+		if orch.URL == nil {
+			return
+		}
+		key := orch.URL.String()
+		if key == "" || seen[key] {
+			return
+		}
+		seen[key] = true
 		numOrchs++
-		go getOrchInfo(orch)
+		go getOrchInfo(orch, level)
+	}
+
+	for _, orch := range orchs {
+		startOrchLookup(orch, 0)
 	}
 
 	var orchNetworkCapabilities []*common.OrchNetworkCapabilities
@@ -414,6 +439,22 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchInfos() error {
 		case res := <-resc:
 			//add response to network capabilities
 			orchNetworkCapabilities = append(orchNetworkCapabilities, orchInfoToOrchNetworkCapabilities(res.orchInfo))
+
+			// discover newly advertised nodes. only recurse the first level.
+			if res.level == 0 && len(res.orchInfo.GetNodes()) > 0 {
+				for idx, inst := range res.orchInfo.GetNodes() {
+					if idx >= nodesPerOrch {
+						break
+					}
+					u, err := parseURI(inst)
+					if err != nil {
+						glog.Errorf("Invalid node URL orch=%v node=%v err=%q", res.orchInfo.GetTranscoder(), inst, err)
+						continue
+					}
+					startOrchLookup(common.OrchestratorLocalInfo{URL: u, Score: common.Score_Untrusted}, res.level+1)
+				}
+			}
+
 			//update db with response
 			if res.dbOrch != nil {
 				if err := dbo.store.UpdateOrch(res.dbOrch); err != nil {
@@ -545,6 +586,7 @@ func orchInfoToOrchNetworkCapabilities(info *net.OrchestratorInfo) *common.OrchN
 		orch.LocalAddress = ethcommon.BytesToAddress(info.GetAddress()).Hex()
 		orch.OrchURI = info.GetTranscoder()
 		orch.Capabilities = info.GetCapabilities()
+		orch.PriceInfo = info.GetPriceInfo()
 		orch.Hardware = info.GetHardware()
 		orch.CapabilitiesPrices = info.GetCapabilitiesPrices()
 		if info.GetTicketParams() != nil {

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -31,12 +31,13 @@ var serverGetOrchInfo = server.GetOrchestratorInfo
 
 // OrchestratorPoolConfig groups options used to construct an orchestratorPool.
 type OrchestratorPoolConfig struct {
-	Broadcaster      common.Broadcaster
-	URIs             []*url.URL
-	Pred             func(*net.OrchestratorInfo) bool
-	Score            float32
-	OrchBlacklist    []string
-	DiscoveryTimeout time.Duration
+	Broadcaster         common.Broadcaster
+	URIs                []*url.URL
+	Pred                func(*net.OrchestratorInfo) bool
+	Score               float32
+	OrchBlacklist       []string
+	DiscoveryTimeout    time.Duration
+	IgnoreCapacityCheck bool
 
 	// Limits the number of additional nodes an orchestrator
 	// can advertise within the GetOrchestratorInfo response.
@@ -45,14 +46,15 @@ type OrchestratorPoolConfig struct {
 }
 
 type orchestratorPool struct {
-	infos            []common.OrchestratorLocalInfo
-	pred             func(info *net.OrchestratorInfo) bool
-	bcast            common.Broadcaster
-	orchBlacklist    []string
-	discoveryTimeout time.Duration
-	node             core.LivepeerNode
-	extraNodes       int
-	getOrchInfo      func(context.Context, common.Broadcaster, *url.URL, server.GetOrchestratorInfoParams) (*net.OrchestratorInfo, error)
+	infos               []common.OrchestratorLocalInfo
+	pred                func(info *net.OrchestratorInfo) bool
+	bcast               common.Broadcaster
+	orchBlacklist       []string
+	discoveryTimeout    time.Duration
+	ignoreCapacityCheck bool
+	node                core.LivepeerNode
+	extraNodes          int
+	getOrchInfo         func(context.Context, common.Broadcaster, *url.URL, server.GetOrchestratorInfoParams) (*net.OrchestratorInfo, error)
 }
 
 func NewOrchestratorPool(bcast common.Broadcaster, uris []*url.URL, score float32, orchBlacklist []string, discoveryTimeout time.Duration) *orchestratorPool {
@@ -100,13 +102,14 @@ func NewOrchestratorPoolWithConfig(cfg OrchestratorPoolConfig) (*orchestratorPoo
 	}
 
 	return &orchestratorPool{
-		infos:            infos,
-		pred:             cfg.Pred,
-		bcast:            cfg.Broadcaster,
-		orchBlacklist:    cfg.OrchBlacklist,
-		discoveryTimeout: cfg.DiscoveryTimeout,
-		extraNodes:       cfg.ExtraNodes,
-		getOrchInfo:      serverGetOrchInfo,
+		infos:               infos,
+		pred:                cfg.Pred,
+		bcast:               cfg.Broadcaster,
+		orchBlacklist:       cfg.OrchBlacklist,
+		discoveryTimeout:    cfg.DiscoveryTimeout,
+		ignoreCapacityCheck: cfg.IgnoreCapacityCheck,
+		extraNodes:          cfg.ExtraNodes,
+		getOrchInfo:         serverGetOrchInfo,
 	}, nil
 }
 
@@ -176,7 +179,10 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 
 	getOrchInfo = func(ctx context.Context, od common.OrchestratorDescriptor, level int, infoCh chan common.OrchestratorDescriptor, errCh chan error, allOrchInfoCh chan common.OrchestratorDescriptor) {
 		start := time.Now()
-		info, err := o.getOrchInfo(ctx, o.bcast, od.LocalInfo.URL, server.GetOrchestratorInfoParams{Caps: caps.ToNetCapabilities()})
+		info, err := o.getOrchInfo(ctx, o.bcast, od.LocalInfo.URL, server.GetOrchestratorInfoParams{
+			Caps:                caps.ToNetCapabilities(),
+			IgnoreCapacityCheck: o.ignoreCapacityCheck,
+		})
 		latency := time.Since(start)
 		clog.V(common.DEBUG).Infof(ctx, "Received GetOrchInfo RPC Response from uri=%v, latency=%v", od.LocalInfo.URL, latency)
 		doingWork := info != nil && info.Transcoder != ""

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1219,6 +1219,12 @@ func TestDeserializeWebhookJSON(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal("https://127.0.0.1:8936", urls[0].URL.String())
 
+	// assert input with extra capabilities field remains backward compatible
+	resp = []byte(`[{"address":"https://127.0.0.1:8937","capabilities":["live-video-to-video/model-a"]}]`)
+	urls, err = deserializeWebhookJSON(resp)
+	assert.Nil(err)
+	assert.Equal("https://127.0.0.1:8937", urls[0].URL.String())
+
 	// assert input of empty byte array returns JSON error
 	urls, err = deserializeWebhookJSON([]byte{})
 	assert.Contains(err.Error(), "unexpected end of JSON input")

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -296,6 +296,99 @@ func TestNewDBOrchestratorPoolCache_InvalidPrices(t *testing.T) {
 	assert.Nil(pool.cacheOrchInfos())
 }
 
+func TestDBOrchestratorPoolCache_cacheOrchInfos_ExtraNodes(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	baseURL := "https://base-orch.example.com:8935"
+	extra1 := "https://extra-1.example.com:8935"
+	extra2 := "https://extra-2.example.com:8935"
+	extra3 := "https://extra-3.example.com:8935"
+	extra4 := "https://extra-4.example.com:8935"
+
+	// Track every lookup so the test can assert the exact expansion behavior.
+	// We expect:
+	// - base to be queried once
+	// - first two advertised nodes to be queried once each (ExtraNodes=2)
+	// - third advertised node to never be queried.
+	// - extra4 advertised by extra1 to never be queried (no second-level expansion).
+	calls := make(map[string]int)
+	var callsMu sync.Mutex
+	getOrchInfo := func(ctx context.Context, bcast common.Broadcaster, orchestratorServer *url.URL, params server.GetOrchestratorInfoParams) (*net.OrchestratorInfo, error) {
+		callsMu.Lock()
+		calls[orchestratorServer.String()]++
+		callsMu.Unlock()
+
+		info := &net.OrchestratorInfo{
+			Address:    pm.RandBytes(20),
+			Transcoder: orchestratorServer.String(),
+			PriceInfo: &net.PriceInfo{
+				PricePerUnit:  1,
+				PixelsPerUnit: 1,
+			},
+			TicketParams: &net.TicketParams{
+				Recipient: ethcommon.BytesToAddress([]byte(orchestratorServer.String())).Bytes(),
+			},
+		}
+		if orchestratorServer.String() == baseURL {
+			info.Nodes = []string{extra1, extra2, extra3}
+		}
+		if orchestratorServer.String() == extra1 {
+			info.Nodes = []string{extra4}
+		}
+		return info, nil
+	}
+
+	dbh, dbraw, err := common.TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	require.NoError(err)
+
+	u, err := url.Parse(baseURL)
+	require.NoError(err)
+
+	// Use the real orchestratorPool type as a source of GetInfos() data.
+	// DB cache code under test only depends on GetInfos() in this branch.
+	orchPool := &orchestratorPool{
+		infos:       []common.OrchestratorLocalInfo{{URL: u, Score: common.Score_Untrusted}},
+		getOrchInfo: getOrchInfo,
+	}
+	node := &core.LivepeerNode{
+		Database:         dbh,
+		ExtraNodes:       2,
+		OrchestratorPool: orchPool,
+	}
+	dbo := &DBOrchestratorPoolCache{
+		store:               dbh,
+		rm:                  &stubRoundsManager{round: big.NewInt(1)},
+		bcast:               core.NewBroadcaster(node),
+		node:                node,
+		ignoreCapacityCheck: true,
+	}
+
+	require.NoError(dbo.cacheOrchInfos())
+	cached := node.GetNetworkCapabilities()
+	// Cache should include base + first two advertised nodes, and exclude the third.
+	require.Len(cached, 3)
+
+	cachedURIs := make(map[string]bool, len(cached))
+	for _, orch := range cached {
+		cachedURIs[orch.OrchURI] = true
+	}
+	assert.True(cachedURIs[baseURL])
+	assert.True(cachedURIs[extra1])
+	assert.True(cachedURIs[extra2])
+	assert.False(cachedURIs[extra3])
+	assert.False(cachedURIs[extra4])
+
+	// Verify first-level expansion is bounded by ExtraNodes.
+	assert.Equal(1, calls[baseURL])
+	assert.Equal(1, calls[extra1])
+	assert.Equal(1, calls[extra2])
+	assert.Equal(0, calls[extra3])
+	assert.Equal(0, calls[extra4])
+}
+
 func sync_TestNewDBOrchestratorPoolCache_GivenListOfOrchs_CreatesPoolCacheCorrectly(t *testing.T) {
 	expPriceInfo := &net.PriceInfo{
 		PricePerUnit:  999,

--- a/discovery/wh_discovery.go
+++ b/discovery/wh_discovery.go
@@ -21,21 +21,38 @@ type webhookResponse struct {
 }
 
 type webhookPool struct {
-	pool             *orchestratorPool
-	callback         *url.URL
-	responseHash     ethcommon.Hash
-	lastRequest      time.Time
-	mu               *sync.RWMutex
-	bcast            common.Broadcaster
-	discoveryTimeout time.Duration
+	pool                *orchestratorPool
+	callback            *url.URL
+	responseHash        ethcommon.Hash
+	lastRequest         time.Time
+	mu                  *sync.RWMutex
+	bcast               common.Broadcaster
+	discoveryTimeout    time.Duration
+	ignoreCapacityCheck bool
 }
 
 func NewWebhookPool(bcast common.Broadcaster, callback *url.URL, discoveryTimeout time.Duration) *webhookPool {
+	return WebhookPoolConfig{
+		Broadcaster:      bcast,
+		Callback:         callback,
+		DiscoveryTimeout: discoveryTimeout,
+	}.New()
+}
+
+type WebhookPoolConfig struct {
+	Broadcaster         common.Broadcaster
+	Callback            *url.URL
+	DiscoveryTimeout    time.Duration
+	IgnoreCapacityCheck bool
+}
+
+func (cfg WebhookPoolConfig) New() *webhookPool {
 	p := &webhookPool{
-		callback:         callback,
-		mu:               &sync.RWMutex{},
-		bcast:            bcast,
-		discoveryTimeout: discoveryTimeout,
+		callback:            cfg.Callback,
+		mu:                  &sync.RWMutex{},
+		bcast:               cfg.Broadcaster,
+		discoveryTimeout:    cfg.DiscoveryTimeout,
+		ignoreCapacityCheck: cfg.IgnoreCapacityCheck,
 	}
 	go p.getInfos()
 	return p
@@ -73,7 +90,14 @@ func (w *webhookPool) getInfos() ([]common.OrchestratorLocalInfo, error) {
 		return nil, err
 	}
 
-	pool = &orchestratorPool{infos: infos, bcast: w.bcast, discoveryTimeout: w.discoveryTimeout, extraNodes: w.bcast.ExtraNodes(), getOrchInfo: serverGetOrchInfo}
+	pool = &orchestratorPool{
+		infos:               infos,
+		bcast:               w.bcast,
+		discoveryTimeout:    w.discoveryTimeout,
+		extraNodes:          w.bcast.ExtraNodes(),
+		ignoreCapacityCheck: w.ignoreCapacityCheck,
+		getOrchInfo:         serverGetOrchInfo,
+	}
 
 	w.mu.Lock()
 	w.responseHash = hash

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -80,7 +80,7 @@ curl "http://127.0.0.1:7936/discover-orchestrators?caps=live-video-to-video/stre
 curl "http://127.0.0.1:7936/discover-orchestrators?caps=live-video-to-video/streamdiffusion&caps=text-to-image/black-forest-labs/FLUX.1-dev"
 ```
 
-The remote signer periodically retrieves latest orchestrator capabilities and pricing from the network. Orchestrators are pre-filtered for pricing: orchestrators that have a price higher than what the remote signer is configured for will not be made available via discovery.
+The remote signer periodically retrieves latest orchestrator capabilities and pricing from the network. The periodicity can be configured via the `-liveAICapReportInterval` flag with a default of 25 minutes. Orchestrators are pre-filtered for pricing: orchestrators that have a price higher than what the remote signer is configured for will not be made available via discovery.
 
 Currently, remote discovery can only be enabled for nodes in remote signing mode.
 

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -1,6 +1,6 @@
 # Remote signer
 
-The **remote signer** is a standalone `go-livepeer` node mode that separates **Ethereum key custody + signing** from the gateway’s **untrusted media handling**. It is intended to:
+The **remote signer** is a standalone `go-livepeer` node mode that separates Ethereum key custody + signing from the gateway’s untrusted media handling. It is intended to:
 
 - Improve security posture by removing Ethereum hot keys from the media processing path
 - Enable web3-less gateway implementations natively on additional platforms such as browser, mobile, serverless and embedded backend apps
@@ -8,15 +8,15 @@ The **remote signer** is a standalone `go-livepeer` node mode that separates **E
 
 ## Current implementation status
 
-Remote signing was designed to initially target **Live AI** (`live-video-to-video`).
+Remote signing was designed to initially target Live AI (`live-video-to-video`).
 
-Support for other workloads may be added in the future.
+Support for other pipelines may be added in the future.
 
-This allows a gateway to run in offchain mode while still working with on-chain orchestrators.
+With remote signers enabled, a gateway runs in offchain mode while still working with on-chain orchestrators.
 
 ## Architecture
 
-At a high level, the gateway uses the remote signer to handle Ethereum-related operations such as generating signatures or probabilistic micropayment tickets:
+At a high level, the gateway uses the remote signer to handle Ethereum-related operations such as generating signatures, probabilistic micropayment tickets, or discovering on-chain orchestrators and filtering them by price and capability:
 
 ```mermaid
 sequenceDiagram
@@ -28,6 +28,9 @@ sequenceDiagram
   RemoteSigner-->>Gateway: {address, signature}
   Gateway->>Orchestrator: GetOrchestratorInfo(Address=address,Sig=signature)
   Orchestrator-->>Gateway: OrchestratorInfo (incl TicketParams)
+
+  Gateway->>RemoteSigner: GET /discover-orchestrators
+  RemoteSigner->>Gateway: [ orchestrators ]
 
   Note over Gateway,RemoteSigner: Live AI payments (asynchronous)
   Gateway->>RemoteSigner: POST /generate-live-payment (orchInfo + signerState)
@@ -52,19 +55,34 @@ The remote signer must have typical Ethereum flags configured (examples: `-netwo
 
 The remote signer listens to the standard go-livepeer HTTP port (8935) by default. To change the listening port or interface, use the `-httpAddr` flag.
 
-The remote signer optionally supports orchestrator discovery via the `-remoteOrchDiscovery` flag. If set, it will fetch orchestrators from the on-chain registry, but this can be overriden via the `-orchWebhookUrl` or the `-orchAddr` flags.
+### Remote discovery
 
-Example (fill in the placeholders for your environment):
+Remote signers can offer a discovery endpoint for gateways to find what orchestrators are on the network for a given capability. Remote discovery is enabled with:
+
+- `-remoteDiscovery=true`
+
+When enabled, the signer exposes:
+
+- `GET /discover-orchestrators`
+
+The endpoint returns a list of orchestrators (`address`, `score`, `capabilities`) in a format that is compatible with the gateway's orchestrator discovery webhook.
+
+Clients can filter for orchestrators matching a given capability via the `caps` query param. This param can be repeated to retrieve orchestrators supporting any one of the given capabilities. For example:
 
 ```bash
-./livepeer \
-  -remoteSigner \
-  -network mainnet \
-  -httpAddr 127.0.0.1:7936 \
-  -ethUrl <eth-rpc-url> \
-  -ethPassword <password-or-password-file>
-  ...
+# All available orchestrators
+curl "http://127.0.0.1:7936/discover-orchestrators"
+
+# Filter by one capability
+curl "http://127.0.0.1:7936/discover-orchestrators?caps=live-video-to-video/streamdiffusion"
+
+# Filter by multiple capabilities (OR behavior)
+curl "http://127.0.0.1:7936/discover-orchestrators?caps=live-video-to-video/streamdiffusion&caps=text-to-image/black-forest-labs/FLUX.1-dev"
 ```
+
+The remote signer periodically retrieves latest orchestrator capabilities and pricing from the network. Orchestrators are pre-filtered for pricing: orchestrators that have a price higher than what the remote signer is configured for will not be made available via discovery.
+
+Currently, remote discovery can only be enabled for nodes in remote signing mode.
 
 ### Gateway node
 
@@ -78,7 +96,7 @@ If `-remoteSignerUrl` is set, the gateway will query the signer at startup and f
 
 By default, if no URL scheme is provided, https is assumed and prepended to the remote signer URL. To override this (eg, to use a http:// URL) then include the scheme, eg `-remoteSignerUrl http://signer-host:port`
 
-If the gateway is configured with a remote signer URL but no orchestrators (`-orchWebhookUrl` or `-orchAddr`) then it will attempt to use the remote signer's discovery endpoint.
+If the gateway is configured with a remote signer URL but no orchestrators (`-orchWebhookUrl` or `-orchAddr`) then it will attempt to use the remote signer's discovery endpoint. Note that not all remote signers may be offering discovery.
 
 Example:
 

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -55,6 +55,18 @@ The remote signer must have typical Ethereum flags configured (examples: `-netwo
 
 The remote signer listens to the standard go-livepeer HTTP port (8935) by default. To change the listening port or interface, use the `-httpAddr` flag.
 
+Example (fill in the placeholders for your environment):
+
+```bash
+./livepeer \
+  -remoteSigner \
+  -network mainnet \
+  -httpAddr 127.0.0.1:7936 \
+  -ethUrl <eth-rpc-url> \
+  -ethPassword <password-or-password-file>
+  ...
+```
+
 ### Remote discovery
 
 Remote signers can offer a discovery endpoint for gateways to find what orchestrators are on the network for a given capability. Remote discovery is enabled with:

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -12,8 +12,6 @@ Remote signing was designed to initially target **Live AI** (`live-video-to-vide
 
 Support for other workloads may be added in the future.
 
-The on-chain service registry is not used for Live AI workloads right now, so orchestrator discovery is not implemented as part of the remote signer. The gateway can learn about orchestrators via an orchestrator webhook (`-orchWebhookUrl`) or a static list (`-orchAddr`).
-
 This allows a gateway to run in offchain mode while still working with on-chain orchestrators.
 
 ## Architecture
@@ -54,6 +52,8 @@ The remote signer must have typical Ethereum flags configured (examples: `-netwo
 
 The remote signer listens to the standard go-livepeer HTTP port (8935) by default. To change the listening port or interface, use the `-httpAddr` flag.
 
+The remote signer optionally supports orchestrator discovery via the `-remoteOrchDiscovery` flag. If set, it will fetch orchestrators from the on-chain registry, but this can be overriden via the `-orchWebhookUrl` or the `-orchAddr` flags.
+
 Example (fill in the placeholders for your environment):
 
 ```bash
@@ -77,6 +77,8 @@ If `-remoteSignerUrl` is set, the gateway will query the signer at startup and f
 **No Ethereum flags are necessary on the gateway** in this mode. Omit the `-network` flag entirely here; this makes the gateway run in offchain mode, but it will still be able to send work to on-chain orchestrators with the `-remoteSignerUrl` flag enabled.
 
 By default, if no URL scheme is provided, https is assumed and prepended to the remote signer URL. To override this (eg, to use a http:// URL) then include the scheme, eg `-remoteSignerUrl http://signer-host:port`
+
+If the gateway is configured with a remote signer URL but no orchestrators (`-orchWebhookUrl` or `-orchAddr`) then it will attempt to use the remote signer's discovery endpoint.
 
 Example:
 

--- a/server/broadcast.go
+++ b/server/broadcast.go
@@ -133,7 +133,7 @@ func (cfg *BroadcastConfig) getCapabilityMaxPrice(cap core.Capability, modelID s
 	if price, modelOk := models[modelID]; modelOk && price != nil {
 		return price.Value()
 	}
-	if defaultPrice, hasDefault := models["default"]; hasDefault {
+	if defaultPrice, hasDefault := models["default"]; hasDefault && defaultPrice != nil {
 		return defaultPrice.Value()
 	}
 
@@ -142,8 +142,8 @@ func (cfg *BroadcastConfig) getCapabilityMaxPrice(cap core.Capability, modelID s
 }
 
 func (cfg *BroadcastConfig) SetCapabilityMaxPrice(cap core.Capability, modelID string, newPrice *core.AutoConvertedPrice) {
-	cfg.mu.RLock()
-	defer cfg.mu.RUnlock()
+	cfg.mu.Lock()
+	defer cfg.mu.Unlock()
 	if _, ok := cfg.maxPricePerCapability[cap]; !ok {
 		cfg.maxPricePerCapability[cap] = make(map[string]*core.AutoConvertedPrice)
 	}

--- a/server/remote_discovery.go
+++ b/server/remote_discovery.go
@@ -119,7 +119,7 @@ func (p *remoteDiscoveryPool) refresh() {
 		ctx,
 		p.pool.Size(),
 		newSuspender(),
-		core.NewCapabilities(nil, nil),
+		&StubCapabilityComparator{NetCaps: nil, IsLegacy: true},
 		common.ScoreAtLeast(common.Score_Untrusted),
 	)
 
@@ -206,7 +206,7 @@ func capabilityToPipeline(capability core.Capability) string {
 
 func capabilityPrice(info *net.OrchestratorInfo, capability core.Capability, modelID string) *big.Rat {
 	if info != nil {
-		var defaultPrice *big.Rat
+		// Check per-capability price if it exists
 		for _, capPrice := range info.CapabilitiesPrices {
 			if capPrice == nil || capPrice.PixelsPerUnit <= 0 || core.Capability(capPrice.Capability) != capability {
 				continue
@@ -215,13 +215,6 @@ func capabilityPrice(info *net.OrchestratorInfo, capability core.Capability, mod
 			if capPrice.Constraint == modelID {
 				return price
 			}
-			// "default" is the per-capability model fallback.
-			if capPrice.Constraint == "default" {
-				defaultPrice = price
-			}
-		}
-		if defaultPrice != nil {
-			return defaultPrice
 		}
 	}
 	// Global fallback if no per-capability price is available.

--- a/server/remote_discovery.go
+++ b/server/remote_discovery.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/core"
+)
+
+const remoteDiscoveryRefreshTimeout = 15 * time.Second
+
+var remoteDiscoveryRefreshInterval = common.WebhookDiscoveryRefreshInterval
+
+type RemoteDiscoveryConfig struct {
+	Pool     common.OrchestratorPool
+	Interval time.Duration
+}
+
+func (cfg RemoteDiscoveryConfig) New() *remoteDiscoveryPool {
+	refreshEvery := cfg.Interval
+	if refreshEvery <= 0 {
+		refreshEvery = remoteDiscoveryRefreshInterval
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &remoteDiscoveryPool{
+		pool:         cfg.Pool,
+		refreshEvery: refreshEvery,
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+	go p.loop()
+	return p
+}
+
+type remoteDiscoveryPool struct {
+	pool common.OrchestratorPool
+
+	mu     sync.RWMutex
+	cached common.OrchestratorDescriptors
+
+	refreshEvery time.Duration
+	ctx          context.Context
+	cancel       context.CancelFunc
+}
+
+func (p *remoteDiscoveryPool) Orchestrators() common.OrchestratorDescriptors {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	ods := make(common.OrchestratorDescriptors, len(p.cached))
+	copy(ods, p.cached)
+	return ods
+}
+
+func (p *remoteDiscoveryPool) Stop() {
+	p.cancel()
+}
+
+func (p *remoteDiscoveryPool) loop() {
+	p.refresh()
+
+	t := time.NewTicker(p.refreshEvery)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			p.refresh()
+		case <-p.ctx.Done():
+			return
+		}
+	}
+}
+
+func (p *remoteDiscoveryPool) refresh() {
+	ctx, cancel := context.WithTimeout(p.ctx, remoteDiscoveryRefreshTimeout)
+	defer cancel()
+
+	ods, err := p.pool.GetOrchestrators(
+		ctx,
+		p.pool.Size(),
+		newSuspender(),
+		core.NewCapabilities(nil, nil),
+		common.ScoreAtLeast(common.Score_Untrusted),
+	)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if err != nil {
+		return
+	}
+
+	p.cached = ods
+}

--- a/server/remote_discovery.go
+++ b/server/remote_discovery.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"math/big"
 	"net/url"
 	"sort"
@@ -28,19 +27,14 @@ func (cfg RemoteDiscoveryConfig) New() *remoteDiscoveryPool {
 		refreshEvery = remoteDiscoveryRefreshInterval
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
 	p := &remoteDiscoveryPool{
-		pool:         cfg.Pool,
 		node:         cfg.Node,
 		refreshEvery: refreshEvery,
-		ctx:          ctx,
-		cancel:       cancel,
 	}
 	return p
 }
 
 type remoteDiscoveryPool struct {
-	pool common.OrchestratorPool
 	node *core.LivepeerNode
 
 	mu          sync.RWMutex
@@ -49,8 +43,6 @@ type remoteDiscoveryPool struct {
 	lastRefresh time.Time
 
 	refreshEvery time.Duration
-	ctx          context.Context
-	cancel       context.CancelFunc
 }
 
 type remoteDiscoveryOrchestrator struct {
@@ -95,10 +87,6 @@ func (p *remoteDiscoveryPool) Size() int {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return len(p.cached)
-}
-
-func (p *remoteDiscoveryPool) Stop() {
-	p.cancel()
 }
 
 func (p *remoteDiscoveryPool) refresh() {

--- a/server/remote_discovery.go
+++ b/server/remote_discovery.go
@@ -227,10 +227,6 @@ func capabilityPrice(info *net.OrchestratorInfo, capability core.Capability, mod
 }
 
 func capabilityMaxPrice(capability core.Capability, modelID string) *big.Rat {
-	defer func() {
-		_ = recover()
-	}()
-
 	caps := core.NewCapabilities([]core.Capability{capability}, nil)
 	caps.SetPerCapabilityConstraints(core.PerCapabilityConstraints{
 		capability: &core.CapabilityConstraints{

--- a/server/remote_discovery.go
+++ b/server/remote_discovery.go
@@ -2,11 +2,15 @@ package server
 
 import (
 	"context"
+	"math/big"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/net"
 )
 
 const remoteDiscoveryRefreshTimeout = 15 * time.Second
@@ -39,20 +43,52 @@ type remoteDiscoveryPool struct {
 	pool common.OrchestratorPool
 
 	mu     sync.RWMutex
-	cached common.OrchestratorDescriptors
+	cached []remoteDiscoveryOrchestrator
+	caps   map[string][]remoteDiscoveryOrchestrator
 
 	refreshEvery time.Duration
 	ctx          context.Context
 	cancel       context.CancelFunc
 }
 
-func (p *remoteDiscoveryPool) Orchestrators() common.OrchestratorDescriptors {
+type remoteDiscoveryOrchestrator struct {
+	OD           common.OrchestratorDescriptor
+	Capabilities []string
+}
+
+func (o remoteDiscoveryOrchestrator) clone() remoteDiscoveryOrchestrator {
+	orch := o
+	orch.Capabilities = append([]string(nil), o.Capabilities...)
+	return orch
+}
+
+func (p *remoteDiscoveryPool) Orchestrators(caps []string) []remoteDiscoveryOrchestrator {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	ods := make(common.OrchestratorDescriptors, len(p.cached))
-	copy(ods, p.cached)
-	return ods
+	if len(caps) == 0 {
+		return cloneRemoteDiscoveryOrchestrators(p.cached)
+	}
+
+	var cached []remoteDiscoveryOrchestrator
+	seen := make(map[string]bool)
+	for _, key := range caps {
+		for _, orch := range p.caps[key] {
+			u := orch.OD.LocalInfo.URL.String()
+			if seen[u] {
+				continue
+			}
+			seen[u] = true
+			cached = append(cached, orch.clone())
+		}
+	}
+	return cached
+}
+
+func (p *remoteDiscoveryPool) Size() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return len(p.cached)
 }
 
 func (p *remoteDiscoveryPool) Stop() {
@@ -87,12 +123,127 @@ func (p *remoteDiscoveryPool) refresh() {
 		common.ScoreAtLeast(common.Score_Untrusted),
 	)
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
 	if err != nil {
 		return
 	}
 
-	p.cached = ods
+	cached := make([]remoteDiscoveryOrchestrator, 0, len(ods))
+	caps := make(map[string][]remoteDiscoveryOrchestrator)
+	for _, od := range ods {
+		if od.LocalInfo == nil || od.LocalInfo.URL == nil {
+			continue
+		}
+		entry := remoteDiscoveryOrchestrator{
+			OD: od,
+		}
+		eligibleCaps := make([]string, 0)
+		// Capabilities in discovery are price-eligible capabilities only.
+		forEachRemoteDiscoveryCapability(od.RemoteInfo, func(key string, capability core.Capability, modelID string) {
+			price := capabilityPrice(od.RemoteInfo, capability, modelID)
+			maxPrice := capabilityMaxPrice(capability, modelID)
+			if maxPrice != nil && price != nil && price.Cmp(maxPrice) > 0 {
+				return
+			}
+			eligibleCaps = append(eligibleCaps, key)
+		})
+		// Drop orchestrators if it doesn't have any eligible capabilities
+		if len(eligibleCaps) == 0 {
+			continue
+		}
+		sort.Strings(eligibleCaps)
+		entry.Capabilities = eligibleCaps
+		// Keep the capability index aligned with the orchestrator capability list.
+		for _, key := range eligibleCaps {
+			caps[key] = append(caps[key], entry.clone())
+		}
+		cached = append(cached, entry)
+	}
+
+	// Publish the cache/index snapshot atomically.
+	p.mu.Lock()
+	p.cached = cached
+	p.caps = caps
+	p.mu.Unlock()
+}
+
+func cloneRemoteDiscoveryOrchestrators(cached []remoteDiscoveryOrchestrator) []remoteDiscoveryOrchestrator {
+	cloned := make([]remoteDiscoveryOrchestrator, 0, len(cached))
+	for _, orch := range cached {
+		cloned = append(cloned, orch.clone())
+	}
+	return cloned
+}
+
+func forEachRemoteDiscoveryCapability(info *net.OrchestratorInfo, f func(key string, capability core.Capability, modelID string)) {
+	if info == nil || info.Capabilities == nil || info.Capabilities.Constraints == nil {
+		return
+	}
+
+	for capabilityInt, constraints := range info.Capabilities.Constraints.PerCapability {
+		if constraints == nil {
+			continue
+		}
+		pipeline := capabilityToPipeline(core.Capability(capabilityInt))
+		if pipeline == "" {
+			continue
+		}
+		for modelID := range constraints.Models {
+			if modelID == "" {
+				continue
+			}
+			f(pipeline+"/"+modelID, core.Capability(capabilityInt), modelID)
+		}
+	}
+}
+
+func capabilityToPipeline(capability core.Capability) string {
+	name, err := core.CapabilityToName(capability)
+	if err != nil || len(name) == 0 {
+		return ""
+	}
+	return strings.ToLower(strings.ReplaceAll(name, " ", "-"))
+}
+
+func capabilityPrice(info *net.OrchestratorInfo, capability core.Capability, modelID string) *big.Rat {
+	if info != nil {
+		var defaultPrice *big.Rat
+		for _, capPrice := range info.CapabilitiesPrices {
+			if capPrice == nil || capPrice.PixelsPerUnit <= 0 || core.Capability(capPrice.Capability) != capability {
+				continue
+			}
+			price := new(big.Rat).SetFrac64(capPrice.PricePerUnit, capPrice.PixelsPerUnit)
+			if capPrice.Constraint == modelID {
+				return price
+			}
+			// "default" is the per-capability model fallback.
+			if capPrice.Constraint == "default" {
+				defaultPrice = price
+			}
+		}
+		if defaultPrice != nil {
+			return defaultPrice
+		}
+	}
+	// Global fallback if no per-capability price is available.
+	if info == nil || info.PriceInfo == nil || info.PriceInfo.PixelsPerUnit <= 0 {
+		return nil
+	}
+	return new(big.Rat).SetFrac64(info.PriceInfo.PricePerUnit, info.PriceInfo.PixelsPerUnit)
+}
+
+func capabilityMaxPrice(capability core.Capability, modelID string) *big.Rat {
+	defer func() {
+		_ = recover()
+	}()
+
+	caps := core.NewCapabilities([]core.Capability{capability}, nil)
+	caps.SetPerCapabilityConstraints(core.PerCapabilityConstraints{
+		capability: &core.CapabilityConstraints{
+			Models: map[string]*core.ModelConstraint{
+				modelID: {},
+			},
+		},
+	})
+	// Broadcast config applies model-specific max price with "default" fallback.
+	return BroadcastCfg.GetCapabilitiesMaxPrice(caps)
 }

--- a/server/remote_discovery.go
+++ b/server/remote_discovery.go
@@ -36,7 +36,6 @@ func (cfg RemoteDiscoveryConfig) New() *remoteDiscoveryPool {
 		ctx:          ctx,
 		cancel:       cancel,
 	}
-	go p.loop()
 	return p
 }
 
@@ -44,9 +43,10 @@ type remoteDiscoveryPool struct {
 	pool common.OrchestratorPool
 	node *core.LivepeerNode
 
-	mu     sync.RWMutex
-	cached []remoteDiscoveryOrchestrator
-	caps   map[string][]remoteDiscoveryOrchestrator
+	mu          sync.RWMutex
+	cached      []remoteDiscoveryOrchestrator
+	caps        map[string][]remoteDiscoveryOrchestrator
+	lastRefresh time.Time
 
 	refreshEvery time.Duration
 	ctx          context.Context
@@ -65,6 +65,8 @@ func (o remoteDiscoveryOrchestrator) clone() remoteDiscoveryOrchestrator {
 }
 
 func (p *remoteDiscoveryPool) Orchestrators(caps []string) []remoteDiscoveryOrchestrator {
+	p.refresh()
+
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
@@ -88,6 +90,8 @@ func (p *remoteDiscoveryPool) Orchestrators(caps []string) []remoteDiscoveryOrch
 }
 
 func (p *remoteDiscoveryPool) Size() int {
+	p.refresh()
+
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return len(p.cached)
@@ -97,23 +101,19 @@ func (p *remoteDiscoveryPool) Stop() {
 	p.cancel()
 }
 
-func (p *remoteDiscoveryPool) loop() {
-	p.refresh()
-
-	t := time.NewTicker(p.refreshEvery)
-	defer t.Stop()
-
-	for {
-		select {
-		case <-t.C:
-			p.refresh()
-		case <-p.ctx.Done():
-			return
-		}
-	}
-}
-
 func (p *remoteDiscoveryPool) refresh() {
+	if p == nil {
+		return
+	}
+
+	// This can run on the request path when cache is stale, so keep it fast.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	now := time.Now()
+	if !p.lastRefresh.IsZero() && now.Sub(p.lastRefresh) <= p.refreshEvery {
+		return
+	}
+
 	var ods common.OrchestratorDescriptors
 	if p.node != nil {
 		networkCaps := p.node.GetNetworkCapabilities()
@@ -175,10 +175,9 @@ func (p *remoteDiscoveryPool) refresh() {
 	}
 
 	// Publish the cache/index snapshot atomically.
-	p.mu.Lock()
 	p.cached = cached
 	p.caps = caps
-	p.mu.Unlock()
+	p.lastRefresh = now
 }
 
 func cloneRemoteDiscoveryOrchestrators(cached []remoteDiscoveryOrchestrator) []remoteDiscoveryOrchestrator {

--- a/server/remote_discovery.go
+++ b/server/remote_discovery.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"math/big"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -13,12 +14,11 @@ import (
 	"github.com/livepeer/go-livepeer/net"
 )
 
-const remoteDiscoveryRefreshTimeout = 15 * time.Second
-
 var remoteDiscoveryRefreshInterval = common.WebhookDiscoveryRefreshInterval
 
 type RemoteDiscoveryConfig struct {
 	Pool     common.OrchestratorPool
+	Node     *core.LivepeerNode
 	Interval time.Duration
 }
 
@@ -31,6 +31,7 @@ func (cfg RemoteDiscoveryConfig) New() *remoteDiscoveryPool {
 	ctx, cancel := context.WithCancel(context.Background())
 	p := &remoteDiscoveryPool{
 		pool:         cfg.Pool,
+		node:         cfg.Node,
 		refreshEvery: refreshEvery,
 		ctx:          ctx,
 		cancel:       cancel,
@@ -41,6 +42,7 @@ func (cfg RemoteDiscoveryConfig) New() *remoteDiscoveryPool {
 
 type remoteDiscoveryPool struct {
 	pool common.OrchestratorPool
+	node *core.LivepeerNode
 
 	mu     sync.RWMutex
 	cached []remoteDiscoveryOrchestrator
@@ -112,19 +114,32 @@ func (p *remoteDiscoveryPool) loop() {
 }
 
 func (p *remoteDiscoveryPool) refresh() {
-	ctx, cancel := context.WithTimeout(p.ctx, remoteDiscoveryRefreshTimeout)
-	defer cancel()
-
-	ods, err := p.pool.GetOrchestrators(
-		ctx,
-		p.pool.Size(),
-		newSuspender(),
-		&StubCapabilityComparator{NetCaps: nil, IsLegacy: true},
-		common.ScoreAtLeast(common.Score_Untrusted),
-	)
-
-	if err != nil {
-		return
+	var ods common.OrchestratorDescriptors
+	if p.node != nil {
+		networkCaps := p.node.GetNetworkCapabilities()
+		ods = make(common.OrchestratorDescriptors, 0, len(networkCaps))
+		for _, orchCaps := range networkCaps {
+			if orchCaps == nil || orchCaps.OrchURI == "" {
+				continue
+			}
+			orchURL, err := url.ParseRequestURI(orchCaps.OrchURI)
+			if err != nil {
+				continue
+			}
+			ods = append(ods, common.OrchestratorDescriptor{
+				LocalInfo: &common.OrchestratorLocalInfo{
+					URL:   orchURL,
+					Score: common.Score_Trusted,
+				},
+				RemoteInfo: &net.OrchestratorInfo{
+					Transcoder:         orchCaps.OrchURI,
+					Capabilities:       orchCaps.Capabilities,
+					PriceInfo:          orchCaps.PriceInfo,
+					CapabilitiesPrices: orchCaps.CapabilitiesPrices,
+					Hardware:           orchCaps.Hardware,
+				},
+			})
+		}
 	}
 
 	cached := make([]remoteDiscoveryOrchestrator, 0, len(ods))

--- a/server/remote_discovery.go
+++ b/server/remote_discovery.go
@@ -144,8 +144,11 @@ func (p *remoteDiscoveryPool) refresh() {
 		forEachRemoteDiscoveryCapability(od.RemoteInfo, func(key string, capability core.Capability, modelID string) {
 			price := capabilityPrice(od.RemoteInfo, capability, modelID)
 			maxPrice := capabilityMaxPrice(capability, modelID)
-			if maxPrice != nil && price != nil && price.Cmp(maxPrice) > 0 {
-				return
+			if maxPrice != nil {
+				// If a max price is configured, missing price data should not be eligible.
+				if price == nil || price.Cmp(maxPrice) > 0 {
+					return
+				}
 			}
 			eligibleCaps = append(eligibleCaps, key)
 		})

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -72,7 +72,11 @@ func StartRemoteSignerServer(ls *LivepeerServer, bind string) error {
 	ls.HTTPMux.Handle("POST /sign-orchestrator-info", http.HandlerFunc(ls.SignOrchestratorInfo))
 	ls.HTTPMux.Handle("POST /generate-live-payment", http.HandlerFunc(ls.GenerateLivePayment))
 	if ls.LivepeerNode.OrchestratorPool != nil {
-		ls.HTTPMux.Handle("GET /discover-orchestrators", http.HandlerFunc(ls.GetOrchestrators))
+		rdp := RemoteDiscoveryConfig{Pool: ls.LivepeerNode.OrchestratorPool}.New()
+		defer rdp.Stop()
+		ls.HTTPMux.Handle("GET /discover-orchestrators", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ls.GetOrchestrators(rdp, w, r)
+		}))
 	}
 
 	// Start the HTTP server
@@ -522,23 +526,27 @@ type discoveryResponse struct {
 }
 
 // GetOrchestrators returns the configured orchestrators in webhook-compatible format
-func (ls *LivepeerServer) GetOrchestrators(w http.ResponseWriter, r *http.Request) {
+func (ls *LivepeerServer) GetOrchestrators(pool *remoteDiscoveryPool, w http.ResponseWriter, r *http.Request) {
 	ctx := clog.AddVal(r.Context(), "request_id", string(core.RandomManifestID()))
 	remoteAddr := getRemoteAddr(r)
 	clog.Info(ctx, "Get orchestrators request", "ip", remoteAddr)
 
-	pool := ls.LivepeerNode.OrchestratorPool
 	if pool == nil {
 		respondJsonError(ctx, w, errors.New("no orchestrator pool configured"), http.StatusServiceUnavailable)
 		return
 	}
 
-	infos := pool.GetInfos()
+	infos := pool.Orchestrators()
+	if len(infos) == 0 {
+		respondJsonError(ctx, w, errors.New("cache empty"), http.StatusServiceUnavailable)
+		return
+	}
+
 	resp := make([]discoveryResponse, 0, len(infos))
-	for _, info := range infos {
+	for _, od := range infos {
 		resp = append(resp, discoveryResponse{
-			Address: info.URL.String(),
-			Score:   info.Score,
+			Address: od.LocalInfo.URL.String(),
+			Score:   od.LocalInfo.Score,
 		})
 	}
 

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -521,8 +521,9 @@ func GetOrchInfoSig(remoteSignerHost *url.URL) (*OrchInfoSigResponse, error) {
 }
 
 type discoveryResponse struct {
-	Address string  `json:"address,omitempty"`
-	Score   float32 `json:"score,omitempty"`
+	Address      string   `json:"address,omitempty"`
+	Score        float32  `json:"score,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // GetOrchestrators returns the configured orchestrators in webhook-compatible format
@@ -536,17 +537,27 @@ func (ls *LivepeerServer) GetOrchestrators(pool *remoteDiscoveryPool, w http.Res
 		return
 	}
 
-	infos := pool.Orchestrators()
-	if len(infos) == 0 {
+	if pool.Size() == 0 {
 		respondJsonError(ctx, w, errors.New("cache empty"), http.StatusServiceUnavailable)
 		return
 	}
 
+	caps := r.URL.Query()["caps"]
+	filteredCaps := make([]string, 0, len(caps))
+	for _, capability := range caps {
+		if capability != "" {
+			filteredCaps = append(filteredCaps, capability)
+		}
+	}
+
+	infos := pool.Orchestrators(filteredCaps)
 	resp := make([]discoveryResponse, 0, len(infos))
-	for _, od := range infos {
+	for _, cached := range infos {
+		od := cached.OD
 		resp = append(resp, discoveryResponse{
-			Address: od.LocalInfo.URL.String(),
-			Score:   od.LocalInfo.Score,
+			Address:      od.LocalInfo.URL.String(),
+			Score:        od.LocalInfo.Score,
+			Capabilities: append([]string(nil), cached.Capabilities...),
 		})
 	}
 

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -78,7 +78,6 @@ func StartRemoteSignerServer(ls *LivepeerServer, bind string) error {
 			Node:     ls.LivepeerNode,
 			Interval: ls.LivepeerNode.LiveAICapReportInterval,
 		}.New()
-		defer rdp.Stop()
 		ls.HTTPMux.Handle("GET /discover-orchestrators", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ls.GetOrchestrators(rdp, w, r)
 		}))

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -72,7 +72,11 @@ func StartRemoteSignerServer(ls *LivepeerServer, bind string) error {
 	ls.HTTPMux.Handle("POST /sign-orchestrator-info", http.HandlerFunc(ls.SignOrchestratorInfo))
 	ls.HTTPMux.Handle("POST /generate-live-payment", http.HandlerFunc(ls.GenerateLivePayment))
 	if ls.LivepeerNode.OrchestratorPool != nil {
-		rdp := RemoteDiscoveryConfig{Pool: ls.LivepeerNode.OrchestratorPool}.New()
+		rdp := RemoteDiscoveryConfig{
+			Pool:     ls.LivepeerNode.OrchestratorPool,
+			Node:     ls.LivepeerNode,
+			Interval: ls.LivepeerNode.LiveAICapReportInterval,
+		}.New()
 		defer rdp.Stop()
 		ls.HTTPMux.Handle("GET /discover-orchestrators", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ls.GetOrchestrators(rdp, w, r)

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -522,7 +522,6 @@ func GetOrchInfoSig(remoteSignerHost *url.URL) (*OrchInfoSigResponse, error) {
 
 type discoveryResponse struct {
 	Address      string   `json:"address,omitempty"`
-	Score        float32  `json:"score,omitempty"`
 	Capabilities []string `json:"capabilities,omitempty"`
 }
 
@@ -556,7 +555,6 @@ func (ls *LivepeerServer) GetOrchestrators(pool *remoteDiscoveryPool, w http.Res
 		od := cached.OD
 		resp = append(resp, discoveryResponse{
 			Address:      od.LocalInfo.URL.String(),
-			Score:        od.LocalInfo.Score,
 			Capabilities: append([]string(nil), cached.Capabilities...),
 		})
 	}

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -72,7 +72,7 @@ func StartRemoteSignerServer(ls *LivepeerServer, bind string) error {
 	// Register the remote signer endpoints
 	ls.HTTPMux.Handle("POST /sign-orchestrator-info", http.HandlerFunc(ls.SignOrchestratorInfo))
 	ls.HTTPMux.Handle("POST /generate-live-payment", http.HandlerFunc(ls.GenerateLivePayment))
-	if ls.LivepeerNode.OrchestratorPool != nil {
+	if ls.LivepeerNode.RemoteDiscovery {
 		rdp := RemoteDiscoveryConfig{
 			Pool:     ls.LivepeerNode.OrchestratorPool,
 			Node:     ls.LivepeerNode,

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -522,6 +522,7 @@ func GetOrchInfoSig(remoteSignerHost *url.URL) (*OrchInfoSigResponse, error) {
 
 type discoveryResponse struct {
 	Address      string   `json:"address,omitempty"`
+	Score        float32  `json:"score,omitempty"`
 	Capabilities []string `json:"capabilities,omitempty"`
 }
 
@@ -555,6 +556,7 @@ func (ls *LivepeerServer) GetOrchestrators(pool *remoteDiscoveryPool, w http.Res
 		od := cached.OD
 		resp = append(resp, discoveryResponse{
 			Address:      od.LocalInfo.URL.String(),
+			Score:        od.LocalInfo.Score,
 			Capabilities: append([]string(nil), cached.Capabilities...),
 		})
 	}

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -68,9 +68,12 @@ func (ls *LivepeerServer) SignOrchestratorInfo(w http.ResponseWriter, r *http.Re
 
 // StartRemoteSignerServer starts the HTTP server for remote signer mode
 func StartRemoteSignerServer(ls *LivepeerServer, bind string) error {
-	// Register the remote signer endpoint
+	// Register the remote signer endpoints
 	ls.HTTPMux.Handle("POST /sign-orchestrator-info", http.HandlerFunc(ls.SignOrchestratorInfo))
 	ls.HTTPMux.Handle("POST /generate-live-payment", http.HandlerFunc(ls.GenerateLivePayment))
+	if ls.LivepeerNode.OrchestratorPool != nil {
+		ls.HTTPMux.Handle("GET /discover-orchestrators", http.HandlerFunc(ls.GetOrchestrators))
+	}
 
 	// Start the HTTP server
 	glog.Info("Starting Remote Signer server on ", bind)
@@ -511,4 +514,34 @@ func GetOrchInfoSig(remoteSignerHost *url.URL) (*OrchInfoSigResponse, error) {
 	}
 
 	return &signerResp, nil
+}
+
+type discoveryResponse struct {
+	Address string  `json:"address,omitempty"`
+	Score   float32 `json:"score,omitempty"`
+}
+
+// GetOrchestrators returns the configured orchestrators in webhook-compatible format
+func (ls *LivepeerServer) GetOrchestrators(w http.ResponseWriter, r *http.Request) {
+	ctx := clog.AddVal(r.Context(), "request_id", string(core.RandomManifestID()))
+	remoteAddr := getRemoteAddr(r)
+	clog.Info(ctx, "Get orchestrators request", "ip", remoteAddr)
+
+	pool := ls.LivepeerNode.OrchestratorPool
+	if pool == nil {
+		respondJsonError(ctx, w, errors.New("no orchestrator pool configured"), http.StatusServiceUnavailable)
+		return
+	}
+
+	infos := pool.GetInfos()
+	resp := make([]discoveryResponse, 0, len(infos))
+	for _, info := range infos {
+		resp = append(resp, discoveryResponse{
+			Address: info.URL.String(),
+			Score:   info.Score,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/base64"
@@ -9,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 	"github.com/golang/protobuf/proto"
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/net"
@@ -66,6 +69,31 @@ func (c *testEthClient) Sign(msg []byte) ([]byte, error) {
 
 func (c *testEthClient) SignTypedData(apitypes.TypedData) ([]byte, error) {
 	return []byte("stub"), nil
+}
+
+// mockOrchestratorPool implements common.OrchestratorPool for testing
+type mockOrchestratorPool struct {
+	infos []common.OrchestratorLocalInfo
+}
+
+func (m *mockOrchestratorPool) GetInfos() []common.OrchestratorLocalInfo {
+	return m.infos
+}
+
+func (m *mockOrchestratorPool) GetOrchestrators(ctx context.Context, num int, suspender common.Suspender, caps common.CapabilityComparator, scorePred common.ScorePred) (common.OrchestratorDescriptors, error) {
+	return nil, nil
+}
+
+func (m *mockOrchestratorPool) Size() int {
+	return len(m.infos)
+}
+
+func (m *mockOrchestratorPool) SizeWith(scorePred common.ScorePred) int {
+	return len(m.infos)
+}
+
+func (m *mockOrchestratorPool) Broadcaster() common.Broadcaster {
+	return nil
 }
 
 func TestGenerateLivePayment_RequestValidationErrors(t *testing.T) {
@@ -629,4 +657,40 @@ func TestGenerateLivePayment_LV2V_Succeeds(t *testing.T) {
 		capBal.RatString(), expectedCapBal.RatString(), capFee.RatString(), len(capPayment.TicketSenderParams), ev.RatString(),
 	)
 
+}
+
+func TestRemoteSigner_Discovery_ReturnsConfiguredOrchestrators(t *testing.T) {
+	require := require.New(t)
+
+	u1, err := url.Parse("https://orch1.example.com:8935")
+	require.NoError(err)
+	u2, err := url.Parse("https://orch2.example.com:8935")
+	require.NoError(err)
+
+	mockPool := &mockOrchestratorPool{
+		infos: []common.OrchestratorLocalInfo{
+			{URL: u1, Score: 1.0},
+			{URL: u2, Score: 0.8},
+		},
+	}
+
+	node, _ := core.NewLivepeerNode(nil, "", nil)
+	node.OrchestratorPool = mockPool
+	ls := &LivepeerServer{LivepeerNode: node}
+
+	req := httptest.NewRequest(http.MethodGet, "/orchestrators", nil)
+	rr := httptest.NewRecorder()
+
+	ls.GetOrchestrators(rr, req)
+
+	require.Equal(http.StatusOK, rr.Code)
+	require.Equal("application/json", rr.Header().Get("Content-Type"))
+
+	var resp []discoveryResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(resp, 2)
+	require.Equal("https://orch1.example.com:8935", resp[0].Address)
+	require.Equal(float32(1.0), resp[0].Score)
+	require.Equal("https://orch2.example.com:8935", resp[1].Address)
+	require.Equal(float32(0.8), resp[1].Score)
 }

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -843,4 +844,90 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	ls.GetOrchestrators(emptyRDP, emptyRR, emptyReq)
 	require.Equal(http.StatusServiceUnavailable, emptyRR.Code)
 	require.Equal("application/json", emptyRR.Header().Get("Content-Type"))
+}
+
+func TestRemoteSigner_Discovery_RefreshesAfterInterval(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		require := require.New(t)
+
+		capability := core.Capability_LiveVideoToVideo
+		modelA := "model-a"
+		modelB := "model-b"
+		BroadcastCfg.SetCapabilityMaxPrice(capability, modelA, core.NewFixedPrice(big.NewRat(100, 1)))
+		BroadcastCfg.SetCapabilityMaxPrice(capability, modelB, core.NewFixedPrice(big.NewRat(100, 1)))
+		defer BroadcastCfg.SetCapabilityMaxPrice(capability, modelA, nil)
+		defer BroadcastCfg.SetCapabilityMaxPrice(capability, modelB, nil)
+
+		capsA := core.NewCapabilities([]core.Capability{capability}, nil)
+		capsA.SetPerCapabilityConstraints(core.PerCapabilityConstraints{
+			capability: &core.CapabilityConstraints{
+				Models: map[string]*core.ModelConstraint{
+					modelA: {},
+				},
+			},
+		})
+		capsB := core.NewCapabilities([]core.Capability{capability}, nil)
+		capsB.SetPerCapabilityConstraints(core.PerCapabilityConstraints{
+			capability: &core.CapabilityConstraints{
+				Models: map[string]*core.ModelConstraint{
+					modelB: {},
+				},
+			},
+		})
+
+		node := &core.LivepeerNode{}
+		require.NoError(node.UpdateNetworkCapabilities([]*common.OrchNetworkCapabilities{
+			{
+				OrchURI:      "https://orch-a.example.com:8935",
+				Capabilities: capsA.ToNetCapabilities(),
+				PriceInfo:    &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 1},
+			},
+		}))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		rdp := &remoteDiscoveryPool{
+			node:         node,
+			refreshEvery: time.Minute,
+			ctx:          ctx,
+			cancel:       cancel,
+		}
+		ls := &LivepeerServer{}
+
+		callDiscovery := func() []discoveryResponse {
+			req := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
+			rr := httptest.NewRecorder()
+			ls.GetOrchestrators(rdp, rr, req)
+			require.Equal(http.StatusOK, rr.Code)
+			var resp []discoveryResponse
+			require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+			return resp
+		}
+
+		// First request populates cache.
+		resp := callDiscovery()
+		require.Len(resp, 1)
+		require.Equal("https://orch-a.example.com:8935", resp[0].Address)
+		require.Equal([]string{"live-video-to-video/model-a"}, resp[0].Capabilities)
+
+		// Update source network capabilities, but stay within refresh interval.
+		require.NoError(node.UpdateNetworkCapabilities([]*common.OrchNetworkCapabilities{
+			{
+				OrchURI:      "https://orch-b.example.com:8935",
+				Capabilities: capsB.ToNetCapabilities(),
+				PriceInfo:    &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 1},
+			},
+		}))
+		time.Sleep(30 * time.Second)
+		resp = callDiscovery()
+		require.Len(resp, 1)
+		require.Equal("https://orch-a.example.com:8935", resp[0].Address)
+
+		// Once interval elapses, discovery response should reflect refreshed cache.
+		time.Sleep(31 * time.Second)
+		resp = callDiscovery()
+		require.Len(resp, 1)
+		require.Equal("https://orch-b.example.com:8935", resp[0].Address)
+		require.Equal([]string{"live-video-to-video/model-b"}, resp[0].Capabilities)
+	})
 }

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/base64"
@@ -775,13 +774,9 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 		},
 	}))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	rdp := &remoteDiscoveryPool{
 		node:         node,
 		refreshEvery: time.Hour,
-		ctx:          ctx,
-		cancel:       cancel,
 	}
 	rdp.refresh()
 	ls := &LivepeerServer{}
@@ -851,8 +846,6 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	invalidRDP := &remoteDiscoveryPool{
 		node:         invalidOnlyNode,
 		refreshEvery: time.Hour,
-		ctx:          ctx,
-		cancel:       cancel,
 	}
 	invalidRDP.refresh()
 	invalidReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
@@ -871,8 +864,6 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	emptyRDP := &remoteDiscoveryPool{
 		node:         emptyNode,
 		refreshEvery: time.Hour,
-		ctx:          ctx,
-		cancel:       cancel,
 	}
 	emptyRDP.refresh()
 	emptyReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
@@ -920,13 +911,9 @@ func TestRemoteSigner_Discovery_RefreshesAfterInterval(t *testing.T) {
 			},
 		}))
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 		rdp := &remoteDiscoveryPool{
 			node:         node,
 			refreshEvery: time.Minute,
-			ctx:          ctx,
-			cancel:       cancel,
 		}
 		ls := &LivepeerServer{}
 

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -678,14 +678,99 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	require.NoError(err)
 	u2, err := url.Parse("https://orch2.example.com:8935")
 	require.NoError(err)
+	u3, err := url.Parse("https://orch3.example.com:8935")
+	require.NoError(err)
+
+	maxPrice, err := core.NewAutoConvertedPrice("", big.NewRat(100, 1), nil)
+	require.NoError(err)
+	BroadcastCfg.SetCapabilityMaxPrice(core.Capability_LiveVideoToVideo, "model-a", maxPrice)
+	defer BroadcastCfg.SetCapabilityMaxPrice(core.Capability_LiveVideoToVideo, "model-a", nil)
+
+	orch1Caps := &net.Capabilities{
+		Constraints: &net.Capabilities_Constraints{
+			PerCapability: map[uint32]*net.Capabilities_CapabilityConstraints{
+				uint32(core.Capability_LiveVideoToVideo): {
+					Models: map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint{
+						"model-a": {},
+					},
+				},
+			},
+		},
+	}
+	orch2Caps := &net.Capabilities{
+		Constraints: &net.Capabilities_Constraints{
+			PerCapability: map[uint32]*net.Capabilities_CapabilityConstraints{
+				uint32(core.Capability_LiveVideoToVideo): {
+					Models: map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint{
+						"model-a": {},
+					},
+				},
+				uint32(core.Capability_TextToImage): {
+					Models: map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint{
+						"model-b": {},
+					},
+				},
+			},
+		},
+	}
 
 	mockPool := &mockOrchestratorPool{
 		descriptors: common.OrchestratorDescriptors{
 			{
 				LocalInfo: &common.OrchestratorLocalInfo{URL: u1, Score: 1.0},
+				RemoteInfo: &net.OrchestratorInfo{
+					Capabilities: orch1Caps,
+					CapabilitiesPrices: []*net.PriceInfo{
+						{
+							PricePerUnit:  80,
+							PixelsPerUnit: 1,
+							Capability:    uint32(core.Capability_LiveVideoToVideo),
+							Constraint:    "model-a",
+						},
+					},
+				},
 			},
 			{
 				LocalInfo: &common.OrchestratorLocalInfo{URL: u2, Score: 0.8},
+				RemoteInfo: &net.OrchestratorInfo{
+					Capabilities: orch2Caps,
+					CapabilitiesPrices: []*net.PriceInfo{
+						{
+							PricePerUnit:  120,
+							PixelsPerUnit: 1,
+							Capability:    uint32(core.Capability_LiveVideoToVideo),
+							Constraint:    "model-a",
+						},
+						{
+							PricePerUnit:  50,
+							PixelsPerUnit: 1,
+							Capability:    uint32(core.Capability_TextToImage),
+							Constraint:    "model-b",
+						},
+					},
+				},
+			},
+			{
+				// All capabilities are above max price; descriptor should be dropped.
+				LocalInfo: &common.OrchestratorLocalInfo{URL: u3, Score: 0.7},
+				RemoteInfo: &net.OrchestratorInfo{
+					Capabilities: orch1Caps,
+					CapabilitiesPrices: []*net.PriceInfo{
+						{
+							PricePerUnit:  200,
+							PixelsPerUnit: 1,
+							Capability:    uint32(core.Capability_LiveVideoToVideo),
+							Constraint:    "model-a",
+						},
+					},
+				},
+			},
+			{
+				// Invalid descriptor should be dropped during refresh and never returned.
+				LocalInfo: nil,
+				RemoteInfo: &net.OrchestratorInfo{
+					Capabilities: orch2Caps,
+				},
 			},
 		},
 	}
@@ -717,8 +802,53 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	require.Len(resp, 2)
 	require.Equal("https://orch1.example.com:8935", resp[0].Address)
 	require.Equal(float32(1.0), resp[0].Score)
+	require.Equal([]string{"live-video-to-video/model-a"}, resp[0].Capabilities)
 	require.Equal("https://orch2.example.com:8935", resp[1].Address)
 	require.Equal(float32(0.8), resp[1].Score)
+	require.Equal([]string{"text-to-image/model-b"}, resp[1].Capabilities)
+
+	capsReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators?caps=live-video-to-video/model-a", nil)
+	capsRR := httptest.NewRecorder()
+	ls.GetOrchestrators(rdp, capsRR, capsReq)
+	require.Equal(http.StatusOK, capsRR.Code)
+	var capsResp []discoveryResponse
+	require.NoError(json.NewDecoder(capsRR.Body).Decode(&capsResp))
+	require.Len(capsResp, 1)
+	require.Equal("https://orch1.example.com:8935", capsResp[0].Address)
+
+	repeatedReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators?caps=live-video-to-video/model-a&caps=text-to-image/model-b", nil)
+	repeatedRR := httptest.NewRecorder()
+	ls.GetOrchestrators(rdp, repeatedRR, repeatedReq)
+	require.Equal(http.StatusOK, repeatedRR.Code)
+	var repeatedResp []discoveryResponse
+	require.NoError(json.NewDecoder(repeatedRR.Body).Decode(&repeatedResp))
+	require.Len(repeatedResp, 2)
+	require.Equal("https://orch1.example.com:8935", repeatedResp[0].Address)
+	require.Equal("https://orch2.example.com:8935", repeatedResp[1].Address)
+
+	// If refresh only receives invalid descriptors, cache should remain empty
+	// and discovery endpoint should return service unavailable.
+	invalidOnlyPool := &mockOrchestratorPool{
+		descriptors: common.OrchestratorDescriptors{
+			{
+				LocalInfo: nil,
+				RemoteInfo: &net.OrchestratorInfo{
+					Capabilities: orch1Caps,
+				},
+			},
+		},
+	}
+	invalidRDP := &remoteDiscoveryPool{
+		pool:         invalidOnlyPool,
+		refreshEvery: time.Hour,
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+	invalidRDP.refresh()
+	invalidReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
+	invalidRR := httptest.NewRecorder()
+	ls.GetOrchestrators(invalidRDP, invalidRR, invalidReq)
+	require.Equal(http.StatusServiceUnavailable, invalidRR.Code)
 
 	emptyReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
 	emptyRR := httptest.NewRecorder()

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -856,10 +856,8 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(resp, 2)
 	require.Equal("https://orch1.example.com:8935", resp[0].Address)
-	require.Equal(float32(1.0), resp[0].Score)
 	require.Equal([]string{"live-video-to-video/model-a"}, resp[0].Capabilities)
 	require.Equal("https://orch2.example.com:8935", resp[1].Address)
-	require.Equal(float32(0.8), resp[1].Score)
 	require.Equal([]string{"text-to-image/model-b"}, resp[1].Capabilities)
 
 	capsReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators?caps=live-video-to-video/model-a", nil)

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -73,7 +74,10 @@ func (c *testEthClient) SignTypedData(apitypes.TypedData) ([]byte, error) {
 
 // mockOrchestratorPool implements common.OrchestratorPool for testing
 type mockOrchestratorPool struct {
-	infos []common.OrchestratorLocalInfo
+	infos                []common.OrchestratorLocalInfo
+	descriptors          common.OrchestratorDescriptors
+	getOrchestratorsErr  error
+	getOrchestratorCalls int32
 }
 
 func (m *mockOrchestratorPool) GetInfos() []common.OrchestratorLocalInfo {
@@ -81,10 +85,14 @@ func (m *mockOrchestratorPool) GetInfos() []common.OrchestratorLocalInfo {
 }
 
 func (m *mockOrchestratorPool) GetOrchestrators(ctx context.Context, num int, suspender common.Suspender, caps common.CapabilityComparator, scorePred common.ScorePred) (common.OrchestratorDescriptors, error) {
-	return nil, nil
+	atomic.AddInt32(&m.getOrchestratorCalls, 1)
+	return m.descriptors, m.getOrchestratorsErr
 }
 
 func (m *mockOrchestratorPool) Size() int {
+	if len(m.descriptors) > 0 {
+		return len(m.descriptors)
+	}
 	return len(m.infos)
 }
 
@@ -94,6 +102,10 @@ func (m *mockOrchestratorPool) SizeWith(scorePred common.ScorePred) int {
 
 func (m *mockOrchestratorPool) Broadcaster() common.Broadcaster {
 	return nil
+}
+
+func (m *mockOrchestratorPool) GetOrchestratorsCalls() int32 {
+	return atomic.LoadInt32(&m.getOrchestratorCalls)
 }
 
 func TestGenerateLivePayment_RequestValidationErrors(t *testing.T) {
@@ -659,7 +671,7 @@ func TestGenerateLivePayment_LV2V_Succeeds(t *testing.T) {
 
 }
 
-func TestRemoteSigner_Discovery_ReturnsConfiguredOrchestrators(t *testing.T) {
+func TestRemoteSigner_Discovery(t *testing.T) {
 	require := require.New(t)
 
 	u1, err := url.Parse("https://orch1.example.com:8935")
@@ -668,23 +680,37 @@ func TestRemoteSigner_Discovery_ReturnsConfiguredOrchestrators(t *testing.T) {
 	require.NoError(err)
 
 	mockPool := &mockOrchestratorPool{
-		infos: []common.OrchestratorLocalInfo{
-			{URL: u1, Score: 1.0},
-			{URL: u2, Score: 0.8},
+		descriptors: common.OrchestratorDescriptors{
+			{
+				LocalInfo: &common.OrchestratorLocalInfo{URL: u1, Score: 1.0},
+			},
+			{
+				LocalInfo: &common.OrchestratorLocalInfo{URL: u2, Score: 0.8},
+			},
 		},
 	}
 
-	node, _ := core.NewLivepeerNode(nil, "", nil)
-	node.OrchestratorPool = mockPool
-	ls := &LivepeerServer{LivepeerNode: node}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rdp := &remoteDiscoveryPool{
+		pool:         mockPool,
+		refreshEvery: time.Hour,
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+	rdp.refresh()
+	ls := &LivepeerServer{}
 
-	req := httptest.NewRequest(http.MethodGet, "/orchestrators", nil)
+	req := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
 	rr := httptest.NewRecorder()
 
-	ls.GetOrchestrators(rr, req)
+	callsBefore := mockPool.GetOrchestratorsCalls()
+	ls.GetOrchestrators(rdp, rr, req)
+	callsAfter := mockPool.GetOrchestratorsCalls()
 
 	require.Equal(http.StatusOK, rr.Code)
 	require.Equal("application/json", rr.Header().Get("Content-Type"))
+	require.Equal(callsBefore, callsAfter, "handler should only read cached data")
 
 	var resp []discoveryResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
@@ -693,4 +719,10 @@ func TestRemoteSigner_Discovery_ReturnsConfiguredOrchestrators(t *testing.T) {
 	require.Equal(float32(1.0), resp[0].Score)
 	require.Equal("https://orch2.example.com:8935", resp[1].Address)
 	require.Equal(float32(0.8), resp[1].Score)
+
+	emptyReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
+	emptyRR := httptest.NewRecorder()
+	ls.GetOrchestrators(&remoteDiscoveryPool{}, emptyRR, emptyReq)
+	require.Equal(http.StatusServiceUnavailable, emptyRR.Code)
+	require.Equal("application/json", emptyRR.Header().Get("Content-Type"))
 }

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -10,8 +10,6 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -70,70 +68,6 @@ func (c *testEthClient) Sign(msg []byte) ([]byte, error) {
 
 func (c *testEthClient) SignTypedData(apitypes.TypedData) ([]byte, error) {
 	return []byte("stub"), nil
-}
-
-// mockOrchestratorPool implements common.OrchestratorPool for testing
-type mockOrchestratorPool struct {
-	infos                []common.OrchestratorLocalInfo
-	descriptors          common.OrchestratorDescriptors
-	getOrchInfo          func(*url.URL, *net.Capabilities) (*net.OrchestratorInfo, error)
-	getOrchestratorsErr  error
-	getOrchestratorCalls int32
-}
-
-func (m *mockOrchestratorPool) GetInfos() []common.OrchestratorLocalInfo {
-	return m.infos
-}
-
-func (m *mockOrchestratorPool) GetOrchestrators(ctx context.Context, num int, suspender common.Suspender, caps common.CapabilityComparator, scorePred common.ScorePred) (common.OrchestratorDescriptors, error) {
-	_ = ctx
-	_ = num
-	_ = suspender
-	_ = scorePred
-	atomic.AddInt32(&m.getOrchestratorCalls, 1)
-	if m.getOrchInfo != nil {
-		var netCaps *net.Capabilities
-		if caps != nil {
-			netCaps = caps.ToNetCapabilities()
-		}
-		if len(m.infos) == 0 {
-			return nil, nil
-		}
-
-		ods := make(common.OrchestratorDescriptors, 0, len(m.infos))
-		for i := range m.infos {
-			localInfo := m.infos[i]
-			remoteInfo, err := m.getOrchInfo(localInfo.URL, netCaps)
-			if err != nil {
-				return nil, err
-			}
-			ods = append(ods, common.OrchestratorDescriptor{
-				LocalInfo:  &localInfo,
-				RemoteInfo: remoteInfo,
-			})
-		}
-		return ods, nil
-	}
-	return m.descriptors, m.getOrchestratorsErr
-}
-
-func (m *mockOrchestratorPool) Size() int {
-	if len(m.descriptors) > 0 {
-		return len(m.descriptors)
-	}
-	return len(m.infos)
-}
-
-func (m *mockOrchestratorPool) SizeWith(scorePred common.ScorePred) int {
-	return len(m.infos)
-}
-
-func (m *mockOrchestratorPool) Broadcaster() common.Broadcaster {
-	return nil
-}
-
-func (m *mockOrchestratorPool) GetOrchestratorsCalls() int32 {
-	return atomic.LoadInt32(&m.getOrchestratorCalls)
 }
 
 func TestGenerateLivePayment_RequestValidationErrors(t *testing.T) {
@@ -702,16 +636,7 @@ func TestGenerateLivePayment_LV2V_Succeeds(t *testing.T) {
 func TestRemoteSigner_Discovery(t *testing.T) {
 	require := require.New(t)
 
-	u1, err := url.Parse("https://orch1.example.com:8935")
-	require.NoError(err)
-	u2, err := url.Parse("https://orch2.example.com:8935")
-	require.NoError(err)
-	u3, err := url.Parse("https://orch3.example.com:8935")
-	require.NoError(err)
-
-	maxPrice, err := core.NewAutoConvertedPrice("", big.NewRat(100, 1), nil)
-	require.NoError(err)
-	BroadcastCfg.SetCapabilityMaxPrice(core.Capability_LiveVideoToVideo, "model-a", maxPrice)
+	BroadcastCfg.SetCapabilityMaxPrice(core.Capability_LiveVideoToVideo, "model-a", core.NewFixedPrice(big.NewRat(100, 1)))
 	defer BroadcastCfg.SetCapabilityMaxPrice(core.Capability_LiveVideoToVideo, "model-a", nil)
 
 	orch1Caps := &net.Capabilities{
@@ -742,18 +667,20 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 		},
 	}
 
-	// Remote discovery refresh calls into the orchestrator pool with nil capabilities in order to
-	// fetch the "capability menu" pricing (i.e. `CapabilitiesPrices`) for all capabilities.
+	// Remote discovery refresh reads from the node's network capability cache.
 	//
 	// Each orchestrator below has a specific purpose:
 	// - orch1: Has a single eligible capability priced below the configured max price.
 	// - orch2: Has two capabilities, but only one is eligible (the other is filtered out).
 	// - orch3: Has capabilities priced above the max price, so it should be dropped entirely.
-	// - invalid: Has an invalid descriptor (nil URL) and should never be returned from cache.
+	// - invalid: Has an invalid URI and should never be returned from discovery.
 	//
-	// Note: Prices are returned as `CapabilitiesPrices` (capability menu pricing), not via global `PriceInfo`.
-	infoByURL := map[string]*net.OrchestratorInfo{
-		u1.String(): {
+	// Note: Prices are returned as `CapabilitiesPrices` (capability menu pricing), not via global
+	// `PriceInfo` (which is intentionally expensive in these fixtures).
+	node := &core.LivepeerNode{}
+	require.NoError(node.UpdateNetworkCapabilities([]*common.OrchNetworkCapabilities{
+		{
+			OrchURI:      "https://orch1.example.com:8935",
 			Capabilities: orch1Caps,
 			// Global fallback price is intentionally expensive.
 			PriceInfo: &net.PriceInfo{PricePerUnit: 200, PixelsPerUnit: 1},
@@ -766,7 +693,8 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 				},
 			},
 		},
-		u2.String(): {
+		{
+			OrchURI:      "https://orch2.example.com:8935",
 			Capabilities: orch2Caps,
 			// Global fallback price is intentionally expensive.
 			PriceInfo: &net.PriceInfo{PricePerUnit: 200, PixelsPerUnit: 1},
@@ -787,7 +715,8 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 				},
 			},
 		},
-		u3.String(): {
+		{
+			OrchURI:      "https://orch3.example.com:8935",
 			Capabilities: orch1Caps,
 			// Global fallback price is intentionally expensive.
 			PriceInfo: &net.PriceInfo{PricePerUnit: 200, PixelsPerUnit: 1},
@@ -801,39 +730,18 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 				},
 			},
 		},
-	}
-
-	mockPool := &mockOrchestratorPool{
-		infos: []common.OrchestratorLocalInfo{
-			// orch1: returned; advertises live-video-to-video/model-a
-			{URL: u1, Score: 1.0},
-			// orch2: returned; advertises text-to-image/model-b
-			{URL: u2, Score: 0.8},
-			// orch3: dropped; all capabilities exceed max price
-			{URL: u3, Score: 0.7},
-			// Invalid descriptor (nil URL) should be dropped during refresh and never returned.
-			{URL: nil, Score: 0.6},
+		// Invalid URI should be dropped during refresh and never returned from discovery.
+		{
+			OrchURI:      "://invalid-uri",
+			Capabilities: orch1Caps,
+			PriceInfo:    &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 1},
 		},
-		getOrchInfo: func(orchURL *url.URL, caps *net.Capabilities) (*net.OrchestratorInfo, error) {
-			require.Nil(caps, "remote discovery refresh should fetch without capabilities")
-
-			// Invalid descriptor should be dropped during refresh and never returned.
-			if orchURL == nil {
-				return &net.OrchestratorInfo{Capabilities: orch2Caps}, nil
-			}
-
-			info := infoByURL[orchURL.String()]
-			if info == nil {
-				return &net.OrchestratorInfo{Capabilities: orch2Caps}, nil
-			}
-			return info, nil
-		},
-	}
+	}))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	rdp := &remoteDiscoveryPool{
-		pool:         mockPool,
+		node:         node,
 		refreshEvery: time.Hour,
 		ctx:          ctx,
 		cancel:       cancel,
@@ -844,22 +752,19 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	httpReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
 	rr := httptest.NewRecorder()
 
-	callsBefore := mockPool.GetOrchestratorsCalls()
 	ls.GetOrchestrators(rdp, rr, httpReq)
-	callsAfter := mockPool.GetOrchestratorsCalls()
 
 	require.Equal(http.StatusOK, rr.Code)
 	require.Equal("application/json", rr.Header().Get("Content-Type"))
-	require.Equal(callsBefore, callsAfter, "handler should only read cached data")
 
 	var resp []discoveryResponse
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(resp, 2)
 	require.Equal("https://orch1.example.com:8935", resp[0].Address)
-	require.Equal(float32(1.0), resp[0].Score)
+	require.Greater(resp[0].Score, float32(0))
 	require.Equal([]string{"live-video-to-video/model-a"}, resp[0].Capabilities)
 	require.Equal("https://orch2.example.com:8935", resp[1].Address)
-	require.Equal(float32(0.8), resp[1].Score)
+	require.Greater(resp[1].Score, float32(0))
 	require.Equal([]string{"text-to-image/model-b"}, resp[1].Capabilities)
 
 	capsReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators?caps=live-video-to-video/model-a", nil)
@@ -881,20 +786,33 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	require.Equal("https://orch1.example.com:8935", repeatedResp[0].Address)
 	require.Equal("https://orch2.example.com:8935", repeatedResp[1].Address)
 
-	// If refresh only receives invalid descriptors, cache should remain empty
+	// If refresh only receives invalid network capability entries, cache should remain empty
 	// and discovery endpoint should return service unavailable.
-	invalidOnlyPool := &mockOrchestratorPool{
-		descriptors: common.OrchestratorDescriptors{
-			{
-				LocalInfo: nil,
-				RemoteInfo: &net.OrchestratorInfo{
-					Capabilities: orch1Caps,
+	invalidOnlyNode := &core.LivepeerNode{}
+	require.NoError(invalidOnlyNode.UpdateNetworkCapabilities([]*common.OrchNetworkCapabilities{
+		{
+			OrchURI: "",
+			Capabilities: &net.Capabilities{
+				Constraints: &net.Capabilities_Constraints{
+					PerCapability: map[uint32]*net.Capabilities_CapabilityConstraints{
+						uint32(core.Capability_LiveVideoToVideo): {
+							Models: map[string]*net.Capabilities_CapabilityConstraints_ModelConstraint{
+								"model-a": {},
+							},
+						},
+					},
 				},
 			},
+			PriceInfo: &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 1},
 		},
-	}
+		{
+			OrchURI:      "://also-invalid",
+			Capabilities: orch1Caps,
+			PriceInfo:    &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 1},
+		},
+	}))
 	invalidRDP := &remoteDiscoveryPool{
-		pool:         invalidOnlyPool,
+		node:         invalidOnlyNode,
 		refreshEvery: time.Hour,
 		ctx:          ctx,
 		cancel:       cancel,
@@ -905,9 +823,24 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	ls.GetOrchestrators(invalidRDP, invalidRR, invalidReq)
 	require.Equal(http.StatusServiceUnavailable, invalidRR.Code)
 
+	emptyNode := &core.LivepeerNode{}
+	require.NoError(emptyNode.UpdateNetworkCapabilities([]*common.OrchNetworkCapabilities{
+		{
+			OrchURI:      "https://too-expensive.example.com:8935",
+			Capabilities: orch1Caps,
+			PriceInfo:    &net.PriceInfo{PricePerUnit: 200, PixelsPerUnit: 1},
+		},
+	}))
+	emptyRDP := &remoteDiscoveryPool{
+		node:         emptyNode,
+		refreshEvery: time.Hour,
+		ctx:          ctx,
+		cancel:       cancel,
+	}
+	emptyRDP.refresh()
 	emptyReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
 	emptyRR := httptest.NewRecorder()
-	ls.GetOrchestrators(&remoteDiscoveryPool{}, emptyRR, emptyReq)
+	ls.GetOrchestrators(emptyRDP, emptyRR, emptyReq)
 	require.Equal(http.StatusServiceUnavailable, emptyRR.Code)
 	require.Equal("application/json", emptyRR.Header().Get("Content-Type"))
 }

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -856,8 +856,10 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
 	require.Len(resp, 2)
 	require.Equal("https://orch1.example.com:8935", resp[0].Address)
+	require.Equal(float32(1.0), resp[0].Score)
 	require.Equal([]string{"live-video-to-video/model-a"}, resp[0].Capabilities)
 	require.Equal("https://orch2.example.com:8935", resp[1].Address)
+	require.Equal(float32(0.8), resp[1].Score)
 	require.Equal([]string{"text-to-image/model-b"}, resp[1].Capabilities)
 
 	capsReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators?caps=live-video-to-video/model-a", nil)

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -76,6 +76,7 @@ func (c *testEthClient) SignTypedData(apitypes.TypedData) ([]byte, error) {
 type mockOrchestratorPool struct {
 	infos                []common.OrchestratorLocalInfo
 	descriptors          common.OrchestratorDescriptors
+	getOrchInfo          func(*url.URL, *net.Capabilities) (*net.OrchestratorInfo, error)
 	getOrchestratorsErr  error
 	getOrchestratorCalls int32
 }
@@ -85,7 +86,34 @@ func (m *mockOrchestratorPool) GetInfos() []common.OrchestratorLocalInfo {
 }
 
 func (m *mockOrchestratorPool) GetOrchestrators(ctx context.Context, num int, suspender common.Suspender, caps common.CapabilityComparator, scorePred common.ScorePred) (common.OrchestratorDescriptors, error) {
+	_ = ctx
+	_ = num
+	_ = suspender
+	_ = scorePred
 	atomic.AddInt32(&m.getOrchestratorCalls, 1)
+	if m.getOrchInfo != nil {
+		var netCaps *net.Capabilities
+		if caps != nil {
+			netCaps = caps.ToNetCapabilities()
+		}
+		if len(m.infos) == 0 {
+			return nil, nil
+		}
+
+		ods := make(common.OrchestratorDescriptors, 0, len(m.infos))
+		for i := range m.infos {
+			localInfo := m.infos[i]
+			remoteInfo, err := m.getOrchInfo(localInfo.URL, netCaps)
+			if err != nil {
+				return nil, err
+			}
+			ods = append(ods, common.OrchestratorDescriptor{
+				LocalInfo:  &localInfo,
+				RemoteInfo: remoteInfo,
+			})
+		}
+		return ods, nil
+	}
 	return m.descriptors, m.getOrchestratorsErr
 }
 
@@ -714,64 +742,91 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 		},
 	}
 
+	// Remote discovery refresh calls into the orchestrator pool with nil capabilities in order to
+	// fetch the "capability menu" pricing (i.e. `CapabilitiesPrices`) for all capabilities.
+	//
+	// Each orchestrator below has a specific purpose:
+	// - orch1: Has a single eligible capability priced below the configured max price.
+	// - orch2: Has two capabilities, but only one is eligible (the other is filtered out).
+	// - orch3: Has capabilities priced above the max price, so it should be dropped entirely.
+	// - invalid: Has an invalid descriptor (nil URL) and should never be returned from cache.
+	//
+	// Note: Prices are returned as `CapabilitiesPrices` (capability menu pricing), not via global `PriceInfo`.
+	infoByURL := map[string]*net.OrchestratorInfo{
+		u1.String(): {
+			Capabilities: orch1Caps,
+			// Global fallback price is intentionally expensive.
+			PriceInfo: &net.PriceInfo{PricePerUnit: 200, PixelsPerUnit: 1},
+			CapabilitiesPrices: []*net.PriceInfo{
+				{
+					PricePerUnit:  80,
+					PixelsPerUnit: 1,
+					Capability:    uint32(core.Capability_LiveVideoToVideo),
+					Constraint:    "model-a",
+				},
+			},
+		},
+		u2.String(): {
+			Capabilities: orch2Caps,
+			// Global fallback price is intentionally expensive.
+			PriceInfo: &net.PriceInfo{PricePerUnit: 200, PixelsPerUnit: 1},
+			CapabilitiesPrices: []*net.PriceInfo{
+				// This capability is above max price and should be filtered out.
+				{
+					PricePerUnit:  120,
+					PixelsPerUnit: 1,
+					Capability:    uint32(core.Capability_LiveVideoToVideo),
+					Constraint:    "model-a",
+				},
+				// This capability remains eligible and should be exposed via discovery.
+				{
+					PricePerUnit:  50,
+					PixelsPerUnit: 1,
+					Capability:    uint32(core.Capability_TextToImage),
+					Constraint:    "model-b",
+				},
+			},
+		},
+		u3.String(): {
+			Capabilities: orch1Caps,
+			// Global fallback price is intentionally expensive.
+			PriceInfo: &net.PriceInfo{PricePerUnit: 200, PixelsPerUnit: 1},
+			CapabilitiesPrices: []*net.PriceInfo{
+				// All capabilities above max price, so the orchestrator should be dropped.
+				{
+					PricePerUnit:  200,
+					PixelsPerUnit: 1,
+					Capability:    uint32(core.Capability_LiveVideoToVideo),
+					Constraint:    "model-a",
+				},
+			},
+		},
+	}
+
 	mockPool := &mockOrchestratorPool{
-		descriptors: common.OrchestratorDescriptors{
-			{
-				LocalInfo: &common.OrchestratorLocalInfo{URL: u1, Score: 1.0},
-				RemoteInfo: &net.OrchestratorInfo{
-					Capabilities: orch1Caps,
-					CapabilitiesPrices: []*net.PriceInfo{
-						{
-							PricePerUnit:  80,
-							PixelsPerUnit: 1,
-							Capability:    uint32(core.Capability_LiveVideoToVideo),
-							Constraint:    "model-a",
-						},
-					},
-				},
-			},
-			{
-				LocalInfo: &common.OrchestratorLocalInfo{URL: u2, Score: 0.8},
-				RemoteInfo: &net.OrchestratorInfo{
-					Capabilities: orch2Caps,
-					CapabilitiesPrices: []*net.PriceInfo{
-						{
-							PricePerUnit:  120,
-							PixelsPerUnit: 1,
-							Capability:    uint32(core.Capability_LiveVideoToVideo),
-							Constraint:    "model-a",
-						},
-						{
-							PricePerUnit:  50,
-							PixelsPerUnit: 1,
-							Capability:    uint32(core.Capability_TextToImage),
-							Constraint:    "model-b",
-						},
-					},
-				},
-			},
-			{
-				// All capabilities are above max price; descriptor should be dropped.
-				LocalInfo: &common.OrchestratorLocalInfo{URL: u3, Score: 0.7},
-				RemoteInfo: &net.OrchestratorInfo{
-					Capabilities: orch1Caps,
-					CapabilitiesPrices: []*net.PriceInfo{
-						{
-							PricePerUnit:  200,
-							PixelsPerUnit: 1,
-							Capability:    uint32(core.Capability_LiveVideoToVideo),
-							Constraint:    "model-a",
-						},
-					},
-				},
-			},
-			{
-				// Invalid descriptor should be dropped during refresh and never returned.
-				LocalInfo: nil,
-				RemoteInfo: &net.OrchestratorInfo{
-					Capabilities: orch2Caps,
-				},
-			},
+		infos: []common.OrchestratorLocalInfo{
+			// orch1: returned; advertises live-video-to-video/model-a
+			{URL: u1, Score: 1.0},
+			// orch2: returned; advertises text-to-image/model-b
+			{URL: u2, Score: 0.8},
+			// orch3: dropped; all capabilities exceed max price
+			{URL: u3, Score: 0.7},
+			// Invalid descriptor (nil URL) should be dropped during refresh and never returned.
+			{URL: nil, Score: 0.6},
+		},
+		getOrchInfo: func(orchURL *url.URL, caps *net.Capabilities) (*net.OrchestratorInfo, error) {
+			require.Nil(caps, "remote discovery refresh should fetch without capabilities")
+
+			// Invalid descriptor should be dropped during refresh and never returned.
+			if orchURL == nil {
+				return &net.OrchestratorInfo{Capabilities: orch2Caps}, nil
+			}
+
+			info := infoByURL[orchURL.String()]
+			if info == nil {
+				return &net.OrchestratorInfo{Capabilities: orch2Caps}, nil
+			}
+			return info, nil
 		},
 	}
 
@@ -786,11 +841,11 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	rdp.refresh()
 	ls := &LivepeerServer{}
 
-	req := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
+	httpReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
 	rr := httptest.NewRecorder()
 
 	callsBefore := mockPool.GetOrchestratorsCalls()
-	ls.GetOrchestrators(rdp, rr, req)
+	ls.GetOrchestrators(rdp, rr, httpReq)
 	callsAfter := mockPool.GetOrchestratorsCalls()
 
 	require.Equal(http.StatusOK, rr.Code)

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -818,10 +818,10 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	require.Equal("https://orch1.example.com:8935", repeatedResp[0].Address)
 	require.Equal("https://orch2.example.com:8935", repeatedResp[1].Address)
 
-	// If refresh only receives invalid network capability entries, cache should remain empty
-	// and discovery endpoint should return service unavailable.
-	invalidOnlyNode := &core.LivepeerNode{}
-	require.NoError(invalidOnlyNode.UpdateNetworkCapabilities([]*common.OrchNetworkCapabilities{
+	// If refresh only receives invalid or ineligible network capability entries,
+	// cache should remain empty and discovery should return service unavailable.
+	ineligibleNode := &core.LivepeerNode{}
+	require.NoError(ineligibleNode.UpdateNetworkCapabilities([]*common.OrchNetworkCapabilities{
 		{
 			OrchURI: "",
 			Capabilities: &net.Capabilities{
@@ -842,35 +842,35 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 			Capabilities: orch1Caps,
 			PriceInfo:    &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 1},
 		},
-	}))
-	invalidRDP := &remoteDiscoveryPool{
-		node:         invalidOnlyNode,
-		refreshEvery: time.Hour,
-	}
-	invalidRDP.refresh()
-	invalidReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
-	invalidRR := httptest.NewRecorder()
-	ls.GetOrchestrators(invalidRDP, invalidRR, invalidReq)
-	require.Equal(http.StatusServiceUnavailable, invalidRR.Code)
-
-	emptyNode := &core.LivepeerNode{}
-	require.NoError(emptyNode.UpdateNetworkCapabilities([]*common.OrchNetworkCapabilities{
 		{
 			OrchURI:      "https://too-expensive.example.com:8935",
 			Capabilities: orch1Caps,
 			PriceInfo:    &net.PriceInfo{PricePerUnit: 200, PixelsPerUnit: 1},
 		},
+		{
+			OrchURI:      "https://missing-price.example.com:8935",
+			Capabilities: orch1Caps,
+			// Missing global and per-capability prices should be treated as ineligible
+			// when a max price is configured for this capability/model.
+			PriceInfo: &net.PriceInfo{PricePerUnit: 0, PixelsPerUnit: 0},
+		},
+		{
+			OrchURI:      "https://nil-price.example.com:8935",
+			Capabilities: orch1Caps,
+			// Explicit nil global price should also be treated as ineligible.
+			PriceInfo: nil,
+		},
 	}))
-	emptyRDP := &remoteDiscoveryPool{
-		node:         emptyNode,
+	ineligibleRDP := &remoteDiscoveryPool{
+		node:         ineligibleNode,
 		refreshEvery: time.Hour,
 	}
-	emptyRDP.refresh()
-	emptyReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
-	emptyRR := httptest.NewRecorder()
-	ls.GetOrchestrators(emptyRDP, emptyRR, emptyReq)
-	require.Equal(http.StatusServiceUnavailable, emptyRR.Code)
-	require.Equal("application/json", emptyRR.Header().Get("Content-Type"))
+	ineligibleRDP.refresh()
+	ineligibleReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators", nil)
+	ineligibleRR := httptest.NewRecorder()
+	ls.GetOrchestrators(ineligibleRDP, ineligibleRR, ineligibleReq)
+	require.Equal(http.StatusServiceUnavailable, ineligibleRR.Code)
+	require.Equal("application/json", ineligibleRR.Header().Get("Content-Type"))
 }
 
 func TestRemoteSigner_Discovery_RefreshesAfterInterval(t *testing.T) {

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -1742,3 +1742,27 @@ func Test_setLiveAICapacity(t *testing.T) {
 		})
 	}
 }
+
+func TestOrchestratorInfoWithCaps_NonNilEmptyCaps_DoesNotIncludeCapabilitiesPrices(t *testing.T) {
+	require := require.New(t)
+
+	oldNodeStorage := drivers.NodeStorage
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
+	defer func() { drivers.NodeStorage = oldNodeStorage }()
+
+	orch := &mockOrchestrator{}
+	addr := ethcommon.HexToAddress("0x1")
+
+	orch.On("Nodes").Return()
+	orch.On("Address").Return(addr)
+	orch.On("TicketParams", addr, mock.Anything).Return(&net.TicketParams{Recipient: pm.RandBytes(32)}, nil)
+	orch.On("AuthToken", mock.Anything, mock.Anything).Return(&net.AuthToken{Token: []byte("tok"), SessionId: "sess", Expiration: time.Now().Add(time.Hour).Unix()})
+
+	nonNilEmptyCaps := core.NewCapabilities(nil, nil).ToNetCapabilities()
+	info, err := orchestratorInfoWithCaps(orch, addr, "https://orch.example.com", "", nonNilEmptyCaps)
+	require.NoError(err)
+	require.Nil(info.CapabilitiesPrices, "non-nil (even if empty) caps should not return capabilities prices")
+
+	orch.AssertNotCalled(t, "GetCapabilitiesPrices", mock.Anything)
+	orch.AssertNotCalled(t, "PriceInfo", mock.Anything)
+}


### PR DESCRIPTION
This adds an optional remote discovery feature to the remote signer node. Client using the remote signer can now discover orchestrators and their supported capabilities on the network. The remote discovery endpoint is compatible with the existing orchestrator webhook, making it usable by go-livepeer as well as local gateway SDKs.

### Usage

* Remote signer node gets a `-remoteDiscovery` flag. This is only usable in remote signer mode for now and is opt-in. All the other gateway-side orchestrator configuration flags are supported here: `-orchWebhookUrl`, `-orchAddr `, `-orchBlocklist`, `-extraNodes` etc. Additionally, operators can tune the orchestrator refresh interval with the existing `-liveAICapReportInterval` flag.

* If the gateway is using a remote signer (via `-remoteSignerUrl`) and has no other orchestrator sources (eg, webhook, orchestrator list) then it will fall back to using the remote signer's discovery endpoint.

* The discovery endpoint is `GET /discover-orchestrators`. It returns a JSON list of [{"address":...,"capabilities":[...]}] where the address is the URI the orchestrator can be reached at, and the `capabilities` is a list of capabilities the orchestrator supports, eg `live-video-to-video/streamdiffusion`. There is also an optional `caps` query parameter to return only the subset of orchestrators matching the capability (exact string match). Multiple `caps` parameters can be included (OR).

### Remote Discovery Implementation

* Remote discovery builds on the existing DB discovery pool's orchestrator polling. The DB discovery pool periodically (via `-liveAICapReportInterval`) fetches orchestrator info from the network and updates the node's capability cache.
* The remote discovery pool lazily reads from this cache and builds a capability-indexed view for quick lookups.
* Price filtering happens during refresh, so it doesn't return orchestrators that will be later rejected by the remote signer due to price

### Supporting Changes

* DB Discovery pool and Webhook Discovery pool are updated to use a "builder pattern" of config structs + initializer, matching the regular orchestrator pool. The existing constructor interfaces are left untouched, but the plumbing underneath uses the new builder pattern. This is done to support the `IgnoreCapacityCheck` flag (see below)

* To avoid returning capacity errors during the DB Discovery refresh call (it is capabilities we want), we need to thread through the `IgnoreCapacityCheck` flag a couple places from the webhook, DB discovery, etc. Note that this flag is *only* in enabled when the node is in remote signer mode, so this change should not affect other modes such as the gateway.

* DB Discovery cache refreshes now incorporate the `ExtraNodes` field in order to fully traverse the orchestrators available on the network.

* To support price filtering during remote discovery, the PriceInfo field is added to `OrchNetworkCapabilities`.

* The `LiveAICapReportInterval` field was added to the LivepeerNode; this is just storing an existing flag so the remote signer node can use it. 

* Tests, docs, etc.