### PR TITLE
feat(remote-signer): fail closed when serving unauthenticated on a public address

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes 🚨🚨
 
+* [#3959](https://github.com/livepeer/go-livepeer/pull/3959) remote-signer: Refuse to start when `/generate-live-payment` would be unauthenticated (`-remoteSignerWebhookUrl` unset) on a publicly-accessible `-httpAddr`; pass `-remoteSignerAllowNoAuth` to override (@rickstaa)
+
 ### Features ⚒
 
 #### General

--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -143,6 +143,7 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.RemoteSignerHeaders = fs.String("remoteSignerHeaders", *cfg.RemoteSignerHeaders, "Map of headers to use for gateway remote signer requests. e.g. 'header:val,header2:val2'")
 	cfg.RemoteSignerWebhookURL = fs.String("remoteSignerWebhookUrl", *cfg.RemoteSignerWebhookURL, "Authentication webhook URL called by remote signer during GenerateLivePayment")
 	cfg.RemoteSignerWebhookHeaders = fs.String("remoteSignerWebhookHeaders", *cfg.RemoteSignerWebhookHeaders, "Map of headers to use for remote signer webhook requests. e.g. 'header:val,header2:val2'")
+	cfg.RemoteSignerAllowNoAuth = fs.Bool("remoteSignerAllowNoAuth", *cfg.RemoteSignerAllowNoAuth, "Allow an unauthenticated remote signer on a public -httpAddr (no webhook). UNSAFE: signs payments from this node's deposit for any reachable caller; restrict access externally (proxy/private network).")
 	cfg.RemoteDiscovery = fs.Bool("remoteDiscovery", *cfg.RemoteDiscovery, "Enable orchestrator discovery on remote signers")
 
 	// Gateway metrics

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -172,6 +172,7 @@ type LivepeerConfig struct {
 	RemoteSignerHeaders        *string
 	RemoteSignerWebhookURL     *string
 	RemoteSignerWebhookHeaders *string
+	RemoteSignerAllowNoAuth    *bool
 	RemoteDiscovery            *bool
 	AIRunnerImage              *string
 	AIRunnerImageOverrides     *string
@@ -313,6 +314,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultRemoteSignerHeaders := ""
 	defaultRemoteSignerWebhookURL := ""
 	defaultRemoteSignerWebhookHeaders := ""
+	defaultRemoteSignerAllowNoAuth := false
 	defaultRemoteDiscovery := false
 
 	// Gateway logs
@@ -440,6 +442,7 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		RemoteSignerHeaders:        &defaultRemoteSignerHeaders,
 		RemoteSignerWebhookURL:     &defaultRemoteSignerWebhookURL,
 		RemoteSignerWebhookHeaders: &defaultRemoteSignerWebhookHeaders,
+		RemoteSignerAllowNoAuth:    &defaultRemoteSignerAllowNoAuth,
 		RemoteDiscovery:            &defaultRemoteDiscovery,
 
 		// Gateway logs
@@ -1947,9 +1950,25 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		// Start remote signer server
 		go func() {
 			*cfg.HttpAddr = defaultAddr(*cfg.HttpAddr, "127.0.0.1", OrchestratorRpcPort)
+
+			// Refuse to start a public signer with no webhook auth. It would sign payments
+			// from this node's deposit for any caller (override with -remoteSignerAllowNoAuth).
+			if n.RemoteSignerWebhookURL == nil {
+				isLocalHTTP, err := isLocalURL("https://" + *cfg.HttpAddr)
+				if err != nil {
+					exit("Error checking for local -httpAddr: %v", err)
+				}
+				if !isLocalHTTP && !*cfg.RemoteSignerAllowNoAuth {
+					exit("Refusing to start: remote signer on public -httpAddr %s with no "+
+						"-remoteSignerWebhookUrl signs payments from this node's deposit for any caller. "+
+						"Set the webhook, or pass -remoteSignerAllowNoAuth to override.", *cfg.HttpAddr)
+				}
+				glog.Warning("WARNING: remote signer has no webhook auth. /generate-live-payment is " +
+					"UNAUTHENTICATED and signs payments from this node's deposit. Set -remoteSignerWebhookUrl.")
+			}
+
 			glog.Info("Starting remote signer server on ", *cfg.HttpAddr)
-			err := server.StartRemoteSignerServer(s, *cfg.HttpAddr)
-			if err != nil {
+			if err := server.StartRemoteSignerServer(s, *cfg.HttpAddr); err != nil {
 				exit("Error starting remote signer server: err=%q", err)
 			}
 		}()


### PR DESCRIPTION
## Problem

The remote signer's `POST /generate-live-payment` signs PM tickets **from this node's on-chain deposit**. Authentication is provided by `-remoteSignerWebhookUrl`; when it's unset, `authLivePayment` returns `200` unconditionally — the endpoint is fully unauthenticated. A remote signer that is both reachable from a network **and** has no webhook can be made to sign tickets for any caller, draining the operator's deposit.

The default `-httpAddr` is loopback, so this only bites operators who deliberately bind to a public address — but nothing stops them from doing so with no auth, and there's no signal beyond it silently working.

Reported by a security researcher against the v0.8.x remote-signer path.

## Change

Before starting the server, apply the same guard the broadcaster already uses for HTTP ingest ([`isLocalURL` check](https://github.com/livepeer/go-livepeer/blob/master/cmd/livepeer/starter/starter.go#L1703)):

- `-httpAddr` **public** + no webhook + no override → **refuse to start** (`exit`).
- New opt-in flag `-remoteSignerAllowNoAuth` overrides the refusal (local/dev only).
- Always **warn** when running without a webhook (even on loopback).

| `-httpAddr` | webhook | `-remoteSignerAllowNoAuth` | result |
|---|---|---|---|
| loopback (default) | set | — | start, silent |
| loopback | unset | — | start + warn |
| public | set | — | start, silent |
| public | unset | not set | **refuse to start** |
| public | unset | set | start + warn |

## Behavior change

Nodes currently running a remote signer on a **non-loopback** `-httpAddr` **without** a webhook will now refuse to start until they set `-remoteSignerWebhookUrl` or pass `-remoteSignerAllowNoAuth`. Loopback and webhook-configured setups are unaffected. Flagging for a release note.

## Testing

**Checklist:**
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to allow remote signer startup without webhook authentication (`-remoteSignerAllowNoAuth`), intended only for restricted local/development scenarios.

* **Bug Fixes**
  * Remote signer startup now uses a fail-closed safety check when no webhook URL is configured, preventing public deployments from enabling unauthenticated `/generate-live-payment`.
  * When overridden, the app emits a warning that `/generate-live-payment` will be unauthenticated.

* **Breaking Changes**
  * Remote signer startup may now refuse to run when `-remoteSignerWebhookUrl` is unset and the HTTP endpoint is publicly accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->