### PR TITLE
feat(ai/runner): per-second live runner pricing (remove 720p pixel scaling)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,8 @@
 
 #### Orchestrator
 
+- [#3952](https://github.com/livepeer/go-livepeer/pull/3952) Live runner: price per second of compute instead of fixed-720p pixel scaling (@rickstaa)
+
 #### Transcoder
 
 ### Bug Fixes 🐞

--- a/ai/runner/live_runner.go
+++ b/ai/runner/live_runner.go
@@ -1359,23 +1359,13 @@ func newConverterForRunner(priceInfo LiveRunnerPriceInfo) (*core.AutoConvertedPr
 		return nil, nil
 	}
 
-	// Price basis: USD per second by default, or USD per hour scaled through a fixed
-	// 720p pixel rate when legacy pricing is enabled (LIVE_AI_LEGACY_PIXEL_PRICING).
+	// Price is USD per second; usage is metered in nanoseconds (see convertedPriceInfo).
 	priceBasis := usdPerSecond(priceInfo)
-	if common.LiveAILegacyPixelPricing() {
-		priceBasis = usdPerPixelFromUSDPerHour(priceInfo)
-	}
 	return core.NewAutoConvertedPrice("USD", priceBasis, nil)
 }
 
 func usdPerSecond(priceInfo LiveRunnerPriceInfo) *big.Rat {
 	return new(big.Rat).SetFrac64(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)
-}
-
-func usdPerPixelFromUSDPerHour(priceInfo LiveRunnerPriceInfo) *big.Rat {
-	pixelsPerHour := 1280 * 720 * 30 * 3600 // 720p @ 30fps
-	usdPerHour := new(big.Rat).SetFrac64(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)
-	return new(big.Rat).Quo(usdPerHour, new(big.Rat).SetInt64(int64(pixelsPerHour)))
 }
 
 func convertedPriceInfo(converter *core.AutoConvertedPrice) (LiveRunnerPriceInfo, error) {
@@ -1386,16 +1376,10 @@ func convertedPriceInfo(converter *core.AutoConvertedPrice) (LiveRunnerPriceInfo
 	if err != nil {
 		return LiveRunnerPriceInfo{}, err
 	}
-	// PixelsPerUnit is the denominator the fee is metered against: nanoseconds for the
-	// default per-second price, or the price's own denominator for legacy per-pixel pricing.
-	pixelsPerUnit := int64(1_000_000_000) // nanoseconds per second
-	if common.LiveAILegacyPixelPricing() {
-		pixelsPerUnit = price.Denom().Int64()
-	}
-
 	return LiveRunnerPriceInfo{
-		PricePerUnit:  price.Num().Int64(),
-		PixelsPerUnit: pixelsPerUnit,
+		PricePerUnit: price.Num().Int64(),
+		// Wei per second, metered in nanoseconds.
+		PixelsPerUnit: 1_000_000_000,
 		Unit:          "WEI",
 	}, nil
 }

--- a/ai/runner/live_runner.go
+++ b/ai/runner/live_runner.go
@@ -1359,8 +1359,17 @@ func newConverterForRunner(priceInfo LiveRunnerPriceInfo) (*core.AutoConvertedPr
 		return nil, nil
 	}
 
-	usdPerPixel := usdPerPixelFromUSDPerHour(priceInfo)
-	return core.NewAutoConvertedPrice("USD", usdPerPixel, nil)
+	// Price basis: USD per second by default, or USD per hour scaled through a fixed
+	// 720p pixel rate when legacy pricing is enabled (LIVE_AI_LEGACY_PIXEL_PRICING).
+	priceBasis := usdPerSecond(priceInfo)
+	if common.LiveAILegacyPixelPricing() {
+		priceBasis = usdPerPixelFromUSDPerHour(priceInfo)
+	}
+	return core.NewAutoConvertedPrice("USD", priceBasis, nil)
+}
+
+func usdPerSecond(priceInfo LiveRunnerPriceInfo) *big.Rat {
+	return new(big.Rat).SetFrac64(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)
 }
 
 func usdPerPixelFromUSDPerHour(priceInfo LiveRunnerPriceInfo) *big.Rat {
@@ -1377,9 +1386,16 @@ func convertedPriceInfo(converter *core.AutoConvertedPrice) (LiveRunnerPriceInfo
 	if err != nil {
 		return LiveRunnerPriceInfo{}, err
 	}
+	// PixelsPerUnit is the denominator the fee is metered against: nanoseconds for the
+	// default per-second price, or the price's own denominator for legacy per-pixel pricing.
+	pixelsPerUnit := int64(1_000_000_000) // nanoseconds per second
+	if common.LiveAILegacyPixelPricing() {
+		pixelsPerUnit = price.Denom().Int64()
+	}
+
 	return LiveRunnerPriceInfo{
 		PricePerUnit:  price.Num().Int64(),
-		PixelsPerUnit: price.Denom().Int64(),
+		PixelsPerUnit: pixelsPerUnit,
 		Unit:          "WEI",
 	}, nil
 }

--- a/ai/runner/live_runner_test.go
+++ b/ai/runner/live_runner_test.go
@@ -17,7 +17,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/eth"
 	"github.com/livepeer/go-livepeer/trickle"
@@ -1105,35 +1104,6 @@ func TestLiveRunnerRegistry_ConvertsUSDToWEI(t *testing.T) {
 	}
 	if runners[0].PriceInfo.Unit != "WEI" {
 		t.Fatalf("unexpected converted unit: %s", runners[0].PriceInfo.Unit)
-	}
-}
-
-func TestLiveRunnerRegistry_LegacyPixelPricing(t *testing.T) {
-	t.Setenv("LIVE_AI_LEGACY_PIXEL_PRICING", "true")
-	prevWatcher := core.PriceFeedWatcher
-	core.PriceFeedWatcher = stubPriceFeedWatcher{price: eth.PriceData{Price: big.NewRat(2000, 1)}}
-	defer func() { core.PriceFeedWatcher = prevWatcher }()
-
-	registry := newOnchainLiveRunnerTestRegistry()
-	req := liveRunnerTestHeartbeat("runner-1")
-	req.PriceInfo = LiveRunnerPriceInfo{PricePerUnit: 10, PixelsPerUnit: 1, Unit: "USD"}
-	liveRunnerTestRegister(t, registry, req)
-
-	runners := registry.Runners()
-	if len(runners) != 1 {
-		t.Fatalf("expected one runner, got %d", len(runners))
-	}
-	if runners[0].PriceInfo == nil {
-		t.Fatal("expected runner price info")
-	}
-	got := big.NewRat(runners[0].PriceInfo.PricePerUnit, runners[0].PriceInfo.PixelsPerUnit)
-	// Legacy: 10 USD/hour scaled through 720p@30fps pixels/hour.
-	expected, err := common.PriceToInt64(big.NewRat(5_000_000_000_000_000, 1280*720*30*3600))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Cmp(expected) != 0 {
-		t.Fatalf("unexpected legacy converted price: got=%s want=%s", got, expected)
 	}
 }
 

