### PR TITLE
docs(changelog): Document ticket params zero-expiration fix

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,4 +18,8 @@
 
 #### General
 
+#### Broadcaster
+
+* [a6c4b1e](https://github.com/livepeer/go-livepeer/commit/a6c4b1ef70d8f4d3da0e7d8164ac8d1faf80ad0e) pm: Reject ticket params with a zero expiration block so they are subjected to the economic caps (@rickstaa)
+
 #### CLI


### PR DESCRIPTION
## What

Documents the security fix merged in [a6c4b1e](https://github.com/livepeer/go-livepeer/commit/a6c4b1ef70d8f4d3da0e7d8164ac8d1faf80ad0e) ("Merge commit from fork") in `CHANGELOG_PENDING.md`. That merge commit used a generic message and did not record the user-facing change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ticket parameters with zero expiration blocks are now properly rejected and subject to economic caps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->