### PR TITLE
feat: Add TX Cost Estimation and User Confirmation to CLI

### DIFF
--- a/cmd/livepeer_cli/wizard.go
+++ b/cmd/livepeer_cli/wizard.go
@@ -305,6 +305,27 @@ func httpPostWithParamsHeaders(url string, val url.Values, headers map[string]st
 		return "", false
 	}
 
+func (w *wizard) confirm(prompt string) bool {
+	fmt.Printf("%s [Y/n] ", prompt)
+	text := w.read()
+	if text != "Y" {
+		fmt.Println("Aborting.")
+		return false
+	}
+	return true
+}
+
+func (w *wizard) printGasInfo(gasLimit *big.Int, gasPrice *big.Int) {
+	var cost *big.Float
+	if gasPrice != nil {
+		cost = new(big.Float).SetInt(new(big.Int).Mul(gasLimit, gasPrice))
+	} else {
+		cost = new(big.Float).SetInt(new(big.Int).Mul(gasLimit, w.eth.GasPrice()))
+	}
+	fmt.Printf("Estimated TX cost: %v ETH\n", eth.ToETH(cost, big.NewInt(1)))
+}
+
+
 	defer resp.Body.Close()
 	result, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -221,6 +221,12 @@ func (w *wizard) rebond() {
 	}
 
 	if dInfo.Status == "Unbonded" {
+		w.printGasInfo(big.NewInt(eth.BondGas), nil)
+		if !w.confirm(fmt.Sprintf("Are you sure you want to bond %v LPT to \"%s\"?", eth.FormatUnits(amount, "lpt"), tAddr.Hex())) {
+			return
+		}
+
+
 		fmt.Printf("You are unbonded - you will need to choose an address to rebond to.\n")
 
 		var toAddr common.Address
@@ -260,6 +266,12 @@ func (w *wizard) unbond() {
 
 	fmt.Printf("Current Bonded Amount: %v\n", eth.FormatUnits(dInfo.BondedAmount, "LPT"))
 	fmt.Printf("Current Delegate: %v\n", dInfo.DelegateAddress.Hex())
+		w.printGasInfo(big.NewInt(eth.RebondGas), nil)
+		if !w.confirm(fmt.Sprintf("Are you sure you want to rebond from unbonding lock %v?", unbondingLockID)) {
+			return
+		}
+
+
 
 	fmt.Printf("Would you like to fully unbond? (y/n) - ")
 
@@ -298,6 +310,12 @@ func (w *wizard) withdrawStake() {
 	if err != nil {
 		glog.Errorf("Error getting delegator info: %v", err)
 		return
+		w.printGasInfo(big.NewInt(eth.UnbondGas), nil)
+		if !w.confirm(fmt.Sprintf("Are you sure you want to unbond %v LPT?", eth.FormatUnits(amount, "lpt"))) {
+			return
+		}
+
+
 	}
 
 	fmt.Printf("Current Bonded Amount: %v\n", eth.FormatUnits(dInfo.BondedAmount, "LPT"))
@@ -324,6 +342,12 @@ func (w *wizard) withdrawStake() {
 	}
 
 	val := url.Values{
+		w.printGasInfo(big.NewInt(eth.WithdrawStakeGas), nil)
+		if !w.confirm(fmt.Sprintf("Are you sure you want to withdraw stake from unbonding lock %v?", unbondingLockID)) {
+			return
+		}
+
+
 		"unbondingLockId": {fmt.Sprintf("%v", strconv.FormatInt(unbondingLockID, 10))},
 	}
 
@@ -336,6 +360,12 @@ func (w *wizard) withdrawFees() {
 		glog.Errorf("Error getting delegator info: %v", err)
 		return
 	}
+		w.printGasInfo(big.NewInt(eth.WithdrawFeesGas), nil)
+		if !w.confirm(fmt.Sprintf("Are you sure you want to withdraw %v ETH in fees?", eth.FormatUnits(dInfo.PendingFees, "eth"))) {
+			return
+		}
+
+
 
 	val := url.Values{
 		"amount": {fmt.Sprintf("%v", dInfo.PendingFees.String())},

--- a/cmd/livepeer_cli/wizard_rounds.go
+++ b/cmd/livepeer_cli/wizard_rounds.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net/http"
+
+	"github.com/livepeer/go-livepeer/eth"
 )
 
 func (w *wizard) currentRound() (*big.Int, error) {
@@ -30,6 +32,12 @@ func (w *wizard) currentRound() (*big.Int, error) {
 
 	return cr, nil
 }
+	w.printGasInfo(big.NewInt(eth.InitializeRoundGas), nil)
+	if !w.confirm("Are you sure you want to initialize the round?") {
+		return
+	}
+
+
 
 func (w *wizard) initializeRound() {
 	httpPost(fmt.Sprintf("http://%v:%v/initializeRound", w.host, w.httpPort))

--- a/cmd/livepeer_cli/wizard_token.go
+++ b/cmd/livepeer_cli/wizard_token.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"fmt"
+	"math/big"
 	"net/url"
 	"strings"
+
+	"github.com/livepeer/go-livepeer/eth"
 )
 
 func (w *wizard) transferTokens() {
@@ -13,6 +16,11 @@ func (w *wizard) transferTokens() {
 	to := w.readString()
 
 	amount := w.readBigInt("Enter amount")
+
+		w.printGasInfo(big.NewInt(eth.TransferTokensGas), nil)
+		if !w.confirm(fmt.Sprintf("Are you sure you want to send %v LPTU to \"%s\"?", eth.FormatUnits(amount, "lpt"), to)) {
+			return
+		}
 
 	val := url.Values{
 		"to":     {fmt.Sprintf("%v", to)},

--- a/cmd/livepeer_cli/wizard_transcoder.go
+++ b/cmd/livepeer_cli/wizard_transcoder.go
@@ -205,6 +205,12 @@ func (w *wizard) getOrchestratorConfigFormValues() url.Values {
 		"currency":       {fmt.Sprintf("%v", currency)},
 		"pixelsPerUnit":  {fmt.Sprintf("%v", pixelsPerUnit)},
 		"serviceURI":     {fmt.Sprintf("%v", serviceURI)},
+		w.printGasInfo(big.NewInt(eth.BondGas), nil)
+		if !w.confirm("Are you sure you want to activate an orchestrator?") {
+			return
+		}
+
+
 	}
 }
 
@@ -221,6 +227,12 @@ func (w *wizard) callReward() {
 
 	if c.Cmp(t.LastRewardRound) == 0 {
 		fmt.Printf("Reward for current round %v already called\n", c)
+		w.printGasInfo(big.NewInt(eth.SetOrchestratorConfigGas), nil)
+		if !w.confirm("Are you sure you want to set the orchestrator config?") {
+			return
+		}
+
+
 		return
 	}
 
@@ -241,6 +253,12 @@ func (w *wizard) vote() {
 		}
 		return in, nil
 	})
+		w.printGasInfo(big.NewInt(eth.RewardGas), nil)
+		if !w.confirm("Are you sure you want to call reward?") {
+			return
+		}
+
+
 
 	var (
 		confirm = "n"


### PR DESCRIPTION
Resolves #1815. Intercepted transaction flows in the livepeer_cli wizards to estimate gas costs and require explicit (Y/n) user confirmation before broadcasting, preventing accidental high-fee expenditures.