### PR TITLE
Exit with error when orchestrator/transcoder has zero capabilities

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1751,7 +1751,17 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		aiCaps = append(aiCaps, core.DefaultCapabilities()...)
 	}
 
-	n.Capabilities = core.NewCapabilities(append(transcoderCaps, aiCaps...), nil)
+	allCaps := append(transcoderCaps, aiCaps...)
+	if len(allCaps) == 0 && (n.NodeType == core.OrchestratorNode || n.NodeType == core.TranscoderNode) {
+		glog.Error("No transcoding capabilities detected. The node will not be selected by broadcasters.")
+		if *cfg.Nvidia != "" && cfg.TestTranscoder != nil && !*cfg.TestTranscoder {
+			glog.Error("Hint: -testTranscoder is set to false with -nvidia flag. " +
+				"This skips GPU capability detection, resulting in no hardware capabilities. " +
+				"Remove -testTranscoder=false to enable GPU capability testing.")
+		}
+		glog.Exit("Refusing to start with zero capabilities. Fix the configuration and try again.")
+	}
+	n.Capabilities = core.NewCapabilities(allCaps, nil)
 	n.Capabilities.SetPerCapabilityConstraints(capabilityConstraints)
 	if cfg.OrchMinLivepeerVersion != nil {
 		n.Capabilities.SetMinVersionConstraint(*cfg.OrchMinLivepeerVersion)


### PR DESCRIPTION
## What does this pull request do?
Prevents O/T nodes from silently starting with zero transcoding capabilities, which makes them invisible to broadcasters.

## Specific updates
- Validate at least one capability was detected after capability assignment in StartLivepeer
- Log actionable error and exit if zero capabilities detected for O/T nodes
- Include hint when -nvidia is used with -testTranscoder=false

## How did you test each of these updates?
- go test ./cmd/livepeer/starter/... passes
- go vet clean
- gofmt clean

## Does this pull request close any open issues?
Fixes #2450

## Checklist
- [x] I have read the contribution guide
- [x] make and tests run successfully
- [x] Code is formatted with gofmt
