### PR TITLE
devtool: tolerate raced round initialization

### DIFF
--- a/cmd/devtool/devtool/devtool_utils.go
+++ b/cmd/devtool/devtool/devtool_utils.go
@@ -289,7 +289,15 @@ func (d *Devtool) InitializeRound() error {
 	} else {
 		err = d.Client.CheckTx(tx)
 		if err != nil {
-			glog.Errorf("Error initializng round: %v", err)
+			initialized, initErr := d.Client.CurrentRoundInitialized()
+			if initErr == nil && initialized {
+				glog.Infof("Round initialized despite failed transaction: %v", err)
+				return nil
+			}
+			if initErr != nil {
+				glog.Errorf("Error checking initialized round after failed transaction: %v", initErr)
+			}
+			glog.Errorf("Error initializing round: %v", err)
 			return err
 		}
 	}


### PR DESCRIPTION
Attempts to fix e2e tests that periodically fail.

During e2e startup, the devtool helper and a running orchestrator can both submit initializeRound transactions. If the orchestrator wins, the helper's tx may mine with status 0 even though the round is now initialized.

After a failed init tx, re-check CurrentRoundInitialized and treat the operation as successful when the desired state was reached. Still return the original error if the round remains uninitialized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved round initialization handling so the app no longer reports a failure when the round was actually initialized successfully.
  * Added a fallback check after an initialization error to confirm the current round state before returning an error.
  * If the follow-up check fails, the original initialization error is still returned as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->