### PR TITLE
fix(orchestrator): always clean up input tempfile

### DIFF
--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -3,9 +3,11 @@ package core
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/golang/glog"
@@ -117,6 +119,35 @@ func TestTranscodeAndBroadcast(t *testing.T) {
 		t.Error("Did not get mismatched segments as expected")
 	}
 	tr.Profiles = p
+}
+
+func TestTranscodeSegCleansTempfileOnUnrecoverableErrorPanic(t *testing.T) {
+	ffmpeg.InitFFmpeg()
+	p := []ffmpeg.VideoProfile{ffmpeg.P720p60fps16x9}
+	tr := stubTranscoderWithProfiles(p)
+	tr.TranscodeFn = func() error {
+		return NewUnrecoverableError(errors.New("boom"))
+	}
+
+	storage := drivers.NewMemoryDriver(nil).NewSession("")
+	config := transcodeConfig{LocalOS: storage, OS: storage}
+
+	workDir := t.TempDir()
+	n, err := NewLivepeerNode(nil, workDir, nil)
+	require.NoError(t, err)
+	n.Transcoder = tr
+
+	md := &SegTranscodingMetadata{Profiles: p, AuthToken: stubAuthToken()}
+	ss := StubSegment()
+
+	require.Panics(t, func() {
+		_ = n.transcodeSeg(context.TODO(), config, ss, md)
+	})
+
+	// Ensure no *.tempfile is left behind after the panic.
+	files, globErr := filepath.Glob(filepath.Join(workDir, "*.tempfile"))
+	require.NoError(t, globErr)
+	require.Len(t, files, 0)
 }
 
 func TestServiceURIChange(t *testing.T) {

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -675,10 +675,15 @@ func (n *LivepeerNode) sendToTranscodeLoop(ctx context.Context, md *SegTranscodi
 
 func (n *LivepeerNode) transcodeSeg(ctx context.Context, config transcodeConfig, seg *stream.HLSSegment, md *SegTranscodingMetadata) *TranscodeResult {
 	var fnamep *string
-	terr := func(err error) *TranscodeResult {
-		if fnamep != nil {
-			os.Remove(*fnamep)
+	keepInput := false
+	defer func() {
+		// Ensure the input tempfile is cleaned up on *all* exit paths, including panics.
+		// We intentionally keep the input when extremely large outputs are detected.
+		if fnamep != nil && !keepInput {
+			_ = os.Remove(*fnamep)
 		}
+	}()
+	terr := func(err error) *TranscodeResult {
 		return &TranscodeResult{Err: err}
 	}
 
@@ -786,7 +791,6 @@ func (n *LivepeerNode) transcodeSeg(ctx context.Context, config transcodeConfig,
 	}
 
 	// check for big inputs
-	keepInput := false
 	for i, seg := range tData.Segments {
 		// 840x480 30fps 10 mins ~ 7.38 billion pixels, or a 1gb output
 		if seg.Pixels > 7_378_560_000 || len(seg.Data) > 1_000_000_000 {
@@ -795,9 +799,7 @@ func (n *LivepeerNode) transcodeSeg(ctx context.Context, config transcodeConfig,
 			clog.Info(ctx, "Extremely large output detected!", "manifestID", md.ManifestID, "seq", md.Seq, "pixels", seg.Pixels, "bytes", len(seg.Data), "profile", md.Profiles[i])
 		}
 	}
-	if !keepInput {
-		os.Remove(fname)
-	}
+	// input tempfile cleanup is handled by the deferred cleanup above
 
 	tr.OS = config.OS
 	tr.TranscodeData = tData


### PR DESCRIPTION
Fixes #1716

Context:
When Transcode() returns an UnrecoverableError, transcodeSeg panics. The panic bypasses the existing error cleanup helper, which can leave the generated `*.tempfile` input file on disk.

Changes:
- Add a deferred cleanup that removes the input tempfile on *all* exit paths (including panics).
- Preserve the existing "keep input for large outputs" behavior by skipping cleanup when keepInput is set.
- Add a regression test that asserts no tempfile is left behind even when UnrecoverableError triggers a panic.

Tests:
- Not run locally (ffmpeg/lpms toolchain mismatch on this environment); please rely on CI.

/attempt #1716