### PR TITLE
Check bonding state before activating orchestrator in CLI

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -525,6 +525,23 @@ func (s *LivepeerServer) activateOrchestratorHandler(client eth.LivepeerEthClien
 			}
 		}
 
+		// Check if already bonded to a different address before attempting to bond
+		delegator, err := client.GetDelegator(client.Account().Address)
+		if err != nil {
+			glog.Error(err)
+			respond500(w, err.Error())
+			return
+		}
+		if delegator != nil && delegator.BondedAmount != nil && delegator.BondedAmount.Cmp(big.NewInt(0)) > 0 {
+			selfAddr := client.Account().Address
+			zeroAddr := ethcommon.Address{}
+			if delegator.DelegateAddress != zeroAddr && delegator.DelegateAddress != selfAddr {
+				msg := fmt.Sprintf("Your wallet is already bonded to %v with %v LPT. You must unbond first before becoming a new orchestrator.", delegator.DelegateAddress.Hex(), delegator.BondedAmount)
+				respond400(w, msg)
+				return
+			}
+		}
+
 		amountStr := r.FormValue("amount")
 		if amountStr != "" {
 			amount, err := common.ParseBigInt(amountStr)

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -673,6 +673,7 @@ func TestActivateOrchestratorHandler_Success(t *testing.T) {
 	client.On("CurrentRoundLocked").Return(false, nil).Once()
 	client.On("CheckTx", mock.Anything).Return(nil).Once()
 	client.On("GetServiceURI", addr).Return(serviceURI, nil).Once()
+	client.On("GetDelegator", addr).Return(&types.Delegator{}, nil).Once()
 
 	status, _ := postForm(handler, url.Values{
 		"blockRewardCut": {"0.5"},


### PR DESCRIPTION
## What does this pull request do?
Adds a pre-flight check that queries on-chain bonding state before the bond transaction, returning a clear error instead of the misleading "ERC20: transfer amount exceeds balance" message.

## Specific updates
- Query GetDelegator before bond transaction in activateOrchestratorHandler
- Return 400 with actionable message if wallet is bonded to a different address
- Handle nil delegator and nil BondedAmount defensively
- Add GetDelegator mock expectation to TestActivateOrchestratorHandler_Success

## How did you test each of these updates?
- go test ./server/... passes
- go vet ./server/... clean
- gofmt clean

## Does this pull request close any open issues?
Fixes #2643

## Checklist
- [x] I have read the contribution guide
- [x] make and tests run successfully
- [x] Code is formatted with gofmt
