### PR TITLE
feat(server): durable, flag-gated usage-ingest POST for signed tickets (default OFF)

### DIFF
--- a/cmd/livepeer/starter/flags.go
+++ b/cmd/livepeer/starter/flags.go
@@ -143,6 +143,8 @@ func NewLivepeerConfig(fs *flag.FlagSet) LivepeerConfig {
 	cfg.RemoteSignerHeaders = fs.String("remoteSignerHeaders", *cfg.RemoteSignerHeaders, "Map of headers to use for gateway remote signer requests. e.g. 'header:val,header2:val2'")
 	cfg.RemoteSignerWebhookURL = fs.String("remoteSignerWebhookUrl", *cfg.RemoteSignerWebhookURL, "Authentication webhook URL called by remote signer during GenerateLivePayment")
 	cfg.RemoteSignerWebhookHeaders = fs.String("remoteSignerWebhookHeaders", *cfg.RemoteSignerWebhookHeaders, "Map of headers to use for remote signer webhook requests. e.g. 'header:val,header2:val2'")
+	cfg.UsageIngestUrl = fs.String("usageIngestUrl", *cfg.UsageIngestUrl, "Durable usage-ingest endpoint URL. When set, the remote signer also delivers each create_signed_ticket usage event via a synchronous bounded-retry POST (in addition to the legacy Kafka path). Unset disables the durable path (default).")
+	cfg.UsageIngestSecret = fs.String("usageIngestSecret", *cfg.UsageIngestSecret, "Bearer secret sent as 'Authorization: Bearer <secret>' to the usage-ingest endpoint (INGEST_SHARED_SECRET).")
 	cfg.RemoteDiscovery = fs.Bool("remoteDiscovery", *cfg.RemoteDiscovery, "Enable orchestrator discovery on remote signers")
 
 	// Gateway metrics

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -173,6 +173,8 @@ type LivepeerConfig struct {
 	RemoteSignerHeaders        *string
 	RemoteSignerWebhookURL     *string
 	RemoteSignerWebhookHeaders *string
+	UsageIngestUrl             *string
+	UsageIngestSecret          *string
 	RemoteDiscovery            *bool
 	AIRunnerImage              *string
 	AIRunnerImageOverrides     *string
@@ -314,6 +316,8 @@ func DefaultLivepeerConfig() LivepeerConfig {
 	defaultRemoteSignerHeaders := ""
 	defaultRemoteSignerWebhookURL := ""
 	defaultRemoteSignerWebhookHeaders := ""
+	defaultUsageIngestUrl := ""
+	defaultUsageIngestSecret := ""
 	defaultRemoteDiscovery := false
 
 	// Gateway logs
@@ -441,6 +445,8 @@ func DefaultLivepeerConfig() LivepeerConfig {
 		RemoteSignerHeaders:        &defaultRemoteSignerHeaders,
 		RemoteSignerWebhookURL:     &defaultRemoteSignerWebhookURL,
 		RemoteSignerWebhookHeaders: &defaultRemoteSignerWebhookHeaders,
+		UsageIngestUrl:             &defaultUsageIngestUrl,
+		UsageIngestSecret:          &defaultUsageIngestSecret,
 		RemoteDiscovery:            &defaultRemoteDiscovery,
 
 		// Gateway logs
@@ -469,6 +475,7 @@ func (cfg LivepeerConfig) PrintConfig(w io.Writer) {
 		"FVfailGsKey":                true,
 		"RemoteSignerHeaders":        true,
 		"RemoteSignerWebhookHeaders": true,
+		"UsageIngestSecret":          true,
 	}
 
 	for i := 0; i < cfgType.NumField(); i++ {
@@ -1591,6 +1598,17 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		n.RemoteSignerWebhookURL = parsedURL
 		if cfg.RemoteSignerWebhookHeaders != nil {
 			n.RemoteSignerWebhookHeaders = parseHeaderMap(*cfg.RemoteSignerWebhookHeaders)
+		}
+	}
+	if cfg.UsageIngestUrl != nil && *cfg.UsageIngestUrl != "" {
+		parsedURL, err := validateURL(*cfg.UsageIngestUrl)
+		if err != nil {
+			glog.Exit("Error setting usage ingest URL ", err)
+		}
+		glog.Info("Using durable usage ingest URL ", parsedURL.Redacted())
+		n.RemoteSignerUsageIngestURL = parsedURL
+		if cfg.UsageIngestSecret != nil {
+			n.RemoteSignerUsageIngestSecret = *cfg.UsageIngestSecret
 		}
 	}
 

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -153,9 +153,15 @@ type LivepeerNode struct {
 	RemoteSignerHeaders        map[string]string // Headers to use for gateway remote signer requests
 	RemoteSignerWebhookURL     *url.URL          // Authentication webhook URL called by remote signer during GenerateLivePayment
 	RemoteSignerWebhookHeaders map[string]string // Headers to use for remote signer webhook requests
-	RemoteEthAddr              ethcommon.Address // eth address of the remote signer
-	InfoSig                    []byte            // sig over eth address for the OrchestratorInfo request
-	RemoteDiscovery            bool              // expose remote discovery endpoint when enabled
+	// Durable usage-ingest (remote signer). When set, the remote signer also
+	// delivers each create_signed_ticket usage event to this endpoint via a
+	// synchronous bounded-retry POST, in addition to the legacy Kafka path.
+	// Unset => durable path is inert (legacy behavior unchanged).
+	RemoteSignerUsageIngestURL    *url.URL          // Durable pymthouse usage-ingest endpoint URL
+	RemoteSignerUsageIngestSecret string            // Bearer secret for the usage-ingest endpoint
+	RemoteEthAddr                 ethcommon.Address // eth address of the remote signer
+	InfoSig                       []byte            // sig over eth address for the OrchestratorInfo request
+	RemoteDiscovery               bool              // expose remote discovery endpoint when enabled
 
 	// Thread safety for config fields
 	mu                  sync.RWMutex

--- a/monitor/census.go
+++ b/monitor/census.go
@@ -161,6 +161,7 @@ type (
 		mHTTPClientTimeout1           *stats.Int64Measure
 		mHTTPClientTimeout2           *stats.Int64Measure
 		mKafkaEventSendError          *stats.Int64Measure
+		mUsageIngestSendError         *stats.Int64Measure
 		mRealtimeRatio                *stats.Float64Measure
 		mRealtime3x                   *stats.Int64Measure
 		mRealtime2x                   *stats.Int64Measure
@@ -314,6 +315,7 @@ func InitCensus(nodeType NodeType, version string) {
 	census.mHTTPClientTimeout1 = stats.Int64("http_client_timeout_1", "Number of times HTTP connection was dropped before transcoding complete", "tot")
 	census.mHTTPClientTimeout2 = stats.Int64("http_client_timeout_2", "Number of times HTTP connection was dropped before transcoded segments was sent back to client", "tot")
 	census.mKafkaEventSendError = stats.Int64("kafka_event_send_errors", "Dropped Kafka events due to a full queue", "tot")
+	census.mUsageIngestSendError = stats.Int64("usage_ingest_send_errors", "Failed durable usage-ingest deliveries (after bounded retries) by event type", "tot")
 	census.mRealtimeRatio = stats.Float64("http_client_segment_transcoded_realtime_ratio", "Ratio of source segment duration / transcode time as measured on HTTP client", "rat")
 	census.mRealtime3x = stats.Int64("http_client_segment_transcoded_realtime_3x", "Number of segment transcoded 3x faster than realtime", "tot")
 	census.mRealtime2x = stats.Int64("http_client_segment_transcoded_realtime_2x", "Number of segment transcoded 2x faster than realtime", "tot")
@@ -511,6 +513,13 @@ func InitCensus(nodeType NodeType, version string) {
 			Name:        "kafka_event_send_errors",
 			Measure:     census.mKafkaEventSendError,
 			Description: "Dropped Kafka events due to a full queue",
+			TagKeys:     append([]tag.Key{census.kEventType}, baseTags...),
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "usage_ingest_send_errors",
+			Measure:     census.mUsageIngestSendError,
+			Description: "Failed durable usage-ingest deliveries (after bounded retries) by event type",
 			TagKeys:     append([]tag.Key{census.kEventType}, baseTags...),
 			Aggregation: view.Count(),
 		},
@@ -1816,6 +1825,19 @@ func KafkaEventSendError(eventType string) {
 	if err := stats.RecordWithTags(census.ctx,
 		[]tag.Mutator{tag.Insert(census.kEventType, eventType)},
 		census.mKafkaEventSendError.M(1)); err != nil {
+		glog.Errorf("Error recording metrics err=%q", err)
+	}
+}
+
+// UsageIngestSendError records a failed durable usage-ingest delivery (after the
+// bounded retries were exhausted) by event type.
+func UsageIngestSendError(eventType string) {
+	if !Enabled || census.mUsageIngestSendError == nil {
+		return
+	}
+	if err := stats.RecordWithTags(census.ctx,
+		[]tag.Mutator{tag.Insert(census.kEventType, eventType)},
+		census.mUsageIngestSendError.M(1)); err != nil {
 		glog.Errorf("Error recording metrics err=%q", err)
 	}
 }

--- a/monitor/usage_ingest.go
+++ b/monitor/usage_ingest.go
@@ -1,0 +1,232 @@
+package monitor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+// Durable usage-ingest delivery.
+//
+// Billed BYOC usage historically reached OpenMeter only through the best-effort,
+// fire-and-forget pipeline in kafka.go (SendQueueEventAsync -> batched producer
+// -> Redpanda -> Benthos collector -> OpenMeter), which has several silent-drop
+// branches and no delivery guarantee. This file adds a strictly additive,
+// synchronous, bounded-retry HTTP POST that delivers each create_signed_ticket
+// usage event to the durable, idempotent pymthouse ingest endpoint. It is only
+// active when an ingest URL is configured; otherwise it is inert and the legacy
+// Kafka path is unchanged.
+const (
+	usageIngestMaxAttempts       = 3
+	usageIngestBaseBackoff       = 100 * time.Millisecond
+	usageIngestMaxBackoff        = 500 * time.Millisecond
+	usageIngestPerAttemptTimeout = 2 * time.Second
+	usageIngestOverallTimeout    = 6 * time.Second
+	// UsageIngestEventType matches the legacy Kafka event type and the pymthouse
+	// ingest contract (`type: "create_signed_ticket"`).
+	UsageIngestEventType = "create_signed_ticket"
+)
+
+// SignedTicketUsageEvent carries the per-served-job usage data delivered to the
+// durable ingest endpoint. Values are sourced verbatim from the data already
+// computed in the remote signer, so the durable path and the legacy Kafka path
+// describe the same event.
+type SignedTicketUsageEvent struct {
+	// RequestID is the unique per-job id. It is the CloudEvent id and the
+	// idempotency key on the pymthouse side (dedupe on (clientId, requestId)).
+	RequestID string
+	// ComputedFeeWei is the deterministic per-job fee in wei (fee.FloatString(0)),
+	// identical to the legacy event's "computed_fee" field. pymthouse converts it
+	// to USD micros, mirroring the Benthos collector.
+	ComputedFeeWei string
+	Pixels         int64
+	Pipeline       string
+}
+
+// usageIngestRequestBody mirrors the request contract of pymthouse
+// `POST /api/v1/internal/ingest/signed-ticket` (PR #178): the endpoint reads the
+// usage fields from the nested `data` object.
+type usageIngestRequestBody struct {
+	Type string                 `json:"type"`
+	Data usageIngestRequestData `json:"data"`
+}
+
+type usageIngestRequestData struct {
+	ClientID     string `json:"client_id"`
+	UsageSubject string `json:"usage_subject"`
+	RequestID    string `json:"request_id"`
+	// ComputedFee is the fee in wei. pymthouse reads "computed_fee_wei" or
+	// "computed_fee" and converts to USD micros via the collector formula.
+	ComputedFee string `json:"computed_fee,omitempty"`
+	Pixels      string `json:"pixels,omitempty"`
+	Pipeline    string `json:"pipeline,omitempty"`
+}
+
+// UsageIngestPoster performs a synchronous, bounded-retry HTTP POST of a
+// signed-ticket usage event to the durable pymthouse ingest endpoint. It is
+// strictly additive to the legacy fire-and-forget Kafka path and is only
+// constructed when an ingest URL is configured, so when unset the behavior is
+// byte-identical to the legacy code (no new POST is ever made).
+type UsageIngestPoster struct {
+	url            string
+	secret         string
+	httpClient     *http.Client
+	maxAttempts    int
+	baseBackoff    time.Duration
+	maxBackoff     time.Duration
+	overallTimeout time.Duration
+}
+
+// NewUsageIngestPoster returns a configured poster, or nil when no ingest URL is
+// set. A nil poster is the OFF (default) state: callers treat it as "no durable
+// delivery configured" and keep only the legacy path.
+func NewUsageIngestPoster(rawURL, secret string) *UsageIngestPoster {
+	if strings.TrimSpace(rawURL) == "" {
+		return nil
+	}
+	return &UsageIngestPoster{
+		url:            strings.TrimSpace(rawURL),
+		secret:         strings.TrimSpace(secret),
+		httpClient:     &http.Client{Timeout: usageIngestPerAttemptTimeout},
+		maxAttempts:    usageIngestMaxAttempts,
+		baseBackoff:    usageIngestBaseBackoff,
+		maxBackoff:     usageIngestMaxBackoff,
+		overallTimeout: usageIngestOverallTimeout,
+	}
+}
+
+// SendSignedTicket delivers the usage event best-effort: it never panics and
+// never returns an error to the caller. Delivery runs under a detached,
+// bounded context so it cannot block the signing path indefinitely. On final
+// failure (after bounded retries) it logs and increments a metric so drops are
+// observable. authID is the signer auth ID (`client_id:external_user_id`).
+func (p *UsageIngestPoster) SendSignedTicket(authID string, evt SignedTicketUsageEvent) {
+	if p == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), p.overallTimeout)
+	defer cancel()
+
+	if err := p.postSignedTicket(ctx, authID, evt); err != nil {
+		glog.Errorf("usage ingest: durable signed-ticket POST failed request_id=%s err=%v", evt.RequestID, err)
+		UsageIngestSendError(UsageIngestEventType)
+	}
+}
+
+// postSignedTicket builds the request body from authID + evt and delivers it
+// with bounded retries. It returns an error on a non-retryable failure or once
+// the retry budget is exhausted. Exposed (unexported) for hermetic testing.
+func (p *UsageIngestPoster) postSignedTicket(ctx context.Context, authID string, evt SignedTicketUsageEvent) error {
+	clientID, externalUserID, ok := splitUsageAuthID(authID)
+	if !ok {
+		return fmt.Errorf("usage ingest: missing or invalid auth_id for request_id=%s", evt.RequestID)
+	}
+
+	body, err := json.Marshal(usageIngestRequestBody{
+		Type: UsageIngestEventType,
+		Data: usageIngestRequestData{
+			ClientID:     clientID,
+			UsageSubject: externalUserID,
+			RequestID:    evt.RequestID,
+			ComputedFee:  evt.ComputedFeeWei,
+			Pixels:       pixelsString(evt.Pixels),
+			Pipeline:     evt.Pipeline,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("usage ingest: failed to marshal request body: %w", err)
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= p.maxAttempts; attempt++ {
+		if attempt > 1 {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("usage ingest: context done before attempt %d: %w", attempt, ctx.Err())
+			case <-time.After(p.backoffFor(attempt - 1)):
+			}
+		}
+
+		retryable, err := p.doOnce(ctx, body)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !retryable {
+			return err
+		}
+	}
+	return fmt.Errorf("usage ingest: giving up after %d attempts: %w", p.maxAttempts, lastErr)
+}
+
+// doOnce performs a single attempt and reports whether the failure (if any) is
+// retryable. A nil error means success (2xx, including an idempotent duplicate).
+func (p *UsageIngestPoster) doOnce(ctx context.Context, body []byte) (retryable bool, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.url, bytes.NewReader(body))
+	if err != nil {
+		// Malformed URL etc. is a configuration error; retrying will not help.
+		return false, fmt.Errorf("usage ingest: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if p.secret != "" {
+		req.Header.Set("Authorization", "Bearer "+p.secret)
+	}
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		// Network / timeout error: transient, retry.
+		return true, fmt.Errorf("usage ingest: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	// Drain a bounded amount so the connection can be reused.
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<14))
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		// 2xx, including an idempotent duplicate, is success.
+		return false, nil
+	case resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests:
+		return true, fmt.Errorf("usage ingest: transient server status %d", resp.StatusCode)
+	default:
+		// Other 4xx (auth, validation, unknown client): not retryable.
+		return false, fmt.Errorf("usage ingest: non-retryable status %d", resp.StatusCode)
+	}
+}
+
+// backoffFor returns the capped exponential backoff for the given completed
+// attempt count (1-based exponent).
+func (p *UsageIngestPoster) backoffFor(completedAttempts int) time.Duration {
+	if completedAttempts < 1 {
+		completedAttempts = 1
+	}
+	backoff := p.baseBackoff << (completedAttempts - 1)
+	if backoff <= 0 || backoff > p.maxBackoff {
+		backoff = p.maxBackoff
+	}
+	return backoff
+}
+
+// splitUsageAuthID splits the signer auth ID (`client_id:external_user_id`) into
+// its OpenMeter subject parts. It returns ok=false when either part is missing.
+func splitUsageAuthID(authID string) (clientID, externalUserID string, ok bool) {
+	idx := strings.Index(authID, ":")
+	if idx <= 0 || idx >= len(authID)-1 {
+		return "", "", false
+	}
+	return authID[:idx], authID[idx+1:], true
+}
+
+func pixelsString(pixels int64) string {
+	if pixels <= 0 {
+		return ""
+	}
+	return strconv.FormatInt(pixels, 10)
+}

--- a/monitor/usage_ingest_test.go
+++ b/monitor/usage_ingest_test.go
@@ -1,0 +1,275 @@
+package monitor
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fastPoster returns a poster pointed at url with near-zero backoff so retry
+// tests run quickly and deterministically.
+func fastPoster(url, secret string) *UsageIngestPoster {
+	p := NewUsageIngestPoster(url, secret)
+	if p != nil {
+		p.baseBackoff = time.Millisecond
+		p.maxBackoff = time.Millisecond
+		p.overallTimeout = 2 * time.Second
+	}
+	return p
+}
+
+func sampleEvent() SignedTicketUsageEvent {
+	return SignedTicketUsageEvent{
+		RequestID:      "req-123",
+		ComputedFeeWei: "547000000000",
+		Pixels:         1920 * 1080,
+		Pipeline:       "live-video-to-video",
+	}
+}
+
+const sampleAuthID = "app_98575870d7ae33589a3f0660:naap-storyboard-preview"
+
+// (a) Flag OFF (no URL) => poster is nil and no POST is ever made, even when an
+// endpoint is available. This is the zero-regression default.
+func TestUsageIngest_FlagOff_NoPost(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Empty URL => nil poster (the OFF state).
+	p := NewUsageIngestPoster("", "secret")
+	require.Nil(t, p, "no ingest URL configured must yield a nil (inert) poster")
+
+	// Calling the best-effort entry point on a nil poster must be a safe no-op.
+	assert.NotPanics(t, func() { p.SendSignedTicket(sampleAuthID, sampleEvent()) })
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&hits), "flag OFF must make zero POSTs")
+}
+
+// (b) Flag ON, success => exactly one POST with the correct body + auth header.
+func TestUsageIngest_FlagOn_SinglePostWithBodyAndAuth(t *testing.T) {
+	var hits int32
+	var gotAuth, gotContentType string
+	var gotBody usageIngestRequestBody
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"ingested":true,"duplicate":false}`))
+	}))
+	defer srv.Close()
+
+	p := fastPoster(srv.URL, "s3cr3t")
+	require.NotNil(t, p)
+
+	err := p.postSignedTicket(context.Background(), sampleAuthID, sampleEvent())
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "exactly one POST on success")
+	assert.Equal(t, "Bearer s3cr3t", gotAuth, "bearer secret must be sent verbatim")
+	assert.Equal(t, "application/json", gotContentType)
+
+	// Body must match the pymthouse #178 contract.
+	assert.Equal(t, "create_signed_ticket", gotBody.Type)
+	assert.Equal(t, "app_98575870d7ae33589a3f0660", gotBody.Data.ClientID)
+	assert.Equal(t, "naap-storyboard-preview", gotBody.Data.UsageSubject)
+	assert.Equal(t, "req-123", gotBody.Data.RequestID)
+	assert.Equal(t, "547000000000", gotBody.Data.ComputedFee)
+	assert.Equal(t, "live-video-to-video", gotBody.Data.Pipeline)
+	assert.Equal(t, "2073600", gotBody.Data.Pixels)
+}
+
+// (c) Retry on 5xx then success.
+func TestUsageIngest_RetriesOn5xxThenSucceeds(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := fastPoster(srv.URL, "")
+	require.NotNil(t, p)
+
+	err := p.postSignedTicket(context.Background(), sampleAuthID, sampleEvent())
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&hits), "two 5xx then success = 3 attempts")
+}
+
+// (d) Bounded give-up on persistent failure: returns an error after exactly
+// maxAttempts, without blocking indefinitely or panicking.
+func TestUsageIngest_GivesUpAfterBoundedRetries(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	p := fastPoster(srv.URL, "")
+	require.NotNil(t, p)
+
+	done := make(chan error, 1)
+	go func() { done <- p.postSignedTicket(context.Background(), sampleAuthID, sampleEvent()) }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "persistent 5xx must surface an error after retries")
+	case <-time.After(5 * time.Second):
+		t.Fatal("postSignedTicket blocked far longer than the bounded retry budget")
+	}
+	assert.Equal(t, int32(usageIngestMaxAttempts), atomic.LoadInt32(&hits), "must stop after maxAttempts")
+}
+
+// (e) A 2xx duplicate (idempotent replay) is treated as success.
+func TestUsageIngest_DuplicateIsSuccess(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"ingested":true,"duplicate":true}`))
+	}))
+	defer srv.Close()
+
+	p := fastPoster(srv.URL, "")
+	require.NotNil(t, p)
+
+	err := p.postSignedTicket(context.Background(), sampleAuthID, sampleEvent())
+	require.NoError(t, err, "a 2xx duplicate response must be treated as success")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hits))
+}
+
+// Non-retryable 4xx (e.g. validation/auth/unknown-client) fails immediately with
+// no retries, so transient-retry never masks a permanent rejection.
+func TestUsageIngest_NonRetryable4xxFailsImmediately(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusBadRequest, http.StatusNotFound} {
+		var hits int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			w.WriteHeader(status)
+		}))
+
+		p := fastPoster(srv.URL, "")
+		require.NotNil(t, p)
+
+		err := p.postSignedTicket(context.Background(), sampleAuthID, sampleEvent())
+		require.Error(t, err)
+		assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "4xx (%d) must not be retried", status)
+		srv.Close()
+	}
+}
+
+// 429 Too Many Requests is treated as transient and retried.
+func TestUsageIngest_429IsRetried(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		if n < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := fastPoster(srv.URL, "")
+	require.NotNil(t, p)
+
+	err := p.postSignedTicket(context.Background(), sampleAuthID, sampleEvent())
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits))
+}
+
+// A missing/invalid auth_id must skip the POST entirely (no client_id/subject to
+// attribute usage to), surfacing an error rather than sending a malformed event.
+func TestUsageIngest_InvalidAuthIDSkipsPost(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := fastPoster(srv.URL, "")
+	require.NotNil(t, p)
+
+	for _, bad := range []string{"", "no-colon", ":only-subject", "only-client:"} {
+		err := p.postSignedTicket(context.Background(), bad, sampleEvent())
+		assert.Error(t, err, "auth_id %q must be rejected", bad)
+	}
+	assert.Equal(t, int32(0), atomic.LoadInt32(&hits), "invalid auth_id must make zero POSTs")
+}
+
+// Context cancellation bounds total time even against an unreachable endpoint.
+func TestUsageIngest_RespectsContextDeadline(t *testing.T) {
+	// Unreachable port: dials fail fast; ensure we still give up promptly.
+	p := fastPoster("http://127.0.0.1:1/never", "")
+	require.NotNil(t, p)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- p.postSignedTicket(ctx, sampleAuthID, sampleEvent()) }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("postSignedTicket did not respect the context deadline")
+	}
+}
+
+// SendSignedTicket is the best-effort entry point used by the signer: it must
+// never panic, even when delivery ultimately fails.
+func TestUsageIngest_SendSignedTicketNeverPanicsOnFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := fastPoster(srv.URL, "")
+	require.NotNil(t, p)
+	assert.NotPanics(t, func() { p.SendSignedTicket(sampleAuthID, sampleEvent()) })
+}
+
+func TestSplitUsageAuthID(t *testing.T) {
+	cases := []struct {
+		in      string
+		client  string
+		subject string
+		ok      bool
+	}{
+		{"app_abc:user-1", "app_abc", "user-1", true},
+		{"app_abc:ns:user-1", "app_abc", "ns:user-1", true}, // split on first colon only
+		{"", "", "", false},
+		{"nocolon", "", "", false},
+		{":user", "", "", false},
+		{"client:", "", "", false},
+	}
+	for _, c := range cases {
+		client, subject, ok := splitUsageAuthID(c.in)
+		assert.Equal(t, c.ok, ok, "ok for %q", c.in)
+		assert.Equal(t, c.client, client, "client for %q", c.in)
+		assert.Equal(t, c.subject, subject, "subject for %q", c.in)
+	}
+}

