### PR TITLE
fix(orchestrator): ensure input tempfile cleanup on all exit paths

### DIFF
--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -3,9 +3,11 @@ package core
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/golang/glog"
@@ -117,6 +119,67 @@ func TestTranscodeAndBroadcast(t *testing.T) {
 		t.Error("Did not get mismatched segments as expected")
 	}
 	tr.Profiles = p
+}
+
+func TestTranscodeSegCleansTempfileOnUnrecoverableError(t *testing.T) {
+	// Regression test for https://github.com/livepeer/go-livepeer/issues/1716
+	// When Transcode() returns an UnrecoverableError, transcodeSeg panics.
+	// The deferred cleanup must still remove the input *.tempfile.
+	ffmpeg.InitFFmpeg()
+	p := []ffmpeg.VideoProfile{ffmpeg.P720p60fps16x9}
+	tr := stubTranscoderWithProfiles(p)
+	tr.TranscodeFn = func() error {
+		return NewUnrecoverableError(errors.New("simulated unrecoverable error"))
+	}
+
+	storage := drivers.NewMemoryDriver(nil).NewSession("")
+	config := transcodeConfig{LocalOS: storage, OS: storage}
+
+	workDir := t.TempDir()
+	n, err := NewLivepeerNode(nil, workDir, nil)
+	require.NoError(t, err)
+	n.Transcoder = tr
+
+	md := &SegTranscodingMetadata{Profiles: p, AuthToken: stubAuthToken()}
+	ss := StubSegment()
+
+	// transcodeSeg panics on UnrecoverableError; the deferred cleanup should
+	// still run and remove the tempfile.
+	require.Panics(t, func() {
+		_ = n.transcodeSeg(context.TODO(), config, ss, md)
+	})
+
+	// Verify no *.tempfile is left behind after the panic.
+	files, globErr := filepath.Glob(filepath.Join(workDir, "*.tempfile"))
+	require.NoError(t, globErr)
+	require.Empty(t, files, "expected no leftover tempfiles but found: %v", files)
+}
+
+func TestTranscodeSegCleansTempfileOnNormalError(t *testing.T) {
+	// Verify tempfile cleanup also works on normal (non-panic) error paths.
+	ffmpeg.InitFFmpeg()
+	p := []ffmpeg.VideoProfile{ffmpeg.P720p60fps16x9}
+	tr := stubTranscoderWithProfiles(p)
+	tr.FailTranscode = true
+
+	storage := drivers.NewMemoryDriver(nil).NewSession("")
+	config := transcodeConfig{LocalOS: storage, OS: storage}
+
+	workDir := t.TempDir()
+	n, err := NewLivepeerNode(nil, workDir, nil)
+	require.NoError(t, err)
+	n.Transcoder = tr
+
+	md := &SegTranscodingMetadata{Profiles: p, AuthToken: stubAuthToken()}
+	ss := StubSegment()
+
+	res := n.transcodeSeg(context.TODO(), config, ss, md)
+	require.Error(t, res.Err)
+
+	// Verify no *.tempfile is left behind after a normal transcoding error.
+	files, globErr := filepath.Glob(filepath.Join(workDir, "*.tempfile"))
+	require.NoError(t, globErr)
+	require.Empty(t, files, "expected no leftover tempfiles but found: %v", files)
 }
 
 func TestServiceURIChange(t *testing.T) {

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -675,10 +675,15 @@ func (n *LivepeerNode) sendToTranscodeLoop(ctx context.Context, md *SegTranscodi
 
 func (n *LivepeerNode) transcodeSeg(ctx context.Context, config transcodeConfig, seg *stream.HLSSegment, md *SegTranscodingMetadata) *TranscodeResult {
 	var fnamep *string
-	terr := func(err error) *TranscodeResult {
-		if fnamep != nil {
+	keepInput := false
+	// Ensure the input tempfile is cleaned up on all exit paths, including
+	// panics triggered by UnrecoverableError from Transcode().
+	defer func() {
+		if fnamep != nil && !keepInput {
 			os.Remove(*fnamep)
 		}
+	}()
+	terr := func(err error) *TranscodeResult {
 		return &TranscodeResult{Err: err}
 	}
 
@@ -785,19 +790,16 @@ func (n *LivepeerNode) transcodeSeg(ctx context.Context, config transcodeConfig,
 		segHashes[i] = hash
 	}
 
-	// check for big inputs
-	keepInput := false
+	// check for big inputs — set keepInput so the deferred cleanup preserves
+	// the tempfile for later analysis when extremely large outputs are detected.
 	for i, seg := range tData.Segments {
 		// 840x480 30fps 10 mins ~ 7.38 billion pixels, or a 1gb output
 		if seg.Pixels > 7_378_560_000 || len(seg.Data) > 1_000_000_000 {
-			// keep input for later analysis to figure out extremely large output
 			keepInput = true
 			clog.Info(ctx, "Extremely large output detected!", "manifestID", md.ManifestID, "seq", md.Seq, "pixels", seg.Pixels, "bytes", len(seg.Data), "profile", md.Profiles[i])
 		}
 	}
-	if !keepInput {
-		os.Remove(fname)
-	}
+	// Input tempfile cleanup is handled by the deferred function above.
 
 	tr.OS = config.OS
 	tr.TranscodeData = tData


### PR DESCRIPTION
Fixes #1716

/claim #1716

## Problem

When `Transcode()` returns an `UnrecoverableError`, `transcodeSeg` panics (line 749). This panic bypasses the explicit `os.Remove(fname)` call at line 799, leaving `*.tempfile` input files on disk. Over time, this fills up the orchestrator's data directory.

The `terr()` error helper also cleaned up the file, but it is never reached on the panic path.

## Solution

Move the input tempfile cleanup into a **deferred function** at the top of `transcodeSeg` so it executes on **all** exit paths:
- Normal return (successful transcode)
- Error return via `terr()`
- Panic from `UnrecoverableError`

The existing `keepInput` flag (for preserving input when extremely large outputs are detected) is hoisted to function scope so the defer can check it.

## Changes

- **`core/orchestrator.go`**: Add `defer` cleanup for `fnamep`; remove redundant cleanup from `terr()` and the explicit `os.Remove` block
- **`core/livepeernode_test.go`**: Add two regression tests:
  - `TestTranscodeSegCleansTempfileOnUnrecoverableError` — triggers panic path, asserts no leftover tempfile
  - `TestTranscodeSegCleansTempfileOnNormalError` — triggers normal error path, asserts no leftover tempfile

## Testing

- Added regression tests covering both panic and normal error cleanup paths
- Existing `TestTranscodeAndBroadcast` continues to pass (deferred cleanup handles the normal path)
- CI workflows should validate full test suite