### PR TITLE
ci: modernize builds for reliability

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,9 +56,7 @@ jobs:
       - name: Setup ubuntu container
         run: |
           apt update
-          apt install -yqq build-essential make software-properties-common
-          add-apt-repository -y ppa:git-core/candidate
-          apt update && apt install -yqq git zip unzip zlib1g-dev zlib1g libzlcore-dev yasm
+          apt install -yqq build-essential make git zip unzip zlib1g-dev zlib1g libzlcore-dev yasm
 
       - name: Check out code
         uses: actions/checkout@v4
@@ -97,15 +95,24 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt update \
-            && apt install -yqq software-properties-common curl apt-transport-https lsb-release \
-            && curl -fsSl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-            && add-apt-repository "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-14 main" \
-            && apt update \
-            && apt -yqq install \
-              nasm clang-14 clang-tools-14 lld-14 build-essential pkg-config autoconf git python3 \
-              gcc-mingw-w64 libgcc-9-dev-arm64-cross mingw-w64-tools gcc-mingw-w64-x86-64 mingw-w64-x86-64-dev \
-              golang-goprotobuf-dev protobuf-compiler-grpc
+          apt update
+          apt install -yqq ca-certificates curl lsb-release
+
+          if ! apt-cache show clang-14 >/dev/null 2>&1; then
+            install -d -m 0755 /usr/share/keyrings
+            curl -fsSL --retry 5 --retry-delay 2 --connect-timeout 15 \
+              -o /usr/share/keyrings/apt.llvm.org.asc \
+              https://apt.llvm.org/llvm-snapshot.gpg.key
+            printf '%s\n' \
+              "deb [signed-by=/usr/share/keyrings/apt.llvm.org.asc] https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-14 main" \
+              > /etc/apt/sources.list.d/llvm-toolchain-14.list
+            apt update
+          fi
+
+          apt install -yqq \
+            nasm clang-14 clang-tools-14 lld-14 build-essential pkg-config autoconf git python3 \
+            gcc-mingw-w64 libgcc-9-dev-arm64-cross mingw-w64-tools gcc-mingw-w64-x86-64 mingw-w64-x86-64-dev \
+            golang-goprotobuf-dev protobuf-compiler-grpc
 
           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 30 \
             && update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 30 \
@@ -124,11 +131,13 @@ jobs:
         if: matrix.target.GOOS == 'windows'
         env:
           CC: x86_64-w64-mingw32-gcc
+          ZLIB_VERSION: 1.2.11
         run: |
