### PR TITLE
feat(ai_mediaserver): Make RTMP output optional in AI media server (lv2v)

### DIFF
--- a/byoc/stream_gateway.go
+++ b/byoc/stream_gateway.go
@@ -567,9 +567,9 @@ func (bsg *BYOCGatewayServer) setupStream(ctx context.Context, r *http.Request, 
 	ctx = clog.AddVal(ctx, "stream_id", streamID)
 	clog.Infof(ctx, "Received live video AI request")
 
-	// collect all RTMP outputs
+	// collect all RTMP outputs (optional; WHEP uses the ring buffer instead)
 	var rtmpOutputs []string
-	if job.Job.Params.EnableVideoEgress {
+	if job.Job.Params.EnableVideoEgress && !media.LiveAIDisableRTMPOutput() {
 		if outputURL != "" {
 			rtmpOutputs = append(rtmpOutputs, outputURL)
 		}
@@ -578,7 +578,7 @@ func (bsg *BYOCGatewayServer) setupStream(ctx context.Context, r *http.Request, 
 		}
 	}
 
-	clog.Info(ctx, "RTMP outputs", "destinations", rtmpOutputs)
+	clog.Info(ctx, "RTMP outputs", "destinations", rtmpOutputs, "disabled", media.LiveAIDisableRTMPOutput())
 
 	// Clear any previous gateway status
 	bsg.statusStore.Clear(streamID)

--- a/media/whip_server.go
+++ b/media/whip_server.go
@@ -576,6 +576,16 @@ func disableTSCorrection() bool {
 	return v
 }
 
+// LiveAIDisableRTMPOutput skips ffmpeg RTMP egress. WHEP reads processed video from
+// the in-memory ring buffer and does not require RTMP outputs.
+func LiveAIDisableRTMPOutput() bool {
+	v, err := strconv.ParseBool(os.Getenv("LIVE_AI_DISABLE_RTMP_OUTPUT"))
+	if err != nil {
+		return false
+	}
+	return v
+}
+
 func getUDPListenerAddr(addrStr string) (*net.UDPAddr, error) {
 	if addrStr == "" {
 		// Default to all interfaces, port 7290

--- a/server/ai_mediaserver.go
+++ b/server/ai_mediaserver.go
@@ -567,15 +567,17 @@ func (ls *LivepeerServer) StartLiveVideo() http.Handler {
 		ctx = clog.AddVal(ctx, "stream_id", streamID)
 		clog.Infof(ctx, "Received live video AI request for %s. pipelineParams=%v", streamName, pipelineParams)
 
-		// collect all RTMP outputs
+		// collect all RTMP outputs (optional; WHEP uses the ring buffer instead)
 		var rtmpOutputs []string
-		if outputURL != "" {
-			rtmpOutputs = append(rtmpOutputs, outputURL)
+		if !media.LiveAIDisableRTMPOutput() {
+			if outputURL != "" {
+				rtmpOutputs = append(rtmpOutputs, outputURL)
+			}
+			if mediaMTXOutputURL != "" {
+				rtmpOutputs = append(rtmpOutputs, mediaMTXOutputURL, mediaMTXOutputAlias)
+			}
 		}
-		if mediaMTXOutputURL != "" {
-			rtmpOutputs = append(rtmpOutputs, mediaMTXOutputURL, mediaMTXOutputAlias)
-		}
-		clog.Info(ctx, "RTMP outputs", "destinations", rtmpOutputs)
+		clog.Info(ctx, "RTMP outputs", "destinations", rtmpOutputs, "disabled", media.LiveAIDisableRTMPOutput())
 
 		// channel that blocks until after orch selection is complete
 		// avoids a race condition with closing the control channel
@@ -1107,13 +1109,15 @@ func (ls *LivepeerServer) CreateWhip(server *media.WHIPServer) http.Handler {
 				})
 			}()
 
-			if outputURL != "" {
-				rtmpOutputs = append(rtmpOutputs, outputURL)
+			if !media.LiveAIDisableRTMPOutput() {
+				if outputURL != "" {
+					rtmpOutputs = append(rtmpOutputs, outputURL)
+				}
+				if mediamtxOutputURL != "" {
+					rtmpOutputs = append(rtmpOutputs, mediamtxOutputURL, mediaMTXOutputAlias)
+				}
 			}
-			if mediamtxOutputURL != "" {
-				rtmpOutputs = append(rtmpOutputs, mediamtxOutputURL, mediaMTXOutputAlias)
-			}
-			clog.Info(ctx, "RTMP outputs", "destinations", rtmpOutputs)
+			clog.Info(ctx, "RTMP outputs", "destinations", rtmpOutputs, "disabled", media.LiveAIDisableRTMPOutput())
 
 			params := aiRequestParams{
 				node:        ls.LivepeerNode,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

This PR adds an optional `LIVE_AI_DISABLE_RTMP_OUTPUT` env var to allow RTMP output to be disabled when streaming LiveVideoToVideo jobs. Since WHIP/WHEP support is now natively supported on the go-livepeer gateway, developers do not want to be required to host an RTMP output when the WHEP egress already works for their needs.

This makes it much easier to start a gateway and _use it for real-time jobs_. We should consider turning off the RTMP output by default.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Introduced a new function `LiveAIDisableRTMPOutput` to determine if RTMP egress should be skipped based on the environment variable `LIVE_AI_DISABLE_RTMP_OUTPUT`.
- Updated the RTMP output collection logic in `setupStream` and `StartLiveVideo` methods to conditionally append outputs based on the new function.
- Improved logging to indicate whether RTMP output is disabled, providing better visibility into the streaming configuration.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
Tested with live-video-to-video : noop streaming with WebRTC browser client

**Does this pull request close any open issues?**
<!-- Fixes # -->


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Read the [contribution guide](./CONTRIBUTING.md)
- [ ] `make` runs successfully
- [ ] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration to disable RTMP egress output during live streaming sessions via environment variable, providing operational flexibility for deployment scenarios where RTMP output is not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->