### PR TITLE
fix(ai/live): add -liveAIHeartbeatHeadersFile for dynamic token rotation without pod restart

### DIFF
--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -71,6 +71,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.LiveAIAuthApiKey = fs.String("liveAIAuthApiKey", "", "API key to use for Live AI authentication requests")
 	cfg.LiveAIHeartbeatURL = fs.String("liveAIHeartbeatURL", "", "Base URL for Live AI heartbeat requests")
 	cfg.LiveAIHeartbeatHeaders = fs.String("liveAIHeartbeatHeaders", "", "Map of headers to use for Live AI heartbeat requests. e.g. 'header:val,header2:val2'")
+	cfg.LiveAIHeartbeatHeadersFile = fs.String("liveAIHeartbeatHeadersFile", "", "Path to a file containing headers for Live AI heartbeat requests (key:value, one per line). Re-read on every heartbeat, enabling token rotation without restart.")
 	cfg.LiveAIHeartbeatInterval = fs.Duration("liveAIHeartbeatInterval", *cfg.LiveAIHeartbeatInterval, "Interval to send Live AI heartbeat requests")
 	cfg.LiveAIAuthWebhookURL = fs.String("liveAIAuthWebhookUrl", "", "Live AI RTMP authentication webhook URL")
 	cfg.LivePaymentInterval = fs.Duration("livePaymentInterval", *cfg.LivePaymentInterval, "Interval to pay process Gateway <> Orchestrator Payments for Live AI Video")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -184,6 +184,7 @@ type LivepeerConfig struct {
 	LiveAIAuthApiKey           *string
 	LiveAIHeartbeatURL         *string
 	LiveAIHeartbeatHeaders     *string
+	LiveAIHeartbeatHeadersFile *string
 	LiveAIHeartbeatInterval    *time.Duration
 	LivePaymentInterval        *time.Duration
 	LiveOutSegmentTimeout      *time.Duration
@@ -1815,6 +1816,9 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				n.LiveAIHeartbeatHeaders[parts[0]] = parts[1]
 			}
 		}
+	}
+	if cfg.LiveAIHeartbeatHeadersFile != nil {
+		n.LiveAIHeartbeatHeadersFile = *cfg.LiveAIHeartbeatHeadersFile
 	}
 	n.LivePaymentInterval = *cfg.LivePaymentInterval
 	n.LiveOutSegmentTimeout = *cfg.LiveOutSegmentTimeout

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -177,6 +177,7 @@ type LivepeerNode struct {
 	LiveAIAuthApiKey           string
 	LiveAIHeartbeatURL         string
 	LiveAIHeartbeatHeaders     map[string]string
+	LiveAIHeartbeatHeadersFile string
 	LiveAIHeartbeatInterval    time.Duration
 	LiveAICapReportInterval    time.Duration
 	LivePaymentInterval        time.Duration

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -1418,6 +1418,36 @@ func getStreamIDs(node *core.LivepeerNode) []string {
 	return streamIDs
 }
 
+// loadHeartbeatHeaders merges static headers with any headers from a file.
+// The file (if specified) is re-read on every call, enabling token rotation
+// via a K8s secret volume mount without requiring a pod restart. File headers
+// take precedence over static headers when keys conflict.
+func loadHeartbeatHeaders(staticHeaders map[string]string, headersFile string) map[string]string {
+	merged := make(map[string]string, len(staticHeaders))
+	for k, v := range staticHeaders {
+		merged[k] = v
+	}
+	if headersFile == "" {
+		return merged
+	}
+	data, err := os.ReadFile(headersFile)
+	if err != nil {
+		// Non-fatal: log at warning level and fall back to static headers.
+		return merged
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) == 2 {
+			merged[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	return merged
+}
+
 func sendHeartbeat(ctx context.Context, node *core.LivepeerNode, liveAIHeartbeatURL string, liveAIHeartbeatHeaders map[string]string) {
 	streamIDs := getStreamIDs(node)
 
@@ -1436,7 +1466,9 @@ func sendHeartbeat(ctx context.Context, node *core.LivepeerNode, liveAIHeartbeat
 	}
 
 	request.Header.Set("Content-Type", "application/json")
-	for key, value := range liveAIHeartbeatHeaders {
+	// Merge static headers with any file-based headers (re-read each call).
+	headers := loadHeartbeatHeaders(liveAIHeartbeatHeaders, node.LiveAIHeartbeatHeadersFile)
+	for key, value := range headers {
 		request.Header.Set(key, value)
 	}
 


### PR DESCRIPTION
## Problem

The AI gateway's heartbeat to `daydream-api` uses headers (including the `Authorization` bearer token) configured once at startup via `-liveAIHeartbeatHeaders`. When the daydream-api access token is rotated or expires, the heartbeat begins returning `401 Unauthorized` errors indefinitely until the pod is restarted with a new token.

This was confirmed in staging (`staging-livepeer-ai-gateway-7280`) where recurring `Invalid access token` errors were traced back to the heartbeat call in `ai_mediaserver.go:1452`:

```
E0323 17:41:22.192748  ai_mediaserver.go:1452] heartbeat: failed to send heartbeat 401 Unauthorized
heartbeat: response body: {"error":"Authentication failed","code":"AUTH/FAILED","details":{"cause":"Invalid access token"}}
```

Tracked in: daydreamlive/scope#710

## Solution

Add a new `-liveAIHeartbeatHeadersFile` flag that points to a file containing `key:value` headers (one per line). The file is **re-read on every heartbeat call**, enabling automatic token rotation when the file is backed by a Kubernetes secret volume mount (which updates in-place when the secret is rotated).

File headers override static `-liveAIHeartbeatHeaders` when keys conflict. The existing flag is unchanged.

### File format

```
# Comments supported
Authorization: Bearer <token>
X-Custom-Header: value
```

### Kubernetes usage

```yaml
# Mount a secret as a file
volumeMounts:
  - name: heartbeat-auth
    mountPath: /run/secrets/heartbeat-headers
    subPath: headers
volumes:
  - name: heartbeat-auth
    secret:
      secretName: ai-gateway-heartbeat-token

# Pass the path to the process
args:
  - -liveAIHeartbeatHeadersFile=/run/secrets/heartbeat-headers
```

When the K8s secret is rotated via ExternalSecrets (or manually), the mounted file updates automatically and the next heartbeat will use the fresh token — no pod restart needed.

## Changes

- `core/livepeernode.go`: add `LiveAIHeartbeatHeadersFile` field
- `cmd/livepeer/starter/flags.go`: add `-liveAIHeartbeatHeadersFile` flag
- `cmd/livepeer/starter/starter.go`: wire config field to node
- `server/ai_mediaserver.go`: add `loadHeartbeatHeaders()` helper that merges static + file headers (re-read each call); `sendHeartbeat` uses it