--- a/ai/runner/live_runner_test.go
+++ b/ai/runner/live_runner_test.go
@@ -1097,15 +1097,43 @@ func TestLiveRunnerRegistry_ConvertsUSDToWEI(t *testing.T) {
 		t.Fatal("expected runner price info")
 	}
 	got := big.NewRat(runners[0].PriceInfo.PricePerUnit, runners[0].PriceInfo.PixelsPerUnit)
-	expected, err := common.PriceToInt64(big.NewRat(5_000_000_000_000_000, 1280*720*30*3600))
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Per-second default: 10 USD/s at 2000 USD/ETH = 5e15 wei/s, published as wei per
+	// nanosecond (PixelsPerUnit = 1e9).
+	expected := big.NewRat(5_000_000_000_000_000, 1_000_000_000)
 	if got.Cmp(expected) != 0 {
 		t.Fatalf("unexpected converted price: got=%s want=%s", got, expected)
 	}
 	if runners[0].PriceInfo.Unit != "WEI" {
 		t.Fatalf("unexpected converted unit: %s", runners[0].PriceInfo.Unit)
+	}
+}
+
+func TestLiveRunnerRegistry_LegacyPixelPricing(t *testing.T) {
+	t.Setenv("LIVE_AI_LEGACY_PIXEL_PRICING", "true")
+	prevWatcher := core.PriceFeedWatcher
+	core.PriceFeedWatcher = stubPriceFeedWatcher{price: eth.PriceData{Price: big.NewRat(2000, 1)}}
+	defer func() { core.PriceFeedWatcher = prevWatcher }()
+
+	registry := newOnchainLiveRunnerTestRegistry()
+	req := liveRunnerTestHeartbeat("runner-1")
+	req.PriceInfo = LiveRunnerPriceInfo{PricePerUnit: 10, PixelsPerUnit: 1, Unit: "USD"}
+	liveRunnerTestRegister(t, registry, req)
+
+	runners := registry.Runners()
+	if len(runners) != 1 {
+		t.Fatalf("expected one runner, got %d", len(runners))
+	}
+	if runners[0].PriceInfo == nil {
+		t.Fatal("expected runner price info")
+	}
+	got := big.NewRat(runners[0].PriceInfo.PricePerUnit, runners[0].PriceInfo.PixelsPerUnit)
+	// Legacy: 10 USD/hour scaled through 720p@30fps pixels/hour.
+	expected, err := common.PriceToInt64(big.NewRat(5_000_000_000_000_000, 1280*720*30*3600))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Cmp(expected) != 0 {
+		t.Fatalf("unexpected legacy converted price: got=%s want=%s", got, expected)
 	}
 }
 

