### PR TITLE
ci: bump docker metadata action

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             livepeer/go-livepeer
@@ -138,7 +138,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for builder image
         id: meta-builder
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             livepeerci/build


### PR DESCRIPTION
## Summary
- bump docker/metadata-action from v5 to v6 in Docker image workflows
- removes the Node 20 action runtime warning for metadata extraction

## Testing
- not run; workflow-only action version bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image metadata processing in the build workflow.
  * Existing image build, publishing, authentication, tagging, and caching behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->