-          apt install -yqq wget
-          wget https://zlib.net/fossils/zlib-1.2.11.tar.gz
-          tar -xzf zlib-1.2.11.tar.gz
-          cd zlib-1.2.11
+          curl -fsSL --retry 5 --retry-delay 2 --connect-timeout 15 \
+            -o "zlib-${ZLIB_VERSION}.tar.gz" \
+            "https://github.com/madler/zlib/archive/refs/tags/v${ZLIB_VERSION}.tar.gz"
+          tar -xzf "zlib-${ZLIB_VERSION}.tar.gz"
+          cd "zlib-${ZLIB_VERSION}"
           ./configure --prefix=/usr/x86_64-w64-mingw32 --static
           make
           make install

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1477,9 +1477,8 @@ func TestOrchestratorPool_GetOrchestrators_SuspendedOrchs(t *testing.T) {
 	wg := sync.WaitGroup{}
 
 	orchCb := func() error { return nil }
-	oldOrchInfo := serverGetOrchInfo
-	defer func() { wg.Wait(); serverGetOrchInfo = oldOrchInfo }()
-	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, server *url.URL, params server.GetOrchestratorInfoParams) (*net.OrchestratorInfo, error) {
+	defer wg.Wait()
+	getOrchInfo := func(ctx context.Context, bcast common.Broadcaster, server *url.URL, params server.GetOrchestratorInfoParams) (*net.OrchestratorInfo, error) {
 		defer wg.Done()
 		err := orchCb()
 		return &net.OrchestratorInfo{
@@ -1488,6 +1487,7 @@ func TestOrchestratorPool_GetOrchestrators_SuspendedOrchs(t *testing.T) {
 	}
 
 	pool := NewOrchestratorPool(&stubBroadcaster{}, addresses, common.Score_Trusted, []string{}, 50*time.Millisecond)
+	pool.getOrchInfo = getOrchInfo
 
 	// suspend https://127.0.0.1:8938
 	sus := newStubSuspender()

--- a/discovery/wh_discovery.go
+++ b/discovery/wh_discovery.go
@@ -13,6 +13,8 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/common"
+	"github.com/livepeer/go-livepeer/net"
+	"github.com/livepeer/go-livepeer/server"
 )
 
 type webhookResponse struct {
@@ -30,6 +32,7 @@ type webhookPool struct {
 	bcast               common.Broadcaster
 	discoveryTimeout    time.Duration
 	ignoreCapacityCheck bool
+	getOrchInfo         func(context.Context, common.Broadcaster, *url.URL, server.GetOrchestratorInfoParams) (*net.OrchestratorInfo, error)
 }
 
 func NewWebhookPool(bcast common.Broadcaster, callback *url.URL, discoveryTimeout time.Duration) *webhookPool {
@@ -56,6 +59,7 @@ func (cfg WebhookPoolConfig) New() *webhookPool {
 		bcast:               cfg.Broadcaster,
 		discoveryTimeout:    cfg.DiscoveryTimeout,
 		ignoreCapacityCheck: cfg.IgnoreCapacityCheck,
+		getOrchInfo:         serverGetOrchInfo,
 	}
 	go p.getInfos()
 	return p
@@ -99,7 +103,7 @@ func (w *webhookPool) getInfos() ([]common.OrchestratorLocalInfo, error) {
 		discoveryTimeout:    w.discoveryTimeout,
 		extraNodes:          w.bcast.ExtraNodes(),
 		ignoreCapacityCheck: w.ignoreCapacityCheck,
-		getOrchInfo:         serverGetOrchInfo,
+		getOrchInfo:         w.getOrchInfo,
 	}
 
 	w.mu.Lock()

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,12 +12,13 @@ ENV	GOARCH="$TARGETARCH" \
 	CGO_LDFLAGS="-L/usr/local/cuda_${TARGETARCH}/lib64"
 
 RUN	apt update \
-	&& apt install -yqq software-properties-common curl apt-transport-https lsb-release \
-	&& curl -fsSL https://dl.google.com/go/go1.21.5.linux-${BUILDARCH}.tar.gz | tar -C /usr/local -xz \
-	&& curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
-	&& add-apt-repository "deb [arch=${BUILDARCH}] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
-	&& curl -fsSl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
-	&& add-apt-repository "deb [arch=${BUILDARCH}] https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-14 main" \
+	&& apt install -yqq ca-certificates curl lsb-release \
+	&& install -d -m 0755 /usr/share/keyrings \
+	&& curl -fsSL --retry 5 --retry-delay 2 --connect-timeout 15 https://dl.google.com/go/go1.21.5.linux-${BUILDARCH}.tar.gz | tar -C /usr/local -xz \
+	&& curl -fsSL --retry 5 --retry-delay 2 --connect-timeout 15 -o /usr/share/keyrings/docker.asc https://download.docker.com/linux/ubuntu/gpg \
+	&& printf '%s\n' "deb [arch=${BUILDARCH} signed-by=/usr/share/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list \
+	&& curl -fsSL --retry 5 --retry-delay 2 --connect-timeout 15 -o /usr/share/keyrings/apt.llvm.org.asc https://apt.llvm.org/llvm-snapshot.gpg.key \
+	&& printf '%s\n' "deb [arch=${BUILDARCH} signed-by=/usr/share/keyrings/apt.llvm.org.asc] https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-14 main" > /etc/apt/sources.list.d/llvm-toolchain-14.list \
 	&& apt update \
 	&& apt -yqq install clang-14 clang-tools-14 lld-14 build-essential pkg-config autoconf git python docker-ce-cli pciutils gcc-multilib libgcc-8-dev-arm64-cross gcc-mingw-w64-x86-64 zlib1g zlib1g-dev libx264-dev libfdk-aac-dev
 

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo 'WARNING: downloading and executing lpms/install_ffmpeg.sh, use it directly in case of issues'
-curl https://raw.githubusercontent.com/livepeer/lpms/5fe66b1044f876b47248c36aed581622fbbe093d/install_ffmpeg.sh | bash -s $1
+curl https://raw.githubusercontent.com/livepeer/lpms/258bcb383e0725d088e4cdea9f93ec7e590f0d37/install_ffmpeg.sh | bash -s $1

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo 'WARNING: downloading and executing lpms/install_ffmpeg.sh, use it directly in case of issues'
-curl https://raw.githubusercontent.com/livepeer/lpms/258bcb383e0725d088e4cdea9f93ec7e590f0d37/install_ffmpeg.sh | bash -s $1
+curl https://raw.githubusercontent.com/livepeer/lpms/dca1710ae43850b2ef752815a060d359ed597f7f/install_ffmpeg.sh | bash -s $1

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo 'WARNING: downloading and executing lpms/install_ffmpeg.sh, use it directly in case of issues'
-curl https://raw.githubusercontent.com/livepeer/lpms/dca1710ae43850b2ef752815a060d359ed597f7f/install_ffmpeg.sh | bash -s $1
+curl https://raw.githubusercontent.com/livepeer/lpms/bc67cafe732afb08053328483f73cf000a28d330/install_ffmpeg.sh | bash -s $1


### PR DESCRIPTION
Builds are extremely flaky; this is an attempt to make them more reliable.

There are a couple things contributing to this:

- The git-core PPA fails. This appears unnecessary anyway
- The zlib / fossils download is unreliable. Use the Github mirror
- Update LPMS install_ffmpeg.sh which as the zlib mirror update

Claude notes below.

---

Replace deprecated `apt-key` and `add-apt-repository` usage in the build workflow and Docker image with explicit `signed-by` keyrings under /usr/share/keyrings and source lists in /etc/apt/sources.list.d. `apt-key` is deprecated and slated for removal, and `add-apt-repository` pulls in software-properties-common; the keyring approach is the recommended method and scopes each key to its own repo instead of trusting it globally.

Drop the git-core/candidate PPA in build.yaml and install the distro's stock git instead. The build only needs git new enough for actions/checkout to do a real clone (>=2.18) and for `git describe` versioning; Ubuntu 20.04 (2.25.1) and 22.04 (2.34.1) both satisfy this, so the PPA was unnecessary.

Harden network fetches with `curl --retry 5 --retry-delay 2 --connect-timeout 15` to reduce flaky-CI failures, and source the pinned zlib 1.2.11 tarball from GitHub release tags instead of zlib.net/fossils, which has had availability issues.

No build outputs or pinned versions change (Go 1.21.5, clang-14, zlib 1.2.11 all retained).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux and Windows build setup for more reliable dependency installation.
  * Updated build container configuration to use keyring-based repository signing for Docker and the LLVM toolchain, including conditional toolchain installation.
  * Streamlined Windows zlib download and extraction for fewer build-time failures.
  * Updated the FFmpeg installer source used during setup.
* **Tests**
  * Improved discovery test isolation by limiting mocking behavior to the test scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->