--- a/common/util.go
+++ b/common/util.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"mime"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -272,6 +273,14 @@ func PriceToFixed(price *big.Rat) (int64, error) {
 // FixedToPrice converts a fixed point number with 3 decimal places represented as in int64 into a big.Rat
 func FixedToPrice(price int64) *big.Rat {
 	return big.NewRat(price, priceScalingFactor)
+}
+
+// LiveAILegacyPixelPricing reports whether legacy fixed-720p USD/hour pricing is
+// enabled for live runners (env LIVE_AI_LEGACY_PIXEL_PRICING); default is USD/second.
+// TODO: remove once daydream runners declare per-second prices.
+func LiveAILegacyPixelPricing() bool {
+	v, _ := strconv.ParseBool(os.Getenv("LIVE_AI_LEGACY_PIXEL_PRICING"))
+	return v
 }
 
 // PriceToInt64 converts a *big.Rat to an *int64 if possible, otherwise returns an error.

--- a/common/util.go
+++ b/common/util.go
@@ -13,7 +13,6 @@ import (
 	"math/rand"
 	"mime"
 	"net/url"
-	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -273,14 +272,6 @@ func PriceToFixed(price *big.Rat) (int64, error) {
 // FixedToPrice converts a fixed point number with 3 decimal places represented as in int64 into a big.Rat
 func FixedToPrice(price int64) *big.Rat {
 	return big.NewRat(price, priceScalingFactor)
-}
-
-// LiveAILegacyPixelPricing reports whether legacy fixed-720p USD/hour pricing is
-// enabled for live runners (env LIVE_AI_LEGACY_PIXEL_PRICING); default is USD/second.
-// TODO: remove once daydream runners declare per-second prices.
-func LiveAILegacyPixelPricing() bool {
-	v, _ := strconv.ParseBool(os.Getenv("LIVE_AI_LEGACY_PIXEL_PRICING"))
-	return v
 }
 
 // PriceToInt64 converts a *big.Rat to an *int64 if possible, otherwise returns an error.

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -1633,8 +1633,9 @@ func liveRunnerReservationPaymentHeadersWithPrice(t *testing.T, orch *stubOrches
 
 func liveRunnerTestPricePerSecond(pricePerSecond int64) *lpnet.PriceInfo {
 	return &lpnet.PriceInfo{
-		PricePerUnit:  pricePerSecond,
-		PixelsPerUnit: int64(defaultSegInfo.Height) * int64(defaultSegInfo.Width) * int64(defaultSegInfo.FPS),
+		PricePerUnit: pricePerSecond,
+		// Wei per second, metered in nanoseconds.
+		PixelsPerUnit: 1_000_000_000,
 	}
 }
 

--- a/server/live_payment_processor.go
+++ b/server/live_payment_processor.go
@@ -57,7 +57,7 @@ func (p *LivePaymentProcessor) processOne(ctx context.Context, timestamp time.Ti
 	secSinceLastProcessed := timestamp.Sub(p.lastProcessedAt).Seconds()
 	// Meter wall-clock nanoseconds, paired with the per-second price.
 	nanos := int64(1_000_000_000 * secSinceLastProcessed)
-	clog.Info(ctx, "Processing live payment", "secsSinceLastProcessed", secSinceLastProcessed, "billedNanos", nanos)
+	clog.Info(ctx, "Processing live payment", "secsSinceLastProcessed", secSinceLastProcessed)
 
 	err := p.processSegmentFunc(nanos)
 	if err != nil {

--- a/server/live_payment_processor.go
+++ b/server/live_payment_processor.go
@@ -6,15 +6,7 @@ import (
 	"time"
 
 	"github.com/livepeer/go-livepeer/clog"
-	"github.com/livepeer/go-livepeer/common"
-	"github.com/livepeer/lpms/ffmpeg"
 )
-
-var defaultSegInfo = ffmpeg.MediaFormatInfo{
-	Height: 720,
-	Width:  1280,
-	FPS:    30.0,
-}
 
 type LivePaymentProcessor struct {
 	interval time.Duration
@@ -63,20 +55,11 @@ func (p *LivePaymentProcessor) processOne(ctx context.Context, timestamp time.Ti
 	}
 
 	secSinceLastProcessed := timestamp.Sub(p.lastProcessedAt).Seconds()
+	// Meter wall-clock nanoseconds, paired with the per-second price.
+	nanos := int64(1_000_000_000 * secSinceLastProcessed)
+	clog.Info(ctx, "Processing live payment", "secsSinceLastProcessed", secSinceLastProcessed, "billedNanos", nanos)
 
-	// Default: meter wall-clock nanoseconds (paired with the per-second price).
-	// Legacy (LIVE_AI_LEGACY_PIXEL_PRICING): meter fixed-720p pixels.
-	quantity := 1_000_000_000 * secSinceLastProcessed // nanoseconds per second
-	unit := "nanoseconds"
-	if common.LiveAILegacyPixelPricing() {
-		info := defaultSegInfo
-		quantity = float64(info.Height) * float64(info.Width) * float64(info.FPS) * secSinceLastProcessed
-		unit = "pixels"
-	}
-
-	clog.Info(ctx, "Processing live payment", "secsSinceLastProcessed", secSinceLastProcessed, "billedQuantity", int64(quantity), "unit", unit)
-
-	err := p.processSegmentFunc(int64(quantity))
+	err := p.processSegmentFunc(nanos)
 	if err != nil {
 		clog.InfofErr(ctx, "Error processing payment", err)
 		// Temporarily ignore failing payments, because they are not critical while we're using our own Os

--- a/server/live_payment_processor.go
+++ b/server/live_payment_processor.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/livepeer/go-livepeer/clog"
+	"github.com/livepeer/go-livepeer/common"
 	"github.com/livepeer/lpms/ffmpeg"
 )
 
@@ -61,14 +62,21 @@ func (p *LivePaymentProcessor) processOne(ctx context.Context, timestamp time.Ti
 		return
 	}
 
-	info := defaultSegInfo
-
-	pixelsPerSec := float64(info.Height) * float64(info.Width) * float64(info.FPS)
 	secSinceLastProcessed := timestamp.Sub(p.lastProcessedAt).Seconds()
-	pixelsSinceLastProcessed := pixelsPerSec * secSinceLastProcessed
-	clog.Info(ctx, "Processing live payment", "secsSinceLastProcessed", secSinceLastProcessed, "pixelsSinceLastProcessed", pixelsSinceLastProcessed)
 
-	err := p.processSegmentFunc(int64(pixelsSinceLastProcessed))
+	// Default: meter wall-clock nanoseconds (paired with the per-second price).
+	// Legacy (LIVE_AI_LEGACY_PIXEL_PRICING): meter fixed-720p pixels.
+	quantity := 1_000_000_000 * secSinceLastProcessed // nanoseconds per second
+	unit := "nanoseconds"
+	if common.LiveAILegacyPixelPricing() {
+		info := defaultSegInfo
+		quantity = float64(info.Height) * float64(info.Width) * float64(info.FPS) * secSinceLastProcessed
+		unit = "pixels"
+	}
+
+	clog.Info(ctx, "Processing live payment", "secsSinceLastProcessed", secSinceLastProcessed, "billedQuantity", int64(quantity), "unit", unit)
+
+	err := p.processSegmentFunc(int64(quantity))
 	if err != nil {
 		clog.InfofErr(ctx, "Error processing payment", err)
 		// Temporarily ignore failing payments, because they are not critical while we're using our own Os

--- a/server/live_payment_test.go
+++ b/server/live_payment_test.go
@@ -488,7 +488,7 @@ func TestRemotePaymentSender_RequestPayment_WithLiveSignerHandler(t *testing.T) 
 	ethClient := newTestEthClient(t)
 	signerNode, _ := core.NewLivepeerNode(ethClient, "", nil)
 	signerNode.Balances = core.NewAddressBalances(1 * time.Minute)
-	signerNode.Sender = mockSender(mockSenderConfig{ev: big.NewRat(20000000, 1)})
+	signerNode.Sender = mockSender(mockSenderConfig{ev: big.NewRat(1000000000, 1)})
 	ls := &LivepeerServer{LivepeerNode: signerNode}
 
 	remoteTS := httptest.NewServer(http.HandlerFunc(ls.GenerateLivePayment))
@@ -532,7 +532,7 @@ func TestRemotePaymentSender_RequestPayment_WithLiveSignerHandler_Refresh(t *tes
 	ethClient := newTestEthClient(t)
 	signerNode, _ := core.NewLivepeerNode(ethClient, "", nil)
 	signerNode.Balances = core.NewAddressBalances(1 * time.Minute)
-	signerNode.Sender = mockSender(mockSenderConfig{ev: big.NewRat(20000000, 1)})
+	signerNode.Sender = mockSender(mockSenderConfig{ev: big.NewRat(1000000000, 1)})
 	ls := &LivepeerServer{LivepeerNode: signerNode}
 
 	remoteTS := httptest.NewServer(http.HandlerFunc(ls.GenerateLivePayment))

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -529,7 +529,7 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 			billableSecs = (60 * time.Second).Seconds()
 		}
 		// Charge per wall-clock nanosecond, matching the orchestrator's per-second metering.
-		pixels = int64(billableSecs * 1_000_000_000)
+		pixels = int64(1_000_000_000 * billableSecs)
 	} else if req.Type != "" {
 		err = errors.New("invalid job type")
 		respondJsonError(ctx, w, err, http.StatusBadRequest)

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -524,13 +524,12 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 	}
 	billableSecs := now.Sub(lastUpdate).Seconds()
 	if req.Type == RemoteType_LiveVideoToVideo {
-		info := defaultSegInfo
 		if billableSecs <= 0 {
 			// preload with 60 seconds of data for LV2V
 			billableSecs = (60 * time.Second).Seconds()
 		}
-		pixelsPerSec := float64(info.Height) * float64(info.Width) * float64(info.FPS)
-		pixels = int64(pixelsPerSec * billableSecs) // pixels to charge for
+		// Charge per wall-clock nanosecond, matching the orchestrator's per-second metering.
+		pixels = int64(billableSecs * 1_000_000_000)
 	} else if req.Type != "" {
 		err = errors.New("invalid job type")
 		respondJsonError(ctx, w, err, http.StatusBadRequest)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Live runner usage is metered per compute-second on the orchestrator, but the price was run through a hidden fixed-720p@30fps pixel conversion: the converter divided the declared price by `1280*720*30*3600` and the meter multiplied wall-clock seconds by `1280*720*30`, so the two 720p factors cancelled to `USD/hour x hours` and every stream was billed as 720p regardless of real resolution. This makes the operator's price and the `/discovery` number confusing.

This makes per-second the only behavior: the declared price converts directly to wei/second and usage is metered in wall-clock nanoseconds; `/discovery` publishes a real wei-per-second rate (`PixelsPerUnit = 1e9`). The remote signer's LV2V pixel computation also moves to nanoseconds so the consumer side matches the orchestrator's metering. Per-second matches the orchestrator's actual cost basis and the serverless GPU market (Modal/Replicate/RunPod bill per second). Full rationale in #3951.

**Specific updates (required)**
- `newConverterForRunner` converts the declared price as USD/second (no 720p scaling).
- `convertedPriceInfo` publishes wei per nanosecond (`PixelsPerUnit = 1e9`).
- `live_payment_processor` meters wall-clock nanoseconds.
- `remote_signer` LV2V pixel computation now uses nanoseconds to match the orchestrator meter; removed the now-unused `defaultSegInfo`.
- Tests updated for per-second; signer test ticket EV recalibrated for the nanosecond quantity.

**How did you test each of these updates (required)**
`go build ./...`, `go test ./ai/runner/ -run LiveRunner`, and `go test ./server/ -run 'LiveRunner|LivePayment|RemoteSigner'` pass. A 10 USD/s price at 2000 USD/ETH converts to 5e15 wei/s, published as `{PricePerUnit: 5e15, PixelsPerUnit: 1e9}`.

**Does this pull request close any open issues?**
Fixes #3951

**Checklist:**
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
