### PR TITLE
fix(signer): meter real BYOC capability + model_id for usage events

### DIFF
--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -247,6 +247,20 @@ type RemotePaymentRequest struct {
 
 	// Capabilities to include in the ticket. Optional; may be set for the lv2v job type.
 	Capabilities []byte `json:"capabilities"`
+
+	// Capability is the real BYOC capability name (e.g. "nano-banana"). When
+	// set, it overrides the metered `pipeline` label for the emitted
+	// create_signed_ticket usage event, decoupling usage attribution from
+	// `Type` (which stays "lv2v" for fee/pixel routing). Optional; empty
+	// preserves the previous behavior (pipeline falls back to the lv2v
+	// constant when Type=="lv2v").
+	Capability string `json:"capability,omitempty"`
+
+	// ModelID is the specific provider model from the request
+	// payload/parameters. When set, it overrides the metered `model_id`
+	// label. Optional; empty preserves the previous behavior (the
+	// capabilities-derived model id, which defaults to "unknown" downstream).
+	ModelID string `json:"model_id,omitempty"`
 }
 
 // Returned by the remote signer and includes a new payment plus updated state.
@@ -353,6 +367,32 @@ func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentS
 	}
 
 	return *webhookResp.Status, &webhookResp, errors.New(webhookResp.Reason)
+}
+
+// resolveUsageLabels derives the metering `pipeline` and `model_id` labels for
+// the emitted create_signed_ticket usage event.
+//
+// The real BYOC capability/model supplied by the gateway (req.Capability /
+// req.ModelID) take precedence so BYOC jobs are attributed to their true
+// pipeline + model. When those additive fields are empty, the labels fall back
+// to the previous behavior: for lv2v the pipeline is the live-video-to-video
+// constant and the model id is derived from the request capabilities; for any
+// other request both remain empty (the collector then defaults them to
+// "unknown"). This makes non-BYOC (lv2v) callers byte-identical to before and
+// keeps usage attribution decoupled from `Type`, which still drives fee/pixel
+// routing.
+func resolveUsageLabels(req *RemotePaymentRequest, caps *core.Capabilities) (pipeline, modelID string) {
+	if req.Type == RemoteType_LiveVideoToVideo {
+		pipeline = PipelineLiveVideoToVideo
+		modelID = caps.ModelIDForCapability(core.Capability_LiveVideoToVideo)
+	}
+	if req.Capability != "" {
+		pipeline = req.Capability
+	}
+	if req.ModelID != "" {
+		modelID = req.ModelID
+	}
+	return pipeline, modelID
 }
 
 // GenerateLivePayment handles remote generation of a payment for live streams.
@@ -680,12 +720,7 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 		if state.SequenceNumber == 0 {
 			sessionStatus = "new"
 		}
