### PR TITLE
fix: prevent goroutine leak in getOutWriter when WHEP clients disconnect

### DIFF
--- a/byoc/trickle.go
+++ b/byoc/trickle.go
@@ -771,17 +771,52 @@ func (bsg *BYOCGatewayServer) startEventsSubscribe(
 }
 
 func (bsg *BYOCGatewayServer) getOutWriter(streamId string) (*media.RingBuffer, string) {
+	return bsg.getOutWriterWithContext(context.Background(), streamId)
+}
+
+// getOutWriterWithContext waits for OutWriter to be set, respecting context cancellation.
+// This prevents goroutine leaks when WHEP clients disconnect before OutWriter is ready.
+func (bsg *BYOCGatewayServer) getOutWriterWithContext(ctx context.Context, streamId string) (*media.RingBuffer, string) {
+	// Use a timeout-based approach since sync.Cond.Wait() doesn't support context
+	const checkInterval = 100 * time.Millisecond
+	const maxWait = 30 * time.Second
+	deadline := time.Now().Add(maxWait)
+
 	stream, err := bsg.streamPipeline(streamId) // streamPipeline handles locking
 	if err != nil || stream.Closed {
 		return nil, ""
 	}
+
 	// hold the cond lock only while waiting
 	stream.OutCond.L.Lock()
 	defer stream.OutCond.L.Unlock()
 
 	for stream.OutWriter == nil {
-		stream.OutCond.Wait()
-		if stream.Closed {
+		// Check if context is cancelled
+		select {
+		case <-ctx.Done():
+			return nil, ""
+		default:
+		}
+
+		// Check if we've exceeded max wait time
+		if time.Now().After(deadline) {
+			return nil, ""
+		}
+
+		// Use a timed wait pattern: release lock, sleep briefly, reacquire
+		stream.OutCond.L.Unlock()
+		select {
+		case <-ctx.Done():
+			stream.OutCond.L.Lock()
+			return nil, ""
+		case <-time.After(checkInterval):
+		}
+		stream.OutCond.L.Lock()
+
+		// Re-check stream state after reacquiring lock
+		stream, err = bsg.streamPipeline(streamId)
+		if err != nil || stream.Closed {
 			return nil, ""
 		}
 	}

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -863,16 +863,54 @@ func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestPar
 }
 
 func getOutWriter(stream string, node *core.LivepeerNode) (*media.RingBuffer, string) {
+	return getOutWriterWithContext(context.Background(), stream, node)
+}
+
+// getOutWriterWithContext waits for OutWriter to be set, respecting context cancellation.
+// This prevents goroutine leaks when WHEP clients disconnect before OutWriter is ready.
+func getOutWriterWithContext(ctx context.Context, stream string, node *core.LivepeerNode) (*media.RingBuffer, string) {
+	// Use a timeout-based approach since sync.Cond.Wait() doesn't support context
+	const checkInterval = 100 * time.Millisecond
+	const maxWait = 30 * time.Second
+	deadline := time.Now().Add(maxWait)
+
 	node.LiveMu.Lock()
 	defer node.LiveMu.Unlock()
+
 	sess, exists := node.LivePipelines[stream]
 	if !exists || sess.Closed {
 		return nil, ""
 	}
-	// could be nil if we haven't gotten an orchestrator yet
+
+	// Wait for OutWriter to be set, checking context and timeout periodically
 	for sess.OutWriter == nil {
-		sess.OutCond.Wait()
-		if sess.Closed {
+		// Check if context is cancelled
+		select {
+		case <-ctx.Done():
+			return nil, ""
+		default:
+		}
+
+		// Check if we've exceeded max wait time
+		if time.Now().After(deadline) {
+			clog.Infof(ctx, "getOutWriter timed out waiting for OutWriter stream=%s", stream)
+			return nil, ""
+		}
+
+		// Use a timed wait pattern: release lock, sleep briefly, reacquire
+		// This allows other goroutines to make progress and lets us check context
+		node.LiveMu.Unlock()
+		select {
+		case <-ctx.Done():
+			node.LiveMu.Lock()
+			return nil, ""
+		case <-time.After(checkInterval):
+		}
+		node.LiveMu.Lock()
+
+		// Re-check session state after reacquiring lock
+		sess, exists = node.LivePipelines[stream]
+		if !exists || sess.Closed {
 			return nil, ""
 		}
 	}

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -1181,7 +1181,7 @@ func (ls *LivepeerServer) CreateWhep(server *media.WHEPServer) http.Handler {
 		stream, requestID := parts[0], parts[1]
 		ctx := r.Context()
 		ctx = clog.AddVal(ctx, "stream", stream)
-		outWriter, rid := getOutWriter(stream, ls.LivepeerNode)
+		outWriter, rid := getOutWriterWithContext(ctx, stream, ls.LivepeerNode)
 		if outWriter == nil || (requestID != rid && requestID != "") {
 			http.Error(w, "Stream not found", http.StatusNotFound)
 			return


### PR DESCRIPTION
## Problem

Gateway nodes are experiencing slow memory leaks, causing OOM restarts several times a day (especially in high-traffic regions like lax-ai).

## Root Cause

The `getOutWriter` function uses `sync.Cond.Wait()` which blocks indefinitely and doesn't respect HTTP context cancellation. This causes goroutine leaks when WHEP clients disconnect before OutWriter is ready.

## Solution

Replace indefinite `cond.Wait()` with a polling approach that:
- Checks context cancellation every 100ms  
- Has a maximum 30 second timeout
- Properly releases and reacquires locks

## Changes

- `server/ai_live_video.go`: Add context-aware `getOutWriterWithContext()`
- `server/ai_mediaserver.go`: Use context-aware version in WHEP handler
- `byoc/trickle.go`: Same fix for BYOC module