### PR TITLE
server: guard nil liveParams when no orchestrators available for AI request

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,8 @@
 
 #### General
 
+* [#3939](https://github.com/livepeer/go-livepeer/pull/3939) server: Guard nil liveParams so gateway no longer panics on non-live AI requests when no orchestrators are available (@SAY-5)
+
 #### Broadcaster
 
 #### CLI

--- a/server/ai_process.go
+++ b/server/ai_process.go
@@ -1588,17 +1588,20 @@ func processAIRequest(ctx context.Context, params aiRequestParams, req interface
 		if monitor.Enabled {
 			monitor.AIRequestError(errMsg, monitor.ToPipeline(capName), modelID, nil)
 		}
-		monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
-			"type":        "gateway_no_orchestrators_available",
-			"timestamp":   time.Now().UnixMilli(),
-			"stream_id":   params.liveParams.streamID,
-			"pipeline_id": params.liveParams.pipelineID,
-			"request_id":  params.liveParams.requestID,
-			"orchestrator_info": map[string]interface{}{
-				"address": "",
-				"url":     "",
-			},
-		})
+		// liveParams is only set for realtime video requests; guard against nil for other pipelines
+		if params.liveParams != nil {
+			monitor.SendQueueEventAsync("stream_trace", map[string]interface{}{
+				"type":        "gateway_no_orchestrators_available",
+				"timestamp":   time.Now().UnixMilli(),
+				"stream_id":   params.liveParams.streamID,
+				"pipeline_id": params.liveParams.pipelineID,
+				"request_id":  params.liveParams.requestID,
+				"orchestrator_info": map[string]interface{}{
+					"address": "",
+					"url":     "",
+				},
+			})
+		}
 		return nil, &ServiceUnavailableError{err: errors.New(errMsg)}
 	}
 	return resp, nil

--- a/server/ai_process_test.go
+++ b/server/ai_process_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/livepeer/go-livepeer/ai/worker"
+	"github.com/livepeer/go-livepeer/core"
 )
 
 func Test_submitLLM(t *testing.T) {
@@ -122,6 +125,52 @@ func TestEncodeReqMetadata(t *testing.T) {
 				t.Errorf("encodeReqMetadata() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// Test_processAIRequest_NoOrchestrators_NonLive ensures that a non-live AI
+// request (liveParams == nil) returns a ServiceUnavailableError instead of
+// panicking when no orchestrators are available.
+func Test_processAIRequest_NoOrchestrators_NonLive(t *testing.T) {
+	cap := core.Capability_AudioToText
+	modelID := "openai/whisper-large-v3"
+
+	node := &core.LivepeerNode{
+		OrchestratorPool:          &stubDiscovery{},
+		AIProcesssingRetryTimeout: time.Second,
+	}
+
+	// Seed the selector cache with empty pools so Select returns nil without
+	// triggering a network refresh (empty OrchestratorPool keeps the refresh
+	// threshold at zero).
+	sel := &AISessionSelector{
+		warmPool:        NewAISessionPool(&LIFOSelector{}, newSuspender(), 0),
+		coldPool:        NewAISessionPool(&LIFOSelector{}, newSuspender(), 0),
+		ttl:             time.Hour,
+		lastRefreshTime: time.Now(),
+		cap:             cap,
+		modelID:         modelID,
+		node:            node,
+		suspender:       newSuspender(),
+	}
+	mgr := NewAISessionManager(node, time.Hour)
+	mgr.selectors[strconv.Itoa(int(cap))+"_"+modelID] = sel
+
+	params := aiRequestParams{
+		node:        node,
+		sessManager: mgr,
+		// liveParams intentionally nil to mimic a non-live pipeline request.
+	}
+
+	req := worker.GenAudioToTextMultipartRequestBody{ModelId: &modelID}
+
+	resp, err := processAIRequest(context.Background(), params, req)
+	if resp != nil {
+		t.Fatalf("expected nil response, got %v", resp)
+	}
+	var unavailable *ServiceUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected ServiceUnavailableError, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #3917. A non-live AI request (e.g. `audio-to-text`) panics with a nil-pointer dereference instead of returning an error when no orchestrators are available, for example when every eligible orchestrator is rejected by the per-capability max price filter and `--ignoreMaxPriceIfNeeded=false`.

In `processAIRequest`, the `resp == nil` ("no orchestrators available") branch builds a `stream_trace` monitor event that unconditionally dereferences `params.liveParams.streamID`, `params.liveParams.pipelineID` and `params.liveParams.requestID`. `liveParams` is only set for realtime video pipelines and is nil for all other AI requests, so the dereference panics and the gateway closes the connection without an HTTP response (`curl: (52) Empty reply from server`).

## Changes

- Guard the `stream_trace` event behind `params.liveParams != nil`, mirroring the existing nil guards used elsewhere in the same function. Non-live requests now return the existing `ServiceUnavailableError` ("no orchestrators available").
- Add a regression test that drives `processAIRequest` with an empty session pool and nil `liveParams`, asserting a `ServiceUnavailableError` is returned rather than a panic.
- Add CHANGELOG_PENDING entry.

## Test plan

- `go test ./server/ -run Test_processAIRequest_NoOrchestrators_NonLive -race`

Note: I could not run the server package test suite locally because building it requires the patched LPMS ffmpeg toolchain (the system ffmpeg here is incompatible with the cgo bindings). The change is gofmt-clean and relies only on existing symbols; please rely on CI to validate the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a crash in the AI request gateway when no orchestrators are available for non-live AI requests, preventing nil-pointer failures.
  * Non-live requests now fail gracefully with the existing service-unavailable behavior rather than terminating unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->