### PR TITLE
feat(signer): restore /sign-byoc-job endpoint

### DIFF
--- a/byoc/types.go
+++ b/byoc/types.go
@@ -3,6 +3,7 @@ package byoc
 import (
 	"context"
 	"crypto/tls"
+	"encoding/binary"
 	"errors"
 	"math/big"
 	gonet "net"
@@ -278,4 +279,66 @@ type byocLiveRequestParams struct {
 
 	// when the write for the last segment started
 	lastSegmentTime time.Time
+}
+
+// Prevents cross-protocol signature replay.
+const BYOCJobSigV1Prefix = "LP_BYOC_JOB_V1\x00\x00"
+
+// BYOCJobSigningInput holds the fields that are bound into a BYOC job signature.
+type BYOCJobSigningInput struct {
+	ID             string
+	Capability     string
+	Request        string
+	Parameters     string
+	TimeoutSeconds int
+}
+
+// FlattenBYOCJob produces a deterministic binary representation of a BYOC job
+// for signing, similar to SegTranscodingMetadata.Flatten() used by LV2V.
+//
+// Wire format:
+//
+//	version(16) || timeout(4,BE) || len(id)(4,BE) || id || len(cap)(4,BE) || cap
+//	           || len(req)(4,BE) || req || len(params)(4,BE) || params
+func FlattenBYOCJob(job *BYOCJobSigningInput) []byte {
+	idBytes := []byte(job.ID)
+	capBytes := []byte(job.Capability)
+	reqBytes := []byte(job.Request)
+	paramsBytes := []byte(job.Parameters)
+
+	size := 16 + 4 +
+		4 + len(idBytes) +
+		4 + len(capBytes) +
+		4 + len(reqBytes) +
+		4 + len(paramsBytes)
+
+	buf := make([]byte, size)
+	offset := 0
+
+	copy(buf[offset:], []byte(BYOCJobSigV1Prefix))
+	offset += 16
+
+	binary.BigEndian.PutUint32(buf[offset:], uint32(job.TimeoutSeconds))
+	offset += 4
+
+	binary.BigEndian.PutUint32(buf[offset:], uint32(len(idBytes)))
+	offset += 4
+	copy(buf[offset:], idBytes)
+	offset += len(idBytes)
+
+	binary.BigEndian.PutUint32(buf[offset:], uint32(len(capBytes)))
+	offset += 4
+	copy(buf[offset:], capBytes)
+	offset += len(capBytes)
+
+	binary.BigEndian.PutUint32(buf[offset:], uint32(len(reqBytes)))
+	offset += 4
+	copy(buf[offset:], reqBytes)
+	offset += len(reqBytes)
+
+	binary.BigEndian.PutUint32(buf[offset:], uint32(len(paramsBytes)))
+	offset += 4
+	copy(buf[offset:], paramsBytes)
+
+	return buf
 }

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -17,6 +17,7 @@ import (
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
+	"github.com/livepeer/go-livepeer/byoc"
 	"github.com/livepeer/go-livepeer/clog"
 	"github.com/livepeer/go-livepeer/core"
 	lpcrypto "github.com/livepeer/go-livepeer/crypto"
@@ -69,11 +70,76 @@ func (ls *LivepeerServer) SignOrchestratorInfo(w http.ResponseWriter, r *http.Re
 	_ = json.NewEncoder(w).Encode(results)
 }
 
+// SignBYOCJobRequest signs a BYOC job using the V1 binary format (FlattenBYOCJob).
+type SignBYOCJobRequestInput struct {
+	ID             string `json:"id"`
+	Capability     string `json:"capability"`
+	Request        string `json:"request"`
+	Parameters     string `json:"parameters"`
+	TimeoutSeconds int    `json:"timeout_seconds"`
+}
+
+type SignBYOCJobRequestResponse struct {
+	Sender    string `json:"sender"`
+	Signature string `json:"signature"`
+}
+
+func (ls *LivepeerServer) SignBYOCJobRequest(w http.ResponseWriter, r *http.Request) {
+	ctx := clog.AddVal(r.Context(), "request_id", string(core.RandomManifestID()))
+	remoteAddr := getRemoteAddr(r)
+	clog.Info(ctx, "BYOC job signing request", "ip", remoteAddr)
+
+	gw := core.NewBroadcaster(ls.LivepeerNode)
+
+	var req SignBYOCJobRequestInput
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		clog.Errorf(ctx, "Failed to decode SignBYOCJobRequest err=%q", err)
+		respondJsonError(ctx, w, err, http.StatusBadRequest)
+		return
+	}
+
+	if req.ID == "" || req.Capability == "" {
+		err := fmt.Errorf("sign-byoc-job requires non-empty id and capability")
+		respondJsonError(ctx, w, err, http.StatusBadRequest)
+		return
+	}
+	if req.TimeoutSeconds <= 0 {
+		err := fmt.Errorf("sign-byoc-job requires positive timeout_seconds")
+		respondJsonError(ctx, w, err, http.StatusBadRequest)
+		return
+	}
+
+	sigPayload := byoc.FlattenBYOCJob(&byoc.BYOCJobSigningInput{
+		ID:             req.ID,
+		Capability:     req.Capability,
+		Request:        req.Request,
+		Parameters:     req.Parameters,
+		TimeoutSeconds: req.TimeoutSeconds,
+	})
+
+	sig, err := gw.Sign(sigPayload)
+	if err != nil {
+		clog.Errorf(ctx, "Failed to sign BYOC job request err=%q", err)
+		respondJsonError(ctx, w, err, http.StatusInternalServerError)
+		return
+	}
+
+	response := SignBYOCJobRequestResponse{
+		Sender:    gw.Address().Hex(),
+		Signature: "0x" + hex.EncodeToString(sig),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(response)
+}
+
 // StartRemoteSignerServer starts the HTTP server for remote signer mode
 func StartRemoteSignerServer(ls *LivepeerServer, bind string) error {
 	// Register the remote signer endpoints
 	ls.HTTPMux.Handle("POST /sign-orchestrator-info", http.HandlerFunc(ls.SignOrchestratorInfo))
 	ls.HTTPMux.Handle("POST /generate-live-payment", http.HandlerFunc(ls.GenerateLivePayment))
+	ls.HTTPMux.Handle("POST /sign-byoc-job", http.HandlerFunc(ls.SignBYOCJobRequest))
 	if ls.LivepeerNode.RemoteDiscovery {
 		rdp := RemoteDiscoveryConfig{
 			Pool:     ls.LivepeerNode.OrchestratorPool,


### PR DESCRIPTION
## Summary

- Restores the `/sign-byoc-job` endpoint that was removed in the `ja/serverless` branch
- The removal broke all BYOC inference: SDK gets HTTP 404 from the signer, then the BYOC orchestrator rejects with `Could not verify job creds`
- Cherry-picks `SignBYOCJobRequest` handler + `FlattenBYOCJob` from `feat/remote-signer-byoc-v2` (PR #3896)
- All new `ja/serverless` features are preserved (Daydream billing webhook auth, cached `AuthExpiry`, etc.)

## Changes

| File | What |
|------|------|
| `server/remote_signer.go` | Add `SignBYOCJobRequest` handler, register `POST /sign-byoc-job` route |
| `byoc/types.go` | Add `BYOCJobSigningInput`, `FlattenBYOCJob()` (V1 binary signing format) |

## Context

The `ja/serverless` image was deployed to `signer-staging-1` and `signer-staging-2`, replacing the `feat-remote-signer-byoc-v2` image. This removed the BYOC signing endpoint, causing all BYOC inference to fail with HTTP 502.

The BYOC orchestrator requires signed job credentials (via `verifyJobCreds` in `byoc/job_orchestrator.go`) — there is no bypass for zero-price jobs. The signer must provide the `/sign-byoc-job` endpoint for BYOC inference to work.

## Test plan

- [ ] Verify `go build ./server/` compiles
- [ ] Verify existing `remote_signer_test.go` passes (no BYOC references in ja/serverless tests)
- [ ] Deploy to signer-staging-1, test `curl -X POST http://127.0.0.1:7936/sign-byoc-job` returns 200
- [ ] End-to-end: storyboard inference via SDK → signer → BYOC orch succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)