### PR TITLE
byoc: support offchain mode without an Eth keystore

### DIFF
--- a/byoc/job_gateway.go
+++ b/byoc/job_gateway.go
@@ -444,10 +444,20 @@ func getJobSender(ctx context.Context, node *core.LivepeerNode) (*JobSender, err
 	addr := ethcommon.BytesToAddress(orchReq.Address)
 	jobSender := &JobSender{
 		Addr: addr.Hex(),
-		Sig:  "0x" + hex.EncodeToString(orchReq.Sig),
+		Sig:  encodeJobSig(orchReq.Sig),
 	}
 
 	return jobSender, nil
+}
+
+// encodeJobSig hex-encodes a signature with the "0x" prefix. Returns an empty
+// string for empty signatures, which can occur in offchain mode when the
+// broadcaster has no Eth keystore (see core.broadcaster.Sign).
+func encodeJobSig(sig []byte) string {
+	if len(sig) == 0 {
+		return ""
+	}
+	return "0x" + hex.EncodeToString(sig)
 }
 
 func genOrchestratorReq(b common.Broadcaster) (*net.OrchestratorRequest, error) {

--- a/byoc/job_gateway_test.go
+++ b/byoc/job_gateway_test.go
@@ -426,3 +426,15 @@ func TestSetupGatewayJob(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, gatewayJob)
 }
+
+func TestEncodeJobSig(t *testing.T) {
+	// Empty signatures occur in offchain mode (broadcaster has no Eth keystore).
+	// The encoded form must be empty so the orchestrator's hex.DecodeString
+	// succeeds and VerifySig short-circuits to true.
+	assert.Equal(t, "", encodeJobSig(nil))
+	assert.Equal(t, "", encodeJobSig([]byte{}))
+
+	// Non-empty signatures get the "0x" prefix.
+	sig := []byte{0xde, 0xad, 0xbe, 0xef}
+	assert.Equal(t, "0xdeadbeef", encodeJobSig(sig))
+}

--- a/byoc/job_orchestrator.go
+++ b/byoc/job_orchestrator.go
@@ -594,13 +594,13 @@ func (bso *BYOCOrchestratorServer) verifyTokenCreds(ctx context.Context, tokenCr
 		return nil, err
 	}
 
-	sigHex := jobSender.Sig
-	if len(jobSender.Sig) > 130 {
-		sigHex = jobSender.Sig[2:]
-	}
+	// Strip the "0x" prefix if present. Empty Sig is valid: the gateway sends
+	// it in offchain mode (broadcaster has no Eth keystore); VerifySig
+	// short-circuits to true in that mode.
+	sigHex := strings.TrimPrefix(jobSender.Sig, "0x")
 	sigByte, err := hex.DecodeString(sigHex)
 	if err != nil {
-		clog.Errorf(ctx, "Unable to hex-decode signature", err)
+		clog.Errorf(ctx, "Unable to hex-decode signature err=%v", err)
 		return nil, errSegSig
 	}
 

--- a/byoc/job_orchestrator_test.go
+++ b/byoc/job_orchestrator_test.go
@@ -969,3 +969,55 @@ func createMockJobToken(hostUrl string) *JobToken {
 		AvailableCapacity: 1,
 	}
 }