-		pipeline := ""
-		modelID := ""
-		if req.Type == RemoteType_LiveVideoToVideo {
-			pipeline = PipelineLiveVideoToVideo
-			modelID = streamParams.Capabilities.ModelIDForCapability(core.Capability_LiveVideoToVideo)
-		}
+		pipeline, modelID := resolveUsageLabels(&req, streamParams.Capabilities)
 		// NB: This could could drop events if tha Kafka queue is full!
 		monitor.SendQueueEventAsync("create_signed_ticket", map[string]interface{}{
 			"session_id":         state.StateID,

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -369,28 +369,50 @@ func (ls *LivepeerServer) authLivePayment(r *http.Request, state *RemotePaymentS
 	return *webhookResp.Status, &webhookResp, errors.New(webhookResp.Reason)
 }
 
+// maxUsageLabelLen bounds the length of gateway-supplied usage labels
+// (pipeline/model_id) before they are emitted to the metering pipeline.
+// req.Capability / req.ModelID come straight from the request body, so a buggy
+// or malicious caller could otherwise send very long / high-cardinality values
+// that inflate Kafka payload size and downstream label cardinality (the
+// pipeline label was previously a small fixed set). 128 runes is generous for
+// real capability/model identifiers.
+const maxUsageLabelLen = 128
+
+// sanitizeUsageLabel trims surrounding whitespace and caps the length (in
+// runes, to never emit invalid UTF-8) of a gateway-supplied metering label.
+func sanitizeUsageLabel(s string) string {
+	s = strings.TrimSpace(s)
+	if r := []rune(s); len(r) > maxUsageLabelLen {
+		return string(r[:maxUsageLabelLen])
+	}
+	return s
+}
+
 // resolveUsageLabels derives the metering `pipeline` and `model_id` labels for
 // the emitted create_signed_ticket usage event.
 //
 // The real BYOC capability/model supplied by the gateway (req.Capability /
-// req.ModelID) take precedence so BYOC jobs are attributed to their true
-// pipeline + model. When those additive fields are empty, the labels fall back
-// to the previous behavior: for lv2v the pipeline is the live-video-to-video
-// constant and the model id is derived from the request capabilities; for any
-// other request both remain empty (the collector then defaults them to
-// "unknown"). This makes non-BYOC (lv2v) callers byte-identical to before and
-// keeps usage attribution decoupled from `Type`, which still drives fee/pixel
-// routing.
+// req.ModelID) take precedence and override the labels whenever they are set,
+// regardless of `Type` — this decouples usage attribution from `Type`, which
+// still drives fee/pixel routing. The gateway-supplied values are sanitized
+// (trimmed + length-capped) to bound payload size and label cardinality.
+//
+// When those additive fields are empty, the labels fall back to the previous
+// behavior: for lv2v the pipeline is the live-video-to-video constant and the
+// model id is derived from the request capabilities; for any other request the
+// untouched label(s) remain empty (the collector then defaults them to
+// "unknown"). This makes non-BYOC (lv2v) callers with no override
+// byte-identical to before.
 func resolveUsageLabels(req *RemotePaymentRequest, caps *core.Capabilities) (pipeline, modelID string) {
 	if req.Type == RemoteType_LiveVideoToVideo {
 		pipeline = PipelineLiveVideoToVideo
 		modelID = caps.ModelIDForCapability(core.Capability_LiveVideoToVideo)
 	}
-	if req.Capability != "" {
-		pipeline = req.Capability
+	if c := sanitizeUsageLabel(req.Capability); c != "" {
+		pipeline = c
 	}
-	if req.ModelID != "" {
-		modelID = req.ModelID
+	if m := sanitizeUsageLabel(req.ModelID); m != "" {
+		modelID = m
 	}
 	return pipeline, modelID
 }

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -1716,8 +1717,6 @@ func lv2vCapsWithModel(t *testing.T, modelID string) *core.Capabilities {
 // This is hermetic: it exercises the pure label-resolution helper without the
 // CGO ffmpeg toolchain, the remote-signer HTTP handler, or Kafka.
 func TestResolveUsageLabels(t *testing.T) {
-	require := require.New(t)
-
 	tests := []struct {
 		name         string
 		req          RemotePaymentRequest
@@ -1767,10 +1766,33 @@ func TestResolveUsageLabels(t *testing.T) {
 			wantPipeline: "",
 			wantModelID:  "",
 		},
+		{
+			name: "byoc: whitespace-only override is ignored, lv2v defaults kept",
+			req: RemotePaymentRequest{
+				Type:       RemoteType_LiveVideoToVideo,
+				Capability: "   ",
+				ModelID:    "\t\n",
+			},
+			caps:         lv2vCapsWithModel(t, "streamdiffusion"),
+			wantPipeline: PipelineLiveVideoToVideo,
+			wantModelID:  "streamdiffusion",
+		},
+		{
+			name: "byoc: oversized override labels are length-capped",
+			req: RemotePaymentRequest{
+				Type:       RemoteType_LiveVideoToVideo,
+				Capability: strings.Repeat("c", maxUsageLabelLen+50),
+				ModelID:    strings.Repeat("m", maxUsageLabelLen+50),
+			},
+			caps:         nil,
+			wantPipeline: strings.Repeat("c", maxUsageLabelLen),
+			wantModelID:  strings.Repeat("m", maxUsageLabelLen),
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
 			req := tc.req
 			pipeline, modelID := resolveUsageLabels(&req, tc.caps)
 			require.Equal(tc.wantPipeline, pipeline, "pipeline")

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -1692,3 +1692,89 @@ func TestGetOrchInfoSig_SendsConfiguredHeaders(t *testing.T) {
 	require.Equal([]byte{0x12, 0x34}, []byte(resp.Address))
 	require.Equal([]byte{0xab, 0xcd}, []byte(resp.Signature))
 }
+
+// lv2vCapsWithModel builds a core.Capabilities advertising a single warm model
+// for the live-video-to-video capability (used to exercise the existing
+// capabilities-derived model_id fallback).
+func lv2vCapsWithModel(t *testing.T, modelID string) *core.Capabilities {
+	t.Helper()
+	c := core.NewCapabilities([]core.Capability{core.Capability_LiveVideoToVideo}, nil)
+	c.SetPerCapabilityConstraints(core.PerCapabilityConstraints{
+		core.Capability_LiveVideoToVideo: &core.CapabilityConstraints{
+			Models: core.ModelConstraints{modelID: &core.ModelConstraint{Warm: true}},
+		},
+	})
+	return c
+}
+
+// TestResolveUsageLabels asserts the additive usage-attribution contract:
+//   - when the gateway supplies the real BYOC capability/model, the metered
+//     pipeline + model_id reflect them (the root-cause fix);
+//   - when those fields are empty, behavior is unchanged (lv2v constant +
+//     capabilities-derived model id, or empty → "unknown" downstream).
+//
+// This is hermetic: it exercises the pure label-resolution helper without the
+// CGO ffmpeg toolchain, the remote-signer HTTP handler, or Kafka.
+func TestResolveUsageLabels(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name         string
+		req          RemotePaymentRequest
+		caps         *core.Capabilities
+		wantPipeline string
+		wantModelID  string
+	}{
+		{
+			name:         "lv2v unchanged: no new fields, no caps",
+			req:          RemotePaymentRequest{Type: RemoteType_LiveVideoToVideo},
+			caps:         nil,
+			wantPipeline: PipelineLiveVideoToVideo,
+			wantModelID:  "",
+		},
+		{
+			name:         "lv2v unchanged: model derived from capabilities",
+			req:          RemotePaymentRequest{Type: RemoteType_LiveVideoToVideo},
+			caps:         lv2vCapsWithModel(t, "streamdiffusion"),
+			wantPipeline: PipelineLiveVideoToVideo,
+			wantModelID:  "streamdiffusion",
+		},
+		{
+			name: "byoc: real capability + model override lv2v defaults",
+			req: RemotePaymentRequest{
+				Type:       RemoteType_LiveVideoToVideo,
+				Capability: "nano-banana",
+				ModelID:    "google/nano-banana",
+			},
+			caps:         lv2vCapsWithModel(t, "streamdiffusion"),
+			wantPipeline: "nano-banana",
+			wantModelID:  "google/nano-banana",
+		},
+		{
+			name: "byoc: capability set, empty model falls back to caps-derived",
+			req: RemotePaymentRequest{
+				Type:       RemoteType_LiveVideoToVideo,
+				Capability: "nano-banana",
+			},
+			caps:         lv2vCapsWithModel(t, "streamdiffusion"),
+			wantPipeline: "nano-banana",
+			wantModelID:  "streamdiffusion",
+		},
+		{
+			name:         "non-lv2v with no fields: both empty (collector defaults to unknown)",
+			req:          RemotePaymentRequest{},
+			caps:         nil,
+			wantPipeline: "",
+			wantModelID:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := tc.req
+			pipeline, modelID := resolveUsageLabels(&req, tc.caps)
+			require.Equal(tc.wantPipeline, pipeline, "pipeline")
+			require.Equal(tc.wantModelID, modelID, "model_id")
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The remote signer's `create_signed_ticket` metering event recorded
`pipeline=live-video-to-video` / `model_id=unknown` for **every** BYOC
capability (e.g. `nano-banana`), so OpenMeter could not attribute BYOC usage to
the real pipeline + model.

## Root cause (model attribution lost upstream at the gateway)

The gateway (`livepeer-python-gateway` → `byoc.py` → `_create_byoc_payment`)
hardcodes `type:"lv2v"` for every BYOC job (it needs lv2v fee/pixel routing —
BYOC has no per-job pixel count) and sent the real capability only as a bare
JSON field this signer dropped, with no model id. As a result
`GenerateLivePayment` here:

```go
pipeline := ""
modelID := ""
if req.Type == RemoteType_LiveVideoToVideo {
    pipeline = PipelineLiveVideoToVideo
    modelID = streamParams.Capabilities.ModelIDForCapability(core.Capability_LiveVideoToVideo)
}
```

emitted `pipeline=live-video-to-video` (because `Type=="lv2v"`) and an empty
`model_id` (because BYOC capabilities aren't `Capability_LiveVideoToVideo`).

## The additive wire contract

Two optional string fields are added to `RemotePaymentRequest`
(POST `/generate-live-payment`):

| field (json) | meaning |
|---|---|
| `capability` | the real BYOC capability (e.g. `nano-banana`) |
| `model_id` | the specific provider model from the request payload/parameters |

When set, they **override** the metered `pipeline` + `model_id` labels,
decoupling usage attribution from `Type` (which still drives fee/pixel routing).
When empty/absent, behavior is **byte-identical** to before: lv2v falls back to
the `PipelineLiveVideoToVideo` constant and the capabilities-derived model id;
non-lv2v stays empty (the collector defaults empties to `"unknown"`). The
gateway side that sends these fields is the cross-linked PR below.

## Changes

- Add `Capability` and `ModelID` (both `omitempty`) to `RemotePaymentRequest`
  (`server/remote_signer.go`).
- Extract label resolution into a pure `resolveUsageLabels(req, caps)` helper
  and call it from `GenerateLivePayment`'s emit block. Generic across
  capabilities (not only `Capability_LiveVideoToVideo`).

## Zero-regression

- Empty new fields ⇒ resolved `pipeline`/`model_id` are identical to the
  previous logic ⇒ byte-identical event for lv2v / non-BYOC callers.
- The existing go-livepeer gateway caller (`server/live_payment.go`) does not
  set the new fields, so it is unaffected (`omitempty`).

## Test plan

`TestResolveUsageLabels` (added to `server/remote_signer_test.go`) is a
hermetic table test asserting:
- lv2v with no new fields → `live-video-to-video` + caps-derived/empty model
  (unchanged);
- BYOC capability + model present → real `pipeline` + `model_id` (override);
- capability present, empty model → caps-derived model fallback;
- non-lv2v, no fields → both empty.

> ⚠️ **Local build limitation (toolchain):** the `server` (and transitively
> `core`) packages require the CGO **ffmpeg** toolchain via
> `github.com/livepeer/lpms/ffmpeg`, which does not compile against this
> macOS host's system ffmpeg 8.x (`avfilter_compare_sign_bypath` undeclared) —
> the same issue a prior go-livepeer PR hit. `gofmt` is clean and the referenced
> `core` types/APIs were verified against source; the Go test is left to run in
> CI. The label-resolution logic is isolated in a pure helper so it is fully
> unit-testable once CI compiles the package.

## End-to-end verification recipe

With this signer change **and** the gateway change deployed: drive a
`nano-banana` generation against the preview chain, then query OpenMeter
`groupBy=pipeline_model` — it should show the real pipeline + model id, not
`live-video-to-video` / `unknown`.

## ⚙️ Deployment note (which build must incorporate this for prod)

The signer DMZ + simple-infra signer are deployed from the Docker image
**`livepeer/go-livepeer:feat-add-model-id-signer-kafka`**, built from the
**`feat/add-model-id-signer-kafka`** branch (the pymthouse
`docker/signer-dmz/Dockerfile*` and `scripts/build-local-signer.sh` pin this
tag). This PR therefore targets that branch so the fix reaches production with
an image rebuild. **For prod to be fixed, the
`livepeer/go-livepeer:feat-add-model-id-signer-kafka` image must be rebuilt
from this branch after merge and the signer redeployed.** (`master` carries an
older variant of the emit block without `model_id`; it can receive the
equivalent change separately, but it is not what is deployed.)

## Cross-link

Gateway side (sends these fields):
https://github.com/livepeer/livepeer-python-gateway/pull/33

Does not modify pymthouse or NaaP; the collector/read `unknown` fallbacks are
left in place as safety nets.

Made with [Cursor](https://cursor.com)