### PR TITLE
signer: Add auth webhook callback

### DIFF
--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -140,6 +140,8 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.TestOrchAvail = fs.Bool("startupAvailabilityCheck", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
 	cfg.RemoteSigner = fs.Bool("remoteSigner", *cfg.RemoteSigner, "Set to true to run remote signer service")
 	cfg.RemoteSignerUrl = fs.String("remoteSignerUrl", *cfg.RemoteSignerUrl, "URL of remote signer service to use (e.g., http://localhost:8935). Gateway only.")
+	cfg.RemoteSignerWebhookURL = fs.String("remoteSignerWebhookUrl", *cfg.RemoteSignerWebhookURL, "Authentication webhook URL called by remote signer during GenerateLivePayment")
+	cfg.RemoteSignerWebhookHeaders = fs.String("remoteSignerWebhookHeaders", *cfg.RemoteSignerWebhookHeaders, "Map of headers to use for remote signer webhook requests. e.g. 'header:val,header2:val2'")
 	cfg.RemoteDiscovery = fs.Bool("remoteDiscovery", *cfg.RemoteDiscovery, "Enable orchestrator discovery on remote signers")
 
 	// Gateway metrics

--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -140,6 +140,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.TestOrchAvail = fs.Bool("startupAvailabilityCheck", *cfg.TestOrchAvail, "Set to false to disable the startup Orchestrator availability check on the configured serviceAddr")
 	cfg.RemoteSigner = fs.Bool("remoteSigner", *cfg.RemoteSigner, "Set to true to run remote signer service")
 	cfg.RemoteSignerUrl = fs.String("remoteSignerUrl", *cfg.RemoteSignerUrl, "URL of remote signer service to use (e.g., http://localhost:8935). Gateway only.")
+	cfg.RemoteSignerHeaders = fs.String("remoteSignerHeaders", *cfg.RemoteSignerHeaders, "Map of headers to use for gateway remote signer requests. e.g. 'header:val,header2:val2'")
 	cfg.RemoteSignerWebhookURL = fs.String("remoteSignerWebhookUrl", *cfg.RemoteSignerWebhookURL, "Authentication webhook URL called by remote signer during GenerateLivePayment")
 	cfg.RemoteSignerWebhookHeaders = fs.String("remoteSignerWebhookHeaders", *cfg.RemoteSignerWebhookHeaders, "Map of headers to use for remote signer webhook requests. e.g. 'header:val,header2:val2'")
 	cfg.RemoteDiscovery = fs.Bool("remoteDiscovery", *cfg.RemoteDiscovery, "Enable orchestrator discovery on remote signers")

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -169,6 +169,7 @@ type LivepeerConfig struct {
 	TestOrchAvail              *bool
 	RemoteSigner               *bool
 	RemoteSignerUrl            *string
+	RemoteSignerHeaders        *string
 	RemoteSignerWebhookURL     *string
 	RemoteSignerWebhookHeaders *string
 	RemoteDiscovery            *bool
@@ -309,6 +310,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultTestOrchAvail := true
 	defaultRemoteSigner := false
 	defaultRemoteSignerUrl := ""
+	defaultRemoteSignerHeaders := ""
 	defaultRemoteSignerWebhookURL := ""
 	defaultRemoteSignerWebhookHeaders := ""
 	defaultRemoteDiscovery := false
@@ -435,6 +437,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		TestOrchAvail:              &defaultTestOrchAvail,
 		RemoteSigner:               &defaultRemoteSigner,
 		RemoteSignerUrl:            &defaultRemoteSignerUrl,
+		RemoteSignerHeaders:        &defaultRemoteSignerHeaders,
 		RemoteSignerWebhookURL:     &defaultRemoteSignerWebhookURL,
 		RemoteSignerWebhookHeaders: &defaultRemoteSignerWebhookHeaders,
 		RemoteDiscovery:            &defaultRemoteDiscovery,
@@ -1618,8 +1621,12 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				}
 			}
 
+			if cfg.RemoteSignerHeaders != nil {
+				n.RemoteSignerHeaders = parseHeaderMap(*cfg.RemoteSignerHeaders)
+			}
+
 			glog.Info("Retrieving OrchestratorInfo fields from remote signer: ", url)
-			fields, err := server.GetOrchInfoSig(url)
+			fields, err := server.GetOrchInfoSig(url, n.RemoteSignerHeaders)
 			if err != nil {
 				glog.Exit("Unable to query remote signer: ", err)
 			}
@@ -1652,13 +1659,21 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				glog.Exit("Error setting orch webhook URL ", err)
 			}
 			glog.Info("Using orchestrator webhook URL ", whurl)
+			// IMPORTANT: Do not forward RemoteSignerHeaders here. These headers may
+			// contain secrets intended only for the configured remote signer, and a
+			// separate orchestrator discovery webhook must never receive them.
 			n.OrchestratorPool = discovery.NewWebhookPool(bcast, whurl, *cfg.DiscoveryTimeout)
 		} else if len(orchURLs) > 0 {
 			n.OrchestratorPool = discovery.NewOrchestratorPool(bcast, orchURLs, common.Score_Trusted, orchBlacklist, *cfg.DiscoveryTimeout)
 		} else if n.RemoteSignerUrl != nil {
 			orchDiscoveryURL := n.RemoteSignerUrl.ResolveReference(&url.URL{Path: "/discover-orchestrators"})
 			glog.Info("Using remote signer orchestrator discovery endpoint ", orchDiscoveryURL)
-			n.OrchestratorPool = discovery.NewWebhookPool(bcast, orchDiscoveryURL, *cfg.DiscoveryTimeout)
+			n.OrchestratorPool = discovery.WebhookPoolConfig{
+				Broadcaster:      bcast,
+				Callback:         orchDiscoveryURL,
+				Headers:          n.RemoteSignerHeaders,
+				DiscoveryTimeout: *cfg.DiscoveryTimeout,
+			}.New()
 		}
 
 		// When the node is on-chain mode always cache the on-chain orchestrators and poll for updates

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -169,6 +169,8 @@ type LivepeerConfig struct {
 	TestOrchAvail              *bool
 	RemoteSigner               *bool
 	RemoteSignerUrl            *string
+	RemoteSignerWebhookURL     *string
+	RemoteSignerWebhookHeaders *string
 	RemoteDiscovery            *bool
 	AIRunnerImage              *string
 	AIRunnerImageOverrides     *string
@@ -307,6 +309,8 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultTestOrchAvail := true
 	defaultRemoteSigner := false
 	defaultRemoteSignerUrl := ""
+	defaultRemoteSignerWebhookURL := ""
+	defaultRemoteSignerWebhookHeaders := ""
 	defaultRemoteDiscovery := false
 
 	// Gateway logs
@@ -428,10 +432,12 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		OrchMinLivepeerVersion: &defaultMinLivepeerVersion,
 
 		// Flags
-		TestOrchAvail:   &defaultTestOrchAvail,
-		RemoteSigner:    &defaultRemoteSigner,
-		RemoteSignerUrl: &defaultRemoteSignerUrl,
-		RemoteDiscovery: &defaultRemoteDiscovery,
+		TestOrchAvail:              &defaultTestOrchAvail,
+		RemoteSigner:               &defaultRemoteSigner,
+		RemoteSignerUrl:            &defaultRemoteSignerUrl,
+		RemoteSignerWebhookURL:     &defaultRemoteSignerWebhookURL,
+		RemoteSignerWebhookHeaders: &defaultRemoteSignerWebhookHeaders,
+		RemoteDiscovery:            &defaultRemoteDiscovery,
 
 		// Gateway logs
 		KafkaBootstrapServers: &defaultKafkaBootstrapServers,
@@ -1570,6 +1576,17 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		glog.Info("Using live AI auth webhook URL ", parsedUrl.Redacted())
 		n.LiveAIAuthWebhookURL = parsedUrl
 	}
+	if *cfg.RemoteSignerWebhookURL != "" {
+		parsedURL, err := validateURL(*cfg.RemoteSignerWebhookURL)
+		if err != nil {
+			glog.Exit("Error setting remote signer webhook URL ", err)
+		}
+		glog.Info("Using remote signer webhook URL ", parsedURL.Redacted())
+		n.RemoteSignerWebhookURL = parsedURL
+		if cfg.RemoteSignerWebhookHeaders != nil {
+			n.RemoteSignerWebhookHeaders = parseHeaderMap(*cfg.RemoteSignerWebhookHeaders)
+		}
+	}
 
 	httpIngest := true
 
@@ -1807,14 +1824,7 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		n.RemoteDiscovery = *cfg.RemoteDiscovery
 	}
 	if cfg.LiveAIHeartbeatHeaders != nil {
-		n.LiveAIHeartbeatHeaders = make(map[string]string)
-		headers := strings.Split(*cfg.LiveAIHeartbeatHeaders, ",")
-		for _, header := range headers {
-			parts := strings.SplitN(header, ":", 2)
-			if len(parts) == 2 {
-				n.LiveAIHeartbeatHeaders[parts[0]] = parts[1]
-			}
-		}
+		n.LiveAIHeartbeatHeaders = parseHeaderMap(*cfg.LiveAIHeartbeatHeaders)
 	}
 	n.LivePaymentInterval = *cfg.LivePaymentInterval
 	n.LiveOutSegmentTimeout = *cfg.LiveOutSegmentTimeout