+
+func TestVerifyTokenCreds_OffchainEmptySig(t *testing.T) {
+	// In offchain mode the gateway sends an empty Sig (no keystore to sign
+	// with). The orchestrator's VerifySig short-circuits to true offchain,
+	// so the empty Sig must round-trip through hex.DecodeString without
+	// erroring.
+	mockJobOrch := newMockJobOrchestrator()
+	mockJobOrch.verifySignature = func(addr ethcommon.Address, msg string, sig []byte) bool {
+		return true
+	}
+	bso := &BYOCOrchestratorServer{
+		node: mockJobLivepeerNode(),
+		orch: mockJobOrch,
+	}
+
+	js := &JobSender{
+		Addr: "0x0000000000000000000000000000000000000000",
+		Sig:  "",
+	}
+	jsBytes, _ := json.Marshal(js)
+	creds := base64.StdEncoding.EncodeToString(jsBytes)
+
+	got, err := bso.verifyTokenCreds(context.Background(), creds)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Equal(t, "", got.Sig)
+}
+
+func TestVerifyTokenCreds_StripsHexPrefix(t *testing.T) {
+	// "0x"-prefixed signatures must be accepted regardless of length.
+	// (Pre-fix code only stripped the prefix when len > 130, breaking
+	// short or empty sigs.)
+	mockJobOrch := newMockJobOrchestrator()
+	mockJobOrch.verifySignature = func(addr ethcommon.Address, msg string, sig []byte) bool {
+		return true
+	}
+	bso := &BYOCOrchestratorServer{
+		node: mockJobLivepeerNode(),
+		orch: mockJobOrch,
+	}
+
+	js := &JobSender{
+		Addr: "0x0000000000000000000000000000000000000000",
+		Sig:  "0xdeadbeef",
+	}
+	jsBytes, _ := json.Marshal(js)
+	creds := base64.StdEncoding.EncodeToString(jsBytes)
+
+	got, err := bso.verifyTokenCreds(context.Background(), creds)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+}


### PR DESCRIPTION
## Summary

Fixes #3905. BYOC currently requires `-ethPassword=...` on both gateway and orchestrator even in `-network offchain` mode — a throwaway keystore exists only to satisfy a vestigial signing requirement. After this PR, BYOC inherits transcoding's existing offchain story: no keystore, no `-ethUrl`, just `-network offchain`.

## Root cause (recap from #3905)

Both halves of the signing flow are *already* offchain-aware:

- [`core/broadcaster.go:14`](https://github.com/livepeer/go-livepeer/blob/master/core/broadcaster.go#L14) — `Sign()` returns `[]byte{}, nil` when `node.Eth == nil`.
- [`core/orchestrator.go:66`](https://github.com/livepeer/go-livepeer/blob/master/core/orchestrator.go#L66) — `VerifySig()` returns `true` when `node.Eth == nil`.

BYOC's wrapper code prevented that bypass from being reached:

1. `byoc/job_gateway.go` — `getJobSender` always prefixed `"0x"`, producing the literal string `"0x"` for empty sigs.
2. `byoc/job_orchestrator.go` — `verifyTokenCreds` only stripped `"0x"` when `len(Sig) > 130`, so the literal `"0x"` passed through to `hex.DecodeString` and failed.

## Changes

- **`byoc/job_gateway.go`** — extracted `encodeJobSig()` that returns `""` for empty sigs and `"0x" + hex` otherwise.
- **`byoc/job_orchestrator.go`** — `verifyTokenCreds` unconditionally trims a `"0x"` prefix via `strings.TrimPrefix`. Empty sig now decodes to empty bytes, `VerifySig` short-circuits to `true` offchain. Also fixed a missing format verb in the existing `Unable to hex-decode signature` log line.
- **Tests** — `TestEncodeJobSig` (helper), `TestVerifyTokenCreds_OffchainEmptySig` (round-trip), `TestVerifyTokenCreds_StripsHexPrefix` (regression for short prefixed sigs).

## Test plan

- [x] `go test ./byoc/...` passes (existing + new tests)
- [x] `go build ./byoc/...` clean
- [ ] Manual E2E: BYOC docker-compose with `-network offchain` on both nodes, no `-ethPassword`, no `-ethUrl`. Capability registers, `/process/request/<suffix>` round-trips through gateway → orchestrator → worker container. (Will validate in [livepeer-python-gateway hello-world example](https://github.com/livepeer/livepeer-python-gateway) once this lands.)

## Context

Surfaced while building a Pipeline SDK hello-world test against unmodified go-livepeer. The example currently uses `-ethPassword=secret-password` as a workaround — once this lands, the compose drops the keystore flag entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)