### PR TITLE
feat(server): log live runner session_duration on release

### DIFF
--- a/ai/runner/live_runner.go
+++ b/ai/runner/live_runner.go
@@ -1381,6 +1381,7 @@ func (r *LiveRunnerRegistry) removeRunnerWithRunnerLocked(runnerID string, runne
 func (runner *liveRunner) releaseSessionLocked(sessionID string) {
 	// releaseSessionLocked requires runner.mu.
 	if session := runner.sessions[sessionID]; session != nil {
+		slog.Debug("live runner session released", "runner_id", runner.RunnerID, "session_id", sessionID, "mode", runner.Mode, "session_duration", time.Since(session.createdAt))
 		runner.sendSessionEvent("released", sessionID)
 		session.closeChannelsLocked()
 	}


### PR DESCRIPTION
## What

Log the reserve-to-release lifetime of a live runner session at debug level from `releaseSessionLocked` in `ai/runner/live_runner.go`.

## Why

The live-runner proxy path never logs how long a job/session took — the reverse proxy just forwards bytes, and the metering loop is a fixed-interval ticker that never measures duration. `releaseSessionLocked` is the single teardown point every release path funnels through (single-shot `defer`, persistent stop, internal cleanup, expiry, payment failure), and the session's `createdAt` timestamp already exists, so it is the one place both modes converge:

- **single-shot** → request / connection lifetime
- **persistent** → full reserve-to-stop session lifetime

Useful for reconciling metered payment intervals against how long a session actually held capacity (`session_duration / LivePaymentInterval` ≈ expected debits), and for spotting leaked or never-released sessions.

## Notes

- Debug level (`slog.Debug`) to match the file's logging idiom and avoid Info-level spam on busy orchestrators.
- No new state: reuses the existing `createdAt` on the session record.
- Stacked on `rs/single-shot-payment-review-followups`; base updated as the stack lands.