@@ -2087,6 +2097,17 @@ func validateURL(u string) (*url.URL, error) {
 		return nil, errors.New("URL should be HTTP or HTTPS")
 	}
 	return p, nil
+}
+
+func parseHeaderMap(raw string) map[string]string {
+	headers := make(map[string]string)
+	for _, header := range strings.Split(raw, ",") {
+		parts := strings.SplitN(header, ":", 2)
+		if len(parts) == 2 {
+			headers[parts[0]] = parts[1]
+		}
+	}
+	return headers
 }
 
 func isLocalURL(u string) (bool, error) {

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -460,13 +460,13 @@ func (cfg LivepeerConfig) PrintConfig(w io.Writer) {
 
 	// Define sensitive field names that should be redacted
 	sensitiveFields := map[string]bool{
-		"EthPassword":               true,
-		"OrchSecret":                true,
-		"KafkaPassword":             true,
-		"MediaMTXApiPassword":       true,
-		"LiveAIAuthApiKey":          true,
-		"FVfailGsKey":               true,
-		"RemoteSignerHeaders":       true,
+		"EthPassword":                true,
+		"OrchSecret":                 true,
+		"KafkaPassword":              true,
+		"MediaMTXApiPassword":        true,
+		"LiveAIAuthApiKey":           true,
+		"FVfailGsKey":                true,
+		"RemoteSignerHeaders":        true,
 		"RemoteSignerWebhookHeaders": true,
 	}
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -460,12 +460,14 @@ func (cfg LivepeerConfig) PrintConfig(w io.Writer) {
 
 	// Define sensitive field names that should be redacted
 	sensitiveFields := map[string]bool{
-		"EthPassword":         true,
-		"OrchSecret":          true,
-		"KafkaPassword":       true,
-		"MediaMTXApiPassword": true,
-		"LiveAIAuthApiKey":    true,
-		"FVfailGsKey":         true,
+		"EthPassword":               true,
+		"OrchSecret":                true,
+		"KafkaPassword":             true,
+		"MediaMTXApiPassword":       true,
+		"LiveAIAuthApiKey":          true,
+		"FVfailGsKey":               true,
+		"RemoteSignerHeaders":       true,
+		"RemoteSignerWebhookHeaders": true,
 	}
 
 	for i := 0; i < cfgType.NumField(); i++ {

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -384,10 +384,12 @@ func TestNewLivepeerConfig_RemoteSignerWebhookFlags(t *testing.T) {
 	fs := flag.NewFlagSet("livepeer-test", flag.ContinueOnError)
 	cfg := NewLivepeerConfig(fs)
 	err := fs.Parse([]string{
+		"-remoteSignerHeaders", "Authorization:Bearer gateway-token",
 		"-remoteSignerWebhookUrl", "https://example.com/webhook",
 		"-remoteSignerWebhookHeaders", "Authorization:Bearer abc,X-API-Key:secret",
 	})
 	require.NoError(err)
+	require.Equal("Authorization:Bearer gateway-token", *cfg.RemoteSignerHeaders)
 	require.Equal("https://example.com/webhook", *cfg.RemoteSignerWebhookURL)
 	require.Equal("Authorization:Bearer abc,X-API-Key:secret", *cfg.RemoteSignerWebhookHeaders)
 }

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -2,6 +2,7 @@ package starter
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"math/big"
 	"os"
@@ -366,6 +367,29 @@ func TestPrintConfigRedaction(t *testing.T) {
 
 	// Verify non-sensitive values are still shown
 	assert.Contains(output, testServiceAddr, "ServiceAddr should not be redacted")
+}
+
+func TestParseHeaderMap(t *testing.T) {
+	require := require.New(t)
+	headers := parseHeaderMap("Authorization:Bearer abc,X-API-Key:secret,invalid")
+	require.Equal("Bearer abc", headers["Authorization"])
+	require.Equal("secret", headers["X-API-Key"])
+	_, exists := headers["invalid"]
+	require.False(exists)
+}
+
+func TestNewLivepeerConfig_RemoteSignerWebhookFlags(t *testing.T) {
+	require := require.New(t)
+
+	fs := flag.NewFlagSet("livepeer-test", flag.ContinueOnError)
+	cfg := NewLivepeerConfig(fs)
+	err := fs.Parse([]string{
+		"-remoteSignerWebhookUrl", "https://example.com/webhook",
+		"-remoteSignerWebhookHeaders", "Authorization:Bearer abc,X-API-Key:secret",
+	})
+	require.NoError(err)
+	require.Equal("https://example.com/webhook", *cfg.RemoteSignerWebhookURL)
+	require.Equal("Authorization:Bearer abc,X-API-Key:secret", *cfg.RemoteSignerWebhookHeaders)
 }
 
 // Helper struct to capture output for testing

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -346,11 +346,15 @@ func TestPrintConfigRedaction(t *testing.T) {
 	testApiKey := "api-key-abc123"
 	testOrchSecret := "orch-secret-456"
 	testServiceAddr := "127.0.0.1:8936"
+	testRemoteSignerHeaders := "Authorization:Bearer gateway-token"
+	testRemoteSignerWebhookHeaders := "Authorization:Bearer webhook-token,X-API-Key:secret"
 
 	cfg.EthPassword = &testPassword
 	cfg.LiveAIAuthApiKey = &testApiKey
 	cfg.OrchSecret = &testOrchSecret
 	cfg.ServiceAddr = &testServiceAddr
+	cfg.RemoteSignerHeaders = &testRemoteSignerHeaders
+	cfg.RemoteSignerWebhookHeaders = &testRemoteSignerWebhookHeaders
 
 	// Capture the output
 	var buf []byte
@@ -363,6 +367,8 @@ func TestPrintConfigRedaction(t *testing.T) {
 	assert.NotContains(output, testPassword, "EthPassword should be redacted")
 	assert.NotContains(output, testApiKey, "LiveAIAuthApiKey should be redacted")
 	assert.NotContains(output, testOrchSecret, "OrchSecret should be redacted")
+	assert.NotContains(output, testRemoteSignerHeaders, "RemoteSignerHeaders should be redacted")
+	assert.NotContains(output, testRemoteSignerWebhookHeaders, "RemoteSignerWebhookHeaders should be redacted")
 	assert.Contains(output, "***", "Should contain redacted placeholder")
 
 	// Verify non-sensitive values are still shown

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -150,6 +150,7 @@ type LivepeerNode struct {
 
 	// Gateway fields for remote signers
 	RemoteSignerUrl            *url.URL          // URL of remote signer service to use (gateway only)
+	RemoteSignerHeaders        map[string]string // Headers to use for gateway remote signer requests
 	RemoteSignerWebhookURL     *url.URL          // Authentication webhook URL called by remote signer during GenerateLivePayment
 	RemoteSignerWebhookHeaders map[string]string // Headers to use for remote signer webhook requests
 	RemoteEthAddr              ethcommon.Address // eth address of the remote signer

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -149,10 +149,12 @@ type LivepeerNode struct {
 	ExtraNodes int
 
 	// Gateway fields for remote signers
-	RemoteSignerUrl *url.URL
-	RemoteEthAddr   ethcommon.Address // eth address of the remote signer
-	InfoSig         []byte            // sig over eth address for the OrchestratorInfo request
-	RemoteDiscovery bool              // expose remote discovery endpoint when enabled
+	RemoteSignerUrl            *url.URL          // URL of remote signer service to use (gateway only)
+	RemoteSignerWebhookURL     *url.URL          // Authentication webhook URL called by remote signer during GenerateLivePayment
+	RemoteSignerWebhookHeaders map[string]string // Headers to use for remote signer webhook requests
+	RemoteEthAddr              ethcommon.Address // eth address of the remote signer
+	InfoSig                    []byte            // sig over eth address for the OrchestratorInfo request
+	RemoteDiscovery            bool              // expose remote discovery endpoint when enabled
 
 	// Thread safety for config fields
 	mu                  sync.RWMutex

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"runtime"
 	"strconv"
@@ -1199,14 +1201,15 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 
 	// mock webhook and orchestrator info request
 	addresses := []string{"https://127.0.0.1:8936", "https://127.0.0.1:8937", "https://127.0.0.1:8938"}
-
-	getURLsfromWebhook = func(cbUrl *url.URL) ([]byte, error) {
+	webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var wh []webhookResponse
 		for _, addr := range addresses {
 			wh = append(wh, webhookResponse{Address: addr})
 		}
-		return json.Marshal(&wh)
-	}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(json.NewEncoder(w).Encode(wh))
+	}))
+	defer webhook.Close()
 
 	wg := sync.WaitGroup{}
 	oldOrchInfo := serverGetOrchInfo
@@ -1217,7 +1220,7 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 	}
 
 	// assert created webhook pool is correct length
-	whURL, _ := url.ParseRequestURI("https://livepeer.live/api/orchestrator")
+	whURL, _ := url.ParseRequestURI(webhook.URL)
 	whpool := NewWebhookPool(&stubBroadcaster{}, whURL, 500*time.Millisecond)
 	assert.Equal(3, whpool.Size())
 
@@ -1300,6 +1303,38 @@ func TestNewWHOrchestratorPoolCache(t *testing.T) {
 	for _, addr := range addresses {
 		uri, _ := url.ParseRequestURI(addr)
 		assert.Contains(removeLatency(infos), common.OrchestratorLocalInfo{URL: uri, Latency: nil})
+	}
+}
+
+func TestWebhookPoolConfig_ForwardsHeaders(t *testing.T) {
+	require := require.New(t)
+
+	headersCh := make(chan map[string]string, 1)
+	webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headersCh <- map[string]string{
+			"Authorization": r.Header.Get("Authorization"),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(json.NewEncoder(w).Encode([]webhookResponse{{Address: "https://127.0.0.1:8936"}}))
+	}))
+	defer webhook.Close()
+
+	whURL, err := url.ParseRequestURI(webhook.URL)
+	require.NoError(err)
+
+	whpool := WebhookPoolConfig{
+		Broadcaster:      &stubBroadcaster{},
+		Callback:         whURL,
+		Headers:          map[string]string{"Authorization": "Bearer gateway-token"},
+		DiscoveryTimeout: 500 * time.Millisecond,
+	}.New()
+	_ = whpool.Size()
+
+	select {
+	case gotHeaders := <-headersCh:
+		require.Equal("Bearer gateway-token", gotHeaders["Authorization"])
+	case <-time.After(time.Second):
+		require.Fail("timed out waiting for webhook call")
 	}
 }
 

--- a/discovery/wh_discovery.go
+++ b/discovery/wh_discovery.go
@@ -23,6 +23,7 @@ type webhookResponse struct {
 type webhookPool struct {
 	pool                *orchestratorPool
 	callback            *url.URL
+	headers             map[string]string
 	responseHash        ethcommon.Hash
 	lastRequest         time.Time
 	mu                  *sync.RWMutex
@@ -42,6 +43,7 @@ func NewWebhookPool(bcast common.Broadcaster, callback *url.URL, discoveryTimeou
 type WebhookPoolConfig struct {
 	Broadcaster         common.Broadcaster
 	Callback            *url.URL
+	Headers             map[string]string
 	DiscoveryTimeout    time.Duration
 	IgnoreCapacityCheck bool
 }
@@ -49,6 +51,7 @@ type WebhookPoolConfig struct {
 func (cfg WebhookPoolConfig) New() *webhookPool {
 	p := &webhookPool{
 		callback:            cfg.Callback,
+		headers:             cfg.Headers,
 		mu:                  &sync.RWMutex{},
 		bcast:               cfg.Broadcaster,
 		discoveryTimeout:    cfg.DiscoveryTimeout,
@@ -70,7 +73,7 @@ func (w *webhookPool) getInfos() ([]common.OrchestratorLocalInfo, error) {
 	}
 
 	// retrieve addrs from webhook if time since lastRequest is more than the refresh interval
-	body, err := getURLsfromWebhook(w.callback)
+	body, err := getURLsfromWebhook(w.callback, w.headers)
 	if err != nil {
 		return nil, err
 	}
@@ -148,11 +151,20 @@ func (w *webhookPool) Broadcaster() common.Broadcaster {
 	return w.pool.bcast
 }
 
-var getURLsfromWebhook = func(cbUrl *url.URL) ([]byte, error) {
+func getURLsfromWebhook(cbUrl *url.URL, headers map[string]string) ([]byte, error) {
 	var httpc = &http.Client{
 		Timeout: 3 * time.Second,
 	}
-	resp, err := httpc.Get(cbUrl.String())
+	req, err := http.NewRequest(http.MethodGet, cbUrl.String(), nil)
+	if err != nil {
+		glog.Error("Unable to create webhook request ", err)
+		return nil, err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := httpc.Do(req)
 	if err != nil {
 		glog.Error("Unable to make webhook request ", err)
 		return nil, err

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -138,6 +138,88 @@ If there are errors about too many tickets (eg `numTickets ... exceeds maximum o
 
 For PM configuration details and how these knobs interact, see `doc/payments.md`.
 
+### Payment Authentication
+
+The remote signer's payment endpoint (POST `/generate-live-payment`) supports an optional authentication webhook that is called during every request. This allows operators to enforce external authorization or policy checks before the signer commits to updated payment state.
+
+Configure the webhook with:
+
+- `-remoteSignerWebhookUrl <url>`: the endpoint that receives the callback
+- `-remoteSignerWebhookHeaders 'key:val,key2:val2'`: headers attached to the outbound webhook request for authenticating against the webhook service itself (e.g. `Authorization:Bearer <token>,X-API-Key:<key>`)
+
+Headers follow the same comma-separated `key:value` format used by `-liveAIHeartbeatHeaders`. The headers flag is only meaningful when a webhook URL is configured.
+
+Omit `-remoteSignerWebhookUrl` to disable the webhook entirely.
+
+Example:
+
+```bash
+./livepeer \
+  -remoteSigner \
+  -network mainnet \
+  -httpAddr 127.0.0.1:7936 \
+  -remoteSignerWebhookUrl https://auth.example.com/livepeer/authorize \
+  -remoteSignerWebhookHeaders 'Authorization:Bearer s3cret,X-Tenant:acme' \
+  -ethUrl <eth-rpc-url> \
+  -ethPassword <password-or-password-file> \
+  ...
+```
+
+#### Webhook request
+
+The signer sends a `POST` with `Content-Type: application/json` to the configured URL. The JSON body contains:
+
+| Field     | Type                          | Description                                                      |
+|-----------|-------------------------------|------------------------------------------------------------------|
+| `headers` | `map[string][]string`         | The incoming HTTP request headers from the gateway's payment call |
+| `state`   | `RemotePaymentState` (object) | The current payment state, after all updates |
+
+Example body:
+
+```json
+{
+  "headers": {
+    "Content-Type": ["application/json"],
+    "X-Request-Id": ["abc-123"]
+  },
+  "state": {
+    "StateID": "xYz",
+    "PMSessionID": "session-1",
+    "LastUpdate": "2026-04-07T20:00:00Z",
+    "OrchestratorAddress": "0x1234...",
+    "AuthExpiry": 0,
+    "SenderNonce": 7,
+    "Balance": "500/1",
+    "InitialPricePerUnit": 1200,
+    "InitialPixelsPerUnit": 1,
+    "SequenceNumber": 3
+  }
+}
+```
+
+#### Webhook response
+
+- **HTTP 200**: the signer proceeds to encode and sign the state as normal.
+- **Any other status**: the signer aborts and returns the webhook's status code and body to the gateway caller, wrapped in the standard API error JSON envelope.
+
+This means the webhook can return domain-specific HTTP codes (e.g. 401, 403, 429) and they will propagate all the way back to the gateway.
+
+#### Timing
+
+The webhook fires after the payment state is fully updated (balance, nonce, timestamps) and immediately before the state is marshalled and signed. If the webhook rejects the request, no updated state is returned to the caller and it will be as if the payment were never made.
+
+### Auth webhook expiry caching
+
+When `-remoteSignerWebhookUrl` is configured, the remote signer calls the auth webhook on every `POST /generate-live-payment` request by default. The webhook can opt in to caching its authorization result by returning an `expiry` field in its HTTP 200 JSON response body:
+
+```json
+{"expiry": 1775574245}
+```
+
+- `expiry` is a Unix timestamp in seconds. While the current time has not exceeded this value, subsequent payment requests reuse the cached authorization and skip the outbound webhook call.
+- When the expiry is reached, the signer calls the webhook normally.
+- A zero, negative, or absent `expiry` means every request triggers the webhook, if one was configured.
+
 ## Operational + security guidance
 
 For the moment, remote signers are intended to sit behind infrastructure controls rather than being exposed directly to end-users. For example, run the remote signer on a private network or behind an authenticated proxy. Do not expose the remote signer to unauthenticated end-users. Run the remote signer close to gateways on a private network; protect it like you would an internal wallet service.

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -140,7 +140,7 @@ For PM configuration details and how these knobs interact, see `doc/payments.md`
 
 ### Payment Authentication
 
-The remote signer's payment endpoint (POST `/generate-live-payment`) supports an optional authentication webhook that is called during every request. This allows operators to enforce external authorization or policy checks before the signer commits to updated payment state.
+The remote signer's payment endpoint (POST `/generate-live-payment`) supports an optional authentication webhook that can be called during every request. This allows operators to enforce external authorization or policy checks before the signer commits to updated payment state.
 
 Configure the webhook with:
 

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -101,12 +101,14 @@ Currently, remote discovery can only be enabled for nodes in remote signing mode
 Configure a gateway to use a remote signer with:
 
 - `-remoteSignerUrl <url>`: base URL of the remote signer service (**gateway only**)
+- `-remoteSignerHeaders 'key:val,key2:val2'`: headers attached to outbound gateway requests to the remote signer (`/sign-orchestrator-info`, `/generate-live-payment`, and `/discover-orchestrators`)
 
 If `-remoteSignerUrl` is set, the gateway will query the signer at startup and fail fast if it cannot reach the signer.
 
 **No Ethereum flags are necessary on the gateway** in this mode. Omit the `-network` flag entirely here; this makes the gateway run in offchain mode, but it will still be able to send work to on-chain orchestrators with the `-remoteSignerUrl` flag enabled.
 
 By default, if no URL scheme is provided, https is assumed and prepended to the remote signer URL. To override this (eg, to use a http:// URL) then include the scheme, eg `-remoteSignerUrl http://signer-host:port`
+Headers follow the same comma-separated `key:value` format used by `-liveAIHeartbeatHeaders`.
 
 If the gateway is configured with a remote signer URL but no orchestrators (`-orchWebhookUrl` or `-orchAddr`) then it will attempt to use the remote signer's discovery endpoint. Note that not all remote signers may be offering discovery.
 
@@ -117,6 +119,7 @@ Example:
   -gateway \
   -httpAddr :9935 \
   -remoteSignerUrl http://127.0.0.1:7936 \
+  -remoteSignerHeaders 'Authorization:Bearer gateway-token,X-Tenant:acme' \
   -orchAddr localhost:8935 \
   -v 6
 ```

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -199,10 +199,30 @@ Example body:
 
 #### Webhook response
 
-- **HTTP 200**: the signer proceeds to encode and sign the state as normal.
-- **Any other status**: the signer aborts and returns the webhook's status code and body to the gateway caller, wrapped in the standard API error JSON envelope.
+The webhook itself must return **HTTP 200** and include a JSON body with:
 
-This means the webhook can return domain-specific HTTP codes (e.g. 401, 403, 429) and they will propagate all the way back to the gateway.
+| Field    | Type    | Required | Description |
+|----------|---------|----------|-------------|
+| `status` | `int`   | Yes      | The status code the signer should use to decide whether to proceed |
+| `reason` | `string`| No       | Error message returned to the gateway caller when `status` is not `200` |
+| `expiry` | `int64` | No       | Unix timestamp in seconds until which the authorization can be reused |
+
+Example success response:
+
+```json
+{"status": 200, "expiry": 1775574245}
+```
+
+Example rejection response:
+
+```json
+{"status": 403, "reason": "denied"}
+```
+
+- **HTTP 200 with `status: 200`**: the signer proceeds to encode and sign the state as normal.
+- **HTTP 200 with `status != 200`**: the signer aborts and returns that `status` to the gateway caller, wrapped in the standard API error JSON envelope. If `reason` is present it is used as the error message. This can be used by implementers to steer downstream caller behavior.
+- **Any non-200 webhook HTTP response**: the signer treats this as an internal webhook failure (eg, webhook service error or signer misconfiguration) and returns HTTP 500.
+- **Missing, zero, malformed, or otherwise invalid `status`**: the signer returns HTTP 500.
 
 #### Timing
 
@@ -210,10 +230,10 @@ The webhook fires after the payment state is fully updated (balance, nonce, time
 
 ### Auth webhook expiry caching
 
-When `-remoteSignerWebhookUrl` is configured, the remote signer calls the auth webhook on every `POST /generate-live-payment` request by default. The webhook can opt in to caching its authorization result by returning an `expiry` field in its HTTP 200 JSON response body:
+When `-remoteSignerWebhookUrl` is configured, the remote signer calls the auth webhook on every `POST /generate-live-payment` request by default. The webhook can opt in to caching its authorization result by returning an `expiry` field alongside `status: 200` in its HTTP 200 JSON response body:
 
 ```json
-{"expiry": 1775574245}
+{"status": 200, "expiry": 1775574245}
 ```
 
 - `expiry` is a Unix timestamp in seconds. While the current time has not exceeded this value, subsequent payment requests reuse the cached authorization and skip the outbound webhook call.

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -230,6 +230,7 @@ Example rejection response:
 - **Any non-200 webhook HTTP response**: the signer treats this as an internal webhook failure (eg, webhook service error or signer misconfiguration) and returns HTTP 500.
 - **Missing, zero, malformed, or otherwise invalid `status`**: the signer returns HTTP 500.
 - If `auth_id` is omitted, the signer falls back to the incoming request's `Signer-Auth-Id` header. If both are present, the webhook `auth_id` takes precedence.
+- Once an auth ID is persisted in signed payment state, a different webhook `auth_id` or fallback `Signer-Auth-Id` on a later request is treated as an internal error and returns HTTP 500.
 
 #### Timing
 

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -183,6 +183,7 @@ Example body:
 {
   "headers": {
     "Content-Type": ["application/json"],
+    "Signer-Auth-Id": ["auth-456"],
     "X-Request-Id": ["abc-123"]
   },
   "state": {
@@ -195,7 +196,8 @@ Example body:
     "Balance": "500/1",
     "InitialPricePerUnit": 1200,
     "InitialPixelsPerUnit": 1,
-    "SequenceNumber": 3
+    "SequenceNumber": 3,
+    "AuthID": "auth-456"
   }
 }
 ```
@@ -209,11 +211,12 @@ The webhook itself must return **HTTP 200** and include a JSON body with:
 | `status` | `int`   | Yes      | The status code the signer should use to decide whether to proceed |
 | `reason` | `string`| No       | Error message returned to the gateway caller when `status` is not `200` |
 | `expiry` | `int64` | No       | Unix timestamp in seconds until which the authorization can be reused |
+| `auth_id` | `string` | No     | Opaque authorization identifier (optional) |
 
 Example success response:
 
 ```json
-{"status": 200, "expiry": 1775574245}
+{"status": 200, "expiry": 1775574245, "auth_id": "auth-456"}
 ```
 
 Example rejection response:
@@ -226,6 +229,7 @@ Example rejection response:
 - **HTTP 200 with `status != 200`**: the signer aborts and returns that `status` to the gateway caller, wrapped in the standard API error JSON envelope. If `reason` is present it is used as the error message. This can be used by implementers to steer downstream caller behavior.
 - **Any non-200 webhook HTTP response**: the signer treats this as an internal webhook failure (eg, webhook service error or signer misconfiguration) and returns HTTP 500.
 - **Missing, zero, malformed, or otherwise invalid `status`**: the signer returns HTTP 500.
+- If `auth_id` is omitted, the signer falls back to the incoming request's `Signer-Auth-Id` header. If both are present, the webhook `auth_id` takes precedence.
 
 #### Timing
 
@@ -245,6 +249,6 @@ When `-remoteSignerWebhookUrl` is configured, the remote signer calls the auth w
 
 ## Operational + security guidance
 
-For the moment, remote signers are intended to sit behind infrastructure controls rather than being exposed directly to end-users. For example, run the remote signer on a private network or behind an authenticated proxy. Do not expose the remote signer to unauthenticated end-users. Run the remote signer close to gateways on a private network; protect it like you would an internal wallet service.
+For the moment, remote signers are intended to sit behind infrastructure controls rather than being exposed directly to end-users. For example, run the remote signer on a private network or behind an authenticated proxy. Do not expose the remote signer to unauthenticated end-users. Run the remote signer close to gateways on a private network; protect it like you would an internal wallet service. If a proxy sits in front of the signer, configure it to scrub all incoming `Signer-` headers from untrusted clients before applying trusted internal headers.
 
 Remote signers are stateless, so signer nodes can operate in a redundant configuration (eg, round-robin DNS, anycasting) with no special gateway-side configuration.

--- a/server/live_payment.go
+++ b/server/live_payment.go
@@ -251,6 +251,9 @@ func (r *remotePaymentSender) RequestPayment(ctx context.Context, segmentInfo *S
 		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
+	for k, v := range r.node.RemoteSignerHeaders {
+		httpReq.Header.Set(k, v)
+	}
 	resp, err := r.client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call remote signer: %w", err)

--- a/server/live_payment_test.go
+++ b/server/live_payment_test.go
@@ -254,6 +254,7 @@ func TestRemotePaymentSender_RequestPayment_Success_CachesStateAndSendsExpectedP
 	remoteTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal("/generate-live-payment", r.URL.Path)
 		require.Equal("application/json", r.Header.Get("Content-Type"))
+		require.Equal("Bearer gateway-token", r.Header.Get("Authorization"))
 
 		require.NoError(json.NewDecoder(r.Body).Decode(&gotReq))
 
@@ -278,6 +279,7 @@ func TestRemotePaymentSender_RequestPayment_Success_CachesStateAndSendsExpectedP
 	sess := StubBroadcastSession("http://orch.example")
 	node, _ := core.NewLivepeerNode(nil, "", nil)
 	node.RemoteSignerUrl = remoteURL
+	node.RemoteSignerHeaders = map[string]string{"Authorization": "Bearer gateway-token"}
 
 	r := NewRemotePaymentSender(node)
 	r.state = RemotePaymentStateSig{State: []byte{0x01}, Sig: []byte{0x02}}

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -633,7 +633,7 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 }
 
 // Gateway helper that calls the remote signer service for the GetOrchestratorInfo signature
-func GetOrchInfoSig(remoteSignerHost *url.URL) (*OrchInfoSigResponse, error) {
+func GetOrchInfoSig(remoteSignerHost *url.URL, headers map[string]string) (*OrchInfoSigResponse, error) {
 
 	url := remoteSignerHost.ResolveReference(&url.URL{Path: "/sign-orchestrator-info"})
 
@@ -642,8 +642,17 @@ func GetOrchInfoSig(remoteSignerHost *url.URL) (*OrchInfoSigResponse, error) {
 		Timeout: 30 * time.Second,
 	}
 
+	req, err := http.NewRequest(http.MethodPost, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
 	// Make the request
-	resp, err := client.Post(url.String(), "application/json", nil)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call remote signer: %w", err)
 	}

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -238,7 +238,7 @@ func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentS
 	if err != nil {
 		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to encode remote signer webhook payload: %v", err)
 	}
-	webhookReq, err := http.NewRequest(http.MethodPost, callbackURL.String(), bytes.NewReader(body))
+	webhookReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, callbackURL.String(), bytes.NewReader(body))
 	if err != nil {
 		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to build remote signer webhook request: %v", err)
 	}
@@ -247,7 +247,8 @@ func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentS
 		webhookReq.Header.Set(key, value)
 	}
 
-	resp, err := http.DefaultClient.Do(webhookReq)
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(webhookReq)
 	if err != nil {
 		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to call remote signer webhook: %v", err)
 	}

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -143,6 +143,7 @@ type RemotePaymentState struct {
 	PMSessionID          string
 	LastUpdate           time.Time
 	OrchestratorAddress  ethcommon.Address
+	AuthExpiry           int64
 	SenderNonce          uint32
 	Balance              string
 	InitialPricePerUnit  int64
@@ -189,6 +190,12 @@ type generateLivePaymentWebhookBody struct {
 	State   *RemotePaymentState `json:"state,omitempty"`
 }
 
+type authResponse struct {
+	// Unix timestamp (seconds) until which auth is considered valid.
+	// Allows for skipping webhook callbacks until this time is exceeded.
+	Expiry int64 `json:"expiry,omitempty"`
+}
+
 // Signs the serialized state with the remote signer's Ethereum key.
 func signState(ls *LivepeerServer, stateBytes []byte) ([]byte, error) {
 	if ls == nil || ls.LivepeerNode == nil || ls.LivepeerNode.Eth == nil {
@@ -214,23 +221,26 @@ func verifyStateSignature(ls *LivepeerServer, stateBytes []byte, sig []byte) err
 	return nil
 }
 
-func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentState) (int, string) {
+func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentState) (int, *authResponse, string) {
 	if ls == nil || ls.LivepeerNode == nil {
-		return http.StatusOK, ""
+		return http.StatusOK, nil, ""
 	}
 	callbackURL := ls.LivepeerNode.RemoteSignerWebhookURL
 	callbackHeaders := ls.LivepeerNode.RemoteSignerWebhookHeaders
 	if callbackURL == nil {
-		return http.StatusOK, ""
+		return http.StatusOK, nil, ""
+	}
+	if state != nil && state.AuthExpiry != 0 && time.Now().Unix() <= state.AuthExpiry {
+		return http.StatusOK, nil, ""
 	}
 
 	body, err := json.Marshal(generateLivePaymentWebhookBody{Headers: r.Header, State: state})
 	if err != nil {
-		return http.StatusInternalServerError, fmt.Sprintf("failed to encode remote signer webhook payload: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to encode remote signer webhook payload: %v", err)
 	}
 	webhookReq, err := http.NewRequest(http.MethodPost, callbackURL.String(), bytes.NewReader(body))
 	if err != nil {
-		return http.StatusInternalServerError, fmt.Sprintf("failed to build remote signer webhook request: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to build remote signer webhook request: %v", err)
 	}
 	webhookReq.Header.Set("Content-Type", "application/json")
 	for key, value := range callbackHeaders {
@@ -239,15 +249,23 @@ func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentS
 
 	resp, err := http.DefaultClient.Do(webhookReq)
 	if err != nil {
-		return http.StatusInternalServerError, fmt.Sprintf("failed to call remote signer webhook: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to call remote signer webhook: %v", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return http.StatusInternalServerError, fmt.Sprintf("failed to read remote signer webhook response: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to read remote signer webhook response: %v", err)
 	}
-	return resp.StatusCode, string(respBody)
+
+	var webhookResp authResponse
+	if resp.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(respBody, &webhookResp); err != nil {
+			return http.StatusInternalServerError, nil, fmt.Sprintf("failed to decode remote signer webhook response: %v", err)
+		}
+		return resp.StatusCode, &webhookResp, ""
+	}
+	return resp.StatusCode, nil, string(respBody)
 }
 
 // GenerateLivePayment handles remote generation of a payment for live streams.
@@ -530,11 +548,14 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	callbackStatus, callbackBody := ls.authLivePayment(r, state)
+	callbackStatus, callbackResp, callbackErr := ls.authLivePayment(r, state)
 	if callbackStatus != http.StatusOK {
-		err = fmt.Errorf("remote signer webhook returned status %d: %s", callbackStatus, callbackBody)
+		err = fmt.Errorf("remote signer webhook returned status %d: %s", callbackStatus, callbackErr)
 		respondJsonError(ctx, w, err, callbackStatus)
 		return
+	}
+	if callbackResp != nil {
+		state.AuthExpiry = callbackResp.Expiry
 	}
 
 	// Encode and sign updated state

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -183,6 +184,11 @@ type RemotePaymentResponse struct {
 	State    RemotePaymentStateSig `json:"state"`
 }
 
+type generateLivePaymentWebhookBody struct {
+	Headers map[string][]string `json:"headers"`
+	State   *RemotePaymentState `json:"state,omitempty"`
+}
+
 // Signs the serialized state with the remote signer's Ethereum key.
 func signState(ls *LivepeerServer, stateBytes []byte) ([]byte, error) {
 	if ls == nil || ls.LivepeerNode == nil || ls.LivepeerNode.Eth == nil {
@@ -206,6 +212,42 @@ func verifyStateSignature(ls *LivepeerServer, stateBytes []byte, sig []byte) err
 		return fmt.Errorf("invalid state signature")
 	}
 	return nil
+}
+
+func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentState) (int, string) {
+	if ls == nil || ls.LivepeerNode == nil {
+		return http.StatusOK, ""
+	}
+	callbackURL := ls.LivepeerNode.RemoteSignerWebhookURL
+	callbackHeaders := ls.LivepeerNode.RemoteSignerWebhookHeaders
+	if callbackURL == nil {
+		return http.StatusOK, ""
+	}
+
+	body, err := json.Marshal(generateLivePaymentWebhookBody{Headers: r.Header, State: state})
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Sprintf("failed to encode remote signer webhook payload: %v", err)
+	}
+	webhookReq, err := http.NewRequest(http.MethodPost, callbackURL.String(), bytes.NewReader(body))
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Sprintf("failed to build remote signer webhook request: %v", err)
+	}
+	webhookReq.Header.Set("Content-Type", "application/json")
+	for key, value := range callbackHeaders {
+		webhookReq.Header.Set(key, value)
+	}
+
+	resp, err := http.DefaultClient.Do(webhookReq)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Sprintf("failed to call remote signer webhook: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return http.StatusInternalServerError, fmt.Sprintf("failed to read remote signer webhook response: %v", err)
+	}
+	return resp.StatusCode, string(respBody)
 }
 
 // GenerateLivePayment handles remote generation of a payment for live streams.
@@ -485,6 +527,13 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		err = fmt.Errorf("remote signer failed to retrieve nonce: %w", err)
 		respondJsonError(ctx, w, err, http.StatusInternalServerError)
+		return
+	}
+
+	callbackStatus, callbackBody := ls.authLivePayment(r, state)
+	if callbackStatus != http.StatusOK {
+		err = fmt.Errorf("remote signer webhook returned status %d: %s", callbackStatus, callbackBody)
+		respondJsonError(ctx, w, err, callbackStatus)
 		return
 	}
 

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -191,6 +191,10 @@ type generateLivePaymentWebhookBody struct {
 }
 
 type authResponse struct {
+	// HTTP status that GenerateLivePayment should return to the caller.
+	Status *int `json:"status,omitempty"`
+	// Optional error message when Status is non-200.
+	Reason string `json:"reason,omitempty"`
 	// Unix timestamp (seconds) until which auth is considered valid.
 	// Allows for skipping webhook callbacks until this time is exceeded.
 	Expiry int64 `json:"expiry,omitempty"`
@@ -221,26 +225,26 @@ func verifyStateSignature(ls *LivepeerServer, stateBytes []byte, sig []byte) err
 	return nil
 }
 
-func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentState) (int, *authResponse, string) {
+func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentState) (int, *authResponse, error) {
 	if ls == nil || ls.LivepeerNode == nil {
-		return http.StatusOK, nil, ""
+		return http.StatusOK, nil, nil
 	}
 	callbackURL := ls.LivepeerNode.RemoteSignerWebhookURL
 	callbackHeaders := ls.LivepeerNode.RemoteSignerWebhookHeaders
 	if callbackURL == nil {
-		return http.StatusOK, nil, ""
+		return http.StatusOK, nil, nil
 	}
 	if state != nil && state.AuthExpiry != 0 && time.Now().Unix() <= state.AuthExpiry {
-		return http.StatusOK, nil, ""
+		return http.StatusOK, nil, nil
 	}
 
 	body, err := json.Marshal(generateLivePaymentWebhookBody{Headers: r.Header, State: state})
 	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to encode remote signer webhook payload: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to encode signer auth payload: %v", err)
 	}
 	webhookReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, callbackURL.String(), bytes.NewReader(body))
 	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to build remote signer webhook request: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to build signer auth request: %v", err)
 	}
 	webhookReq.Header.Set("Content-Type", "application/json")
 	for key, value := range callbackHeaders {
@@ -250,23 +254,32 @@ func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentS
 	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Do(webhookReq)
 	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to call remote signer webhook: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to call remote signer webhook: %v", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return http.StatusInternalServerError, nil, fmt.Sprintf("failed to read remote signer webhook response: %v", err)
+		return http.StatusInternalServerError, nil, fmt.Errorf("failed to read signer auth response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Error with webhook service or signer misconfiguration, so treat as internal
+		return http.StatusInternalServerError, nil, fmt.Errorf("signer auth error status %d", resp.StatusCode)
 	}
 
 	var webhookResp authResponse
-	if resp.StatusCode == http.StatusOK {
-		if err := json.Unmarshal(respBody, &webhookResp); err != nil {
-			return http.StatusInternalServerError, nil, fmt.Sprintf("failed to decode remote signer webhook response: %v", err)
-		}
-		return resp.StatusCode, &webhookResp, ""
+	if err := json.Unmarshal(respBody, &webhookResp); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("signer auth invalid response: %v", err)
 	}
-	return resp.StatusCode, nil, string(respBody)
+	if webhookResp.Status == nil || *webhookResp.Status <= 0 {
+		return http.StatusInternalServerError, nil, errors.New("signer auth invalid status")
+	}
+	if *webhookResp.Status != http.StatusOK && webhookResp.Reason == "" {
+		webhookResp.Reason = fmt.Sprintf("signer auth rejected request with status %d", *webhookResp.Status)
+	}
+
+	return *webhookResp.Status, &webhookResp, errors.New(webhookResp.Reason)
 }
 
 // GenerateLivePayment handles remote generation of a payment for live streams.
@@ -551,8 +564,7 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 
 	callbackStatus, callbackResp, callbackErr := ls.authLivePayment(r, state)
 	if callbackStatus != http.StatusOK {
-		err = fmt.Errorf("remote signer webhook returned status %d: %s", callbackStatus, callbackErr)
-		respondJsonError(ctx, w, err, callbackStatus)
+		respondJsonError(ctx, w, callbackErr, callbackStatus)
 		return
 	}
 	if callbackResp != nil {

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -578,9 +578,11 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 	if callbackResp != nil && callbackResp.AuthID != "" {
 		authID = callbackResp.AuthID
 	}
-	if state.AuthID != authID {
+	if authID != "" && state.AuthID != authID {
 		if state.AuthID != "" {
 			clog.Warningf(ctx, "Remote signer auth ID changed oldAuthID=%s newAuthID=%s", state.AuthID, authID)
+			respondJsonError(ctx, w, errors.New("remote signer auth ID changed"), http.StatusInternalServerError)
+			return
 		}
 		state.AuthID = authID
 	}

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -30,6 +30,7 @@ const HTTPStatusPriceExceeded = 481
 const HTTPStatusNoTickets = 482
 const RemoteType_LiveVideoToVideo = "lv2v"
 const PipelineLiveVideoToVideo = "live-video-to-video"
+const remoteSignerAuthIDHeader = "Signer-Auth-Id"
 
 // SignOrchestratorInfo handles signing GetOrchestratorInfo requests for multiple orchestrators
 func (ls *LivepeerServer) SignOrchestratorInfo(w http.ResponseWriter, r *http.Request) {
@@ -149,6 +150,7 @@ type RemotePaymentState struct {
 	InitialPricePerUnit  int64
 	InitialPixelsPerUnit int64
 	SequenceNumber       uint64
+	AuthID               string
 }
 
 type RemotePaymentStateSig struct {
@@ -198,6 +200,8 @@ type authResponse struct {
 	// Unix timestamp (seconds) until which auth is considered valid.
 	// Allows for skipping webhook callbacks until this time is exceeded.
 	Expiry int64 `json:"expiry,omitempty"`
+	// Optional opaque identifier.
+	AuthID string `json:"auth_id,omitempty"`
 }
 
 // Signs the serialized state with the remote signer's Ethereum key.
@@ -570,6 +574,17 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 	if callbackResp != nil {
 		state.AuthExpiry = callbackResp.Expiry
 	}
+	authID := r.Header.Get(remoteSignerAuthIDHeader)
+	if callbackResp != nil && callbackResp.AuthID != "" {
+		authID = callbackResp.AuthID
+	}
+	if state.AuthID != authID {
+		if state.AuthID != "" {
+			clog.Warningf(ctx, "Remote signer auth ID changed oldAuthID=%s newAuthID=%s", state.AuthID, authID)
+		}
+		state.AuthID = authID
+	}
+	ctx = clog.AddVal(ctx, "auth_id", state.AuthID)
 
 	// Encode and sign updated state
 	stateBytes, err := json.Marshal(state)
@@ -618,6 +633,7 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 			"cost_per_pixel":     orchPrice.FloatString(10),
 			"sequence_number":    state.SequenceNumber,
 			"num_tickets":        balUpdate.NumTickets,
+			"auth_id":            state.AuthID,
 		})
 	}
 

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -692,11 +693,12 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 	orchBlob, err := proto.Marshal(oInfo)
 	require.NoError(err)
 
-	doPayment := func(requestHeader string) *httptest.ResponseRecorder {
+	doPaymentWithState := func(requestHeader string, state RemotePaymentStateSig) *httptest.ResponseRecorder {
 		reqBody, err := json.Marshal(RemotePaymentRequest{
 			Orchestrator: orchBlob,
 			ManifestID:   "manifest",
 			InPixels:     1,
+			State:        state,
 		})
 		require.NoError(err)
 
@@ -705,6 +707,16 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		rr := httptest.NewRecorder()
 		ls.GenerateLivePayment(rr, req)
 		return rr
+	}
+	doPayment := func(requestHeader string) *httptest.ResponseRecorder {
+		return doPaymentWithState(requestHeader, RemotePaymentStateSig{})
+	}
+	parseResponseState := func(rr *httptest.ResponseRecorder) RemotePaymentState {
+		var resp RemotePaymentResponse
+		require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+		var state RemotePaymentState
+		require.NoError(json.Unmarshal(resp.State.State, &state))
+		return state
 	}
 
 	t.Run("callback omitted succeeds", func(t *testing.T) {
@@ -725,7 +737,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 			require.Equal("application/json", r.Header.Get("Content-Type"))
 			require.NoError(json.NewDecoder(r.Body).Decode(&payload))
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`ok`))
+			_, _ = w.Write([]byte(`{}`))
 		}))
 		defer webhook.Close()
 
@@ -743,6 +755,75 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		require.Equal([]string{"req-123"}, payload.Headers["X-Request-Id"])
 		require.NotNil(payload.State)
 		require.Equal("pmSession", payload.State.PMSessionID)
+	})
+
+	t.Run("callback 200 with expiry sets state auth expiry", func(t *testing.T) {
+		expiry := time.Now().Add(5 * time.Minute).Unix()
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"expiry":%d}`, expiry)))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPayment("req-expiry-set")
+		require.Equal(http.StatusOK, rr.Code)
+		state := parseResponseState(rr)
+		require.Equal(expiry, state.AuthExpiry)
+	})
+
+	t.Run("sequential requests skip callback while auth expiry still valid", func(t *testing.T) {
+		callbackCalls := 0
+		expiry := time.Now().Add(5 * time.Minute).Unix()
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callbackCalls++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"expiry":%d}`, expiry)))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		first := doPayment("req-skip-first")
+		require.Equal(http.StatusOK, first.Code)
+
+		var firstResp RemotePaymentResponse
+		require.NoError(json.NewDecoder(first.Body).Decode(&firstResp))
+		second := doPaymentWithState("req-skip-second", firstResp.State)
+		require.Equal(http.StatusOK, second.Code)
+		require.Equal(1, callbackCalls)
+	})
+
+	t.Run("expired auth expiry triggers callback on next request", func(t *testing.T) {
+		callbackCalls := 0
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callbackCalls++
+			expiry := time.Now().Add(-1 * time.Minute).Unix()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"expiry":%d}`, expiry)))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		first := doPayment("req-expired-first")
+		require.Equal(http.StatusOK, first.Code)
+
+		var firstResp RemotePaymentResponse
+		require.NoError(json.NewDecoder(first.Body).Decode(&firstResp))
+		second := doPaymentWithState("req-expired-second", firstResp.State)
+		require.Equal(http.StatusOK, second.Code)
+		require.Equal(2, callbackCalls)
 	})
 
 	t.Run("callback non-200 returns same status in api error", func(t *testing.T) {

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -737,7 +737,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 			require.Equal("application/json", r.Header.Get("Content-Type"))
 			require.NoError(json.NewDecoder(r.Body).Decode(&payload))
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{}`))
+			_, _ = w.Write([]byte(`{"status":200}`))
 		}))
 		defer webhook.Close()
 
