### PR TITLE
byoc: drain ffmpeg output cleanly on stream stop

### DIFF
--- a/byoc/trickle.go
+++ b/byoc/trickle.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/livepeer/go-livepeer/clog"
@@ -393,14 +392,25 @@ func (bsg *BYOCGatewayServer) ffmpegOutput(ctx context.Context, outputUrl string
 			"-f", "flv",
 			outputUrl,
 		)
-		// Change Cancel function to send a SIGTERM instead of SIGKILL. Still send a SIGKILL after 5s (WaitDelay) if it's stuck.
-		cmd.Cancel = func() error {
-			return cmd.Process.Signal(syscall.SIGTERM)
-		}
+		// Don't kill ffmpeg on ctx cancel. The trickle-subscriber
+		// goroutine that feeds outWriter calls Close on shutdown,
+		// which sends stdin EOF and lets ffmpeg finalize the FLV
+		// trailer cleanly. Sending SIGTERM here interrupts that
+		// drain and produces spurious "Broken pipe" / "Error
+		// writing trailer" logs at every /stream/stop. WaitDelay
+		// still hard-kills ffmpeg if it hangs after I/O closes.
+		cmd.Cancel = func() error { return nil }
 		cmd.WaitDelay = 5 * time.Second
 		cmd.Stdin = outWriter.MakeReader() // start at leading edge of output for each retry
 		output, err := cmd.CombinedOutput()
-		clog.Infof(ctx, "Process err=%v output: %s", err, output)
+		if ctx.Err() != nil {
+			// Expected shutdown — suppress any residual ffmpeg
+			// stderr (e.g. RTMP destination disconnected before
+			// trailer flush completed).
+			clog.V(common.DEBUG).Infof(ctx, "ffmpeg exited (ctx cancelled) err=%v", err)
+		} else {
+			clog.Infof(ctx, "Process err=%v output: %s", err, output)
+		}
 
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
## Summary

- Stop sending SIGTERM to the BYOC gateway's RTMP-output `ffmpeg` subprocess on context cancellation; rely on stdin EOF (delivered when the trickle-subscriber goroutine closes the feeding `media.RingBuffer`) for graceful drain.
- Suppress residual `ffmpeg` stderr at INFO when the exit was caused by ctx cancellation, since brief broken-pipe output can still happen if the RTMP destination disconnects before the FLV trailer finishes flushing.

Fixes #3922.

## Why

Every clean `/process/stream/.../stop` produced a block of error-looking ffmpeg output in the gateway log:

```
[in#0/flv @ ...] Error during demuxing: Input/output error
[vost#0:0/copy @ ...] Error submitting a packet to the muxer: Broken pipe
[out#0/flv @ ...] Error muxing a packet
[out#0/flv @ ...] Task finished with error code: -32 (Broken pipe)
[flv @ ...] Failed to update header with correct duration.
[flv @ ...] Failed to update header with correct filesize.
[out#0/flv @ ...] Error writing trailer: Broken pipe
[out#0/flv @ ...] Error closing file: Broken pipe
Conversion failed!
```

These weren't real failures — `ffmpeg` was reporting accurately what it observed. The gateway was shutting things down in parallel: `cmd.Cancel = SIGTERM` fired, the trickle subscriber was already closing the RingBuffer feeding ffmpeg's stdin, and the RTMP destination was tearing down concurrently. ffmpeg got hit from three sides and dumped its stderr.

[`media.RingBuffer.readFrom`](https://github.com/livepeer/go-livepeer/blob/master/media/ring.go#L75-L112) already returns `io.EOF` to readers once `rb.closed && rb.nb == head`, so closing the writer is a clean shutdown signal that ffmpeg interprets correctly — it reads to EOF, finalizes the FLV trailer, and exits.

By making `cmd.Cancel` a no-op, ffmpeg gets to finish on its own terms. `cmd.WaitDelay` (5 s) still hard-kills it if it hangs after I/O closes.

## Test plan

- [x] `go build ./byoc/...` — compiles
- [x] `gofmt -d byoc/trickle.go` — no diff
- [x] `go vet ./byoc/...` — no new warnings (pre-existing warnings in other files unrelated to this change)
- [ ] Manual: BYOC `/process/stream/start` → push RTMP → `/process/stream/stop` and confirm the gateway log no longer contains the ffmpeg broken-pipe block at INFO. (Locally reproduced via the [Python pipeline SDK examples](https://github.com/livepeer/livepeer-python-gateway/tree/main/examples/runner) — `live_grayscale`, `live_depth`, `live_transcribe`.)

## Out of scope

- Replacing the ffmpeg subprocess entirely with native FLV muxing (much bigger change; tracked separately).
- Other call sites that capture subprocess stderr verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)