### PR TITLE
Register gRPC health check service on orchestrator server

### DIFF
--- a/server/rpc.go
+++ b/server/rpc.go
@@ -15,6 +15,8 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/livepeer/go-livepeer/ai/worker"
 	"github.com/livepeer/go-livepeer/byoc"
@@ -236,6 +238,7 @@ func StartTranscodeServer(orch Orchestrator, bind string, mux *http.ServeMux, wo
 		node:         n,
 	}
 	net.RegisterOrchestratorServer(s, &lp)
+	grpc_health_v1.RegisterHealthServer(s, health.NewServer())
 	lp.transRPC.HandleFunc("/segment", lp.ServeSegment)
 	lp.transRPC.HandleFunc("/payment", lp.Payment)
 	if acceptRemoteTranscoders {


### PR DESCRIPTION
## What does this pull request do?
Registers the standard gRPC health checking protocol (grpc.health.v1.Health) on the orchestrator's gRPC server, enabling native Kubernetes gRPC health probes.

## Specific updates
- Register health.NewServer() on the gRPC server in StartTranscodeServer
- Matches existing pattern used in router.go

## How did you test each of these updates?
- go test ./server/... passes
- go vet ./server/... clean
- gofmt clean

## Does this pull request close any open issues?
Fixes #2076

## Checklist
- [x] I have read the contribution guide
- [x] make and tests run successfully
- [x] Code is formatted with gofmt