@@ -757,11 +757,27 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		require.Equal("pmSession", payload.State.PMSessionID)
 	})
 
+	t.Run("callback 200 with status 200 succeeds", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":200}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPayment("req-status-200")
+		require.Equal(http.StatusOK, rr.Code)
+	})
+
 	t.Run("callback 200 with expiry sets state auth expiry", func(t *testing.T) {
 		expiry := time.Now().Add(5 * time.Minute).Unix()
 		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"expiry":%d}`, expiry)))
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"status":200,"expiry":%d}`, expiry)))
 		}))
 		defer webhook.Close()
 
@@ -782,7 +798,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callbackCalls++
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"expiry":%d}`, expiry)))
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"status":200,"expiry":%d}`, expiry)))
 		}))
 		defer webhook.Close()
 
@@ -807,7 +823,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 			callbackCalls++
 			expiry := time.Now().Add(-1 * time.Minute).Unix()
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"expiry":%d}`, expiry)))
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"status":200,"expiry":%d}`, expiry)))
 		}))
 		defer webhook.Close()
 
@@ -826,7 +842,67 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		require.Equal(2, callbackCalls)
 	})
 
-	t.Run("callback non-200 returns same status in api error", func(t *testing.T) {
+	t.Run("callback 200 missing status returns 500", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"expiry":123}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPayment("req-missing-status")
+		require.Equal(http.StatusInternalServerError, rr.Code)
+
+		var apiErr apiErrorResponse
+		require.NoError(json.NewDecoder(rr.Body).Decode(&apiErr))
+		require.Equal("Internal Server Error", apiErr.Error.Message)
+	})
+
+	t.Run("callback 200 with rejection status returns reason", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":403,"reason":"denied"}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPayment("req-rejected")
+		require.Equal(http.StatusForbidden, rr.Code)
+
+		var apiErr apiErrorResponse
+		require.NoError(json.NewDecoder(rr.Body).Decode(&apiErr))
+		require.Contains(apiErr.Error.Message, "denied")
+	})
+
+	t.Run("callback 200 with rejection status and no reason uses fallback", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":429}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPayment("req-no-reason")
+		require.Equal(http.StatusTooManyRequests, rr.Code)
+
+		var apiErr apiErrorResponse
+		require.NoError(json.NewDecoder(rr.Body).Decode(&apiErr))
+		require.Contains(apiErr.Error.Message, "signer auth rejected request with status 429")
+	})
+
+	t.Run("callback HTTP non-200 returns 500", func(t *testing.T) {
 		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte(`denied`))
@@ -839,12 +915,11 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
 
 		rr := doPayment("req-401")
-		require.Equal(http.StatusUnauthorized, rr.Code)
+		require.Equal(http.StatusInternalServerError, rr.Code)
 
 		var apiErr apiErrorResponse
 		require.NoError(json.NewDecoder(rr.Body).Decode(&apiErr))
-		require.Contains(apiErr.Error.Message, "remote signer webhook returned status 401")
-		require.Contains(apiErr.Error.Message, "denied")
+		require.Equal("Internal Server Error", apiErr.Error.Message)
 	})
 }
 

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -669,6 +670,101 @@ func TestGenerateLivePayment_LV2V_Succeeds(t *testing.T) {
 		capBal.RatString(), expectedCapBal.RatString(), capFee.RatString(), len(capPayment.TicketSenderParams), ev.RatString(),
 	)
 
