### PR TITLE
byoc: per-job balance keying — design discussion

### DIFF
--- a/byoc/job_gateway.go
+++ b/byoc/job_gateway.go
@@ -121,7 +121,7 @@ func (bsg *BYOCGatewayServer) submitJob(ctx context.Context, w http.ResponseWrit
 				continue
 			}
 
-			gatewayBalance := updateGatewayBalance(bsg.node, orchToken, gatewayJob.Job.Req.Capability, time.Since(start))
+			gatewayBalance := updateGatewayBalance(bsg.node, orchToken, gatewayJob.Job.Req.ID, time.Since(start))
 			clog.V(common.SHORT).Infof(ctx, "Job processed successfully took=%v balance=%v balance_from_orch=%v", time.Since(start), gatewayBalance.FloatString(0), orchBalance)
 			w.Write(data)
 			return
@@ -186,7 +186,7 @@ func (bsg *BYOCGatewayServer) submitJob(ctx context.Context, w http.ResponseWrit
 				}
 			}
 
-			gatewayBalance := updateGatewayBalance(bsg.node, orchToken, gatewayJob.Job.Req.Capability, time.Since(start))
+			gatewayBalance := updateGatewayBalance(bsg.node, orchToken, gatewayJob.Job.Req.ID, time.Since(start))
 
 			clog.V(common.SHORT).Infof(ctx, "Job processed successfully took=%v balance=%v balance_from_orch=%v", time.Since(start), gatewayBalance.FloatString(0), orchBalance.FloatString(0))
 		}
@@ -468,7 +468,11 @@ func genOrchestratorReq(b common.Broadcaster) (*net.OrchestratorRequest, error) 
 	return &net.OrchestratorRequest{Address: b.Address().Bytes(), Sig: sig}, nil
 }
 
