### PR TITLE
Add CLI transaction cost confirmations

### DIFF
--- a/cmd/livepeer_cli/wizard.go
+++ b/cmd/livepeer_cli/wizard.go
@@ -266,6 +266,31 @@ func (w *wizard) readDefaultFloat(def float64) float64 {
 	return def
 }
 
+const defaultTxGasLimit = uint64(21000)
+
+func (w *wizard) confirmTransaction(action string) bool {
+	maxGasPrice, ok := new(big.Int).SetString(strings.TrimSpace(w.maxGasPrice()), 10)
+	if !ok || maxGasPrice.Sign() <= 0 {
+		fmt.Printf("Estimated transaction cost for %s: unavailable (max gas price is not set).\n", action)
+	} else {
+		maxCost := new(big.Int).Mul(new(big.Int).SetUint64(defaultTxGasLimit), maxGasPrice)
+		fmt.Printf("Estimated maximum transaction cost for %s: %s ETH (%s wei, assuming %d gas at the configured max gas price).\n", action, eth.FormatUnits(maxCost, "ETH"), maxCost.String(), defaultTxGasLimit)
+	}
+	fmt.Printf("Submit this transaction? (y/n) - ")
+	if strings.ToLower(w.readStringYesOrNo()) != "y" {
+		fmt.Printf("Transaction cancelled: Interrupted by user.\n")
+		return false
+	}
+	return true
+}
+
+func (w *wizard) httpPostTxWithParams(action string, url string, val url.Values) (string, bool) {
+	if !w.confirmTransaction(action) {
+		return "", false
+	}
+	return httpPostWithParams(url, val)
+}
+
 func httpGet(url string) string {
 	resp, err := http.Get(url)
 	if err != nil {

--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -183,7 +183,7 @@ func (w *wizard) bond() {
 		"toAddr": {fmt.Sprintf("%v", tAddr.Hex())},
 	}
 
-	httpPostWithParams(fmt.Sprintf("http://%v:%v/bond", w.host, w.httpPort), val)
+	w.httpPostTxWithParams("bond", fmt.Sprintf("http://%v:%v/bond", w.host, w.httpPort), val)
 }
 
 func (w *wizard) rebond() {
@@ -243,7 +243,7 @@ func (w *wizard) rebond() {
 		val["toAddr"] = []string{fmt.Sprintf("%v", toAddr.Hex())}
 	}
 
-	httpPostWithParams(fmt.Sprintf("http://%v:%v/rebond", w.host, w.httpPort), val)
+	w.httpPostTxWithParams("rebond", fmt.Sprintf("http://%v:%v/rebond", w.host, w.httpPort), val)
 }
 
 func (w *wizard) unbond() {
@@ -290,7 +290,7 @@ func (w *wizard) unbond() {
 		"amount": {fmt.Sprintf("%v", amount.String())},
 	}
 
-	httpPostWithParams(fmt.Sprintf("http://%v:%v/unbond", w.host, w.httpPort), val)
+	w.httpPostTxWithParams("unbond", fmt.Sprintf("http://%v:%v/unbond", w.host, w.httpPort), val)
 }
 
 func (w *wizard) withdrawStake() {
@@ -327,7 +327,7 @@ func (w *wizard) withdrawStake() {
 		"unbondingLockId": {fmt.Sprintf("%v", strconv.FormatInt(unbondingLockID, 10))},
 	}
 
-	httpPostWithParams(fmt.Sprintf("http://%v:%v/withdrawStake", w.host, w.httpPort), val)
+	w.httpPostTxWithParams("withdraw stake", fmt.Sprintf("http://%v:%v/withdrawStake", w.host, w.httpPort), val)
 }
 
 func (w *wizard) withdrawFees() {
@@ -341,5 +341,5 @@ func (w *wizard) withdrawFees() {
 		"amount": {fmt.Sprintf("%v", dInfo.PendingFees.String())},
 	}
 
-	httpPostWithParams(fmt.Sprintf("http://%v:%v/withdrawFees", w.host, w.httpPort), val)
+	w.httpPostTxWithParams("withdraw fees", fmt.Sprintf("http://%v:%v/withdrawFees", w.host, w.httpPort), val)
 }

--- a/cmd/livepeer_cli/wizard_ticketbroker.go
+++ b/cmd/livepeer_cli/wizard_ticketbroker.go
@@ -59,7 +59,7 @@ func (w *wizard) deposit() {
 		"depositAmount": {depositAmount.String()},
 		"reserveAmount": {reserveAmount.String()},
 	}
-	fmt.Println(httpPostWithParams(fmt.Sprintf("http://%v:%v/fundDepositAndReserve", w.host, w.httpPort), form))
+	fmt.Println(w.httpPostTxWithParams("fund deposit and reserve", fmt.Sprintf("http://%v:%v/fundDepositAndReserve", w.host, w.httpPort), form))
 
 	return
 }

--- a/cmd/livepeer_cli/wizard_token.go
+++ b/cmd/livepeer_cli/wizard_token.go
@@ -37,7 +37,7 @@ func (w *wizard) transferTokens() {
 		}
 	}
 
-	httpPostWithParams(fmt.Sprintf("http://%v:%v/transferTokens", w.host, w.httpPort), val)
+	w.httpPostTxWithParams("transfer LPT", fmt.Sprintf("http://%v:%v/transferTokens", w.host, w.httpPort), val)
 }
 
 func (w *wizard) requestTokens() {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Adds a transaction confirmation step to `livepeer_cli` that shows an estimated maximum ETH cost before common wallet-affecting transaction actions are submitted to the local node.

**Specific updates (required)**

- Adds `confirmTransaction()` and `httpPostTxWithParams()` helpers in the CLI wizard.
- Shows an estimated maximum transaction cost using the configured max gas price and a standard 21,000 gas baseline when max gas price is available.
- Falls back to an explicit "unavailable" estimate message when max gas price is unset.
- Requires explicit `y/n` confirmation before submitting bond, rebond, unbond, withdraw stake/fees, transfer LPT, and fund deposit/reserve calls.

**How did you test each of these updates (required)**

- Ran `gofmt` on changed files.
- Ran `git diff --check` successfully.
- Installed Go, pkgconf, and ffmpeg locally and attempted `go test ./cmd/livepeer_cli`. The package build reaches existing upstream `github.com/livepeer/lpms/ffmpeg` C bindings, but fails against Homebrew ffmpeg 8.1 with undeclared `avfilter_compare_sign_*` symbols. This appears to be a local ffmpeg/LPMS compatibility issue rather than a syntax error in this CLI patch.

**Does this pull request close any open issues?**

Fixes #1815

/claim #1815

**Checklist:**

- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated