### PR TITLE
fix(remote-signer): authorize before generating payment

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,8 @@
 
 #### General
 
+* [#3958](https://github.com/livepeer/go-livepeer/pull/3958) remote-signer: Authorize the request before generating or signing a payment, so an unauthorized request no longer triggers ticket signing or sender-nonce consumption (@rickstaa)
+
 #### Broadcaster
 
 * [a6c4b1e](https://github.com/livepeer/go-livepeer/commit/a6c4b1ef70d8f4d3da0e7d8164ac8d1faf80ad0e) pm: Reject ticket params with a zero expiration block so they are subjected to the economic caps (@rickstaa)

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -383,6 +383,30 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 	}
 	ctx = clog.AddVal(ctx, "manifest_id", manifestID)
 
+	// Authorize the caller before generating or signing any payment, so an
+	// unauthorized request never causes ticket signing or sender-nonce consumption.
+	callbackStatus, callbackResp, callbackErr := ls.authLivePayment(r, state)
+	if callbackStatus != http.StatusOK {
+		respondJsonError(ctx, w, callbackErr, callbackStatus)
+		return
+	}
+	if callbackResp != nil {
+		state.AuthExpiry = callbackResp.Expiry
+	}
+	authID := r.Header.Get(remoteSignerAuthIDHeader)
+	if callbackResp != nil && callbackResp.AuthID != "" {
+		authID = callbackResp.AuthID
+	}
+	if authID != "" && state.AuthID != authID {
+		if state.AuthID != "" {
+			clog.Warningf(ctx, "Remote signer auth ID changed oldAuthID=%s newAuthID=%s", state.AuthID, authID)
+			respondJsonError(ctx, w, errors.New("remote signer auth ID changed"), http.StatusInternalServerError)
+			return
+		}
+		state.AuthID = authID
+	}
+	ctx = clog.AddVal(ctx, "auth_id", state.AuthID)
+
 	streamParams := &core.StreamParameters{
 		// Embedded within genSegCreds, may be used by orch for payment accounting
 		ManifestID: core.ManifestID(manifestID),
@@ -565,28 +589,6 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 		respondJsonError(ctx, w, err, http.StatusInternalServerError)
 		return
 	}
-
-	callbackStatus, callbackResp, callbackErr := ls.authLivePayment(r, state)
-	if callbackStatus != http.StatusOK {
-		respondJsonError(ctx, w, callbackErr, callbackStatus)
-		return
-	}
-	if callbackResp != nil {
-		state.AuthExpiry = callbackResp.Expiry
-	}
-	authID := r.Header.Get(remoteSignerAuthIDHeader)
-	if callbackResp != nil && callbackResp.AuthID != "" {
-		authID = callbackResp.AuthID
-	}
-	if authID != "" && state.AuthID != authID {
-		if state.AuthID != "" {
-			clog.Warningf(ctx, "Remote signer auth ID changed oldAuthID=%s newAuthID=%s", state.AuthID, authID)
-			respondJsonError(ctx, w, errors.New("remote signer auth ID changed"), http.StatusInternalServerError)
-			return
-		}
-		state.AuthID = authID
-	}
-	ctx = clog.AddVal(ctx, "auth_id", state.AuthID)
 
 	// Encode and sign updated state
 	stateBytes, err := json.Marshal(state)


### PR DESCRIPTION
## Problem

`GenerateLivePayment` calls the identity webhook (`authLivePayment`) **after** `genPayment` has already signed the ticket batch and consumed a sender nonce:

```
genPayment(...)        // signs tickets, consumes nonce  (was ~line 525)
...
authLivePayment(...)   // authorization check            (was ~line 569)
```

When a webhook is configured, an unauthorized caller is correctly denied the *response* (no payment is returned). But the request still reaches the signer: it signs a ticket batch and churns the sender nonce/session before being rejected. That's wasted signing work and unnecessary nonce/session churn driven by an unauthenticated caller.

## Change

Move the authorization block to immediately after the request is parsed and `state` is initialized — **before** any payment is generated or signed. An unauthorized request now returns early and never triggers signing.

The auth block only depends on `r`, `state`, and `ctx`, all available at the new location, so this is a straightforward reorder (no logic change to the auth itself).

## Behavior note

The webhook now receives the **pre-generation** `state` (without the post-payment `Balance`/`SenderNonce`/`PMSessionID` fields). This is the correct input for an authorization decision — the webhook authorizes the *caller*, not the resulting payment — but it is a change to the webhook request body, so flagging it explicitly for reviewers. The signed state returned to the caller is unchanged.

## Scope

This is one of two related hardening PRs. The companion PR makes the remote signer refuse to start unauthenticated on a public address (fail-closed + `-remoteSignerInsecureNoAuth` opt-in). Binding the ticket *recipient* to a trusted source is tracked separately.

## Testing

`gofmt` clean. Existing `server` tests cover the handler (`TestGenerateLivePayment_*`, including `TestGenerateLivePayment_WebhookCallback`).

**Checklist:**
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization handling for live payment requests so unauthorized callers are rejected earlier, before any session or ticket generation begins.
  * Added stricter consistency checks for the authorization ID used during payment processing.
  * Updated authorization timing details so valid access periods are applied more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->