### PR TITLE
fix(ai/live-runner): derive Session-Control header from liveRunnerAddr

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -670,7 +670,7 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 		respondWithError(w, err.Error(), http.StatusBadGateway)
 		return
 	}
-	sessionControlURL := h.orchestrator.ServiceURI().JoinPath("runner", runnerID, "session", sessionID).String()
+	sessionControlURL := liveRunnerURI(h.node, h.orchestrator).JoinPath("runner", runnerID, "session", sessionID).String()
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(req *httputil.ProxyRequest) {
 			req.Out.URL.Scheme = target.Scheme

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -1215,6 +1215,40 @@ func TestLiveRunnerProxyForwardsGetPathQueryAndSessionHeaders(t *testing.T) {
 	require.Equal(t, "http://localhost:1234/runner/runner-1/session/"+sessionID, gotSessionControl)
 }
 
+func TestLiveRunnerProxySessionControlBaseURL(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		liveRunnerAddr string
+		wantBase       string
+	}{
+		{"falls back to serviceURI", "", "http://localhost:1234"},
+		{"uses liveRunnerAddr", "http://go-livepeer:8935", "http://go-livepeer:8935"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotSessionControl string
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotSessionControl = r.Header.Get("Livepeer-Session-Control")
+				w.WriteHeader(http.StatusAccepted)
+			}))
+			defer upstream.Close()
+
+			lp := newLiveRunnerHTTP(t, true)
+			if tc.liveRunnerAddr != "" {
+				addr, err := url.Parse(tc.liveRunnerAddr)
+				require.NoError(t, err)
+				lp.node.LiveRunnerAddr = addr
+			}
+			registerLiveRunnerForSession(t, lp, &liveRunnerRegistrationOptions{RunnerURL: upstream.URL})
+			sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
+
+			req := httptest.NewRequest(http.MethodGet, "/apps/runner-1/session/"+sessionID+"/app/x", nil)
+			lp.ServeHTTP(httptest.NewRecorder(), req)
+
+			require.Equal(t, tc.wantBase+"/runner/runner-1/session/"+sessionID, gotSessionControl)
+		})
+	}
+}
+
 func TestLiveRunnerProxyForwardsPostBody(t *testing.T) {
 	var gotMethod, gotBody string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

Build the `Livepeer-Session-Control` header (proxied to live runners) from `liveRunnerURI()` instead of `ServiceURI()`.

## Why

The orchestrator stamps `Livepeer-Session-Control` into every proxied live-runner request; the runner uses it to create/remove its session trickle channels. It was built from `ServiceURI()`, the public, client-facing address. But a runner can sit on a different network than external clients (a separate Docker container, or a separate host), where the public address isn't reachable. In that topology `create_trickle_channels(request)` fails.

`liveRunnerURI()` is the runner-facing address (`-liveRunnerAddr`). The heartbeat response (`ai/runner/live_runner.go`) and the internal trickle base URL (`startAIServer`) already advertise it to runners , Session-Control was the one control-plane callback still using `ServiceURI()`. This closes that gap.

## Safety

- `liveRunnerURI()` falls back to `ServiceURI()` when `-liveRunnerAddr` is unset, so single-network deployments are byte-for-byte unchanged.
- Session-Control has a single consumer (the runner) and one direction (runner → orchestrator control plane) — same as heartbeat and internal trickle — so when `-liveRunnerAddr` is set, this address is the correct one. Clients never read this header.

## Checks

- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
