### PR TITLE
byoc: drain data subscriber on /stream/stop before tearing down

### DIFF
--- a/byoc/trickle.go
+++ b/byoc/trickle.go
@@ -794,12 +794,31 @@ func (bsg *BYOCGatewayServer) startDataSubscribe(ctx context.Context, url *url.U
 		return
 	}
 
+	// The data subscriber outlives /stream/stop's ctx cancellation by
+	// drainTimeout so we can read the runner's final emit_data segment(s)
+	// published from on_stream_stop before tearing down the SSE proxy.
+	// The trickle channel closes cleanly when the runner SDK tears down
+	// its data publisher (DELETE → trickle.EOS on the next Read), at which
+	// point we exit normally below. The timeout caps the drain so a hung
+	// runner can't keep this goroutine alive forever.
+	const drainTimeout = 10 * time.Second
+	drainCtx, drainCancel := context.WithCancel(context.Background())
+	go func() {
+		<-ctx.Done()
+		select {
+		case <-time.After(drainTimeout):
+			drainCancel()
+		case <-drainCtx.Done():
+		}
+	}()
+
 	// subscribe to the outputs
 	subscriber, err := trickle.NewTrickleSubscriber(trickle.TrickleSubscriberConfig{
 		URL: url.String(),
-		Ctx: ctx,
+		Ctx: drainCtx,
 	})
 	if err != nil {
+		drainCancel()
 		clog.Infof(ctx, "Failed to create data subscriber: %s", err)
 		return
 	}
@@ -809,6 +828,7 @@ func (bsg *BYOCGatewayServer) startDataSubscribe(ctx context.Context, url *url.U
 	// read segments from trickle subscription
 	go func() {
 		defer dataWriter.Close()
+		defer drainCancel()
 
 		var err error
 		firstSegment := true
@@ -819,12 +839,15 @@ func (bsg *BYOCGatewayServer) startDataSubscribe(ctx context.Context, url *url.U
 		const maxRetries = 5
 		for {
 			select {
-			case <-ctx.Done():
+			case <-drainCtx.Done():
 				clog.Info(ctx, "data subscribe done")
 				return
 			default:
 			}
-			if !params.inputStreamExists(params.liveParams.streamID) {
+			// Skip the input-stream-exists guard once /stream/stop has fired —
+			// during the drain window the input stream has already gone away,
+			// but we still want to read the runner's pending final segments.
+			if ctx.Err() == nil && !params.inputStreamExists(params.liveParams.streamID) {
 				clog.Infof(ctx, "data subscribe stopping, input stream does not exist.")
 				break
 			}


### PR DESCRIPTION
**Draft.** Pending end-to-end validation against `examples/runner/live_transcribe` once CI publishes a docker image for this branch.

Fixes #3924.

## The bug

The gateway's data SSE proxy was tearing down its trickle subscriber as
soon as `/stream/stop` arrived, which races the runner's `on_stream_stop`
hook. Any final `emit_data` the runner publishes during its stop hook
(e.g. `live_transcribe`'s last partial-window flush) is written to the
trickle channel **after** the gateway has already cancelled its
subscriber's context — so the segment is never read, never relayed to
the SSE caller.

## Reproduction (3/3)

Against [`livepeer-python-gateway/examples/runner/live_transcribe`](https://github.com/livepeer/livepeer-python-gateway/tree/main/examples/runner/live_transcribe), running the existing `./test.sh` 3 times:

| Run | Runner emitted | Gateway delivered | Dropped |
|---|---|---|---|
| 1 | 7 (transcript 0–6) | 6 (transcript 0–5) | transcript[6] (on_stream_stop flush) |
| 2 | 7 | 6 | transcript[6] |
| 3 | 7 | 6 | transcript[6] |

Gateway log on each run:

```
trickle subscribe error reading: failed to complete GET for next segment:
Get .../{stream}-data/N: context canceled
```

The data subscriber was mid-GET on the next segment when ctx cancellation fired.

## The fix

Decouple the data subscriber's context from `/stream/stop`. After the
stream context is cancelled, give the subscriber up to `drainTimeout`
(10s) to keep reading. The trickle channel closes cleanly when the
runner SDK tears down its data publisher (DELETE → next Read returns
`trickle.EOS`), at which point the loop exits via the existing EOS
path. The timeout caps the drain so a hung runner can't keep the
goroutine alive forever.

## What changed

`byoc/trickle.go:startDataSubscribe`:

- Introduced `drainCtx` rooted in `context.Background()` so it doesn't get cancelled by `/stream/stop`
- Watchdog goroutine waits for `ctx.Done()` (stream stop), then starts a 10s timer before cancelling `drainCtx`
- Subscriber + loop's exit check now use `drainCtx` instead of `ctx`
- `inputStreamExists()` guard is skipped once `ctx` is already cancelled — during drain the stream tracking is gone but we still want to read pending segments
- `defer drainCancel()` ensures the watchdog goroutine never leaks

## Companion SDK fix

Tracked at livepeer/livepeer-python-gateway#12 (probe + fallback fix landed in PR #3925 + #3926). This PR closes the data-channel half of the live_transcribe drop story.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./byoc/...` passes (existing tests; no new ones added in this PR)
- [ ] CI Docker image build green
- [ ] Manual E2E: rebuild `live_transcribe` compose against this image, run `./test.sh` 3× and confirm 7/7 transcripts deliver
- [ ] Confirm normal-stop (no on_stream_stop emit) doesn't add latency to `/stream/stop` response

## Risk / scope

Worst case adds up to 10s to gateway cleanup when the runner doesn't close its data publisher. Doesn't affect the `/stream/stop` HTTP response time — the drain happens in a background goroutine. No changes to other subscribers (media-out, events) or to the publisher path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)