### PR TITLE
trickle: Enforce TLS cert validity by default.

### DIFF
--- a/ai/worker/serverless_worker.go
+++ b/ai/worker/serverless_worker.go
@@ -405,7 +405,8 @@ func (f *ServerlessWorker) LiveVideoToVideo(ctx context.Context, req GenLiveVide
 				clog.Info(ctx, "Subscribing to events stream", "url", eventsUrl)
 
 				subscriber, err := trickle.NewTrickleSubscriber(trickle.TrickleSubscriberConfig{
-					URL: eventsUrl,
+					URL:                eventsUrl,
+					InsecureSkipVerify: true,
 				})
 				if err != nil {
 					clog.Error(ctx, "Failed to create events subscriber", "error", err)

--- a/byoc/trickle.go
+++ b/byoc/trickle.go
@@ -42,7 +42,10 @@ var (
 
 func (bsg *BYOCGatewayServer) startTricklePublish(ctx context.Context, url *url.URL, params byocAIRequestParams, orchAddr string, orchUrl string) {
 	ctx = clog.AddVal(ctx, "url", url.Redacted())
-	publisher, err := trickle.NewTricklePublisher(url.String())
+	publisher, err := trickle.NewTricklePublisherWithConfig(trickle.TricklePublisherConfig{
+		URL:                url.String(),
+		InsecureSkipVerify: params.node.TrickleInsecureSkipVerify,
+	})
 	if err != nil {
 		stopProcessing(ctx, params, fmt.Errorf("trickle publish init err: %w", err))
 		return
@@ -181,8 +184,9 @@ func (bsg *BYOCGatewayServer) startTrickleSubscribe(ctx context.Context, url *ur
 	// subscribe to inference outputs and send them into the world
 
 	subscriber, err := trickle.NewTrickleSubscriber(trickle.TrickleSubscriberConfig{
-		URL: url.String(),
-		Ctx: ctx,
+		URL:                url.String(),
+		Ctx:                ctx,
+		InsecureSkipVerify: params.node.TrickleInsecureSkipVerify,
 	})
 	if err != nil {
 		stopProcessing(ctx, params, fmt.Errorf("trickle subscription init failed: %w", err))
@@ -471,7 +475,10 @@ func (bsg *BYOCGatewayServer) setOutWriter(ctx context.Context, writer *media.Ri
 }
 
 func (bsg *BYOCGatewayServer) startControlPublish(ctx context.Context, control *url.URL, params byocAIRequestParams, orchAddr string, orchUrl string) {
-	controlPub, err := trickle.NewTricklePublisher(control.String())
+	controlPub, err := trickle.NewTricklePublisherWithConfig(trickle.TricklePublisherConfig{
+		URL:                control.String(),
+		InsecureSkipVerify: params.node.TrickleInsecureSkipVerify,
+	})
 	if err != nil {
 		stopProcessing(ctx, params, fmt.Errorf("error starting control publisher, err=%w", err))
 		return
@@ -579,8 +586,9 @@ func (bsg *BYOCGatewayServer) startEventsSubscribe(
 	orchUrl string,
 ) {
 	subscriber, err := trickle.NewTrickleSubscriber(trickle.TrickleSubscriberConfig{
-		URL: url.String(),
-		Ctx: ctx,
+		URL:                url.String(),
+		Ctx:                ctx,
+		InsecureSkipVerify: params.node.TrickleInsecureSkipVerify,
 	})
 	if err != nil {
 		stopProcessing(ctx, params, fmt.Errorf("event sub init failed: %w", err))
@@ -796,8 +804,9 @@ func (bsg *BYOCGatewayServer) startDataSubscribe(ctx context.Context, url *url.U
 
 	// subscribe to the outputs
 	subscriber, err := trickle.NewTrickleSubscriber(trickle.TrickleSubscriberConfig{
-		URL: url.String(),
-		Ctx: ctx,
+		URL:                url.String(),
+		Ctx:                ctx,
+		InsecureSkipVerify: params.node.TrickleInsecureSkipVerify,
 	})
 	if err != nil {
 		clog.Infof(ctx, "Failed to create data subscriber: %s", err)

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -638,6 +638,8 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	if err != nil {
 		glog.Errorf("Error creating livepeer node: %v", err)
 	}
+	n.TrickleInsecureSkipVerify = !((cfg.UseLiveRunners != nil && *cfg.UseLiveRunners) ||
+		(cfg.LiveRunnerConfig != nil && *cfg.LiveRunnerConfig != ""))
 	n.AIProcesssingRetryTimeout = *cfg.AIProcessingRetryTimeout
 
 	if *cfg.OrchSecret != "" {

--- a/core/livepeernode.go
+++ b/core/livepeernode.go
@@ -146,6 +146,8 @@ type LivepeerNode struct {
 	AutoAdjustPrice      bool
 	AutoSessionLimit     bool
 
+	TrickleInsecureSkipVerify bool
+
 	// Broadcaster public fields
 	Sender     pm.Sender
 	ExtraNodes int
@@ -213,21 +215,22 @@ func NewLivepeerNode(e eth.LivepeerEthClient, wd string, dbh *common.DB) (*Livep
 	extCapPrices["default"] = make(map[string]*big.Rat)
 
 	return &LivepeerNode{
-		Eth:                  e,
-		WorkDir:              wd,
-		Database:             dbh,
-		AutoAdjustPrice:      true,
-		SegmentChans:         make(map[ManifestID]SegmentChan),
-		segmentMutex:         &sync.RWMutex{},
-		Capabilities:         &Capabilities{capacities: map[Capability]int{}, version: LivepeerVersion},
-		ExternalCapabilities: NewExternalCapabilities(),
-		priceInfo:            make(map[string]*AutoConvertedPrice),
-		priceInfoForCaps:     make(map[string]CapabilityPrices),
-		jobPriceInfo:         extCapPrices,
-		StorageConfigs:       make(map[string]*transcodeConfig),
-		storageMutex:         &sync.RWMutex{},
-		LivePipelines:        make(map[string]*LivePipeline),
-		LiveMu:               &sync.RWMutex{},
+		Eth:                       e,
+		WorkDir:                   wd,
+		Database:                  dbh,
+		AutoAdjustPrice:           true,
+		SegmentChans:              make(map[ManifestID]SegmentChan),
+		TrickleInsecureSkipVerify: true,
+		segmentMutex:              &sync.RWMutex{},
+		Capabilities:              &Capabilities{capacities: map[Capability]int{}, version: LivepeerVersion},
+		ExternalCapabilities:      NewExternalCapabilities(),
+		priceInfo:                 make(map[string]*AutoConvertedPrice),
+		priceInfoForCaps:          make(map[string]CapabilityPrices),
+		jobPriceInfo:              extCapPrices,
+		StorageConfigs:            make(map[string]*transcodeConfig),
+		storageMutex:              &sync.RWMutex{},
+		LivePipelines:             make(map[string]*LivePipeline),
+		LiveMu:                    &sync.RWMutex{},
 	}, nil
 }
 

--- a/core/livepeernode_test.go
+++ b/core/livepeernode_test.go
@@ -59,6 +59,15 @@ func (t *StubTranscoder) Stop() {
 	t.StoppedCount++
 }
 
+func TestTrickleInsecureSkipVerify(t *testing.T) {
+	n, err := NewLivepeerNode(nil, t.TempDir(), nil)
+	require.NoError(t, err)
+	require.True(t, n.TrickleInsecureSkipVerify)
+
+	n.TrickleInsecureSkipVerify = false
+	require.False(t, n.TrickleInsecureSkipVerify)
+}
+
 func TestTranscodeAndBroadcast(t *testing.T) {
 	ffmpeg.InitFFmpeg()
 	p := []ffmpeg.VideoProfile{ffmpeg.P720p60fps16x9, ffmpeg.P144p30fps16x9}

--- a/server/ai_live_video.go
+++ b/server/ai_live_video.go
@@ -72,7 +72,10 @@ func (os *orchestratorSwapper) checkSwap(ctx context.Context) error {
 
 func startTricklePublish(ctx context.Context, url *url.URL, params aiRequestParams, sess *AISession) {
 	ctx = clog.AddVal(ctx, "url", url.Redacted())
-	publisher, err := trickle.NewTricklePublisher(url.String())
+	publisher, err := trickle.NewTricklePublisherWithConfig(trickle.TricklePublisherConfig{
+		URL:                url.String(),
+		InsecureSkipVerify: params.node.TrickleInsecureSkipVerify,
+	})
 	if err != nil {
 		stopProcessing(ctx, params, fmt.Errorf("trickle publish init err: %w", err))
 		return
@@ -223,8 +226,9 @@ func startTrickleSubscribe(ctx context.Context, url *url.URL, params aiRequestPa
 	// subscribe to inference outputs and send them into the world
 
 	subscriber, err := trickle.NewTrickleSubscriber(trickle.TrickleSubscriberConfig{
-		URL: url.String(),
-		Ctx: ctx,
+		URL:                url.String(),
+		Ctx:                ctx,
+		InsecureSkipVerify: params.node.TrickleInsecureSkipVerify,
 	})
 	if err != nil {
 		stopProcessing(ctx, params, fmt.Errorf("trickle subscription init failed: %w", err))
@@ -596,7 +600,10 @@ func registerControl(ctx context.Context, params aiRequestParams) {
 
 func startControlPublish(ctx context.Context, control *url.URL, params aiRequestParams) {
 	stream := params.liveParams.stream
-	controlPub, err := trickle.NewTricklePublisher(control.String())
+	controlPub, err := trickle.NewTricklePublisherWithConfig(trickle.TricklePublisherConfig{
+		URL:                control.String(),
+		InsecureSkipVerify: params.node.TrickleInsecureSkipVerify,
+	})
 	if err != nil {
 		stopProcessing(ctx, params, fmt.Errorf("error starting control publisher, err=%w", err))
 		return
@@ -692,8 +699,9 @@ const clearStreamDelay = 1 * time.Minute
 
 func startEventsSubscribe(ctx context.Context, url *url.URL, params aiRequestParams, sess *AISession) {
 	subscriber, err := trickle.NewTrickleSubscriber(trickle.TrickleSubscriberConfig{
-		URL: url.String(),
-		Ctx: ctx,
+		URL:                url.String(),
+		Ctx:                ctx,
+		InsecureSkipVerify: params.node.TrickleInsecureSkipVerify,
 	})
 	if err != nil {
 		stopProcessing(ctx, params, fmt.Errorf("event sub init failed: %w", err))

--- a/trickle/trickle_publisher.go
+++ b/trickle/trickle_publisher.go
@@ -15,12 +15,13 @@ var StreamNotFoundErr = errors.New("stream not found")
 
 // TricklePublisher represents a trickle streaming client
 type TricklePublisher struct {
-	client      *http.Client
-	baseURL     string
-	index       int          // Current index for segments
-	writeLock   sync.Mutex   // Mutex to manage concurrent access
-	pendingPost *pendingPost // Pre-initialized POST request
-	contentType string
+	client             *http.Client
+	baseURL            string
+	index              int          // Current index for segments
+	writeLock          sync.Mutex   // Mutex to manage concurrent access
+	pendingPost        *pendingPost // Pre-initialized POST request
+	contentType        string
+	insecureSkipVerify bool
 }
 
 // HTTPError gets returned with a >=400 status code (non-400)
@@ -44,12 +45,25 @@ type pendingPost struct {
 	client  *TricklePublisher
 }
 
+type TricklePublisherConfig struct {
+	URL string
+
+	// InsecureSkipVerify skips TLS certificate validation when true.
+	// Defaults to false.
+	InsecureSkipVerify bool
+}
+
 // NewTricklePublisher creates a new trickle stream client
 func NewTricklePublisher(url string) (*TricklePublisher, error) {
+	return NewTricklePublisherWithConfig(TricklePublisherConfig{URL: url})
+}
+
+func NewTricklePublisherWithConfig(config TricklePublisherConfig) (*TricklePublisher, error) {
 	c := &TricklePublisher{
-		baseURL:     url,
-		contentType: "video/MP2T",
-		client:      httpClient(),
+		baseURL:            config.URL,
+		contentType:        "video/MP2T",
+		client:             httpClient(config.InsecureSkipVerify),
+		insecureSkipVerify: config.InsecureSkipVerify,
 	}
 	p, err := c.preconnect()
 	if err != nil {
@@ -83,6 +97,7 @@ func (c *TricklePublisher) preconnect() (*pendingPost, error) {
 		resp, err := httpclient.Do(req)
 		if err != nil {
 			slog.Error("Failed to complete POST for segment", "url", url, "err", err)
+			_ = pr.CloseWithError(err)
 			errCh <- err
 			return
 		}
@@ -132,7 +147,7 @@ func (c *TricklePublisher) Close() error {
 		return err
 	}
 	// Use a new client for a fresh connection
-	resp, err := httpClient().Do(req)
+	resp, err := httpClient(c.insecureSkipVerify).Do(req)
 	if err != nil {
 		return err
 	}
@@ -188,7 +203,7 @@ func (p *pendingPost) reconnect() (*pendingPost, error) {
 	defer p.client.writeLock.Unlock()
 	currentSeq := p.client.index
 	p.client.index = p.index
-	p.client.client = httpClient()
+	p.client.client = httpClient(p.client.insecureSkipVerify)
 	pp, err := p.client.preconnect()
 	p.client.index = currentSeq
 	return pp, err
@@ -278,7 +293,7 @@ func (p *pendingPost) Close() error {
 	// Since this method typically gets invoked when
 	// there is a problem sending the segment, use a
 	// new client for a fresh connection just in case
-	resp, err := httpClient().Do(req)
+	resp, err := httpClient(p.client.insecureSkipVerify).Do(req)
 	if err != nil {
 		return err
 	}
@@ -300,12 +315,11 @@ func (c *TricklePublisher) Write(data io.Reader) error {
 	return err
 }
 
-func httpClient() *http.Client {
+func httpClient(insecureSkipVerify bool) *http.Client {
 	return &http.Client{Transport: &http.Transport{
 		// Re-enable keepalives to avoid connection pooling
 		// DisableKeepAlives: true,
-		// ignore orch certs for now
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
 
 		// Prevent old TCP connections from accumulating
 		IdleConnTimeout: 1 * time.Minute,

--- a/trickle/trickle_subscriber.go
+++ b/trickle/trickle_subscriber.go
@@ -26,6 +26,10 @@ type TrickleSubscriberConfig struct {
 	// Trickle URL to subscribe to (required).
 	URL string
 
+	// InsecureSkipVerify skips TLS certificate validation when true.
+	// Defaults to false.
+	InsecureSkipVerify bool
+
 	// Pass in a context for custom cancellation of
 	// the entire subscription.
 	//
@@ -56,14 +60,15 @@ var preconnectTimeoutErr = errors.New("preconnect timed out")
 
 // TrickleSubscriber represents a trickle streaming reader that always fetches from index -1
 type TrickleSubscriber struct {
-	client     *http.Client
-	url        string
-	mu         sync.Mutex      // Mutex to manage concurrent access
-	pendingGet *http.Response  // Pre-initialized GET request
-	baseCtx    context.Context // base context to use for the next context
-	ctx        context.Context // Parent context to use for pending GETs. This is bad
-	cancelCtx  func()          // cancel the pending GET
-	idx        int             // Segment index to request
+	client             *http.Client
+	url                string
+	mu                 sync.Mutex      // Mutex to manage concurrent access
+	pendingGet         *http.Response  // Pre-initialized GET request
+	baseCtx            context.Context // base context to use for the next context
+	ctx                context.Context // Parent context to use for pending GETs. This is bad
+	cancelCtx          func()          // cancel the pending GET
+	idx                int             // Segment index to request
+	insecureSkipVerify bool
 
 	// Number of errors from preconnect
 	preconnectErrorCount int
@@ -90,12 +95,13 @@ func NewTrickleSubscriber(config TrickleSubscriberConfig) (*TrickleSubscriber, e
 	}
 
 	return &TrickleSubscriber{
-		client:    httpClient(),
-		url:       config.URL,
-		baseCtx:   baseCtx,
-		ctx:       ctx,
-		cancelCtx: cancel,
-		idx:       idx,
+		client:             httpClient(config.InsecureSkipVerify),
+		url:                config.URL,
+		baseCtx:            baseCtx,
+		ctx:                ctx,
+		cancelCtx:          cancel,
+		idx:                idx,
+		insecureSkipVerify: config.InsecureSkipVerify,
 	}, nil
 }
 
@@ -136,7 +142,7 @@ func (c *TrickleSubscriber) SetSeq(seq int) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// Reset client in case SetSeq is called due to slow reads falling too far behind
-	c.client = httpClient()
+	c.client = httpClient(c.insecureSkipVerify)
 	c.idx = seq
 	c.ctx, c.cancelCtx = context.WithCancel(c.baseCtx)
 	c.pendingGet = nil

--- a/trickle/trickle_test.go
+++ b/trickle/trickle_test.go
@@ -97,6 +97,74 @@ func TestTrickle_Close(t *testing.T) {
 	require.Error(StreamNotFoundErr, pub2.Write(bytes.NewReader([]byte("bad post"))))
 }
 
+func TestTrickle_TLSDefaultValidatesCertificates(t *testing.T) {
+	require := require.New(t)
+	mux := http.NewServeMux()
+	server := ConfigureServer(TrickleServerConfig{
+		Mux: mux,
+	})
+	stop := server.Start()
+	ts := httptest.NewTLSServer(mux)
+	defer ts.Close()
+	defer stop()
+
+	channelURL := ts.URL + "/tls-default"
+	lp := NewLocalPublisher(server, "tls-default", "text/plain")
+	lp.CreateChannel()
+	require.NoError(lp.Write(bytes.NewReader([]byte("hello"))))
+
+	pub, err := NewTricklePublisher(channelURL)
+	require.NoError(err)
+	err = pub.Write(bytes.NewReader([]byte("world")))
+	require.Error(err)
+	require.Contains(err.Error(), "certificate")
+
+	sub, err := NewTrickleSubscriber(subConfig(t, channelURL))
+	require.NoError(err)
+	_, err = sub.Read()
+	require.Error(err)
+	require.Contains(err.Error(), "certificate")
+}
+
+func TestTrickle_InsecureSkipVerifyAllowsSelfSignedCertificates(t *testing.T) {
+	require := require.New(t)
+	mux := http.NewServeMux()
+	server := ConfigureServer(TrickleServerConfig{
+		Mux: mux,
+	})
+	stop := server.Start()
+	ts := httptest.NewTLSServer(mux)
+	defer ts.Close()
+	defer stop()
+
+	channelURL := ts.URL + "/tls-insecure"
+	lp := NewLocalPublisher(server, "tls-insecure", "text/plain")
+	lp.CreateChannel()
+
+	pub, err := NewTricklePublisherWithConfig(TricklePublisherConfig{
+		URL:                channelURL,
+		InsecureSkipVerify: true,
+	})
+	require.NoError(err)
+	defer pub.Close()
+	require.NoError(pub.Write(bytes.NewReader([]byte("hello"))))
+
+	sub, err := NewTrickleSubscriber(TrickleSubscriberConfig{
+		URL:                channelURL,
+		Ctx:                t.Context(),
+		InsecureSkipVerify: true,
+	})
+	require.NoError(err)
+	sub.SetSeq(0)
+
+	resp, err := sub.Read()
+	require.NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(err)
+	require.Equal("hello", string(body))
+}
+
 func TestLocalPublisher_CreateContract(t *testing.T) {
 	t.Run("write without autocreate returns stream not found", func(t *testing.T) {
 		require := require.New(t)


### PR DESCRIPTION
Enforced if live runners are enabled, disabled for everything else to preserve old behavior with self-signed orchestrator certs.

This does mean you can't use, eg live runners + BYOC in the same setup unless all endpoints have a valid certificate, but this is probably a niche case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable TLS certificate verification for live streaming connections.
  - Supports deployments using self-signed certificates when explicitly enabled.
  - Live streaming and BYOC connections now consistently follow the configured TLS security setting.

- **Bug Fixes**
  - Improved error propagation when a segment upload connection fails, helping failures surface more reliably.

- **Tests**
  - Added coverage for secure certificate validation and explicitly permitted self-signed certificate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->