### PR TITLE
Add POST /self-check endpoint for on-demand transcoder health checks

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -661,6 +661,12 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 			}
 			// Initialize LB transcoder
 			n.Transcoder = core.NewLoadBalancingTranscoder(devices, tf)
+			// Store self-check function for on-demand transcoder health verification
+			selfCheckDevices, selfCheckFactory := devices, tf
+			n.TranscoderSelfCheck = func() error {
+				_, err := core.TestTranscoderCapabilities(selfCheckDevices, selfCheckFactory)
+				return err
+			}
 		} else {
 			// for local software mode, enable most capabilities but remove expensive decoders and non-H264 encoders
 			capsToRemove := []core.Capability{core.Capability_HEVC_Decode, core.Capability_HEVC_Encode, core.Capability_VP8_Encode, core.Capability_VP9_Decode, core.Capability_VP9_Encode}

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -138,6 +138,7 @@ type LivepeerNode struct {
 	OrchSecret           string
 	Transcoder           Transcoder
 	TranscoderManager    *RemoteTranscoderManager
+	TranscoderSelfCheck  func() error // Re-runs GPU transcoding capability test; set at startup
 	Balances             *AddressBalances
 	Capabilities         *Capabilities
 	ExternalCapabilities *ExternalCapabilities

--- a/server/webserver.go
+++ b/server/webserver.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 
 	// pprof adds handlers to default mux via `init()`
@@ -112,10 +113,36 @@ func (s *LivepeerServer) cliWebServerHandlers(bindAddr string) *http.ServeMux {
 	mux.Handle("/getLogLevel", getLogLevelHandler())
 	mux.Handle("/debug", s.debugHandler())
 
+	// Health check
+	mux.Handle("/self-check", s.selfCheckHandler())
+
 	// Metrics
 	if monitor.Enabled {
 		mux.Handle("/metrics", monitor.Exporter)
 	}
 
 	return mux
+}
+
+func (s *LivepeerServer) selfCheckHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed. Use POST.", http.StatusMethodNotAllowed)
+			return
+		}
+		selfCheck := s.LivepeerNode.TranscoderSelfCheck
+		if selfCheck == nil {
+			http.Error(w, "Self-check not available: node is not configured as a transcoder with hardware acceleration", http.StatusServiceUnavailable)
+			return
+		}
+		glog.Info("Running transcoder self-check...")
+		if err := selfCheck(); err != nil {
+			glog.Errorf("Transcoder self-check failed: %v", err)
+			http.Error(w, fmt.Sprintf("Self-check FAILED: %v", err), http.StatusServiceUnavailable)
+			return
+		}
+		glog.Info("Transcoder self-check passed")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "Self-check PASSED: transcoder capabilities verified")
+	})
 }


### PR DESCRIPTION
## What does this pull request do?
Adds an HTTP endpoint that re-runs the GPU transcoding capability test on demand, enabling Kubernetes liveness probes that detect stuck orchestrators.

## Specific updates
- Add TranscoderSelfCheck field to LivepeerNode struct
- Capture GPU devices and transcoder factory in a closure at startup
- Register POST /self-check on the CLI web server (port 7935)
- Return 200 on pass, 503 with error details on failure
- Usage: curl -X POST http://localhost:7935/self-check

## How did you test each of these updates?
- go test ./core/... ./server/... ./cmd/livepeer/starter/... all pass
- go vet clean
- gofmt clean

## Does this pull request close any open issues?
Fixes #1920

## Checklist
- [x] I have read the contribution guide
- [x] make and tests run successfully
- [x] Code is formatted with gofmt
