### PR TITLE
Remove x11 from MacOS builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -219,8 +219,6 @@ jobs:
           # brew upgrade  # temporarily disabled because of the issues it's causing
           brew uninstall --ignore-dependencies --force pkg-config@0.29.2
           brew install coreutils pkgconf
-          wget https://github.com/XQuartz/XQuartz/releases/download/XQuartz-2.8.5/XQuartz-2.8.5.pkg -O XQuartz.pkg
-          sudo installer -verbose -pkg XQuartz.pkg -target /
 
       - name: Install go modules
         # if: steps.go.outputs.cache-hit != 'true'

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo 'WARNING: downloading and executing lpms/install_ffmpeg.sh, use it directly in case of issues'
-curl https://raw.githubusercontent.com/livepeer/lpms/e1872bf609de6befe3cfcdc7a464d1e3469ea843/install_ffmpeg.sh | bash -s $1
+curl https://raw.githubusercontent.com/livepeer/lpms/38b00f0947bfd05ac39e594d94ea38950ea82cd2/install_ffmpeg.sh | bash -s $1

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo 'WARNING: downloading and executing lpms/install_ffmpeg.sh, use it directly in case of issues'
-curl https://raw.githubusercontent.com/livepeer/lpms/38b00f0947bfd05ac39e594d94ea38950ea82cd2/install_ffmpeg.sh | bash -s $1
+curl https://raw.githubusercontent.com/livepeer/lpms/5fe66b1044f876b47248c36aed581622fbbe093d/install_ffmpeg.sh | bash -s $1


### PR DESCRIPTION
Somehow LPMS started pulling in x11 (maybe via CI runner update) and as a [workaround](https://github.com/livepeer/go-livepeer/pull/3872) we started dynamically linking x11 but this broke pre-built downloads in environments where x11 isn't available.

Fixed this correctly by disabling X11 builds in LPMS: https://github.com/livepeer/lpms/pull/448 ; This PR updates the LPMS build to pull in the fixed ffmpeg.