-func getToken(ctx context.Context, respTimeout time.Duration, orchUrl, capability, sender, senderSig string) (*JobToken, error) {
+// getToken fetches a JobToken from an Orchestrator. If jobID is non-empty,
+// the orchestrator will return the per-job balance keyed by that ID — used
+// when refreshing tokens for an existing stream so the gateway can
+// reconcile its local balance with the orchestrator's view.
+func getToken(ctx context.Context, respTimeout time.Duration, orchUrl, capability, jobID, sender, senderSig string) (*JobToken, error) {
 	start := time.Now()
 	tokenReq, err := http.NewRequestWithContext(ctx, "GET", orchUrl+"/process/token", nil)
 	jobSender := JobSender{Addr: sender, Sig: senderSig}
@@ -476,6 +480,9 @@ func getToken(ctx context.Context, respTimeout time.Duration, orchUrl, capabilit
 	reqSenderStr, _ := json.Marshal(jobSender)
 	tokenReq.Header.Set(jobEthAddressHdr, base64.StdEncoding.EncodeToString(reqSenderStr))
 	tokenReq.Header.Set(jobCapabilityHdr, capability)
+	if jobID != "" {
+		tokenReq.Header.Set(jobIdHdr, jobID)
+	}
 	if err != nil {
 		clog.Errorf(ctx, "Failed to create request for Orchestrator to verify job token request err=%v", err)
 		return nil, err

--- a/byoc/job_orchestrator.go
+++ b/byoc/job_orchestrator.go
@@ -170,11 +170,19 @@ func (bso *BYOCOrchestratorServer) GetJobToken() http.Handler {
 			return
 		}
 
-		capBal := orch.Balance(senderAddr, core.ManifestID(jobCapsHdr))
+		// Balances are keyed per-job. If the gateway is refreshing a token
+		// for an existing job/stream it sends Livepeer-Job-Id; we look up
+		// the per-job balance against that key. For initial token requests
+		// no job exists yet, so balance is 0.
+		jobIDHdr := r.Header.Get(jobIdHdr)
+		var capBal *big.Rat
+		if jobIDHdr != "" {
+			capBal = orch.Balance(senderAddr, core.ManifestID(jobIDHdr))
+		}
 		if capBal != nil {
 			capBal, err = common.PriceToInt64(capBal)
 			if err != nil {
-				clog.Errorf(context.TODO(), "could not convert balance to int64 sender=%v capability=%v err=%v", senderAddr.Hex(), jobCapsHdr, err.Error())
+				clog.Errorf(context.TODO(), "could not convert balance to int64 sender=%v job_id=%v err=%v", senderAddr.Hex(), jobIDHdr, err.Error())
 				capBal = big.NewRat(0, 1)
 			}
 		} else {
@@ -183,7 +191,7 @@ func (bso *BYOCOrchestratorServer) GetJobToken() http.Handler {
 		//convert to int64. Note: returns with 000 more digits to allow for precision of 3 decimal places.
 		capBalInt, err := common.PriceToFixed(capBal)
 		if err != nil {
-			glog.Errorf("could not convert balance to int64 sender=%v capability=%v err=%v", senderAddr.Hex(), jobCapsHdr, err.Error())
+			glog.Errorf("could not convert balance to int64 sender=%v job_id=%v err=%v", senderAddr.Hex(), jobIDHdr, err.Error())
 			capBalInt = 0
 		} else {
 			// Remove the last three digits from capBalInt
@@ -291,8 +299,8 @@ func (bso *BYOCOrchestratorServer) processJob(ctx context.Context, w http.Respon
 			bso.orch.RemoveExternalCapability(orchJob.Req.Capability)
 		}
 
-		bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.Capability)
-		w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
+		bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.ID)
+		w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
 		http.Error(w, fmt.Sprintf("job not able to be processed, removing capability err=%v", err.Error()), http.StatusInternalServerError)
 		return
 	}
@@ -301,8 +309,8 @@ func (bso *BYOCOrchestratorServer) processJob(ctx context.Context, w http.Respon
 	if resp.StatusCode == http.StatusUnauthorized {
 		clog.Errorf(ctx, "received 401 Unauthorized from worker, removing capability %v", orchJob.Req.Capability)
 		bso.orch.RemoveExternalCapability(orchJob.Req.Capability)
-		bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.Capability)
-		w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
+		bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.ID)
+		w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
 		http.Error(w, "job not able to be processed, removing capability err=worker auth token failed", http.StatusInternalServerError)
 		return
 	}
@@ -322,8 +330,8 @@ func (bso *BYOCOrchestratorServer) processJob(ctx context.Context, w http.Respon
 		if err != nil {
 			clog.Errorf(ctx, "Unable to read response err=%v", err)
 
-			bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.Capability)
-			w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
+			bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.ID)
+			w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -332,16 +340,16 @@ func (bso *BYOCOrchestratorServer) processJob(ctx context.Context, w http.Respon
 		if resp.StatusCode > 399 {
 			clog.Errorf(ctx, "error processing request err=%v ", string(data))
 
-			bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.Capability)
-			w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
+			bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.ID)
+			w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
 			//return error response from the worker
 			http.Error(w, string(data), resp.StatusCode)
 			return
 		}
 
-		bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.Capability)
-		w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
-		clog.V(common.SHORT).Infof(ctx, "Job processed successfully took=%v balance=%v", time.Since(start), bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
+		bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.ID)
+		w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
+		clog.V(common.SHORT).Infof(ctx, "Job processed successfully took=%v balance=%v", time.Since(start), bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
 		w.Write(data)
 		//request completed and returned a response
 
@@ -354,15 +362,15 @@ func (bso *BYOCOrchestratorServer) processJob(ctx context.Context, w http.Respon
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
 		//send payment balance back so client can determine if payment is needed
-		bso.addPaymentBalanceHeader(w, orchJob.Sender, orchJob.Req.Capability)
+		bso.addPaymentBalanceHeader(w, orchJob.Sender, orchJob.Req.ID)
 
 		// Flush to ensure data is sent immediately
 		flusher, ok := w.(http.Flusher)
 		if !ok {
 			clog.Errorf(ctx, "streaming not supported")
 
-			bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.Capability)
-			w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
+			bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.ID)
+			w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
 			http.Error(w, "Streaming not supported", http.StatusInternalServerError)
 			return
 		}
@@ -378,7 +386,7 @@ func (bso *BYOCOrchestratorServer) processJob(ctx context.Context, w http.Respon
 			for scanner.Scan() {
 				select {
 				case <-respCtx.Done():
-					orchBal := orch.Balance(orchJob.Sender, core.ManifestID(orchJob.Req.Capability))
+					orchBal := orch.Balance(orchJob.Sender, core.ManifestID(orchJob.Req.ID))
 					if orchBal == nil {
 						orchBal = big.NewRat(0, 1)
 					}
@@ -388,7 +396,7 @@ func (bso *BYOCOrchestratorServer) processJob(ctx context.Context, w http.Respon
 				default:
 					line := scanner.Text()
 					if strings.Contains(line, "[DONE]") {
-						orchBal := orch.Balance(orchJob.Sender, core.ManifestID(orchJob.Req.Capability))
+						orchBal := orch.Balance(orchJob.Sender, core.ManifestID(orchJob.Req.ID))
 						if orchBal == nil {
 							orchBal = big.NewRat(0, 1)
 						}
@@ -412,8 +420,8 @@ func (bso *BYOCOrchestratorServer) processJob(ctx context.Context, w http.Respon
 				//skips if price is 0
 				jobPriceRat := big.NewRat(orchJob.JobPrice.PricePerUnit, orchJob.JobPrice.PixelsPerUnit)
 				if jobPriceRat.Cmp(big.NewRat(0, 1)) > 0 {
-					bso.orch.DebitFees(orchJob.Sender, core.ManifestID(orchJob.Req.Capability), orchJob.JobPrice, 5)
-					senderBalance := bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability)
+					bso.orch.DebitFees(orchJob.Sender, core.ManifestID(orchJob.Req.ID), orchJob.JobPrice, 5)
+					senderBalance := bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID)
 					if senderBalance != nil {
 						if senderBalance.Cmp(big.NewRat(0, 1)) < 0 {
 							w.Write([]byte("event: insufficient balance\n"))
@@ -433,7 +441,7 @@ func (bso *BYOCOrchestratorServer) processJob(ctx context.Context, w http.Respon
 		}
 
 		//capacity released with defer stmt above
-		clog.V(common.SHORT).Infof(ctx, "Job processed successfully took=%v balance=%v", time.Since(start), bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
+		clog.V(common.SHORT).Infof(ctx, "Job processed successfully took=%v balance=%v", time.Since(start), bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
 	}
 }
 
@@ -461,7 +469,7 @@ func (bso *BYOCOrchestratorServer) setupOrchJob(ctx context.Context, r *http.Req
 		return nil, errors.New("Could not get job price")
 	}
 
-	pmtErr := bso.confirmPayment(ctx, sender, jobReq.Capability, jobPrice, r.Header.Get(jobPaymentHeaderHdr))
+	pmtErr := bso.confirmPayment(ctx, sender, jobReq.ID, jobReq.Capability, jobPrice, r.Header.Get(jobPaymentHeaderHdr))
 	if pmtErr != nil {
 		orch.FreeExternalCapabilityCapacity(jobReq.Capability)
 		return nil, pmtErr
@@ -478,7 +486,13 @@ func (bso *BYOCOrchestratorServer) setupOrchJob(ctx context.Context, r *http.Req
 	return &orchJob{Req: jobReq, Sender: sender, JobPrice: jobPrice, Details: &jobDetails}, nil
 }
 
-func (bso *BYOCOrchestratorServer) confirmPayment(ctx context.Context, sender ethcommon.Address, capability string, jobPrice *net.PriceInfo, paymentHdr string) error {
+// confirmPayment validates and applies any payment present in the request,
+// and verifies the sender has at least a minimum balance for the job.
+//
+// jobID is used as the ManifestID for balance keying — each job/stream gets
+// an isolated balance bucket. capability is only used for capacity-slot
+// management on payment failure (FreeExternalCapabilityCapacity).
+func (bso *BYOCOrchestratorServer) confirmPayment(ctx context.Context, sender ethcommon.Address, jobID, capability string, jobPrice *net.PriceInfo, paymentHdr string) error {
 
 	clog.V(common.DEBUG).Infof(ctx, "job price=%v units=%v", jobPrice.PricePerUnit, jobPrice.PixelsPerUnit)
 
@@ -488,7 +502,7 @@ func (bso *BYOCOrchestratorServer) confirmPayment(ctx context.Context, sender et
 	if jobPriceRat.Cmp(big.NewRat(0, 1)) > 0 {
 		minBal := new(big.Rat).Mul(jobPriceRat, big.NewRat(60, 1)) //minimum 1 minute balance
 		//process payment if included
-		orchBal, pmtErr := bso.processPayment(ctx, sender, capability, paymentHdr)
+		orchBal, pmtErr := bso.processPayment(ctx, sender, jobID, capability, paymentHdr)
 		if pmtErr != nil {
 			//log if there are payment errors but continue, balance will runout and clean up
 			clog.Infof(ctx, "job payment error: %v", pmtErr)
@@ -502,8 +516,10 @@ func (bso *BYOCOrchestratorServer) confirmPayment(ctx context.Context, sender et
 	return nil
 }
 
-// process payment and return balance
-func (bso *BYOCOrchestratorServer) processPayment(ctx context.Context, sender ethcommon.Address, capability string, paymentHdr string) (*big.Rat, error) {
+// processPayment processes the ticket payment (if any) keyed by jobID and
+// returns the resulting per-job balance. capability is used only to release
+// the capacity slot on failure.
+func (bso *BYOCOrchestratorServer) processPayment(ctx context.Context, sender ethcommon.Address, jobID, capability string, paymentHdr string) (*big.Rat, error) {
 	if paymentHdr != "" {
 		payment, err := getPayment(paymentHdr)
 		if err != nil {
@@ -511,13 +527,13 @@ func (bso *BYOCOrchestratorServer) processPayment(ctx context.Context, sender et
 			return nil, errPaymentError
 		}
 
-		if err := bso.orch.ProcessPayment(ctx, payment, core.ManifestID(capability)); err != nil {
+		if err := bso.orch.ProcessPayment(ctx, payment, core.ManifestID(jobID)); err != nil {
 			bso.orch.FreeExternalCapabilityCapacity(capability)
 			clog.Errorf(ctx, "Error processing payment: %v", err)
 			return nil, errPaymentError
 		}
 	}
-	orchBal := bso.getPaymentBalance(sender, capability)
+	orchBal := bso.getPaymentBalance(sender, jobID)
 
 	return orchBal, nil
 

--- a/byoc/job_orchestrator_test.go
+++ b/byoc/job_orchestrator_test.go
@@ -910,7 +910,7 @@ func TestProcessPayment(t *testing.T) {
 			}
 
 			before := orch.Balance(sender, core.ManifestID(tc.capability)).FloatString(0)
-			bal, err := bso.processPayment(ctx, sender, tc.capability, testPmtHdr)
+			bal, err := bso.processPayment(ctx, sender, tc.capability, tc.capability, testPmtHdr)
 			after := orch.Balance(sender, core.ManifestID(tc.capability)).FloatString(0)
 			t.Logf("Balance before: %s, after: %s", before, after)
 			assert.NoError(t, err)

--- a/byoc/payment.go
+++ b/byoc/payment.go
@@ -88,20 +88,21 @@ func (bsg *BYOCGatewayServer) createPayment(ctx context.Context, jobReq *JobRequ
 	orchAddr := ethcommon.BytesToAddress(orchToken.TicketParams.Recipient)
 	sessionID := bsg.node.Sender.StartSession(*pmTicketParams(orchToken.TicketParams))
 
-	//setup balances and update Gateway balance to Orchestrator balance, log differences
-	//Orchestrator tracks balance paid and will not perform work if the balance it
-	//has is not sufficient
+	// Balances are keyed per-job (ManifestID = jobReq.ID) so each job/stream
+	// gets an isolated balance bucket — no aggregation at the sender or
+	// capability level. This mirrors how live-video-to-video uses a fresh
+	// ManifestID per stream (see server/ai_process.go clearSessionBalance).
 	orchBal := big.NewRat(orchToken.Balance, 1)
 	price := big.NewRat(orchToken.Price.PricePerUnit, orchToken.Price.PixelsPerUnit)
 	cost := new(big.Rat).Mul(price, big.NewRat(int64(jobReq.Timeout), 1))
 	minBal := new(big.Rat).Mul(price, big.NewRat(120, 1)) //minimum 2 minute balance, Orchestrator requires 1 minute.  Use 2 to have a buffer.
-	balance, diffToOrch, minBalCovered, resetToZero := compareAndUpdateBalance(bsg, orchAddr, jobReq.Capability, orchBal, minBal)
+	balance, diffToOrch, minBalCovered, resetToZero := compareAndUpdateBalance(bsg, orchAddr, jobReq.ID, orchBal, minBal)
 
 	if diffToOrch.Sign() != 0 {
-		clog.Infof(ctx, "Updated balance for sender=%v capability=%v by %v to match Orchestrator reported balance %v", sender.Hex(), jobReq.Capability, diffToOrch.FloatString(3), orchBal.FloatString(3))
+		clog.Infof(ctx, "Updated balance for sender=%v job_id=%v capability=%v by %v to match Orchestrator reported balance %v", sender.Hex(), jobReq.ID, jobReq.Capability, diffToOrch.FloatString(3), orchBal.FloatString(3))
 	}
 	if resetToZero {
-		clog.Infof(ctx, "Reset balance to zero for to match Orchestrator reported balance sender=%v capability=%v", sender.Hex(), jobReq.Capability)
+		clog.Infof(ctx, "Reset balance to zero to match Orchestrator reported balance sender=%v job_id=%v capability=%v", sender.Hex(), jobReq.ID, jobReq.Capability)
 	}
 	if minBalCovered {
 		createTickets = false
@@ -110,7 +111,7 @@ func (bsg *BYOCGatewayServer) createPayment(ctx context.Context, jobReq *JobRequ
 			ExpectedPrice: orchToken.Price,
 		}
 	}
-	clog.V(common.DEBUG).Infof(ctx, "current balance for sender=%v capability=%v is %v, cost=%v price=%v", sender.Hex(), jobReq.Capability, balance.FloatString(3), cost.FloatString(3), price.FloatString(3))
+	clog.V(common.DEBUG).Infof(ctx, "current balance for sender=%v job_id=%v capability=%v is %v, cost=%v price=%v", sender.Hex(), jobReq.ID, jobReq.Capability, balance.FloatString(3), cost.FloatString(3), price.FloatString(3))
 
 	if !createTickets {
 		clog.V(common.DEBUG).Infof(ctx, "No payment required, using balance=%v", balance.FloatString(3))
@@ -134,7 +135,7 @@ func (bsg *BYOCGatewayServer) createPayment(ctx context.Context, jobReq *JobRequ
 		fv := big.NewRat(tickets.FaceValue.Int64(), 1)
 		pmtTotal := new(big.Rat).Mul(fv, winProb)
 		pmtTotal = new(big.Rat).Mul(pmtTotal, big.NewRat(int64(ticketCnt), 1))
-		bsg.node.Balances.Credit(orchAddr, core.ManifestID(jobReq.Capability), pmtTotal)
+		bsg.node.Balances.Credit(orchAddr, core.ManifestID(jobReq.ID), pmtTotal)
 		//create the payment
 		payment = &net.Payment{
 			Sender:        sender.Bytes(),
@@ -157,13 +158,14 @@ func (bsg *BYOCGatewayServer) createPayment(ctx context.Context, jobReq *JobRequ
 		payment.TicketSenderParams = senderParams
 
 		ratPrice, _ := common.RatPriceInfo(payment.ExpectedPrice)
-		balanceForOrch := bsg.node.Balances.Balance(orchAddr, core.ManifestID(jobReq.Capability))
+		balanceForOrch := bsg.node.Balances.Balance(orchAddr, core.ManifestID(jobReq.ID))
 		balanceForOrchStr := ""
 		if balanceForOrch != nil {
 			balanceForOrchStr = balanceForOrch.FloatString(3)
 		}
 
-		clog.V(common.DEBUG).Infof(ctx, "Created new payment - capability=%v recipient=%v faceValue=%v winProb=%v price=%v numTickets=%v balance=%v",
+		clog.V(common.DEBUG).Infof(ctx, "Created new payment - job_id=%v capability=%v recipient=%v faceValue=%v winProb=%v price=%v numTickets=%v balance=%v",
+			jobReq.ID,
 			jobReq.Capability,
 			tickets.Recipient.Hex(),
 			eth.FormatUnits(tickets.FaceValue, "ETH"),
@@ -202,15 +204,16 @@ func ticketCountForCost(cost *big.Rat, ticketEv *big.Rat, timeoutSeconds int64) 
 	return int64(math.Max(0, math.Ceil(ticketCnt)))
 }
 
-func updateGatewayBalance(node *core.LivepeerNode, orchToken JobToken, capability string, took time.Duration) *big.Rat {
+// updateGatewayBalance debits the gateway-side balance for a job by the cost
+// of the elapsed time. The balance is keyed per-job (jobID is used as the
+// ManifestID), giving each job its own isolated balance bucket.
+func updateGatewayBalance(node *core.LivepeerNode, orchToken JobToken, jobID string, took time.Duration) *big.Rat {
 	orchAddr := ethcommon.BytesToAddress(orchToken.TicketParams.Recipient)
-	// update for usage of compute
 	orchPrice := big.NewRat(orchToken.Price.PricePerUnit, orchToken.Price.PixelsPerUnit)
 	cost := new(big.Rat).Mul(orchPrice, big.NewRat(int64(math.Ceil(took.Seconds())), 1))
-	node.Balances.Debit(orchAddr, core.ManifestID(capability), cost)
+	node.Balances.Debit(orchAddr, core.ManifestID(jobID), cost)
 
-	//get the updated balance
-	balance := node.Balances.Balance(orchAddr, core.ManifestID(capability))
+	balance := node.Balances.Balance(orchAddr, core.ManifestID(jobID))
 	if balance == nil {
 		return big.NewRat(0, 1)
 	}

--- a/byoc/stream_gateway.go
+++ b/byoc/stream_gateway.go
@@ -124,7 +124,7 @@ func (bsg *BYOCGatewayServer) sendStopStreamToOrch(ctx context.Context, streamID
 		return nil, fmt.Errorf("error getting job sender: %w", err)
 	}
 
-	newToken, err := getToken(ctx, getNewTokenTimeout, orch.ServiceAddr, stopJob.Job.Req.Capability, jobSender.Addr, jobSender.Sig)
+	newToken, err := getToken(ctx, getNewTokenTimeout, orch.ServiceAddr, stopJob.Job.Req.Capability, streamID, jobSender.Addr, jobSender.Sig)
 	if err != nil {
 		return nil, fmt.Errorf("error converting session to token: %w", err)
 	}
@@ -295,7 +295,7 @@ func (bsg *BYOCGatewayServer) runStream(gatewayJob *gatewayJob) {
 
 func (bsg *BYOCGatewayServer) refreshToken(ctx context.Context, streamID string, orch JobToken, gatewayJob *gatewayJob) JobToken {
 	clog.Infof(ctx, "Refreshing token for orchestrator %v", orch.ServiceAddr)
-	newToken, err := getToken(ctx, getNewTokenTimeout, orch.ServiceAddr, gatewayJob.Job.Req.Capability, gatewayJob.Job.Req.Sender, gatewayJob.Job.Req.Sig)
+	newToken, err := getToken(ctx, getNewTokenTimeout, orch.ServiceAddr, gatewayJob.Job.Req.Capability, streamID, gatewayJob.Job.Req.Sender, gatewayJob.Job.Req.Sig)
 	if err != nil {
 		clog.Errorf(ctx, "Error getting token for orch=%v err=%v", orch.ServiceAddr, err)
 		return orch
@@ -366,7 +366,7 @@ func (bsg *BYOCGatewayServer) sendPaymentForStream(ctx context.Context, streamID
 
 	// fetch new JobToken with each payment
 	// update the session for the LivePipeline with new token
-	newToken, err := getToken(ctx, getNewTokenTimeout, orch.ServiceAddr, stream.Pipeline, jobSender.Addr, jobSender.Sig)
+	newToken, err := getToken(ctx, getNewTokenTimeout, orch.ServiceAddr, stream.Pipeline, streamID, jobSender.Addr, jobSender.Sig)
 	if err != nil {
 		clog.Errorf(ctx, "Error getting new token for %s: %v", orch.ServiceAddr, err)
 		return err
@@ -383,7 +383,8 @@ func (bsg *BYOCGatewayServer) sendPaymentForStream(ctx context.Context, streamID
 		clog.Errorf(ctx, "Error marshalling job details: %v", err)
 		return err
 	}
-	req := &JobRequest{Request: string(jobDetailsStr), Parameters: "{}", Capability: stream.Pipeline,
+	// ID must be set so orch keys per-stream balance correctly
+	req := &JobRequest{ID: streamID, Request: string(jobDetailsStr), Parameters: "{}", Capability: stream.Pipeline,
 		Sender:  jobSender.Addr,
 		Timeout: 70,
 	}
@@ -639,7 +640,7 @@ func (bsg *BYOCGatewayServer) setupStream(ctx context.Context, r *http.Request, 
 			pipeline:               pipeline,
 			sendErrorEvent:         sendErrorEvent,
 
-			manifestID: pipeline, //byoc uses one balance per capability name
+			manifestID: pipeline, // log/segment-file label only; balance is keyed per-stream by streamID via JobRequest.ID
 		},
 	}
 
@@ -997,7 +998,7 @@ func (bsg *BYOCGatewayServer) UpdateStream() http.Handler {
 		orch := params.liveParams.orchToken
 		params.liveParams.mu.Unlock()
 
-		newToken, err := getToken(ctx, getNewTokenTimeout, orch.ServiceAddr, updateJob.Job.Req.Capability, jobSender.Addr, jobSender.Sig)
+		newToken, err := getToken(ctx, getNewTokenTimeout, orch.ServiceAddr, updateJob.Job.Req.Capability, streamId, jobSender.Addr, jobSender.Sig)
 		if err != nil {
 			clog.Errorf(ctx, "Error converting session to token: %s", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/byoc/stream_orchestrator.go
+++ b/byoc/stream_orchestrator.go
@@ -171,8 +171,8 @@ func (bso *BYOCOrchestratorServer) StartStream() http.Handler {
 
 		statusCode, respBody := bso.processWorkerResp(ctx, orchJob.Req.Capability, resp)
 		if statusCode > 399 {
-			bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.Capability)
-			w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
+			bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.ID)
+			w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
 			//return error response from the worker
 			w.WriteHeader(statusCode)
 			w.Write(respBody)
@@ -180,10 +180,10 @@ func (bso *BYOCOrchestratorServer) StartStream() http.Handler {
 			return
 		}
 
-		bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.Capability)
-		w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
+		bso.chargeForCompute(start, orchJob.JobPrice, orchJob.Sender, orchJob.Req.ID)
+		w.Header().Set(jobPaymentBalanceHdr, bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
 
-		clog.V(common.SHORT).Infof(ctx, "stream start processed successfully took=%v balance=%v", time.Since(start), bso.getPaymentBalance(orchJob.Sender, orchJob.Req.Capability).FloatString(0))
+		clog.V(common.SHORT).Infof(ctx, "stream start processed successfully took=%v balance=%v", time.Since(start), bso.getPaymentBalance(orchJob.Sender, orchJob.Req.ID).FloatString(0))
 
 		//setup the stream
 		stream, err := bso.node.ExternalCapabilities.AddStream(orchJob.Req.ID, orchJob.Req.Capability, reqBodyBytes)
@@ -244,9 +244,11 @@ func (bso *BYOCOrchestratorServer) monitorOrchStream(job *orchJob) {
 			jobPriceRat := big.NewRat(job.JobPrice.PricePerUnit, job.JobPrice.PixelsPerUnit)
 			if jobPriceRat.Cmp(big.NewRat(0, 1)) > 0 {
 				//lock during balance update to complete balance update
+				// balance is keyed per-stream (streamID) so concurrent
+				// streams from the same sender don't share a balance pool
 				extCap.Mu.Lock()
-				bso.orch.DebitFees(senderAddr, core.ManifestID(capability), job.JobPrice, int64(pmtCheckDur.Seconds()))
-				senderBalance := bso.getPaymentBalance(senderAddr, capability)
+				bso.orch.DebitFees(senderAddr, core.ManifestID(streamID), job.JobPrice, int64(pmtCheckDur.Seconds()))
+				senderBalance := bso.getPaymentBalance(senderAddr, streamID)
 				extCap.Mu.Unlock()
 				if senderBalance != nil {
 					if senderBalance.Cmp(big.NewRat(0, 1)) < 0 {
@@ -467,18 +469,19 @@ func (bso *BYOCOrchestratorServer) ProcessStreamPayment() http.Handler {
 
 		senderAddr := ethcommon.HexToAddress(orchJob.Req.Sender)
 
-		capBal := orch.Balance(senderAddr, core.ManifestID(orchJob.Req.Capability))
-		if capBal != nil {
-			capBal, err = common.PriceToInt64(capBal)
+		// Balance is keyed per-stream (Req.ID is the stream ID for stream payments).
+		streamBal := orch.Balance(senderAddr, core.ManifestID(orchJob.Req.ID))
+		if streamBal != nil {
+			streamBal, err = common.PriceToInt64(streamBal)
 			if err != nil {
-				clog.Errorf(ctx, "could not convert balance to int64 sender=%v capability=%v err=%v", senderAddr.Hex(), orchJob.Req.Capability, err.Error())
-				capBal = big.NewRat(0, 1)
+				clog.Errorf(ctx, "could not convert balance to int64 sender=%v stream_id=%v err=%v", senderAddr.Hex(), orchJob.Req.ID, err.Error())
+				streamBal = big.NewRat(0, 1)
 			}
 		} else {
-			capBal = big.NewRat(0, 1)
+			streamBal = big.NewRat(0, 1)
 		}
 
-		w.Header().Set(jobPaymentBalanceHdr, capBal.FloatString(0))
+		w.Header().Set(jobPaymentBalanceHdr, streamBal.FloatString(0))
 		w.WriteHeader(http.StatusOK)
 	})
 }

--- a/byoc/types.go
+++ b/byoc/types.go
@@ -26,6 +26,7 @@ const (
 	jobRequestHdr                   = "Livepeer"
 	jobEthAddressHdr                = "Livepeer-Eth-Address"
 	jobCapabilityHdr                = "Livepeer-Capability"
+	jobIdHdr                        = "Livepeer-Job-Id"
 	jobPaymentHeaderHdr             = "Livepeer-Payment"
 	jobPaymentBalanceHdr            = "Livepeer-Balance"
 	jobOrchSearchTimeoutHdr         = "Livepeer-Orch-Search-Timeout"


### PR DESCRIPTION
## Context

While reviewing #3869, the BYOC payment accounting model surfaced a structural concern: balances are keyed by `(sender_address, capability_id)` rather than per-job/per-stream. Effects:

- Multiple concurrent jobs from the same sender for the same capability share one balance pool.
- The orchestrator can't manage admission for individual jobs based on payment state — only aggregate sender balance for that capability.
- Remote signers (clearinghouse signing on behalf of multiple downstream customers) collapse all customer balances into one bucket, so per-customer billing has to be reconstructed out-of-band.

LiveAI explicitly works around this — `server/ai_process.go` calls `clearSessionBalance(sess, RandomManifestID())` per stream to force per-session isolation in the existing `AddressBalances` map. BYOC inherited the per-capability pattern without that band-aid.

## What this PR does

Switches the `ManifestID` used for balance keying from `capability` to `JobRequest.ID` across the BYOC orch + gateway:

**Orchestrator**
- `processJob`, `monitorOrchStream`, `ProcessStreamPayment`, `confirmPayment`, `processPayment`, `chargeForCompute`, `getPaymentBalance` all key Balance/DebitFees/ProcessPayment on `jobReq.ID`.
- `confirmPayment`/`processPayment` take both `jobID` (balance) and `capability` (capacity-slot management) since the two concerns are now distinct.
- `GetJobToken` accepts an optional `Livepeer-Job-Id` header. Initial token requests (no job context) return balance=0; refresh calls for an existing job/stream pass the ID and get the per-job balance.

**Gateway**
- `createPayment`, `updateGatewayBalance`, `getToken` thread `jobID`.
- `sendPaymentForStream` sets `req.ID = streamID` so the orch matches per-stream payments.

Capacity-management call sites (`FreeExternalCapabilityCapacity`, `RemoveExternalCapability`, worker routing) still use `Capability` — those are scheduling, not money.

Stacked on #3906 to keep the diff scoped to the refactor.

## The genuine question for the author

@eliteprox — before going further, I'd like to understand the reasoning behind sender+capability keying. Reasons it might have been intentional:

1. **PM session alignment.** One `pm.Sender.StartSession()` produces tickets for many jobs. Capability-keyed balance lets one PM session feed one balance bucket cleanly. Per-job keying creates a many-to-one routing question on ticket payout that this PR doesn't yet solve.
2. **Prepaid-credit mental model.** \"User buys \$X of compute for capability Y, spends across many requests\" maps cleanly to capability balance.
3. **First-token discovery info.** The capability balance returned in the initial token response was a useful signal for the gateway. Per-job balance is always 0 there.
4. **Bounded key cardinality.** `(senders × capabilities)` is bounded. `(senders × job_ids)` grows unbounded — every completed job leaves a dust balance that needs GC.
5. **Residual carry-over.** User does job A, gateway crashes mid-flow, user submits job B with same capability — capability-keyed model preserves leftover credit. Per-job keying strands it.

If any of these were primary drivers, this refactor needs to address them rather than ignore them. If the original choice was inherited from the pre-existing AI-jobs pattern without explicit consideration of streams or remote signers, the trade-offs above are mostly recoverable.

## Out of scope (deferred)

- **Per-job PM session reset.** LiveAI calls `clearSessionBalance` per stream to avoid ticket nonce reuse. BYOC still calls `Sender.StartSession()` once per `createPayment`. If we go per-job balance, per-job PM sessions likely need to follow.
- **Test suite update.** `TestGetJobToken_Success` now correctly returns 0 (no jobID provided) and the test asserts the legacy 1000. Other tests in `payment_test.go` / `job_orchestrator_test.go` / `stream_test.go` still assume capability-keyed balance. Left so the diff is reviewable as a design question first.
- **Backward compat.** No wire-format change, but old gateways/orchs talking to new ones will create capability-keyed balances the new code never reads. Coordinate-deploy or fall-through-during-deprecation needs deciding.
- **Dust-balance GC.** Per-job keying leaves orphan balances after job completion.

## Status

Draft. Builds clean (`go build ./...`). One test fails intentionally to document the behavior change. Not ready to merge — raising for design discussion before investing in the test pass and PM session refactor.