+}
+
+func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
+	require := require.New(t)
+
+	ethClient := newTestEthClient(t)
+	node, _ := core.NewLivepeerNode(ethClient, "", nil)
+	node.Balances = core.NewAddressBalances(1 * time.Minute)
+	node.Sender = newMockSender(mockSenderConfig{})
+	ls := &LivepeerServer{LivepeerNode: node}
+
+	oInfo := &net.OrchestratorInfo{
+		Address:   ethClient.addr.Bytes(),
+		PriceInfo: &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 1},
+		TicketParams: &net.TicketParams{
+			Recipient: pm.RandAddress().Bytes(),
+		},
+		AuthToken: stubAuthToken,
+	}
+	orchBlob, err := proto.Marshal(oInfo)
+	require.NoError(err)
+
+	doPayment := func(requestHeader string) *httptest.ResponseRecorder {
+		reqBody, err := json.Marshal(RemotePaymentRequest{
+			Orchestrator: orchBlob,
+			ManifestID:   "manifest",
+			InPixels:     1,
+		})
+		require.NoError(err)
+
+		req := httptest.NewRequest(http.MethodPost, "/generate-live-payment", bytes.NewReader(reqBody))
+		req.Header.Set("X-Request-ID", requestHeader)
+		rr := httptest.NewRecorder()
+		ls.GenerateLivePayment(rr, req)
+		return rr
+	}
+
+	t.Run("callback omitted succeeds", func(t *testing.T) {
+		ls.LivepeerNode.RemoteSignerWebhookURL = nil
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPayment("no-callback")
+		require.Equal(http.StatusOK, rr.Code)
+	})
+
+	t.Run("callback receives request headers and outbound auth headers", func(t *testing.T) {
+		callbackCalled := false
+		var payload generateLivePaymentWebhookBody
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callbackCalled = true
+			require.Equal("Bearer abc", r.Header.Get("Authorization"))
+			require.Equal("secret", r.Header.Get("X-API-Key"))
+			require.Equal("application/json", r.Header.Get("Content-Type"))
+			require.NoError(json.NewDecoder(r.Body).Decode(&payload))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`ok`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = map[string]string{
+			"Authorization": "Bearer abc",
+			"X-API-Key":     "secret",
+		}
+
+		rr := doPayment("req-123")
+		require.Equal(http.StatusOK, rr.Code)
+		require.True(callbackCalled)
+		require.Equal([]string{"req-123"}, payload.Headers["X-Request-Id"])
+		require.NotNil(payload.State)
+		require.Equal("pmSession", payload.State.PMSessionID)
+	})
+
+	t.Run("callback non-200 returns same status in api error", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`denied`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPayment("req-401")
+		require.Equal(http.StatusUnauthorized, rr.Code)
+
+		var apiErr apiErrorResponse
+		require.NoError(json.NewDecoder(rr.Body).Decode(&apiErr))
+		require.Contains(apiErr.Error.Message, "remote signer webhook returned status 401")
+		require.Contains(apiErr.Error.Message, "denied")
+	})
 }
 
 func TestRemoteSigner_Discovery(t *testing.T) {

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -1208,3 +1208,29 @@ func TestRemoteSigner_Discovery_RefreshesAfterInterval(t *testing.T) {
 		require.Equal([]string{"live-video-to-video/model-b"}, resp[0].Capabilities)
 	})
 }
