### PR TITLE
fix: properly close WHIP PeerConnections to prevent memory leak

### DIFF
--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -104,18 +104,34 @@ func (s *WHIPServer) CreateWHIP(ctx context.Context, ssr *SwitchableSegmentReade
 
 	// OnTrack callback: handle incoming media
 	trackCh := make(chan *webrtc.TrackRemote)
+	var trackChClosed sync.Once
+	closeTrackCh := func() {
+		trackChClosed.Do(func() {
+			close(trackCh)
+		})
+	}
 	peerConnection.OnTrack(func(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
 		clog.Info(ctx, "New track", "codec", track.Codec().MimeType, "ssrc", track.SSRC(), "rate", track.Codec().ClockRate)
-		trackCh <- track
+		select {
+		case trackCh <- track:
+		default:
+			// Channel closed or blocked, ignore
+		}
 	})
 
 	// PeerConnection state management
 	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
 		clog.Info(ctx, "whip ice connection state changed", "state", connectionState)
-		if connectionState == webrtc.ICEConnectionStateFailed {
-			mediaState.CloseError(errors.New("ICE connection state failed"))
-		} else if connectionState == webrtc.ICEConnectionStateClosed {
-			// Business logic when PeerConnection done
+		switch connectionState {
+		case webrtc.ICEConnectionStateFailed:
+			closeTrackCh()
+			mediaState.CloseError(errors.New("ICE connection failed"))
+		case webrtc.ICEConnectionStateDisconnected:
+			closeTrackCh()
+			mediaState.CloseError(errors.New("ICE connection disconnected"))
+		case webrtc.ICEConnectionStateClosed:
+			closeTrackCh()
+			mediaState.CloseError(errors.New("ICE connection closed"))
 		}
 	})
 
@@ -386,7 +402,9 @@ func gatherIncomingTracks(ctx context.Context, pc *webrtc.PeerConnection, trackC
 	AudioOnlyTimeout := VideoTimeout
 	AudioTimeout := 500 * time.Millisecond
 	videoTimer := time.NewTimer(time.Duration(VideoTimeout))
+	defer videoTimer.Stop()
 	audioTimer := time.NewTimer(time.Duration(AudioOnlyTimeout))
+	defer audioTimer.Stop()
 	sdp, err := pc.RemoteDescription().Unmarshal()
 	if err != nil {
 		clog.InfofErr(ctx, "error unmarshaling remote sdp", err)
@@ -400,11 +418,17 @@ func gatherIncomingTracks(ctx context.Context, pc *webrtc.PeerConnection, trackC
 	var videoTrack *webrtc.TrackRemote
 	for {
 		select {
+		case <-ctx.Done():
+			return audioTrack, videoTrack, fmt.Errorf("context cancelled: %w", ctx.Err())
 		case <-videoTimer.C:
-			return audioTrack, nil, nil
+			return audioTrack, nil, errors.New("timed out waiting for video track")
 		case <-audioTimer.C:
-			return nil, videoTrack, nil
-		case track := <-trackCh:
+			return nil, videoTrack, errors.New("timed out waiting for audio track")
+		case track, ok := <-trackCh:
+			if !ok {
+				// Channel closed (connection ended)
+				return audioTrack, videoTrack, errors.New("track channel closed (connection ended)")
+			}
 			switch track.Kind() {
 			case webrtc.RTPCodecTypeAudio:
 				if !awaitingAudio {


### PR DESCRIPTION
## Problem

Gateway nodes are experiencing OOM restarts due to WHIP PeerConnections not being properly closed when clients disconnect.

### Evidence from production heap profile:
```
2588.31MB 70.80%  github.com/pion/webrtc/v4.rtcpFeedbackIntersection
```

**2.5 GB (70.8%)** of memory was held in WebRTC codec parameters from unclosed PeerConnections.

### Call path:
```
CreateWHIP (2.7 GB cumulative)
  └─ SetRemoteDescription (2.6 GB)
      └─ rtcpFeedbackIntersection (2.5 GB flat)
```

## Root Cause

The ICE connection state handler only closed on `Failed`, not `Disconnected` or `Closed`:
```go
// BEFORE (incomplete):
if connectionState == webrtc.ICEConnectionStateFailed {
    mediaState.CloseError(...)
} else if connectionState == webrtc.ICEConnectionStateClosed {
    // Business logic when PeerConnection done  <-- DID NOTHING
}
// ICEConnectionStateDisconnected was NOT handled!
```

When clients disconnect gracefully, ICE transitions to `Disconnected`, not `Failed`. The PeerConnections stayed alive indefinitely, accumulating memory.

## Changes

1. **Handle all terminal ICE states**
   - `ICEConnectionStateFailed` ✓ (was working)
   - `ICEConnectionStateDisconnected` ✓ (NEW)
   - `ICEConnectionStateClosed` ✓ (was no-op, now closes)

2. **Close trackCh when connection ends**
   - Prevents `gatherIncomingTracks` from blocking forever
   - Uses `sync.Once` to ensure channel is only closed once

3. **Fix gatherIncomingTracks error handling**
   - Return proper errors on timeout (was returning nil)
   - Handle context cancellation
   - Handle closed channel case

4. **Properly stop timers with defer**
   - Prevents timer goroutine leaks

## Testing

- Verified code compiles
- Existing tests should pass
- Recommend monitoring memory after deployment

## Related

Investigation thread: OOM Debug in #openclaw
Symptoms: ~7GB RSS, frequent restarts in lax-ai region