### PR TITLE
server: nil-check OrchestratorInfo on BroadcastSession getters

### DIFF
--- a/server/rpc.go
+++ b/server/rpc.go
@@ -164,12 +164,18 @@ type GetOrchestratorInfoParams struct {
 func (bs *BroadcastSession) Transcoder() string {
 	bs.lock.RLock()
 	defer bs.lock.RUnlock()
+	if bs.OrchestratorInfo == nil {
+		return ""
+	}
 	return bs.OrchestratorInfo.Transcoder
 }
 
 func (bs *BroadcastSession) Address() string {
 	bs.lock.RLock()
 	defer bs.lock.RUnlock()
+	if bs.OrchestratorInfo == nil {
+		return ""
+	}
 	return hexutil.Encode(bs.OrchestratorInfo.Address)
 }
 


### PR DESCRIPTION
`Transcoder()` and `Address()` panicked when a session whose `OrchestratorInfo` had been wiped by selection filters was reused. Return empty strings rather than crashing the caller goroutine. Fixes #3917.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential runtime errors in broadcast session management to improve application stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/livepeer/go-livepeer/pull/3919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->