+
+func TestGetOrchInfoSig_SendsConfiguredHeaders(t *testing.T) {
+	require := require.New(t)
+
+	remoteTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(http.MethodPost, r.Method)
+		require.Equal("/sign-orchestrator-info", r.URL.Path)
+		require.Equal("application/json", r.Header.Get("Content-Type"))
+		require.Equal("Bearer gateway-token", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"address":   "0x1234",
+			"signature": "0xabcd",
+		})
+	}))
+	defer remoteTS.Close()
+
+	remoteURL, err := url.Parse(remoteTS.URL)
+	require.NoError(err)
+
+	resp, err := GetOrchInfoSig(remoteURL, map[string]string{"Authorization": "Bearer gateway-token"})
+	require.NoError(err)
+	require.Equal([]byte{0x12, 0x34}, []byte(resp.Address))
+	require.Equal([]byte{0xab, 0xcd}, []byte(resp.Signature))
+}

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -879,13 +879,20 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		require.NoError(json.Unmarshal(firstResp.State.State, &firstState))
 		require.Equal("cached-auth-id", firstState.AuthID)
 
-		second := doPaymentWithStateAndAuthID("req-skip-second", "new-header-auth-id", firstResp.State)
+		second := doPaymentWithState("req-skip-second", firstResp.State)
 		require.Equal(http.StatusOK, second.Code)
 		var secondResp RemotePaymentResponse
 		require.NoError(json.NewDecoder(second.Body).Decode(&secondResp))
 		var secondState RemotePaymentState
 		require.NoError(json.Unmarshal(secondResp.State.State, &secondState))
