### PR TITLE
fix(remote-signer): default -cliAddr to loopback in remote signer mode

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,8 @@
 
 #### General
 
+* [#3962](https://github.com/livepeer/go-livepeer/pull/3962) remote-signer: Default `-cliAddr` to a loopback address in remote signer mode so the node no longer fails to start by binding the CLI server to `:80` (@rickstaa)
+
 #### Broadcaster
 
 * [a6c4b1e](https://github.com/livepeer/go-livepeer/commit/a6c4b1ef70d8f4d3da0e7d8164ac8d1faf80ad0e) pm: Reject ticket params with a zero expiration block so they are subjected to the economic caps (@rickstaa)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -75,6 +75,7 @@ const (
 	OrchestratorCliPort = "7935"
 	TranscoderCliPort   = "6935"
 	AIWorkerCliPort     = "4935"
+	RemoteSignerCliPort = "3935"
 
 	RefreshPerfScoreInterval = 10 * time.Minute
 )
@@ -1778,6 +1779,8 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", TranscoderCliPort)
 	} else if n.NodeType == core.AIWorkerNode {
 		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", AIWorkerCliPort)
+	} else if n.NodeType == core.RemoteSignerNode {
+		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", RemoteSignerCliPort)
 	}
 
 	// Apply default capabilities if not running as a transcoder.

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -53,7 +53,7 @@ The remote signer is intended to be its own standalone node type. The `-remoteSi
 
 The remote signer must have typical Ethereum flags configured (examples: `-network`, `-ethUrl`, `-ethController`, keystore/password flags). See the go-livepeer [devtool](https://github.com/livepeer/go-livepeer/blob/92bdb59f169056e3d1beba9b511554ea5d9eda72/cmd/devtool/devtool.go#L200-L212) for an example of what flags might be required.
 
-The remote signer listens to the standard go-livepeer HTTP port (8935) by default. To change the listening port or interface, use the `-httpAddr` flag.
+The remote signer listens to the standard go-livepeer HTTP port (8935) by default. Change the port or interface with the `-httpAddr` flag. The CLI webserver defaults to `127.0.0.1:3935` (loopback only). Override it with `-cliAddr`.
 
 Example (fill in the placeholders for your environment):
 


### PR DESCRIPTION
Fixes #3960

## Problem

In remote signer mode (`-remoteSigner`) without an explicit `-cliAddr`, the CLI/management webserver binds to `:80`, which fails with `permission denied` for non-root users and shuts the node down:

```
I ... Starting remote signer server on 0.0.0.0:8081
I ... CLI server listening on
E ... webserver.go:22] listen tcp :80: bind: permission denied
I ... CLI webserver shut down
I ... livepeer.go:98] Graceful shutdown complete
```

## Root cause

`-cliAddr` is defaulted to loopback only for Broadcaster / Orchestrator / Transcoder / AIWorker node types. `RemoteSignerNode` has no branch in that chain, so `cfg.CliAddr` stays `""` -> `http.Server{Addr: ""}` -> `ListenAndServe("")` defaults to `:80`.

## Fix

Add a `RemoteSignerNode` branch that defaults `-cliAddr` to `127.0.0.1`, using a dedicated `RemoteSignerCliPort = "3935"` (the other X935 slots are taken: 1935/4935/5935/6935/7935/8935/9935). A dedicated port means a co-located broadcaster and remote signer do not collide on the same default CLI port.

Existing setups that pass `-cliAddr` explicitly (e.g. the clearinghouse entrypoint's `-cliAddr=127.0.0.1:4935`) are unaffected -- `defaultAddr` only fills in when empty.

**Checklist:**
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote-signer mode now defaults the CLI webserver address to a loopback interface when `-cliAddr` isn’t provided, preventing startup failures from binding to `:80`.
* **New Features**
  * Remote-signer node support includes an automatic default local CLI endpoint (`127.0.0.1:3935`).
* **Documentation**
  * Updated remote-signer usage guidance to clarify default networking behavior, including `-httpAddr` and the CLI webserver loopback default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->