### PR TITLE
trickle: Add a /<channel>/next endpoint

### DIFF
--- a/trickle/README.md
+++ b/trickle/README.md
@@ -22,6 +22,8 @@ Publishers POST to /channel-name/seq
 
 Subscribers GET to /channel-name/seq
 
+Clients can query the next segment seq with GET to /channel-name/next
+
 The `channel-name` is any valid HTTP path part.
 
 The `seq` is an integer sequence number indicating the segment, and must increase sequentially without gaps.
@@ -51,6 +53,10 @@ Publishers are responsible for segmenting content (if necessary) and subscribers
 Subscribers can initiate a subscribe with a `seq` of -1 to retrieve the most recent publish. With preconnects, the subscriber may be waiting for the *next* publish. For video this allows clients to eg, start streaming at the live edge of the next GOP.
 
 Subscribers can retrieve the current `seq` with the `Lp-Trickle-Seq` metadata (HTTP header). This is useful in case `-1` was used to initiate the subscription; the subscribing client can then pre-connect to `Lp-Trickle-Seq + 1`
+
+GET `/channel-name/next` returns the next segment seq as plain text in the response body and in the `Lp-Trickle-Latest` response header.
+If the channel does not exist, the server returns 404.
+If the channel is closed, the server also includes `Lp-Trickle-Closed: terminated`.
 
 Subscribers can initiate a subscribe with a `seq` of -N to get the Nth-from-last segment. (TODO)
 

--- a/trickle/trickle_server.go
+++ b/trickle/trickle_server.go
@@ -117,6 +117,7 @@ func ConfigureServer(config TrickleServerConfig) *Server {
 	)
 
 	mux.HandleFunc("POST "+basePath+"{streamName}", streamManager.handleCreate)
+	mux.HandleFunc("GET "+basePath+"{streamName}/next", streamManager.handleNext)
 	mux.HandleFunc("GET "+basePath+"{streamName}/{idx}", streamManager.handleGet)
 	mux.HandleFunc("POST "+basePath+"{streamName}/{idx}", streamManager.handlePost)
 	mux.HandleFunc("DELETE "+basePath+"{streamName}/{idx}", streamManager.closeSeq)
@@ -505,6 +506,25 @@ func (sm *Server) handleGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	stream.handleGet(w, r, idx)
+}
+
+func (sm *Server) handleNext(w http.ResponseWriter, r *http.Request) {
+	stream, exists := sm.getStream(r.PathValue("streamName"))
+	if !exists {
+		http.Error(w, "Stream not found", http.StatusNotFound)
+		return
+	}
+	stream.mutex.RLock()
+	nextWrite := stream.nextWrite
+	closed := stream.closed
+	stream.mutex.RUnlock()
+
+	next := strconv.Itoa(nextWrite)
+	w.Header().Set("Lp-Trickle-Latest", next)
+	if closed {
+		w.Header().Set("Lp-Trickle-Closed", "terminated")
+	}
+	w.Write([]byte(next))
 }
 
 func (s *Stream) handleGet(w http.ResponseWriter, r *http.Request, idx int) {


### PR DESCRIPTION
Extracted from #3884 — a small, independent piece that unblocks the livepeer-python-gateway [pipeline SDK](https://github.com/livepeer/livepeer-python-gateway/pull/7) without waiting for the rest of the "Serverless" work.

## What this adds

`GET /{streamName}/next` returns the channel's current `nextWrite`:

- Body: the next seq as plain text
- Header: `Lp-Trickle-Latest: {seq}`
- 404 if the channel doesn't exist
- `Lp-Trickle-Closed: terminated` if the channel is closed

## Why now

The Python SDK ([livepeer-python-gateway](https://github.com/livepeer/livepeer-python-gateway)) probes `/next` to learn `nextWrite` before its first POST so it doesn't collide with the server's own `-1`-resolves-to-slot-0 behavior. Without this endpoint on master, the SDK's probe fails (the path matches the `{idx}` route, fails to parse `"next"` as an int, returns 400) and the publisher's fallback drops the first segment on every channel.

**Companion SDK fallback fix:** livepeer/livepeer-python-gateway#14
**Bug context:** livepeer/livepeer-python-gateway#12

## Relationship to #3884

Cherry-picked from commit `8da1c69224a866386770927de30f43bb565508cf` on the `ja/serverless` branch. The Lp-Trickle-Reset hunk in `handlePost` that travelled with that commit on the branch belongs to a separate "trickle: Support publisher resets" feature and was excluded here — landing it would expand scope beyond what the SDK needs.

When #3884 lands, this commit will already be on master; the rebase should be clean.

## Co-author

Original code by @j0sh — preserved as commit author. Extraction + adapted commit message by Rick Staa, with this PR opened on Josh's behalf to unblock dependent SDK work.

## Test plan

- [x] `go build ./trickle/...` passes
- [x] `go test ./trickle/...` passes
- [ ] Manual: build a `:trickle-next-endpoint` orchestrator image, point the SDK at it, confirm `live_transcribe` delivers transcripts 0–3 (vs. the current 0, 2, 3 due to the slot-0 race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)