-		require.Equal("new-header-auth-id", secondState.AuthID)
+		require.Equal("cached-auth-id", secondState.AuthID)
+		require.Equal(1, callbackCalls)
+
+		third := doPaymentWithStateAndAuthID("req-skip-third", "new-header-auth-id", secondResp.State)
+		require.Equal(http.StatusInternalServerError, third.Code)
+		var apiErr apiErrorResponse
+		require.NoError(json.NewDecoder(third.Body).Decode(&apiErr))
+		require.Equal("Internal Server Error", apiErr.Error.Message)
 		require.Equal(1, callbackCalls)
 	})
 
@@ -914,7 +921,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		require.Equal(2, callbackCalls)
 	})
 
-	t.Run("callback auth id replaces cached state auth id", func(t *testing.T) {
+	t.Run("callback auth id change returns 500", func(t *testing.T) {
 		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"status":200,"auth_id":"updated-auth-id"}`))
@@ -939,9 +946,10 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		require.NoError(err)
 
 		rr := doPaymentWithState("req-auth-id-replaced", RemotePaymentStateSig{State: stateBytes, Sig: stateSig})
-		require.Equal(http.StatusOK, rr.Code)
-		state := parseResponseState(rr)
-		require.Equal("updated-auth-id", state.AuthID)
+		require.Equal(http.StatusInternalServerError, rr.Code)
+		var apiErr apiErrorResponse
+		require.NoError(json.NewDecoder(rr.Body).Decode(&apiErr))
+		require.Equal("Internal Server Error", apiErr.Error.Message)
 	})
 
 	t.Run("callback 200 missing status returns 500", func(t *testing.T) {

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -693,7 +693,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 	orchBlob, err := proto.Marshal(oInfo)
 	require.NoError(err)
 
-	doPaymentWithState := func(requestHeader string, state RemotePaymentStateSig) *httptest.ResponseRecorder {
+	doPaymentWithStateAndAuthID := func(requestHeader string, authID string, state RemotePaymentStateSig) *httptest.ResponseRecorder {
 		reqBody, err := json.Marshal(RemotePaymentRequest{
 			Orchestrator: orchBlob,
 			ManifestID:   "manifest",
@@ -704,9 +704,18 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodPost, "/generate-live-payment", bytes.NewReader(reqBody))
 		req.Header.Set("X-Request-ID", requestHeader)
+		if authID != "" {
+			req.Header.Set(remoteSignerAuthIDHeader, authID)
+		}
 		rr := httptest.NewRecorder()
 		ls.GenerateLivePayment(rr, req)
 		return rr
+	}
+	doPaymentWithState := func(requestHeader string, state RemotePaymentStateSig) *httptest.ResponseRecorder {
+		return doPaymentWithStateAndAuthID(requestHeader, "", state)
+	}
+	doPaymentWithAuthID := func(requestHeader string, authID string) *httptest.ResponseRecorder {
+		return doPaymentWithStateAndAuthID(requestHeader, authID, RemotePaymentStateSig{})
 	}
 	doPayment := func(requestHeader string) *httptest.ResponseRecorder {
 		return doPaymentWithState(requestHeader, RemotePaymentStateSig{})
@@ -792,13 +801,67 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		require.Equal(expiry, state.AuthExpiry)
 	})
 
+	t.Run("callback auth id sets state", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":200,"auth_id":"webhook-auth-id"}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPayment("req-auth-id")
+		require.Equal(http.StatusOK, rr.Code)
+		state := parseResponseState(rr)
+		require.Equal("webhook-auth-id", state.AuthID)
+	})
+
+	t.Run("request auth id header is fallback when callback omits auth id", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":200}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPaymentWithAuthID("req-auth-id-fallback", "header-auth-id")
+		require.Equal(http.StatusOK, rr.Code)
+		state := parseResponseState(rr)
+		require.Equal("header-auth-id", state.AuthID)
+	})
+
+	t.Run("callback auth id wins over request header", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":200,"auth_id":"webhook-auth-id"}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPaymentWithAuthID("req-auth-id-priority", "header-auth-id")
+		require.Equal(http.StatusOK, rr.Code)
+		state := parseResponseState(rr)
+		require.Equal("webhook-auth-id", state.AuthID)
+	})
+
 	t.Run("sequential requests skip callback while auth expiry still valid", func(t *testing.T) {
 		callbackCalls := 0
 		expiry := time.Now().Add(5 * time.Minute).Unix()
 		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callbackCalls++
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"status":200,"expiry":%d}`, expiry)))
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"status":200,"expiry":%d,"auth_id":"cached-auth-id"}`, expiry)))
 		}))
 		defer webhook.Close()
 
@@ -812,8 +875,17 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 
 		var firstResp RemotePaymentResponse
 		require.NoError(json.NewDecoder(first.Body).Decode(&firstResp))
-		second := doPaymentWithState("req-skip-second", firstResp.State)
+		var firstState RemotePaymentState
+		require.NoError(json.Unmarshal(firstResp.State.State, &firstState))
+		require.Equal("cached-auth-id", firstState.AuthID)
+
+		second := doPaymentWithStateAndAuthID("req-skip-second", "new-header-auth-id", firstResp.State)
 		require.Equal(http.StatusOK, second.Code)
+		var secondResp RemotePaymentResponse
+		require.NoError(json.NewDecoder(second.Body).Decode(&secondResp))
+		var secondState RemotePaymentState
+		require.NoError(json.Unmarshal(secondResp.State.State, &secondState))
+		require.Equal("new-header-auth-id", secondState.AuthID)
 		require.Equal(1, callbackCalls)
 	})
 
@@ -840,6 +912,36 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		second := doPaymentWithState("req-expired-second", firstResp.State)
 		require.Equal(http.StatusOK, second.Code)
 		require.Equal(2, callbackCalls)
+	})
+
+	t.Run("callback auth id replaces cached state auth id", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":200,"auth_id":"updated-auth-id"}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		initialState := RemotePaymentState{
+			StateID:              string(core.RandomManifestID()),
+			OrchestratorAddress:  ethcommon.BytesToAddress(oInfo.Address),
+			InitialPricePerUnit:  oInfo.PriceInfo.PricePerUnit,
+			InitialPixelsPerUnit: oInfo.PriceInfo.PixelsPerUnit,
+			AuthID:               "cached-auth-id",
+		}
+		stateBytes, err := json.Marshal(initialState)
+		require.NoError(err)
+		stateSig, err := signState(ls, stateBytes)
+		require.NoError(err)
+
+		rr := doPaymentWithState("req-auth-id-replaced", RemotePaymentStateSig{State: stateBytes, Sig: stateSig})
+		require.Equal(http.StatusOK, rr.Code)
+		state := parseResponseState(rr)
+		require.Equal("updated-auth-id", state.AuthID)
 	})
 
 	t.Run("callback 200 missing status returns 500", func(t *testing.T) {

--- a/test_args.sh
+++ b/test_args.sh
@@ -56,7 +56,7 @@ CUSTOM_DATADIR="$TMPDIR"/customDatadir2
 [ ! -d "$CUSTOM_DATADIR" ]
 
 # check invalid service address via inserting control character
-$TMPDIR/livepeer -orchestrator -orchSecret asdf -serviceAddr "hibye" 2>&1 | grep "Error getting service URI"
+$TMPDIR/livepeer -orchestrator -orchSecret asdf -serviceAddr $'hi\b\bbye' 2>&1 | grep "Error getting service URI"
 [ ${PIPESTATUS[0]} -ne 0 ]
 
 # check missing service address via failed availability check


### PR DESCRIPTION
Optionally add an auth callback to remote payment requests so operators
can enforce policy checks before the remote signer sends down payments.

When configured, the handler POSTs a JSON body containing the incoming
request headers and the current signer state to the webhook URL right
before encoding and signing. Configured auth headers are attached to the
outbound request. Non-200 responses are propagated back to the caller
through the existing API error envelope, preserving the upstream status
code.

Allow the auth webhook to return an `expiry` field (Unix seconds) in
its 200 response. The value is persisted in the signer's state and
checked on subsequent requests. If the expiry hasn't yet passed, the
webhook call is skipped. Once expired (or absent), auth resumes.

New CLI flags:
  -remoteSignerWebhookUrl       Webhook endpoint to call
  -remoteSignerWebhookHeaders   Outbound auth headers (key:val,key2:val2)

Omit -remoteSignerWebhookUrl to keep the existing behavior unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom HTTP headers on remote-signer requests and webhook callbacks.
  * Webhook-based payment authentication with auth ID/expiry handling and caching to reduce callbacks.
  * Orchestrator discovery and signature requests can forward configured headers to webhook endpoints.

* **Documentation**
  * Updated remote-signer guide with header/webhook flags, request/response formats, and status semantics.

* **Tests**
  * Added tests for header parsing, webhook behavior, config redaction, and remote-signer auth flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->