### PR TITLE
fix(remote-signer): keep retrying discovery while the cache is empty

### DIFF
--- a/server/remote_discovery.go
+++ b/server/remote_discovery.go
@@ -116,7 +116,7 @@ func (p *remoteDiscoveryPool) refresh() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	now := time.Now()
-	// Rate-limit rebuilds to once per interval, unless empty — else an empty startup snapshot locks in for a full interval.
+	// Rate-limit non-empty snapshots.
 	if len(p.cached) > 0 && !p.lastRefresh.IsZero() && now.Sub(p.lastRefresh) <= p.refreshEvery {
 		return
 	}

--- a/server/remote_discovery.go
+++ b/server/remote_discovery.go
@@ -116,7 +116,8 @@ func (p *remoteDiscoveryPool) refresh() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	now := time.Now()
-	if !p.lastRefresh.IsZero() && now.Sub(p.lastRefresh) <= p.refreshEvery {
+	// Rate-limit rebuilds to once per interval, unless empty — else an empty startup snapshot locks in for a full interval.
+	if len(p.cached) > 0 && !p.lastRefresh.IsZero() && now.Sub(p.lastRefresh) <= p.refreshEvery {
 		return
 	}
 

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -1311,6 +1311,55 @@ func TestRemoteSigner_Discovery(t *testing.T) {
 	require.Equal("application/json", ineligibleRR.Header().Get("Content-Type"))
 }
 
+func TestRemoteSigner_Discovery_EmptyCacheRetriesBeforeInterval(t *testing.T) {
+	require := require.New(t)
+
+	capability := core.Capability_LiveVideoToVideo
+	modelID := "scope"
+	BroadcastCfg.SetCapabilityMaxPrice(capability, modelID, core.NewFixedPrice(big.NewRat(200, 995328000000)))
+	defer BroadcastCfg.SetCapabilityMaxPrice(capability, modelID, nil)
+
+	// Node starts with no network capabilities (pool poll has not populated the cache yet).
+	node := &core.LivepeerNode{}
+
+	// Long interval: with the bug, an empty first refresh would lock discovery out for an hour.
+	rdp := &remoteDiscoveryPool{
+		node:         node,
+		refreshEvery: time.Hour,
+	}
+	ls := &LivepeerServer{}
+
+	// First request lands before the cache is populated: 503, cache empty.
+	emptyReq := httptest.NewRequest(http.MethodGet, "/discover-orchestrators?caps=live-video-to-video/scope", nil)
+	emptyRR := httptest.NewRecorder()
+	ls.GetOrchestrators(rdp, emptyRR, emptyReq)
+	require.Equal(http.StatusServiceUnavailable, emptyRR.Code)
+
+	// The orchestrator pool finishes its poll and populates network capabilities.
+	require.NoError(node.UpdateNetworkCapabilities([]*common.OrchNetworkCapabilities{
+		{
+			OrchURI: "https://late.example.com:8935",
+			Discovery: discoveryRaw(t, `[{
+				"address": "https://late.example.com:8935",
+				"runners": [
+					{"url":"https://late.example.com:8935/apps/runner/session","app":"live-video-to-video/scope","capacity":1,"price_info":{"price_per_unit":5,"pixels_per_unit":995328000000,"unit":"WEI"}}
+				]
+			}]`),
+		},
+	}))
+
+	// Follow-up within refreshEvery: the empty cache re-derives instead of staying rate-limited.
+	req := httptest.NewRequest(http.MethodGet, "/discover-orchestrators?caps=live-video-to-video/scope", nil)
+	rr := httptest.NewRecorder()
+	ls.GetOrchestrators(rdp, rr, req)
+
+	require.Equal(http.StatusOK, rr.Code)
+	var resp []discoveryResponse
+	require.NoError(json.NewDecoder(rr.Body).Decode(&resp))
+	require.Len(resp, 1)
+	require.Equal("https://late.example.com:8935", resp[0].Address)
+}
+
 func TestRemoteSigner_Discovery_UsesRunnerDiscoveryWhenRPCCapabilitiesMissing(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
## Problem

On the remote signer, `GET /discover-orchestrators` returns `503 "cache empty"` for up to `-liveAICapReportInterval` (default **25m**) after startup, even once orchestrators are advertising. The only known workaround was setting a very short `-liveAICapReportInterval`, which then makes the metrics poll run far more often than intended.

Reported by @eliteprox:

```
$ curl -s http://localhost:8081/discover-orchestrators | jq
{ "error": { "message": "Service Unavailable Error" } }
```

## Root cause

The `/discover-orchestrators` snapshot in `remoteDiscoveryPool` is derived from the node's network-capabilities cache (`GetNetworkCapabilities()`), which the orchestrator pool (`DBOrchestratorPoolCache`) populates on its **first poll — asynchronously at startup**.

`remoteDiscoveryPool.refresh()` set `lastRefresh = now` **unconditionally**, including when the derived snapshot was empty. So the first request that landed *before* that first poll completed built an empty snapshot and then rate-limited every subsequent refresh for a full `refreshEvery` (= `-liveAICapReportInterval`). Result: the empty result is locked in for 25m; a short interval "fixes" it only because the next allowed refresh comes soon enough to pick up the now-populated node cache.

## Fix

Rate-limit refreshes only once a **non-empty** snapshot exists:

```go
if len(p.cached) > 0 && !p.lastRefresh.IsZero() && now.Sub(p.lastRefresh) <= p.refreshEvery {
    return
}
```

While the cache is empty, every call re-derives from the in-memory `GetNetworkCapabilities()` snapshot. `refresh()` does **no network I/O** (the actual polling is on the separate `DBOrchestratorPoolCache` ticker), so retrying while empty is cheap and bounded. Once populated, the normal interval applies. This removes the need to shorten `-liveAICapReportInterval`.

## Test

Adds `TestRemoteSigner_Discovery_EmptyCacheRetriesBeforeInterval`: with `refreshEvery = 1h`, a first request against an unpopulated node returns 503; after `UpdateNetworkCapabilities`, a follow-up request *within the interval* returns the orchestrator. Fails on `main` (503), passes with the fix.

**Checklist:**
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [x] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
