### PR TITLE
feat(server): Live runner single shot payments

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -43,6 +43,9 @@ var TrickleHTTPPath = "/ai/trickle/"
 
 const maxLiveRunnerTrickleChannelsPerRequest = 25
 const liveRunnerSenderHeader = "Livepeer-Payer-Address"
+const liveRunnerSessionIDHeader = "Livepeer-Session-Id"
+const liveRunnerSessionControlHeader = "Livepeer-Session-Control"
+const liveRunnerSessionPaymentHeader = "Livepeer-Session-Payment"
 const maxScopeRequestBodySize = 1 << 20 // 1 MB
 
 func startAIServer(lp *lphttp) error {
@@ -255,44 +258,7 @@ func (h *lphttp) ReserveLiveRunnerSession(w http.ResponseWriter, r *http.Request
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		monitorCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-		paymentReceiver := livePaymentReceiver{orchestrator: h.orchestrator}
-		accountPaymentFunc := func(inPixels int64) error {
-			err := paymentReceiver.AccountPayment(monitorCtx, &SegmentInfoReceiver{
-				sender:    getPaymentSender(payment),
-				inPixels:  inPixels,
-				priceInfo: payment.GetExpectedPrice(),
-				sessionID: string(segData.ManifestID),
-			})
-			if err != nil {
-				clog.Errorf(monitorCtx, "Error accounting live runner payment, releasing session err=%v", err)
-				if releaseErr := manager.ReleaseSession(runnerID, sessionID); releaseErr != nil {
-					clog.Errorf(monitorCtx, "Error releasing live runner session after payment failure err=%v", releaseErr)
-				}
-				// Stop both the ticker loop below and the LivePaymentProcessor goroutine.
-				cancel()
-			}
-			return err
-		}
-		paymentProcessor := NewLivePaymentProcessor(monitorCtx, h.node.LivePaymentInterval, accountPaymentFunc)
-		go func() {
-			ticker := time.NewTicker(h.node.LivePaymentInterval)
-			defer ticker.Stop()
-			defer cancel()
-			for {
-				select {
-				case <-ticker.C:
-					// Stop monitoring once the live runner session has been released
-					// by an explicit stop, runner cleanup, expiry, or payment failure.
-					if _, err := manager.RunnerEndpointForSession(runnerID, sessionID); err != nil {
-						return
-					}
-					paymentProcessor.process(monitorCtx)
-				case <-monitorCtx.Done():
-					return
-				}
-			}
-		}()
+		h.startLiveRunnerSessionPaymentMonitor(ctx, manager, runnerID, sessionID, payment, string(segData.ManifestID))
 	}
 	controlURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID).String()
 	appURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID, "app").String()
@@ -639,16 +605,64 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	sessionID, endpoint, err := manager.ReserveSession(runnerID)
+	priceInfo, err := manager.PaymentInfo(runnerID)
 	if err != nil {
 		respondWithLiveRunnerError(w, err)
 		return
 	}
