### PR TITLE
feat(cmd): bridge slog level to the glog -v flag

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,8 @@
 
 #### General
 
+- [#3944](https://github.com/livepeer/go-livepeer/pull/3944) Bridge slog level to the glog `-v` flag so `-v` controls newer subsystem logging (@rickstaa)
+
 #### Broadcaster
 
 #### Orchestrator

--- a/cmd/livepeer/livepeer.go
+++ b/cmd/livepeer/livepeer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"runtime"
@@ -52,6 +53,12 @@ func main() {
 	}
 
 	vFlag.Value.Set(*verbosity)
+
+	// Bridge slog (used by newer subsystems) to the glog -v level until we
+	// migrate off glog; without this, slog.Debug is dropped regardless of -v.
+	if glog.V(6) {
+		slog.SetLogLoggerLevel(slog.LevelDebug)
+	}
 
 	if *mistJSON {
 		mistconnector.PrintMistConfigJson(


### PR DESCRIPTION
## What

Enable slog `Debug` output at `-v 6`, so the existing glog verbosity flag also controls slog.

```go
vFlag.Value.Set(*verbosity)   // glog verbosity goes live here
if glog.V(6) {                // ...read it here
    slog.SetLogLoggerLevel(slog.LevelDebug)
}
```

## Why

go-livepeer uses two loggers: older code on `glog` (driven by `-v`), and newer subsystems (live runner registry, `trickle/`, `ai/worker/`, `media/`) on the stdlib `log/slog`. Nothing ever set slog's level, so it sat at `Info` and **every `slog.Debug` line was dropped regardless of `-v`** — no way to turn them on.

This bridges them: `-v 6` (the documented max verbosity, already used via `glog.V(6)` for the deepest logging) now also enables slog `Debug`. Works because nothing calls `slog.SetDefault`, so the package-level `slog.Debug`/`slog.Info` calls flow through the default handler that `SetLogLoggerLevel` controls. The check runs right after `vFlag.Value.Set(*verbosity)`, the line that applies `-v` to glog, so it reads the configured value.

Interim by design — the long-term direction is migrating off glog onto slog, at which point this goes away. For now it makes the newer slog code usable with the flag operators already know.

**Checklist:**
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Made debug logging consistent by mapping the existing verbose flag to the newer structured logging, so verbose mode enables debug output across updated subsystems.
* **Documentation**
  * Added an Unreleased changelog note describing how verbose logging now controls newer subsystem debug messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