--- a/server/mediaserver.go
+++ b/server/mediaserver.go
@@ -132,6 +132,11 @@ type LivepeerServer struct {
 	livePaymentInterval  time.Duration
 	outSegmentTimeout    time.Duration
 
+	// usageIngest delivers per-served-job usage events to the durable pymthouse
+	// ingest endpoint. It is nil (and the durable path inert) unless an ingest
+	// URL is configured, in which case behavior is byte-identical to legacy.
+	usageIngest *monitor.UsageIngestPoster
+
 	byocSrv *byoc.BYOCGatewayServer
 }
 
@@ -191,6 +196,11 @@ func NewLivepeerServer(ctx context.Context, rtmpAddr string, lpNode *core.Livepe
 			BroadcastJobVideoProfiles = profiles
 		}
 	}
+	var usageIngestURL string
+	if lpNode.RemoteSignerUsageIngestURL != nil {
+		usageIngestURL = lpNode.RemoteSignerUsageIngestURL.String()
+	}
+
 	server := lpmscore.New(&opts)
 	ls := &LivepeerServer{RTMPSegmenter: server, LPMS: server, LivepeerNode: lpNode, HTTPMux: opts.HttpMux, connectionLock: &sync.RWMutex{},
 		serverLock:              &sync.RWMutex{},
@@ -203,6 +213,7 @@ func NewLivepeerServer(ctx context.Context, rtmpAddr string, lpNode *core.Livepe
 		liveAIAuthApiKey:        lpNode.LiveAIAuthApiKey,
 		livePaymentInterval:     lpNode.LivePaymentInterval,
 		outSegmentTimeout:       lpNode.LiveOutSegmentTimeout,
+		usageIngest:             monitor.NewUsageIngestPoster(usageIngestURL, lpNode.RemoteSignerUsageIngestSecret),
 	}
 	if lpNode.NodeType == core.BroadcasterNode && httpIngest {
 		opts.HttpMux.HandleFunc("/live/", ls.HandlePush)

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -648,6 +648,32 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
+
+	// Durable, flag-gated usage delivery. This is strictly additive to the legacy
+	// fire-and-forget Kafka path above and is a no-op unless an ingest URL is
+	// configured. We flush the payment response first so the gateway's decode is
+	// not blocked while we synchronously deliver the usage event (the ingest is
+	// idempotent on (clientId, requestId), so the safe double-write converges).
+	if ls.usageIngest != nil {
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		ls.usageIngest.SendSignedTicket(state.AuthID, monitor.SignedTicketUsageEvent{
+			RequestID:      requestID,
+			ComputedFeeWei: fee.FloatString(0),
+			Pixels:         pixels,
+			Pipeline:       livePaymentPipeline(req.Type),
+		})
+	}
+}
+
+// livePaymentPipeline maps the remote payment request type to the pipeline label
+// used in usage events.
+func livePaymentPipeline(reqType string) string {
+	if reqType == RemoteType_LiveVideoToVideo {
+		return PipelineLiveVideoToVideo
+	}
+	return ""
 }
 
 // Gateway helper that calls the remote signer service for the GetOrchestratorInfo signature


### PR DESCRIPTION
## The bug — lossy fire-and-forget metering → lost billed usage

Billed BYOC usage reaches OpenMeter **only** through a best-effort, fire-and-forget telemetry pipeline:

```
server/remote_signer.go GenerateLivePayment
  → monitor.SendQueueEventAsync        (non-blocking; drops on full queue / nil producer)
  → in-process batched Kafka producer  (1s ticker; 3 retries then DROP whole batch; no shutdown flush)
  → Redpanda                           (single broker, ephemeral)
  → Benthos openmeter-collector        (silently deleted() on auth_id=="" or any mapping error)
  → OpenMeter
```

There is **no durable, acked write path**. Metering fires on *every served job* (deterministic `computed_fee` in `GenerateLivePayment`), **not** win-gated — so any dropped event is lost revenue/usage. Observed: 46/46 billed gens succeeded but OpenMeter stayed flat (effective hit-rate ≈ 0% over the most recent ≥43 gens).

The pymthouse side now has a durable, idempotent, acked ingest endpoint (`POST /api/v1/internal/ingest/signed-ticket`, pymthouse#178), but nothing POSTs to it yet. **This PR is that companion** — it is what makes pymthouse#178 actually receive data.

## The fix — a flagged, synchronous, bounded-retry POST (additive, default OFF)

When `-usageIngestUrl` is configured, the remote signer also delivers each `create_signed_ticket` usage event to the durable pymthouse ingest endpoint via a synchronous bounded-retry HTTP POST, **in addition to** the existing Kafka path (the legacy path is untouched). The payment response is flushed first, so the gateway's decode is not blocked while delivery runs.

- **Bounded retry:** up to 3 attempts with a small capped exponential backoff. Retries only on transient failures (network errors, 5xx, 429). A `2xx` (including an idempotent duplicate) is treated as success; other 4xx are non-retryable. Delivery runs under a detached, bounded context (≤ ~6s) so a single served job can never block the signer indefinitely. On final failure it logs and increments a new `usage_ingest_send_errors` metric. It never panics and never blocks the response to the orchestrator.
- **Exact request contract (matches pymthouse#178):** `type: "create_signed_ticket"`, with `data.{ client_id, usage_subject, request_id, computed_fee (wei), pixels, pipeline }`, and `Authorization: Bearer <INGEST_SHARED_SECRET>`. `client_id` / `usage_subject` are derived from the signer `auth_id` (`client_id:external_user_id`). pymthouse converts the wei `computed_fee` to USD micros via the collector formula, so usage aggregates under the same subject as the legacy path.
- **Idempotent / safe double-write:** pymthouse#178 dedupes on `(clientId, requestId)` (and on the CloudEvent id), so running this in parallel with the legacy Kafka collector during rollout converges to exactly one metered event per job — no double counting.

### Feature flag / zero regression

Gated entirely behind `-usageIngestUrl` (+ `-usageIngestSecret`). **Unset (default) ⇒ byte-identical legacy behavior**: the poster is `nil`, the new block is skipped, no new POST is made, and the Kafka → Benthos → OpenMeter pipeline remains the sole metering path. The secret flag is redacted in `PrintConfig`. **No flag was enabled in any prod/preview/CI deploy.**

## Files

| File | Change |
|---|---|
| `monitor/usage_ingest.go` | New `UsageIngestPoster`: contract-matching body builder, bounded-retry transport, auth, `auth_id` split (DI for hermetic testing) |
| `monitor/census.go` | New `usage_ingest_send_errors` metric + `UsageIngestSendError` |
| `server/remote_signer.go` | Flag-gated additive delivery after the response flush (legacy path untouched) |
| `server/mediaserver.go` | Construct the poster on `LivepeerServer` from node config |
| `core/livepeernode.go` | New `RemoteSignerUsageIngest{URL,Secret}` node fields |
| `cmd/livepeer/starter/{flags,starter}.go` | New `-usageIngestUrl` / `-usageIngestSecret` flags + wiring (secret redacted) |
| `monitor/usage_ingest_test.go` | Hermetic httptest unit tests |

## Test plan

`monitor` package: `go build`, `go vet`, and `go test ./monitor/...` all green (gofmt clean). Hermetic httptest unit tests cover:

- **flag OFF ⇒ zero POSTs** (nil poster, no-op),
- **flag ON ⇒ exactly one POST** with correct body + `Bearer` auth,
- **retry on 5xx then success**, **429 retried**,
- **bounded give-up** on persistent 5xx (exactly `maxAttempts`, no hang/panic),
- **2xx duplicate treated as success**,
- **non-retryable 4xx** (401/400/404) fail immediately without retry,
- **invalid/missing `auth_id` skips the POST**,
- **context deadline respected** against an unreachable endpoint,
- `SendSignedTicket` never panics on failure, and `auth_id` split correctness.

> Note: the `server` / `core` / `cmd` packages require go-livepeer's pinned (CGO) ffmpeg to compile, which could not be built in this local environment (the pinned bundled zlib is rejected by the host's C23-default clang). Those changes are small, mechanical wiring mirroring the existing `-remoteSignerWebhookUrl` flow and will be compiled by CI.

### End-to-end verification

With pymthouse#178 flag ON and `-usageIngestUrl` set on the signer, drive N served jobs ⇒ OpenMeter `requestCount` delta == N (vs ≈0 today), and the delta holds even across a Kafka/collector restart (HTTP path is independent). Double-write with the legacy path does not double-count (pymthouse dedupe holds).

## Links

- Companion durable endpoint: pymthouse#178 (`POST /api/v1/internal/ingest/signed-ticket`)
- Root cause + design: `OPENMETER-USAGE-FIX-PLAN.md`, plan item **PF-2**

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable usage reporting for signed-ticket events with automatic retries and secure authentication support.
  * Enabled configuration of a new usage-ingest endpoint and secret through startup settings.
  * Expanded live payment handling to send usage data after a successful response when configured.

* **Bug Fixes**
  * Improved failure handling for usage delivery, including retry behavior for transient errors and safer handling of invalid inputs.
  * Sensitive configuration values are now hidden in printed settings output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->