+	paymentRequired := priceInfo != nil
+	if paymentRequired && r.Header.Get(paymentHeader) == "" && r.Header.Get(segmentHeader) == "" {
+		h.runnerChallenge(w, r, priceInfo)
+		return
+	}
+
+	var (
+		payment         lpnet.Payment
+		segData         *core.SegTranscodingMetadata
+		ctx             = clog.AddVal(r.Context(), "runner_id", runnerID)
+		reservedID      string
+		reservedIDInput string
+	)
+	if paymentRequired {
+		var err error
+		payment, segData, ctx, err = h.processPaymentAndSegmentHeaders(w, r)
+		if err != nil {
+			return
+		}
+		if string(segData.ManifestID) != segData.AuthToken.SessionId {
+			respondWithError(w, "mismatched manifest and auth token", http.StatusForbidden)
+			return
+		}
+		reservedIDInput = string(segData.ManifestID)
+	}
+
+	sessionID, endpoint, err := manager.ReserveSession(runnerID, reservedIDInput)
+	if err != nil {
+		respondWithLiveRunnerError(w, err)
+		return
+	}
+	reservedID = sessionID
+	ctx = clog.AddVal(ctx, "session_id", sessionID)
 	defer func() {
-		if err := manager.ReleaseSession(runnerID, sessionID); err != nil {
+		if reservedID == "" {
+			return
+		}
+		if err := manager.ReleaseSession(runnerID, reservedID); err != nil {
 			slog.Error("error releasing single-shot session", "runner_id", runnerID, "session_id", sessionID, "err", err)
 		}
 	}()
+
+	if paymentRequired {
+		if string(segData.ManifestID) != sessionID {
+			respondWithError(w, "mismatched session and payment manifest", http.StatusForbidden)
+			return
+		}
+		if err := h.orchestrator.ProcessPayment(ctx, payment, segData.ManifestID); err != nil {
+			respondWithError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		h.startLiveRunnerSessionPaymentMonitor(ctx, manager, runnerID, sessionID, payment, string(segData.ManifestID))
+	}
 
 	sessionToken, err := manager.SessionTokenForSession(runnerID, sessionID)
 	if err != nil {
@@ -671,6 +685,7 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 		return
 	}
 	sessionControlURL := liveRunnerURI(h.node, h.orchestrator).JoinPath("runner", runnerID, "session", sessionID).String()
+	sessionPaymentURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID, "payment").String()
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(req *httputil.ProxyRequest) {
 			req.Out.URL.Scheme = target.Scheme
@@ -680,15 +695,62 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 			req.Out.URL.RawQuery = req.In.URL.RawQuery
 			req.Out.Host = target.Host
 			req.Out.Header.Set("Livepeer-Runner-Route", runnerID)
-			req.Out.Header.Set("Livepeer-Session-Id", sessionID)
+			req.Out.Header.Set(liveRunnerSessionIDHeader, sessionID)
 			req.Out.Header.Set("Livepeer-Session-Token", sessionToken)
-			req.Out.Header.Set("Livepeer-Session-Control", sessionControlURL)
+			req.Out.Header.Set(liveRunnerSessionControlHeader, sessionControlURL)
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			resp.Header.Set(liveRunnerSessionIDHeader, sessionID)
+			resp.Header.Set(liveRunnerSessionControlHeader, sessionControlURL)
+			resp.Header.Set(liveRunnerSessionPaymentHeader, sessionPaymentURL)
+			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
 			respondWithError(w, err.Error(), http.StatusBadGateway)
 		},
 	}
 	proxy.ServeHTTP(w, r)
+}
+
+func (h *lphttp) startLiveRunnerSessionPaymentMonitor(ctx context.Context, manager liveRunnerManager, runnerID, sessionID string, payment lpnet.Payment, manifestID string) {
+	monitorCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	paymentReceiver := livePaymentReceiver{orchestrator: h.orchestrator}
+	accountPaymentFunc := func(inPixels int64) error {
+		err := paymentReceiver.AccountPayment(monitorCtx, &SegmentInfoReceiver{
+			sender:    getPaymentSender(payment),
+			inPixels:  inPixels,
+			priceInfo: payment.GetExpectedPrice(),
+			sessionID: manifestID,
+		})
+		if err != nil {
+			clog.Errorf(monitorCtx, "Error accounting live runner payment, releasing session err=%v", err)
+			if releaseErr := manager.ReleaseSession(runnerID, sessionID); releaseErr != nil {
+				clog.Errorf(monitorCtx, "Error releasing live runner session after payment failure err=%v", releaseErr)
+			}
+			// Stop both the ticker loop below and the LivePaymentProcessor goroutine.
+			cancel()
+		}
+		return err
+	}
+	paymentProcessor := NewLivePaymentProcessor(monitorCtx, h.node.LivePaymentInterval, accountPaymentFunc)
+	go func() {
+		ticker := time.NewTicker(h.node.LivePaymentInterval)
+		defer ticker.Stop()
+		defer cancel()
+		for {
+			select {
+			case <-ticker.C:
+				// Stop monitoring once the live runner session has been released
+				// by an explicit stop, runner cleanup, expiry, or payment failure.
+				if _, err := manager.RunnerEndpointForSession(runnerID, sessionID); err != nil {
+					return
+				}
+				paymentProcessor.process(monitorCtx)
+			case <-monitorCtx.Done():
+				return
+			}
+		}
+	}()
 }
 
 func respondWithLiveRunnerError(w http.ResponseWriter, err error) {

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -45,7 +45,6 @@ const maxLiveRunnerTrickleChannelsPerRequest = 25
 const liveRunnerSenderHeader = "Livepeer-Payer-Address"
 const liveRunnerSessionIDHeader = "Livepeer-Session-Id"
 const liveRunnerSessionControlHeader = "Livepeer-Session-Control"
-const liveRunnerSessionPaymentHeader = "Livepeer-Session-Payment"
 const maxScopeRequestBodySize = 1 << 20 // 1 MB
 
 func startAIServer(lp *lphttp) error {
@@ -184,6 +183,8 @@ type liveRunnerPaymentChallengeResponse struct {
 	// Keep the URL in top-level JSON so clients do not need to parse the protobuf just to route payment.
 	Orchestrator string `json:"orchestrator"`
 	ManifestID   string `json:"manifest_id"`
+	// Interval at which the orchestrator debits the session balance.
+	PaymentIntervalMs int64 `json:"payment_interval_ms"`
 }
 
 type liveRunnerTrickleChannelRequest struct {
@@ -258,7 +259,8 @@ func (h *lphttp) ReserveLiveRunnerSession(w http.ResponseWriter, r *http.Request
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		h.startLiveRunnerSessionPaymentMonitor(ctx, manager, runnerID, sessionID, payment, string(segData.ManifestID))
+		// Detach from the request ctx so the loop outlives this reservation call.
+		h.startLiveRunnerSessionPaymentLoop(context.WithoutCancel(ctx), manager, runnerID, sessionID, payment, segData.ManifestID)
 	}
 	controlURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID).String()
 	appURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID, "app").String()
@@ -281,7 +283,7 @@ func (h *lphttp) runnerChallenge(w http.ResponseWriter, r *http.Request, priceIn
 		respondWithError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		respondWithError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -306,7 +308,7 @@ func (h *lphttp) scopePaymentChallenge(w http.ResponseWriter, r *http.Request) (
 	if err != nil {
 		return false, err
 	}
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		return false, err
 	}
@@ -316,15 +318,16 @@ func (h *lphttp) scopePaymentChallenge(w http.ResponseWriter, r *http.Request) (
 	return true, nil
 }
 
-func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo) ([]byte, error) {
+func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo, paymentInterval time.Duration) ([]byte, error) {
 	buf, err := proto.Marshal(oInfo)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(liveRunnerPaymentChallengeResponse{
-		PaymentParams: base64.StdEncoding.EncodeToString(buf),
-		Orchestrator:  oInfo.GetTranscoder(),
-		ManifestID:    oInfo.GetAuthToken().GetSessionId(),
+		PaymentParams:     base64.StdEncoding.EncodeToString(buf),
+		Orchestrator:      oInfo.GetTranscoder(),
+		ManifestID:        oInfo.GetAuthToken().GetSessionId(),
+		PaymentIntervalMs: paymentInterval.Milliseconds(),
 	})
 }
 
@@ -617,11 +620,10 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 	}
 
 	var (
-		payment         lpnet.Payment
-		segData         *core.SegTranscodingMetadata
-		ctx             = clog.AddVal(r.Context(), "runner_id", runnerID)
-		reservedID      string
-		reservedIDInput string
+		payment   lpnet.Payment
+		segData   *core.SegTranscodingMetadata
+		ctx       = r.Context()
+		sessionID string
 	)
 	if paymentRequired {
 		var err error
@@ -633,35 +635,32 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 			respondWithError(w, "mismatched manifest and auth token", http.StatusForbidden)
 			return
 		}
-		reservedIDInput = string(segData.ManifestID)
+		// for easier correlation across orch, gw, signer
+		sessionID = string(segData.ManifestID)
 	}
-
-	sessionID, endpoint, err := manager.ReserveSession(runnerID, reservedIDInput)
+	sessionID, endpoint, err := manager.ReserveSession(runnerID, sessionID)
 	if err != nil {
 		respondWithLiveRunnerError(w, err)
 		return
 	}
-	reservedID = sessionID
-	ctx = clog.AddVal(ctx, "session_id", sessionID)
+
+	// Release on return: a single-shot session lives for exactly one request.
 	defer func() {
-		if reservedID == "" {
-			return
-		}
-		if err := manager.ReleaseSession(runnerID, reservedID); err != nil {
+		if err := manager.ReleaseSession(runnerID, sessionID); err != nil {
 			slog.Error("error releasing single-shot session", "runner_id", runnerID, "session_id", sessionID, "err", err)
 		}
 	}()
 
+	ctx = clog.AddVal(r.Context(), "runner_id", runnerID)
+	ctx = clog.AddVal(ctx, "session_id", sessionID)
 	if paymentRequired {
-		if string(segData.ManifestID) != sessionID {
-			respondWithError(w, "mismatched session and payment manifest", http.StatusForbidden)
-			return
-		}
 		if err := h.orchestrator.ProcessPayment(ctx, payment, segData.ManifestID); err != nil {
+			// Session released by the defer above.
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		h.startLiveRunnerSessionPaymentMonitor(ctx, manager, runnerID, sessionID, payment, string(segData.ManifestID))
+		// Bound to the request ctx so the loop ends when this single-shot call returns.
+		h.startLiveRunnerSessionPaymentLoop(ctx, manager, runnerID, sessionID, payment, segData.ManifestID)
 	}
 
 	sessionToken, err := manager.SessionTokenForSession(runnerID, sessionID)
@@ -669,6 +668,7 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 		respondWithLiveRunnerError(w, err)
 		return
 	}
+
 	h.proxyLiveRunner(w, r, runnerID, sessionID, sessionToken, endpoint)
 }
 
@@ -685,7 +685,6 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 		return
 	}
 	sessionControlURL := liveRunnerURI(h.node, h.orchestrator).JoinPath("runner", runnerID, "session", sessionID).String()
-	sessionPaymentURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID, "payment").String()
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(req *httputil.ProxyRequest) {
 			req.Out.URL.Scheme = target.Scheme
@@ -699,12 +698,6 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 			req.Out.Header.Set("Livepeer-Session-Token", sessionToken)
 			req.Out.Header.Set(liveRunnerSessionControlHeader, sessionControlURL)
 		},
-		ModifyResponse: func(resp *http.Response) error {
-			resp.Header.Set(liveRunnerSessionIDHeader, sessionID)
-			resp.Header.Set(liveRunnerSessionControlHeader, sessionControlURL)
-			resp.Header.Set(liveRunnerSessionPaymentHeader, sessionPaymentURL)
-			return nil
-		},
 		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
 			respondWithError(w, err.Error(), http.StatusBadGateway)
 		},
@@ -712,27 +705,29 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 	proxy.ServeHTTP(w, r)
 }
 
-func (h *lphttp) startLiveRunnerSessionPaymentMonitor(ctx context.Context, manager liveRunnerManager, runnerID, sessionID string, payment lpnet.Payment, manifestID string) {
-	monitorCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+// startLiveRunnerSessionPaymentLoop starts the metering loop; the caller controls
+// its lifetime via the ctx it passes.
+func (h *lphttp) startLiveRunnerSessionPaymentLoop(ctx context.Context, manager liveRunnerManager, runnerID, sessionID string, payment lpnet.Payment, manifestID core.ManifestID) {
+	loopCtx, cancel := context.WithCancel(ctx)
 	paymentReceiver := livePaymentReceiver{orchestrator: h.orchestrator}
 	accountPaymentFunc := func(inPixels int64) error {
-		err := paymentReceiver.AccountPayment(monitorCtx, &SegmentInfoReceiver{
+		err := paymentReceiver.AccountPayment(loopCtx, &SegmentInfoReceiver{
 			sender:    getPaymentSender(payment),
 			inPixels:  inPixels,
 			priceInfo: payment.GetExpectedPrice(),
-			sessionID: manifestID,
+			sessionID: string(manifestID),
 		})
 		if err != nil {
-			clog.Errorf(monitorCtx, "Error accounting live runner payment, releasing session err=%v", err)
+			clog.Errorf(loopCtx, "Error accounting live runner payment, releasing session err=%v", err)
 			if releaseErr := manager.ReleaseSession(runnerID, sessionID); releaseErr != nil {
-				clog.Errorf(monitorCtx, "Error releasing live runner session after payment failure err=%v", releaseErr)
+				clog.Errorf(loopCtx, "Error releasing live runner session after payment failure err=%v", releaseErr)
 			}
 			// Stop both the ticker loop below and the LivePaymentProcessor goroutine.
 			cancel()
 		}
 		return err
 	}
-	paymentProcessor := NewLivePaymentProcessor(monitorCtx, h.node.LivePaymentInterval, accountPaymentFunc)
+	paymentProcessor := NewLivePaymentProcessor(loopCtx, h.node.LivePaymentInterval, accountPaymentFunc)
 	go func() {
 		ticker := time.NewTicker(h.node.LivePaymentInterval)
 		defer ticker.Stop()
@@ -740,13 +735,13 @@ func (h *lphttp) startLiveRunnerSessionPaymentMonitor(ctx context.Context, manag
 		for {
 			select {
 			case <-ticker.C:
-				// Stop monitoring once the live runner session has been released
+				// Stop the loop once the live runner session has been released
 				// by an explicit stop, runner cleanup, expiry, or payment failure.
 				if _, err := manager.RunnerEndpointForSession(runnerID, sessionID); err != nil {
 					return
 				}
-				paymentProcessor.process(monitorCtx)
-			case <-monitorCtx.Done():
+				paymentProcessor.process(loopCtx)
+			case <-loopCtx.Done():
 				return
 			}
 		}

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -1304,6 +1304,9 @@ func TestLiveRunnerSingleShotProxyForwardsAndReleasesCapacity(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, w.Code)
 	require.Equal(t, "single-shot", w.Body.String())
 	require.Equal(t, "ok", w.Header().Get("X-Upstream"))
+	require.Equal(t, gotSessionID, w.Header().Get(liveRunnerSessionIDHeader))
+	require.Equal(t, gotSessionControl, w.Header().Get(liveRunnerSessionControlHeader))
+	require.Equal(t, "http://localhost:1234/apps/runner-1/session/"+gotSessionID+"/payment", w.Header().Get(liveRunnerSessionPaymentHeader))
 	require.Equal(t, "/base/v1/foo/bar", gotPath)
 	require.Equal(t, "x=1&y=two", gotQuery)
 	require.Equal(t, "runner-1", gotRunnerRoute)
@@ -1317,6 +1320,76 @@ func TestLiveRunnerSingleShotProxyForwardsAndReleasesCapacity(t *testing.T) {
 	req = httptest.NewRequest(http.MethodGet, "/apps/runner-1/app/next", nil)
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusAccepted, w.Code)
+}
+
+func TestLiveRunnerSingleShotProxyOnchainReturnsPaymentChallenge(t *testing.T) {
+	lp := newLiveRunnerHTTPOnchain(t)
+	registerLiveRunnerForSession(t, lp, &liveRunnerRegistrationOptions{Mode: runner.LiveRunnerModeSingleShot})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/apps/runner-1/app/v1/foo", strings.NewReader(`{"prompt":"hi"}`))
+	setRequestHeaders(req, liveRunnerSenderHeaders(lp.orchestrator.(*stubOrchestrator)))
+	lp.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusPaymentRequired, w.Code)
+	challenge, oInfo := decodeLiveRunnerPaymentChallenge(t, w.Body.Bytes())
+	require.NotEmpty(t, challenge.ManifestID)
+	require.Equal(t, int64(10), oInfo.GetPriceInfo().GetPricePerUnit())
+	require.Equal(t, int64(1), oInfo.GetPriceInfo().GetPixelsPerUnit())
+}
+
+func TestLiveRunnerSingleShotProxyAllowsPaymentWhileRequestOpen(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("done"))
+	}))
+	defer upstream.Close()
+
+	oldStorage := drivers.NodeStorage
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
+	t.Cleanup(func() { drivers.NodeStorage = oldStorage })
+
+	lp := newLiveRunnerHTTPOnchain(t)
+	registerLiveRunnerForSession(t, lp, &liveRunnerRegistrationOptions{RunnerURL: upstream.URL, Mode: runner.LiveRunnerModeSingleShot})
+	orch := lp.orchestrator.(*stubOrchestrator)
+	orch.balances = make(map[ethcommon.Address]map[core.ManifestID]*big.Rat)
+	orch.paymentCredit = big.NewRat(100, 1)
+
+	challenge, oInfo := requestLiveRunnerPaymentChallenge(t, lp, "runner-1")
+	headers := liveRunnerReservationPaymentHeaders(t, orch, oInfo.GetAuthToken(), challenge.ManifestID)
+
+	proxyDone := make(chan int, 1)
+	go func() {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/apps/runner-1/app/hold", nil)
+		setRequestHeaders(req, headers)
+		lp.ServeHTTP(w, req)
+		proxyDone <- w.Code
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for single-shot request to reach runner")
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/apps/runner-1/session/"+challenge.ManifestID+"/payment", nil)
+	setRequestHeaders(req, headers)
+	lp.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var paymentResult lpnet.PaymentResult
+	require.NoError(t, proto.Unmarshal(w.Body.Bytes(), &paymentResult))
+	require.NotNil(t, paymentResult.GetInfo())
+	require.Equal(t, challenge.ManifestID, paymentResult.GetInfo().GetAuthToken().GetSessionId())
+
+	close(release)
+	require.Equal(t, http.StatusOK, <-proxyDone)
 }
 
 func TestLiveRunnerSingleShotProxyNoCapacityWhileRequestInFlight(t *testing.T) {

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -1304,9 +1304,6 @@ func TestLiveRunnerSingleShotProxyForwardsAndReleasesCapacity(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, w.Code)
 	require.Equal(t, "single-shot", w.Body.String())
 	require.Equal(t, "ok", w.Header().Get("X-Upstream"))
-	require.Equal(t, gotSessionID, w.Header().Get(liveRunnerSessionIDHeader))
-	require.Equal(t, gotSessionControl, w.Header().Get(liveRunnerSessionControlHeader))
-	require.Equal(t, "http://localhost:1234/apps/runner-1/session/"+gotSessionID+"/payment", w.Header().Get(liveRunnerSessionPaymentHeader))
 	require.Equal(t, "/base/v1/foo/bar", gotPath)
 	require.Equal(t, "x=1&y=two", gotQuery)
 	require.Equal(t, "runner-1", gotRunnerRoute)
@@ -1334,6 +1331,7 @@ func TestLiveRunnerSingleShotProxyOnchainReturnsPaymentChallenge(t *testing.T) {
 	require.Equal(t, http.StatusPaymentRequired, w.Code)
 	challenge, oInfo := decodeLiveRunnerPaymentChallenge(t, w.Body.Bytes())
 	require.NotEmpty(t, challenge.ManifestID)
+	require.Equal(t, int64(5000), challenge.PaymentIntervalMs)
 	require.Equal(t, int64(10), oInfo.GetPriceInfo().GetPricePerUnit())
 	require.Equal(t, int64(1), oInfo.GetPriceInfo().GetPixelsPerUnit())
 }

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -493,7 +493,7 @@ func (h *lphttp) RefreshPayment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		respondJsonError(ctx, w, err, http.StatusInternalServerError)
 		return


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Enables on-chain payments for single-shot live runner calls. Single-shot mode was functional but unpaid: `ProxyLiveRunnerSingleShot` reserved a session, proxied, and released with no payment gate. This makes single-shot (request/response and short-lived / batch) calls billable, mirroring the existing persistent (`ReserveLiveRunnerSession`) payment flow. Parity with the persistent path is intentional. The deliberate differences are the single-shot mode guard, release-on-return, the metering-loop lifetime, and the proxy (vs JSON) response.

**Specific updates (required)**
- Return a `402` payment challenge on the single-shot path (shared `runnerChallenge`), carrying ticket params, `manifest_id`, and `payment_interval_ms` (the orchestrator's debit interval).
- Process the inline payment (`Livepeer-Payment` / `Livepeer-Segment` headers) with `ProcessPayment`, reserve the session (`manifest_id` = session id), proxy to the runner, and release on return.
- Add a per-session metering loop (`startLiveRunnerSessionPaymentLoop`) that debits the prepaid balance every `LivePaymentInterval` while the request is open. Lifetime is set by the caller's context (single-shot: request ctx; persistent: `context.WithoutCancel`).
- Keep held-open (SSE / WebSocket) sessions funded via the session-scoped `POST /apps/{runner}/session/{id}/payment` endpoint.

**How did you test each of these updates (required)**

Ensured `go-livepeer` builds, tests pass and ran the new logic against this branch in the [app-examples](https://github.com/livepeer/app-examples/tree/test/single-shot-examples) repo confirming payments now work for single-shot runners.

**Does this pull request close any open issues?**

Fixes #3955

**Checklist:**
- [x] Read the [contribution guide](./CONTRIBUTING.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- ~[x] README and other documentation updated~
- ~[ ] [Pending changelog](./CHANGELOG_PENDING.md) updated~

---

**Follow-ups (out of scope, tracked separately)**
- Payment enforcement + post-release overcharge in `LivePaymentProcessor.processOne` (currently best-effort). #3982
- Client SDK: streaming `call_runner` (https://github.com/livepeer/livepeer-python-gateway/pull/25), session payment streamer (https://github.com/livepeer/livepeer-python-gateway/pull/31), single-shot WebSocket (ENG-180).
- Lower the pre paid seconds value from 60s to 10s for `single-shot`. 

_**EDIT:** Description updated to explain the PRs behavoir by @rickstaa at 14-07-2026._