### PR TITLE
Propagate dynamic BYOC capability prices

### DIFF
--- a/byoc/job_orchestrator_test.go
+++ b/byoc/job_orchestrator_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"net/http"
@@ -21,10 +22,13 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/livepeer/go-livepeer/core"
+	"github.com/livepeer/go-livepeer/eth"
 
 	"github.com/livepeer/go-livepeer/net"
+	"github.com/livepeer/go-livepeer/pm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockJobOrchestrator struct {
@@ -56,6 +60,40 @@ type mockJobOrchestrator struct {
 	ticketParams                    func(ethcommon.Address, *net.PriceInfo) (*net.TicketParams, error)
 
 	mock.Mock
+}
+
+type testPriceFeedWatcher struct {
+	mu      sync.Mutex
+	current eth.PriceData
+	sinks   []chan<- eth.PriceData
+}
+
+func (w *testPriceFeedWatcher) Currencies() (string, string, error) {
+	return "ETH", "USD", nil
+}
+
+func (w *testPriceFeedWatcher) Current() (eth.PriceData, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.current, nil
+}
+
+func (w *testPriceFeedWatcher) Subscribe(ctx context.Context, sink chan<- eth.PriceData) {
+	w.mu.Lock()
+	w.sinks = append(w.sinks, sink)
+	w.mu.Unlock()
+}
+
+func (w *testPriceFeedWatcher) update(price *big.Rat) {
+	data := eth.PriceData{Price: price}
+	w.mu.Lock()
+	w.current = data
+	sinks := append([]chan<- eth.PriceData(nil), w.sinks...)
+	w.mu.Unlock()
+
+	for _, sink := range sinks {
+		sink <- data
+	}
 }
 
 func (r *mockJobOrchestrator) ServiceURI() *url.URL {
@@ -766,6 +804,92 @@ func TestGetJobToken_Success(t *testing.T) {
 
 	assert.NotNil(t, token.TicketParams)
 	assert.Equal(t, int64(1000), token.Balance)
+}
+
+func TestGetToken_GatewaySeesDistinctDynamicBYOCPrices(t *testing.T) {
+	watcher := &testPriceFeedWatcher{current: eth.PriceData{Price: big.NewRat(100, 1)}}
+	oldWatcher := core.PriceFeedWatcher
+	core.PriceFeedWatcher = watcher
+	t.Cleanup(func() { core.PriceFeedWatcher = oldWatcher })
+
+	n, err := core.NewLivepeerNode(nil, "", nil)
+	require.NoError(t, err)
+	n.NodeType = core.OrchestratorNode
+	n.AutoAdjustPrice = false
+	n.SetBasePrice("default", core.NewFixedPrice(big.NewRat(1, 1)))
+
+	recipient := new(pm.MockRecipient)
+	recipient.On("TicketParams", mock.Anything, mock.Anything).Return(&pm.TicketParams{
+		Recipient:         ethcommon.HexToAddress("0x1111111111111111111111111111111111111111"),
+		FaceValue:         big.NewInt(1000),
+		WinProb:           big.NewInt(1),
+		RecipientRandHash: ethcommon.HexToHash("0x01"),
+		Seed:              big.NewInt(1234),
+		ExpirationBlock:   big.NewInt(100000),
+		ExpirationParams:  &pm.TicketExpirationParams{},
+	}, nil)
+	n.Recipient = recipient
+
+	orch := core.NewOrchestrator(n, nil)
+	for _, settings := range []string{
+		`{"name":"byoc-cap-a","description":"test A","url":"http://worker-a","capacity":1,"price_per_unit":1,"price_scaling":1,"currency":"USD"}`,
+		`{"name":"byoc-cap-b","description":"test B","url":"http://worker-b","capacity":1,"price_per_unit":2,"price_scaling":1,"currency":"USD"}`,
+	} {
+		_, err := orch.RegisterExternalCapability(settings)
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() {
+		n.SetAutoPriceForExternalCapability("default", "byoc-cap-a", nil)
+		n.SetAutoPriceForExternalCapability("default", "byoc-cap-b", nil)
+	})
+
+	mux := http.NewServeMux()
+	NewBYOCOrchestratorServer(n, orch, nil, "", mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	sender := "0x1000000000000000000000000000000000000000"
+	sig := fmt.Sprintf("%0128d", 0)
+	priceFor := func(capability string) *net.PriceInfo {
+		jobSender := JobSender{Addr: sender, Sig: sig}
+		reqSenderStr, err := json.Marshal(jobSender)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/process/token", nil)
+		require.NoError(t, err)
+		req.Header.Set(jobEthAddressHdr, base64.StdEncoding.EncodeToString(reqSenderStr))
+		req.Header.Set(jobCapabilityHdr, capability)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equalf(t, http.StatusOK, resp.StatusCode, "body=%s", body)
+
+		var token JobToken
+		require.NoError(t, json.Unmarshal(body, &token))
+		require.Equal(t, int64(1), token.AvailableCapacity)
+		require.NotNil(t, token.Price)
+		return token.Price
+	}
+
+	capA := priceFor("byoc-cap-a")
+	require.Equal(t, int64(10000000000000000), capA.PricePerUnit)
+	require.Equal(t, int64(1), capA.PixelsPerUnit)
+
+	capB := priceFor("byoc-cap-b")
+	require.Equal(t, int64(20000000000000000), capB.PricePerUnit)
+	require.Equal(t, int64(1), capB.PixelsPerUnit)
+
+	watcher.update(big.NewRat(200, 1))
+
+	require.Eventually(t, func() bool {
+		capA = priceFor("byoc-cap-a")
+		capB = priceFor("byoc-cap-b")
+		return capA.PricePerUnit == 5000000000000000 &&
+			capB.PricePerUnit == 10000000000000000
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestProcessJob_MethodNotAllowed(t *testing.T) {

--- a/core/ai_orchestrator.go
+++ b/core/ai_orchestrator.go
@@ -1128,7 +1128,7 @@ func (orch *orchestrator) RegisterExternalCapability(extCapabilitySettings strin
 	}
 
 	//set the price for the capability
-	orch.node.SetPriceForExternalCapability("default", cap.Name, cap.GetPrice())
+	orch.node.SetAutoPriceForExternalCapability("default", cap.Name, cap.price)
 
 	return cap, nil
 }

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -162,7 +162,7 @@ type LivepeerNode struct {
 	// Transcoder private fields
 	priceInfo        map[string]*AutoConvertedPrice
 	priceInfoForCaps map[string]CapabilityPrices
-	jobPriceInfo     map[string]map[string]*big.Rat
+	jobPriceInfo     map[string]map[string]*AutoConvertedPrice
 	serviceURI       url.URL
 	segmentMutex     *sync.RWMutex
 	Nodes            []string // instance URLs of this orch available to do work
@@ -203,8 +203,8 @@ type LivePipeline struct {
 // NewLivepeerNode creates a new Livepeer Node. Eth can be nil.
 func NewLivepeerNode(e eth.LivepeerEthClient, wd string, dbh *common.DB) (*LivepeerNode, error) {
 	rand.Seed(time.Now().UnixNano())
-	extCapPrices := make(map[string]map[string]*big.Rat)
-	extCapPrices["default"] = make(map[string]*big.Rat)
+	extCapPrices := make(map[string]map[string]*AutoConvertedPrice)
+	extCapPrices["default"] = make(map[string]*AutoConvertedPrice)
 
 	return &LivepeerNode{
 		Eth:                  e,
@@ -366,18 +366,34 @@ func (n *LivepeerNode) GetNetworkCapabilities() []*common.OrchNetworkCapabilitie
 }
 
 func (n *LivepeerNode) SetPriceForExternalCapability(senderEthAddress string, extCapability string, price *big.Rat) {
+	if price == nil {
+		n.SetAutoPriceForExternalCapability(senderEthAddress, extCapability, nil)
+		return
+	}
+	n.SetAutoPriceForExternalCapability(senderEthAddress, extCapability, NewFixedPrice(price))
+}
+
+func (n *LivepeerNode) SetAutoPriceForExternalCapability(senderEthAddress string, extCapability string, price *AutoConvertedPrice) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	//default price list initialized at startup
 	// check if the senderEthAddress is initialized if not default
 	if _, ok := n.jobPriceInfo[senderEthAddress]; !ok {
-		n.jobPriceInfo[senderEthAddress] = make(map[string]*big.Rat)
+		n.jobPriceInfo[senderEthAddress] = make(map[string]*AutoConvertedPrice)
 	}
 
 	//set the price
 	senderPrices := n.jobPriceInfo[senderEthAddress]
+	prevPrice := senderPrices[extCapability]
 	senderPrices[extCapability] = price
-	glog.Infof("Set price for %s to %s", extCapability, price.FloatString(2))
+	if prevPrice != nil && prevPrice != price {
+		prevPrice.Stop()
+	}
+	if price == nil {
+		glog.Infof("Cleared price for %s", extCapability)
+		return
+	}
+	glog.Infof("Set price for %s to %s", extCapability, price.Value().FloatString(2))
 }
 
 func (n *LivepeerNode) GetPriceForJob(senderEthAddress string, extCapability string) *big.Rat {
@@ -390,8 +406,8 @@ func (n *LivepeerNode) GetPriceForJob(senderEthAddress string, extCapability str
 	}
 	jobPrice := big.NewRat(0, 1)
 
-	if extCapInfo, ok := senderPrices[extCapability]; ok {
-		jobPrice = extCapInfo
+	if extCapInfo, ok := senderPrices[extCapability]; ok && extCapInfo != nil {
+		jobPrice = extCapInfo.Value()
 	}
 
 	return jobPrice

--- a/core/orch_test.go
+++ b/core/orch_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/pm"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -1750,6 +1751,57 @@ func TestBYOCExternalCapsSenderPricing(t *testing.T) {
 	assert.Equal(t, int64(100), getBYOCPrice(addr1), "sender-specific price")
 	assert.Equal(t, int64(200), getBYOCPrice(addr2), "sender-specific price")
 	assert.Equal(t, int64(10), getBYOCPrice(addr3), "falls back to default")
+}
+
+func TestBYOCExternalCapsDynamicPriceUpdates(t *testing.T) {
+	watcherMock := NewPriceFeedWatcherMock(t)
+	PriceFeedWatcher = watcherMock
+	t.Cleanup(func() { PriceFeedWatcher = nil })
+
+	watcherMock.On("Currencies").Return("ETH", "USD", nil)
+	watcherMock.On("Current").Return(eth.PriceData{Price: big.NewRat(100, 1)}, nil)
+
+	var sink chan<- eth.PriceData
+	watcherMock.On("Subscribe", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		sink = args.Get(1).(chan<- eth.PriceData)
+	}).Once()
+
+	n, _ := NewLivepeerNode(nil, "", nil)
+	n.SetBasePrice("default", NewFixedPrice(big.NewRat(1, 1)))
+	n.Recipient = new(pm.MockRecipient)
+	orch := NewOrchestrator(n, nil)
+
+	cap, err := orch.RegisterExternalCapability(`{
+		"name": "dynamic-byoc-service",
+		"description": "Dynamic BYOC price test",
+		"url": "http://localhost:8000",
+		"capacity": 1,
+		"price_per_unit": 1,
+		"price_scaling": 1,
+		"currency": "USD"
+	}`)
+	require.NoError(t, err)
+	defer cap.price.Stop()
+
+	priceFor := func() int64 {
+		prices, err := orch.GetCapabilitiesPrices(ethcommon.HexToAddress("0x1000000000000000000000000000000000000000"))
+		require.NoError(t, err)
+		for _, p := range prices {
+			if p.Capability == uint32(Capability_BYOC) && p.Constraint == "dynamic-byoc-service" {
+				return p.PricePerUnit
+			}
+		}
+		t.Fatal("no BYOC price found for dynamic-byoc-service")
+		return 0
+	}
+
+	require.Equal(t, int64(10000000000000000), priceFor()) // 1 USD at 100 USD/ETH
+
+	sink <- eth.PriceData{Price: big.NewRat(200, 1)}
+
+	require.Eventually(t, func() bool {
+		return priceFor() == int64(5000000000000000) // 1 USD at 200 USD/ETH
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestBYOCExternalCapsPriceEdgeCases(t *testing.T) {


### PR DESCRIPTION
## Summary

- Store BYOC external capability prices as `*AutoConvertedPrice` handles instead of `*big.Rat` snapshots.
- Wire `RegisterExternalCapability()` to preserve the dynamic price handle created from `price_per_unit`, `price_scaling`, and `currency`.
- Add regression tests proving oracle/feed updates change advertised BYOC prices without re-registering the capability.
- Add BYOC gateway-token coverage proving two registered external capabilities return distinct dynamic prices through `/process/token`, and both update after a feed change.

Refs #3929.

This is the first working slice for per-capability oracle pricing: BYOC prices now remain live after registration and the gateway-visible token path sees the current price for each requested external capability. It does not yet add separate per-capability oracle/feed selection fields.

## Verification

Run inside dedicated PC2 VM `go-livepeer-byoc-usdc-20260509` with Go `1.26.3` and Livepeer-patched FFmpeg `libavfilter 10.1.100`:

```bash
go test ./byoc -run TestGetToken_GatewaySeesDistinctDynamicBYOCPrices -count=1 -v
go test ./byoc -count=1
go test ./core -run TestBYOCExternalCapsDynamicPriceUpdates -count=1
```

Passed:

```text
=== RUN   TestGetToken_GatewaySeesDistinctDynamicBYOCPrices
--- PASS: TestGetToken_GatewaySeesDistinctDynamicBYOCPrices (0.01s)
PASS
ok  github.com/livepeer/go-livepeer/byoc  0.031s
ok  github.com/livepeer/go-livepeer/byoc  0.080s
ok  github.com/livepeer/go-livepeer/core  0.037s
```

Previous focused coverage also passed in the same VM:

```bash
go test ./core -run 'TestBYOCExternalCaps(DynamicPriceUpdates|PriceInfo|SenderPricing|PriceEdgeCases)|TestNewAutoConvertedPrice|TestAutoConvertedPrice_Update|TestExternalCapability_GetPrice' -count=1
go test ./byoc -count=1
```

Also checked broader `go test ./core ./byoc -count=1`; `./byoc` passed, while `./core` hits existing base-branch failure `TestPriceInfo_GivenNilRecipient_ReturnsNilError`. Verified the same focused failure exists on base commit `a78e876ff6c97d935344643c2547d0f84d4b26dd`, so it is not introduced by this PR.
