### PR TITLE
feat(capabilities): Merge byoc capabilities with existing capabilities and pricing

### DIFF
--- a/core/capabilities.go
+++ b/core/capabilities.go
@@ -88,6 +88,7 @@ const (
 	Capability_ImageToText                Capability = 34
 	Capability_LiveVideoToVideo           Capability = 35
 	Capability_TextToSpeech               Capability = 36
+	Capability_BYOCExternal               Capability = 37
 )
 
 var CapabilityNameLookup = map[Capability]string{
@@ -129,6 +130,7 @@ var CapabilityNameLookup = map[Capability]string{
 	Capability_ImageToText:                "Image to text",
 	Capability_LiveVideoToVideo:           "Live video to video",
 	Capability_TextToSpeech:               "Text to speech",
+	Capability_BYOCExternal:               "byoc_external",
 }
 
 var CapabilityTestLookup = map[Capability]CapabilityTest{

--- a/core/capabilities.go
+++ b/core/capabilities.go
@@ -88,7 +88,7 @@ const (
 	Capability_ImageToText                Capability = 34
 	Capability_LiveVideoToVideo           Capability = 35
 	Capability_TextToSpeech               Capability = 36
-	Capability_BYOCExternal               Capability = 37
+	Capability_BYOC                       Capability = 37
 )
 
 var CapabilityNameLookup = map[Capability]string{
@@ -130,7 +130,7 @@ var CapabilityNameLookup = map[Capability]string{
 	Capability_ImageToText:                "Image to text",
 	Capability_LiveVideoToVideo:           "Live video to video",
 	Capability_TextToSpeech:               "Text to speech",
-	Capability_BYOCExternal:               "byoc_external",
+	Capability_BYOC:                       "byoc",
 }
 
 var CapabilityTestLookup = map[Capability]CapabilityTest{

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1667,6 +1667,140 @@ func TestAllCapsPriceInfo(t *testing.T) {
 	}
 }
 
+func TestBYOCExternalCapabilityConstant(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal(Capability(37), Capability_BYOCExternal)
+
+	name, ok := CapabilityNameLookup[Capability_BYOCExternal]
+	assert.True(ok, "Capability_BYOCExternal should exist in CapabilityNameLookup")
+	assert.Equal("byoc_external", name)
+}
+
+func TestBYOCExternalCapsPriceInfo(t *testing.T) {
+	n, _ := NewLivepeerNode(nil, "", nil)
+	n.SetBasePrice("default", NewFixedPrice(big.NewRat(1, 1)))
+	n.Recipient = new(pm.MockRecipient)
+	orch := NewOrchestrator(n, nil)
+
+	addr1 := "0x1000000000000000000000000000000000000000"
+
+	n.ExternalCapabilities.Capabilities["my-service"] = &ExternalCapability{Name: "my-service"}
+	n.ExternalCapabilities.Capabilities["another-service"] = &ExternalCapability{Name: "another-service"}
+	n.SetPriceForExternalCapability("default", "my-service", big.NewRat(10, 1))
+	n.SetPriceForExternalCapability("default", "another-service", big.NewRat(20, 1))
+
+	// Also set a built-in cap price so we verify both coexist
+	n.SetBasePriceForCap("default", Capability_TextToImage, "default", NewFixedPrice(big.NewRat(5, 1)))
+
+	prices, err := orch.GetCapabilitiesPrices(ethcommon.HexToAddress(addr1))
+	assert.Nil(t, err)
+	assert.Len(t, prices, 3) // 1 built-in + 2 BYOC external
+
+	byocPrices := map[string]*net.PriceInfo{}
+	builtInCount := 0
+	for _, p := range prices {
+		if p.Capability == uint32(Capability_BYOCExternal) {
+			byocPrices[p.Constraint] = p
+		} else {
+			builtInCount++
+		}
+	}
+	assert.Equal(t, 1, builtInCount)
+	assert.Len(t, byocPrices, 2)
+
+	myService := byocPrices["my-service"]
+	assert.NotNil(t, myService)
+	assert.Equal(t, int64(10), myService.PricePerUnit)
+	assert.Equal(t, int64(1), myService.PixelsPerUnit)
+	assert.Equal(t, uint32(Capability_BYOCExternal), myService.Capability)
+	assert.Equal(t, "my-service", myService.Constraint)
+
+	anotherService := byocPrices["another-service"]
+	assert.NotNil(t, anotherService)
+	assert.Equal(t, int64(20), anotherService.PricePerUnit)
+}
+
+func TestBYOCExternalCapsSenderPricing(t *testing.T) {
+	n, _ := NewLivepeerNode(nil, "", nil)
+	n.SetBasePrice("default", NewFixedPrice(big.NewRat(1, 1)))
+	n.Recipient = new(pm.MockRecipient)
+	orch := NewOrchestrator(n, nil)
+
+	addr1 := "0x1000000000000000000000000000000000000000"
+	addr2 := "0x2000000000000000000000000000000000000000"
+	addr3 := "0x3000000000000000000000000000000000000000"
+
+	n.ExternalCapabilities.Capabilities["my-service"] = &ExternalCapability{Name: "my-service"}
+	n.SetPriceForExternalCapability("default", "my-service", big.NewRat(10, 1))
+	n.SetPriceForExternalCapability(addr1, "my-service", big.NewRat(100, 1))
+	n.SetPriceForExternalCapability(addr2, "my-service", big.NewRat(200, 1))
+
+	getBYOCPrice := func(addr string) int64 {
+		prices, err := orch.GetCapabilitiesPrices(ethcommon.HexToAddress(addr))
+		assert.Nil(t, err)
+		for _, p := range prices {
+			if p.Capability == uint32(Capability_BYOCExternal) {
+				return p.PricePerUnit
+			}
+		}
+		t.Fatalf("no BYOC price found for %s", addr)
+		return 0
+	}
+
+	assert.Equal(t, int64(100), getBYOCPrice(addr1), "sender-specific price")
+	assert.Equal(t, int64(200), getBYOCPrice(addr2), "sender-specific price")
+	assert.Equal(t, int64(10), getBYOCPrice(addr3), "falls back to default")
+}
+
+func TestBYOCExternalCapsPriceEdgeCases(t *testing.T) {
+	addr := "0x1000000000000000000000000000000000000000"
+
+	tests := []struct {
+		name          string
+		price         *big.Rat
+		nilExtCaps    bool
+		expectPresent bool
+		expectPrice   int64
+	}{
+		{"zero price included", big.NewRat(0, 1), false, true, 0},
+		{"negative price skipped", big.NewRat(-5, 1), false, false, 0},
+		{"nil ExternalCapabilities", nil, true, false, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, _ := NewLivepeerNode(nil, "", nil)
+			n.SetBasePrice("default", NewFixedPrice(big.NewRat(1, 1)))
+			n.Recipient = new(pm.MockRecipient)
+
+			if tt.nilExtCaps {
+				n.ExternalCapabilities = nil
+			} else {
+				n.ExternalCapabilities.Capabilities["svc"] = &ExternalCapability{Name: "svc"}
+				n.SetPriceForExternalCapability("default", "svc", tt.price)
+			}
+
+			orch := NewOrchestrator(n, nil)
+			prices, err := orch.GetCapabilitiesPrices(ethcommon.HexToAddress(addr))
+			assert.Nil(t, err)
+
+			var byocPrice *net.PriceInfo
+			for _, p := range prices {
+				if p.Capability == uint32(Capability_BYOCExternal) {
+					byocPrice = p
+				}
+			}
+
+			if tt.expectPresent {
+				assert.NotNil(t, byocPrice, "BYOC price should be present")
+				assert.Equal(t, tt.expectPrice, byocPrice.PricePerUnit)
+			} else {
+				assert.Nil(t, byocPrice, "BYOC price should not be present")
+			}
+		})
+	}
+}
+
 func TestDebitFees(t *testing.T) {
 	n, _ := NewLivepeerNode(nil, "", nil)
 	n.Balances = NewAddressBalances(5 * time.Second)

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -1669,11 +1669,11 @@ func TestAllCapsPriceInfo(t *testing.T) {
 
 func TestBYOCExternalCapabilityConstant(t *testing.T) {
 	assert := assert.New(t)
-	assert.Equal(Capability(37), Capability_BYOCExternal)
+	assert.Equal(Capability(37), Capability_BYOC)
 
-	name, ok := CapabilityNameLookup[Capability_BYOCExternal]
-	assert.True(ok, "Capability_BYOCExternal should exist in CapabilityNameLookup")
-	assert.Equal("byoc_external", name)
+	name, ok := CapabilityNameLookup[Capability_BYOC]
+	assert.True(ok, "Capability_BYOC should exist in CapabilityNameLookup")
+	assert.Equal("byoc", name)
 }
 
 func TestBYOCExternalCapsPriceInfo(t *testing.T) {
@@ -1699,7 +1699,7 @@ func TestBYOCExternalCapsPriceInfo(t *testing.T) {
 	byocPrices := map[string]*net.PriceInfo{}
 	builtInCount := 0
 	for _, p := range prices {
-		if p.Capability == uint32(Capability_BYOCExternal) {
+		if p.Capability == uint32(Capability_BYOC) {
 			byocPrices[p.Constraint] = p
 		} else {
 			builtInCount++
@@ -1712,7 +1712,7 @@ func TestBYOCExternalCapsPriceInfo(t *testing.T) {
 	assert.NotNil(t, myService)
 	assert.Equal(t, int64(10), myService.PricePerUnit)
 	assert.Equal(t, int64(1), myService.PixelsPerUnit)
-	assert.Equal(t, uint32(Capability_BYOCExternal), myService.Capability)
+	assert.Equal(t, uint32(Capability_BYOC), myService.Capability)
 	assert.Equal(t, "my-service", myService.Constraint)
 
 	anotherService := byocPrices["another-service"]
@@ -1739,7 +1739,7 @@ func TestBYOCExternalCapsSenderPricing(t *testing.T) {
 		prices, err := orch.GetCapabilitiesPrices(ethcommon.HexToAddress(addr))
 		assert.Nil(t, err)
 		for _, p := range prices {
-			if p.Capability == uint32(Capability_BYOCExternal) {
+			if p.Capability == uint32(Capability_BYOC) {
 				return p.PricePerUnit
 			}
 		}
@@ -1786,7 +1786,7 @@ func TestBYOCExternalCapsPriceEdgeCases(t *testing.T) {
 
 			var byocPrice *net.PriceInfo
 			for _, p := range prices {
-				if p.Capability == uint32(Capability_BYOCExternal) {
+				if p.Capability == uint32(Capability_BYOC) {
 					byocPrice = p
 				}
 			}

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -306,7 +306,7 @@ func (orch *orchestrator) GetCapabilitiesPrices(sender ethcommon.Address) ([]*ne
 		capPrices = append(capPrices, price)
 	}
 
-	// Append BYOC external capability prices using Capability_BYOCExternal.
+	// Append BYOC external capability prices using Capability_BYOC.
 	// The registered capability name is set as the Constraint, making BYOC
 	// pricing seamless alongside built-in capabilities like LiveVideoToVideo.
 	if orch.node != nil && orch.node.ExternalCapabilities != nil {
@@ -326,7 +326,7 @@ func (orch *orchestrator) GetCapabilitiesPrices(sender ethcommon.Address) ([]*ne
 			capPrices = append(capPrices, &net.PriceInfo{
 				PricePerUnit:  priceInt64.Num().Int64(),
 				PixelsPerUnit: priceInt64.Denom().Int64(),
-				Capability:    uint32(Capability_BYOCExternal),
+				Capability:    uint32(Capability_BYOC),
 				Constraint:    name,
 			})
 		}

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -306,6 +306,32 @@ func (orch *orchestrator) GetCapabilitiesPrices(sender ethcommon.Address) ([]*ne
 		capPrices = append(capPrices, price)
 	}
 
+	// Append BYOC external capability prices using Capability_BYOCExternal.
+	// The registered capability name is set as the Constraint, making BYOC
+	// pricing seamless alongside built-in capabilities like LiveVideoToVideo.
+	if orch.node != nil && orch.node.ExternalCapabilities != nil {
+		for name := range orch.node.ExternalCapabilities.Capabilities {
+			price := orch.node.GetPriceForJob(ethAddr, name)
+			if price == nil {
+				price = orch.node.GetPriceForJob("default", name)
+			}
+			if price == nil || price.Num().Sign() < 0 {
+				continue
+			}
+			priceInt64, err := common.PriceToInt64(price)
+			if err != nil {
+				glog.Errorf("error converting external capability %q price to int64: %v", name, err)
+				continue
+			}
+			capPrices = append(capPrices, &net.PriceInfo{
+				PricePerUnit:  priceInt64.Num().Int64(),
+				PixelsPerUnit: priceInt64.Denom().Int64(),
+				Capability:    uint32(Capability_BYOCExternal),
+				Constraint:    name,
+			})
+		}
+	}
+
 	return capPrices, nil
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Merges BYOC external capability pricing into the existing `OrchestratorInfo.CapabilitiesPrices` response, making BYOC capabilities discoverable through the same gRPC channel used for built-in capabilities like Live Video to Video. This eliminates the need for clients to call a separate HTTP endpoint to discover which BYOC capabilities an orchestrator offers and at what price.

A new `Capability_BYOC` (37) enum value is used as the capability ID, with the registered BYOC capability name (e.g., "comfystream") placed in the `PriceInfo.Constraint` field — the same pattern used by LV2V models (capability 35 + constraint = model_id).

**Specific updates (required)**

- Added `Capability_BYOC = 37` to the capability enum in `core/capabilities.go` and registered `"byoc"` in `CapabilityNameLookup`
- Enhanced `GetCapabilitiesPrices` in `core/orchestrator.go` to iterate over registered external capabilities (`ExternalCapabilities.Capabilities`) and append a `PriceInfo` entry for each, using `Capability_BYOC` as the capability ID and the capability name as the constraint
- Price resolution follows the existing pattern: looks up per-sender pricing first, falls back to the `"default"` price, and skips capabilities with no valid price

**How did you test each of these updates (required)**

- Tested against the companion Python gateway client ([livepeer-python-gateway](https://github.com/eliteprox/livepeer-python-gateway)) which parses `capabilities_prices` entries with capability 37 to discover BYOC capabilities and construct payment tickets using the same `_select_price_info` path as LV2V

**Does this pull request close any open issues?**

No

**Checklist:**

- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated