### PR TITLE
ai: consolidate Live Runner test coverage

### DIFF
--- a/ai/runner/live_runner.go
+++ b/ai/runner/live_runner.go
@@ -32,14 +32,13 @@ const (
 	defaultLiveRunnerHealthInterval    = 5 * time.Second
 	defaultLiveRunnerHealthStatusCode  = http.StatusOK
 	defaultLiveRunnerHealthTimeout     = 3 * time.Second
+	defaultLiveRunnerO2RInterval       = 10 * time.Second
 	liveRunnerO2RKeepaliveMessage      = `{"keep":"alive"}`
 	liveRunnerIDRandomBytes            = 5
 	proxyIDRandomBytes                 = 16
 	liveRunnerSeedBytes                = 32
 	maxMetadataBytes                   = 1024
 )
-
-var liveRunnerO2RKeepaliveInterval = 10 * time.Second
 
 const (
 	LiveRunnerModePersistent      = "persistent"
@@ -268,6 +267,7 @@ type LiveRunnerRegistry struct {
 	heartbeatTTL      time.Duration
 	healthClient      *http.Client
 	healthInterval    time.Duration
+	o2rInterval       time.Duration
 	stopRegistry      chan struct{}
 	stopRegistryOnce  sync.Once
 
@@ -292,6 +292,7 @@ type LiveRunnerRegistryConfig struct {
 	Host             RunnerHost
 	Onchain          bool
 	ProxyURLTemplate string
+	O2RInterval      time.Duration
 }
 
 var liveRunnerChannelNamePattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
@@ -315,6 +316,10 @@ func NewLiveRunnerRegistry(config LiveRunnerRegistryConfig) *LiveRunnerRegistry 
 	if err != nil {
 		panic(fmt.Sprintf("invalid live runner proxy url: %v", err))
 	}
+	o2rInterval := config.O2RInterval
+	if o2rInterval <= 0 {
+		o2rInterval = defaultLiveRunnerO2RInterval
+	}
 	r := &LiveRunnerRegistry{
 		host:              config.Host,
 		offchain:          !config.Onchain,
@@ -323,6 +328,7 @@ func NewLiveRunnerRegistry(config LiveRunnerRegistryConfig) *LiveRunnerRegistry 
 		heartbeatTTL:      defaultLiveRunnerHeartbeatTTL,
 		healthClient:      &http.Client{Timeout: defaultLiveRunnerHealthTimeout},
 		healthInterval:    defaultLiveRunnerHealthInterval,
+		o2rInterval:       o2rInterval,
 		stopRegistry:      make(chan struct{}),
 		proxyTemplate:     proxyTemplate,
 	}
@@ -403,7 +409,7 @@ func (r *LiveRunnerRegistry) Heartbeat(req LiveRunnerHeartbeatRequest, auth stri
 			route:           req.RunnerID, // No label-based routing for now
 			sessions:        make(map[string]*liveRunnerSession),
 		}
-		if err := runner.setRunnerTrickleChannels(trickleSrv, trickleBaseURL, req.RunnerID); err != nil {
+		if err := runner.setRunnerTrickleChannels(trickleSrv, trickleBaseURL, req.RunnerID, r.o2rInterval); err != nil {
 			runner.closeChannelsLocked()
 			r.mu.Unlock()
 			return nil, err
@@ -1135,13 +1141,13 @@ func (r *LiveRunnerRegistry) CreateTrickleChannel(runnerID, sessionID, name, mim
 	return channel.channel, nil
 }
 
-func (runner *liveRunner) setRunnerTrickleChannels(trickleSrv *trickle.Server, trickleBaseURL, runnerID string) error {
+func (runner *liveRunner) setRunnerTrickleChannels(trickleSrv *trickle.Server, trickleBaseURL, runnerID string, o2rInterval time.Duration) error {
 	o2r, err := runner.createBootstrapTrickleChannel(trickleSrv, trickleBaseURL, runnerID, LiveRunnerTrickleOrchestratorToRunner)
 	if err != nil {
 		return err
 	}
 	runner.o2r = o2r
-	go writeO2RLoop(runner.o2r)
+	go writeO2RLoop(runner.o2r, o2rInterval)
 	return nil
 }
 
@@ -1557,8 +1563,8 @@ func (session *liveRunnerSession) closeChannelsLocked() {
 	}
 }
 
-func writeO2RLoop(channel *liveRunnerTrickleChannel) {
-	ticker := time.NewTicker(liveRunnerO2RKeepaliveInterval)
+func writeO2RLoop(channel *liveRunnerTrickleChannel, o2rInterval time.Duration) {
+	ticker := time.NewTicker(o2rInterval)
 	defer ticker.Stop()
 
 	for {

--- a/ai/runner/live_runner_test.go
+++ b/ai/runner/live_runner_test.go
@@ -8,17 +8,14 @@ import (
 	"io"
 	"math/big"
 	"math/rand"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"regexp"
 	"slices"
 	"strings"
 	"sync"
 	"testing"
-	"testing/quick"
 	"time"
 
 	"github.com/livepeer/go-livepeer/common"
@@ -113,16 +110,32 @@ func (liveRunnerTestHostWithoutSecret) RegistrationSecret() string {
 }
 
 func newLiveRunnerTestRegistry() *LiveRunnerRegistry {
-	return NewLiveRunnerRegistry(LiveRunnerRegistryConfig{Host: liveRunnerTestHost{}})
+	return newLiveRunnerTestRegistryWithConfig(LiveRunnerRegistryConfig{Host: liveRunnerTestHost{}})
+}
+
+func newLiveRunnerTestRegistryWithO2RInterval(interval time.Duration) *LiveRunnerRegistry {
+	return newLiveRunnerTestRegistryWithConfig(LiveRunnerRegistryConfig{
+		Host:        liveRunnerTestHost{},
+		O2RInterval: interval,
+	})
 }
 
 func newOnchainLiveRunnerTestRegistry() *LiveRunnerRegistry {
-	return NewLiveRunnerRegistry(LiveRunnerRegistryConfig{Host: liveRunnerTestHost{}, Onchain: true})
+	return newLiveRunnerTestRegistryWithConfig(LiveRunnerRegistryConfig{Host: liveRunnerTestHost{}, Onchain: true})
+}
+
+func newLiveRunnerTestRegistryWithConfig(config LiveRunnerRegistryConfig) *LiveRunnerRegistry {
+	registry := NewLiveRunnerRegistry(config)
+	trickleSrv := trickle.ConfigureServer(trickle.TrickleServerConfig{
+		Mux:      http.NewServeMux(),
+		BasePath: "/ai/trickle/",
+	})
+	registry.SetTrickleServer(trickleSrv, "http://localhost/ai/trickle/", "http://localhost/ai/trickle/")
+	return registry
 }
 
 func liveRunnerTestRegister(t *testing.T, registry *LiveRunnerRegistry, req LiveRunnerHeartbeatRequest) *LiveRunnerHeartbeatResponse {
 	t.Helper()
-	ensureLiveRunnerTestTrickleServer(t, registry)
 	resp, err := registry.Heartbeat(req, liveRunnerTestBootstrapSecret)
 	if err != nil {
 		t.Fatal(err)
@@ -137,20 +150,6 @@ func liveRunnerTestRegister(t *testing.T, registry *LiveRunnerRegistry, req Live
 		t.Fatalf("unexpected orchestrator URL: %s", resp.Orchestrator)
 	}
 	return resp
-}
-
-func ensureLiveRunnerTestTrickleServer(t *testing.T, registry *LiveRunnerRegistry) (string, func(string) int) {
-	t.Helper()
-	registry.mu.Lock()
-	hasTrickleServer := registry.trickleSrv != nil
-	channelBaseURL := registry.internalTrickleBaseURL
-	registry.mu.Unlock()
-	if hasTrickleServer {
-		return channelBaseURL, nil
-	}
-	trickleSrv, channelBaseURL, channelStatus := newLiveRunnerTestTrickleServer(t)
-	registry.SetTrickleServer(trickleSrv, channelBaseURL, channelBaseURL)
-	return channelBaseURL, channelStatus
 }
 
 func liveRunnerTestBootstrapChannels(resp *LiveRunnerHeartbeatResponse) []LiveRunnerTrickleChannel {
@@ -171,9 +170,9 @@ func TestLiveRunnerRegistry_HeartbeatUpsertCapacity(t *testing.T) {
 	if !liveRunnerTestGeneratedRunnerIDPattern.MatchString(resp.RunnerID) {
 		t.Fatalf("expected generated base32 runner id, got %q", resp.RunnerID)
 	}
-	runner := registry.runners[resp.RunnerID]
-	if runner == nil || runner.Capacity != 1 {
-		t.Fatalf("unexpected initial runner state: %+v", runner)
+	runners := registry.Runners()
+	if len(runners) != 1 || runners[0].Capacity != 1 {
+		t.Fatalf("unexpected initial runner state: %+v", runners)
 	}
 
 	_, err := registry.Heartbeat(LiveRunnerHeartbeatRequest{
@@ -187,9 +186,9 @@ func TestLiveRunnerRegistry_HeartbeatUpsertCapacity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	runner = registry.runners[resp.RunnerID]
-	if runner == nil || runner.Capacity != 2 {
-		t.Fatalf("unexpected heartbeat runner state: %+v", runner)
+	runners = registry.Runners()
+	if len(runners) != 1 || runners[0].Capacity != 2 {
+		t.Fatalf("unexpected heartbeat runner state: %+v", runners)
 	}
 }
 
@@ -252,9 +251,9 @@ func TestLiveRunnerRegistry_HeartbeatUnknownIDCreatesRunner(t *testing.T) {
 	if resp.RunnerID != "runner_custom_1" {
 		t.Fatalf("expected supplied runner id to be used, got %s", resp.RunnerID)
 	}
-	runner := registry.runners[resp.RunnerID]
-	if runner == nil || runner.Capacity != 1 {
-		t.Fatalf("unexpected state after create-by-unknown-id heartbeat: %+v", runner)
+	runners := registry.Runners()
+	if len(runners) != 1 || runners[0].Capacity != 1 {
+		t.Fatalf("unexpected state after create-by-unknown-id heartbeat: %+v", runners)
 	}
 }
 
@@ -296,11 +295,8 @@ func TestLiveRunnerRegistry_HeartbeatCreatesBootstrapTrickleChannels(t *testing.
 }
 
 func TestLiveRunnerRegistry_O2RKeepaliveWriteLoop(t *testing.T) {
-	restore := liveRunnerTestSetO2RKeepaliveInterval(t, 10*time.Millisecond)
-	defer restore()
-
 	trickleSrv, channelBaseURL, _ := newLiveRunnerTestTrickleServer(t)
-	registry := newLiveRunnerTestRegistry()
+	registry := newLiveRunnerTestRegistryWithO2RInterval(liveRunnerTestRandomO2RInterval())
 	t.Cleanup(registry.Stop)
 	registry.SetTrickleServer(trickleSrv, channelBaseURL, channelBaseURL)
 	resp := liveRunnerTestRegister(t, registry, liveRunnerTestHeartbeat("runner-o2r-keepalive"))
@@ -314,11 +310,8 @@ func TestLiveRunnerRegistry_O2RKeepaliveWriteLoop(t *testing.T) {
 }
 
 func TestLiveRunnerRegistry_O2RSessionLifecycleMessages(t *testing.T) {
-	restore := liveRunnerTestSetO2RKeepaliveInterval(t, time.Hour)
-	defer restore()
-
 	trickleSrv, channelBaseURL, _ := newLiveRunnerTestTrickleServer(t)
-	registry := newLiveRunnerTestRegistry()
+	registry := newLiveRunnerTestRegistryWithO2RInterval(liveRunnerTestQuietO2RInterval())
 	t.Cleanup(registry.Stop)
 	registry.SetTrickleServer(trickleSrv, channelBaseURL, channelBaseURL)
 	req := liveRunnerTestHeartbeat("runner-o2r-session")
@@ -338,28 +331,20 @@ func TestLiveRunnerRegistry_O2RSessionLifecycleMessages(t *testing.T) {
 }
 
 func TestLiveRunnerRegistry_O2RWriteLoopClosesOnUnregister(t *testing.T) {
-	restore := liveRunnerTestSetO2RKeepaliveInterval(t, time.Hour)
-	defer restore()
-
-	registry := newLiveRunnerTestRegistry()
+	trickleSrv, channelBaseURL, channelStatus := newLiveRunnerTestTrickleServer(t)
+	registry := newLiveRunnerTestRegistryWithO2RInterval(liveRunnerTestQuietO2RInterval())
 	t.Cleanup(registry.Stop)
+	registry.SetTrickleServer(trickleSrv, channelBaseURL, channelBaseURL)
 	resp := liveRunnerTestRegister(t, registry, liveRunnerTestHeartbeat("runner-o2r-close"))
-
-	registry.mu.Lock()
-	runner := registry.runners["runner-o2r-close"]
-	registry.mu.Unlock()
-	if runner == nil || runner.o2r == nil {
-		t.Fatal("expected registered runner with o2r channel")
+	if status := channelStatus(resp.O2R.ChannelName); status != http.StatusOK {
+		t.Fatalf("expected o2r channel to exist, got status=%d", status)
 	}
-	o2r := runner.o2r
 
 	if err := registry.Unregister("runner-o2r-close", resp.HeartbeatSecret); err != nil {
 		t.Fatal(err)
 	}
-	select {
-	case <-o2r.done:
-	case <-time.After(time.Second):
-		t.Fatal("expected o2r write loop to close on unregister")
+	if status := channelStatus(resp.O2R.ChannelName); status != http.StatusNotFound {
+		t.Fatalf("expected unregister to close o2r channel, got status=%d", status)
 	}
 }
 
@@ -374,14 +359,6 @@ func TestLiveRunnerRegistry_HeartbeatDoesNotReturnBootstrapChannelsAgain(t *test
 	if nextResp.O2R != nil {
 		t.Fatalf("expected no bootstrap channels on follow-up heartbeat, got %+v", nextResp)
 	}
-	registry.mu.Lock()
-	runner := registry.runners[resp.RunnerID]
-	registry.mu.Unlock()
-	runner.mu.Lock()
-	defer runner.mu.Unlock()
-	if runner.o2r == nil {
-		t.Fatalf("expected existing bootstrap channel to be preserved, got o2r=%+v", runner.o2r)
-	}
 }
 
 func TestLiveRunnerRegistry_HeartbeatSessionIDs(t *testing.T) {
@@ -393,15 +370,6 @@ func TestLiveRunnerRegistry_HeartbeatSessionIDs(t *testing.T) {
 	if len(resp.SessionIDs) != 0 {
 		t.Fatalf("expected no active session ids on initial heartbeat, got %+v", resp.SessionIDs)
 	}
-
-	registry.mu.Lock()
-	runner := registry.runners[resp.RunnerID]
-	registry.mu.Unlock()
-	runner.mu.Lock()
-	if !slices.Equal(runner.LiveRunnerHeartbeatRequest.SessionIDs, []string{"runner-reported-session"}) {
-		t.Fatalf("expected request session_ids to be retained, got %+v", runner.LiveRunnerHeartbeatRequest.SessionIDs)
-	}
-	runner.mu.Unlock()
 
 	if _, _, err := registry.ReserveSession(resp.RunnerID, "session-z-oldest"); err != nil {
 		t.Fatal(err)
@@ -421,15 +389,6 @@ func TestLiveRunnerRegistry_HeartbeatSessionIDs(t *testing.T) {
 	want := []string{"session-z-oldest", "session-a-newest"}
 	if !slices.Equal(nextResp.SessionIDs, want) {
 		t.Fatalf("unexpected session ids: got %+v want %+v", nextResp.SessionIDs, want)
-	}
-
-	registry.mu.Lock()
-	runner = registry.runners[resp.RunnerID]
-	registry.mu.Unlock()
-	runner.mu.Lock()
-	defer runner.mu.Unlock()
-	if !slices.Equal(runner.LiveRunnerHeartbeatRequest.SessionIDs, []string{"runner-reported-session"}) {
-		t.Fatalf("expected follow-up request session_ids to be retained, got %+v", runner.LiveRunnerHeartbeatRequest.SessionIDs)
 	}
 }
 
@@ -498,12 +457,10 @@ func TestLiveRunnerRegistry_DefaultCapacityWhenUnset(t *testing.T) {
 	req := liveRunnerTestHeartbeat("runner_default_capacity")
 	req.Capacity = 0
 
-	resp := liveRunnerTestRegister(t, registry, req)
-	registry.mu.Lock()
-	runner := registry.runners[resp.RunnerID]
-	registry.mu.Unlock()
-	if runner == nil || runner.Capacity != 1 {
-		t.Fatalf("expected default capacity=1, got %+v", runner)
+	liveRunnerTestRegister(t, registry, req)
+	runners := registry.Runners()
+	if len(runners) != 1 || runners[0].Capacity != 1 {
+		t.Fatalf("expected default capacity=1, got %+v", runners)
 	}
 }
 
@@ -600,31 +557,31 @@ func TestLiveRunnerRegistry_MetadataValidationReturnsBadRequest(t *testing.T) {
 	}
 }
 
-func TestLiveRunnerRegistry_DefaultModeWhenUnset(t *testing.T) {
-	registry := newLiveRunnerTestRegistry()
-	resp := liveRunnerTestRegister(t, registry, liveRunnerTestHeartbeat("runner_default_mode"))
-
-	mode, err := registry.RunnerMode(resp.RunnerID)
-	if err != nil {
-		t.Fatal(err)
+func TestLiveRunnerRegistry_HeartbeatModes(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		want string
+	}{
+		{name: "default", want: LiveRunnerModePersistent},
+		{name: "explicit persistent", mode: LiveRunnerModePersistent, want: LiveRunnerModePersistent},
+		{name: "single shot", mode: LiveRunnerModeSingleShot, want: LiveRunnerModeSingleShot},
+		{name: "single shot alias", mode: "single_shot", want: LiveRunnerModeSingleShot},
 	}
-	if mode != LiveRunnerModePersistent {
-		t.Fatalf("expected default mode %q, got %q", LiveRunnerModePersistent, mode)
-	}
-}
-
-func TestLiveRunnerRegistry_HeartbeatSingleShotMode(t *testing.T) {
-	registry := newLiveRunnerTestRegistry()
-	req := liveRunnerTestHeartbeat("runner-single-shot")
-	req.Mode = LiveRunnerModeSingleShot
-	resp := liveRunnerTestRegister(t, registry, req)
-
-	mode, err := registry.RunnerMode(resp.RunnerID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if mode != LiveRunnerModeSingleShot {
-		t.Fatalf("expected mode %q, got %q", LiveRunnerModeSingleShot, mode)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := newLiveRunnerTestRegistry()
+			req := liveRunnerTestHeartbeat("runner-" + strings.ReplaceAll(test.name, " ", "-"))
+			req.Mode = test.mode
+			resp := liveRunnerTestRegister(t, registry, req)
+			mode, err := registry.RunnerMode(resp.RunnerID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if mode != test.want {
+				t.Fatalf("expected mode %q, got %q", test.want, mode)
+			}
+		})
 	}
 }
 
@@ -646,21 +603,6 @@ func TestLiveRunnerRegistry_HeartbeatSingleShotProxyUsesRunnerIDRoute(t *testing
 	}
 	if !matched || route.LocalPath != "/apps/runner-single-shot-proxy/app/v1/foo" {
 		t.Fatalf("unexpected dynamic proxy route: matched=%v route=%+v", matched, route)
-	}
-}
-
-func TestLiveRunnerRegistry_HeartbeatSingleShotModeAlias(t *testing.T) {
-	registry := newLiveRunnerTestRegistry()
-	req := liveRunnerTestHeartbeat("runner-single-shot-alias")
-	req.Mode = "single_shot"
-	resp := liveRunnerTestRegister(t, registry, req)
-
-	mode, err := registry.RunnerMode(resp.RunnerID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if mode != LiveRunnerModeSingleShot {
-		t.Fatalf("expected mode %q, got %q", LiveRunnerModeSingleShot, mode)
 	}
 }
 
@@ -694,38 +636,6 @@ func TestLiveRunnerRegistry_OnchainRequiresStaticRunnerPriceInfo(t *testing.T) {
 	}}})
 	if !isRunnerErrorStatus(err, http.StatusBadRequest) || !strings.Contains(err.Error(), "price_info") {
 		t.Fatalf("expected missing price_info bad request, got %v", err)
-	}
-}
-
-func TestLiveRunnerRegistry_OnchainDefaultsPriceCurrencyAndUnit(t *testing.T) {
-	registry := newOnchainLiveRunnerTestRegistry()
-	req := liveRunnerTestHeartbeat("runner-usd-price")
-	req.PriceInfo = LiveRunnerPriceInfo{Price: json.Number("10")}
-
-	liveRunnerTestRegister(t, registry, req)
-	runner, unlock, err := registry.lockLiveRunner("runner-usd-price")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer unlock()
-	if runner.PriceInfo != (LiveRunnerPriceInfo{Price: json.Number("10"), Currency: "usd", Unit: "hour"}) {
-		t.Fatalf("unexpected runner price info: %+v", runner.PriceInfo)
-	}
-}
-
-func TestLiveRunnerRegistry_OnchainNormalizes720pPriceUnit(t *testing.T) {
-	registry := newOnchainLiveRunnerTestRegistry()
-	req := liveRunnerTestHeartbeat("runner-720p-price")
-	req.PriceInfo = LiveRunnerPriceInfo{Price: json.Number("10"), Unit: "720p"}
-
-	liveRunnerTestRegister(t, registry, req)
-	runner, unlock, err := registry.lockLiveRunner("runner-720p-price")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer unlock()
-	if runner.PriceInfo != (LiveRunnerPriceInfo{Price: json.Number("10"), Currency: "usd", Unit: "720p"}) {
-		t.Fatalf("unexpected runner price info: %+v", runner.PriceInfo)
 	}
 }
 
@@ -1426,90 +1336,43 @@ func TestLiveRunnerRegistry_ConvertsUSDToWEI(t *testing.T) {
 	core.PriceFeedWatcher = stubPriceFeedWatcher{price: eth.PriceData{Price: big.NewRat(2000, 1)}}
 	defer func() { core.PriceFeedWatcher = prevWatcher }()
 
-	registry := newOnchainLiveRunnerTestRegistry()
-	req := liveRunnerTestHeartbeat("runner-1")
-	req.PriceInfo = LiveRunnerPriceInfo{Price: json.Number("10")}
-	liveRunnerTestRegister(t, registry, req)
+	tests := []struct {
+		name        string
+		inputUnit   string
+		outputUnit  string
+		unitDivisor int64
+	}{
+		{name: "default hour", outputUnit: "seconds", unitDivisor: 3600},
+		{name: "720p", inputUnit: "720p", outputUnit: "720p-pixel-seconds", unitDivisor: 3600 * 1280 * 720 * 30},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := newOnchainLiveRunnerTestRegistry()
+			req := liveRunnerTestHeartbeat("runner-" + test.outputUnit)
+			req.PriceInfo = LiveRunnerPriceInfo{Price: json.Number("10"), Unit: test.inputUnit}
+			liveRunnerTestRegister(t, registry, req)
 
-	paymentInfo, err := registry.PaymentInfo("runner-1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if paymentInfo == nil {
-		t.Fatal("expected payment price info")
-	}
-	expected, err := common.PriceToInt64(big.NewRat(5_000_000_000_000_000, 3600))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := paymentInfo.Price.String(); got != expected.Num().String() {
-		t.Fatalf("unexpected converted price: got=%s want=%s", got, expected.Num().String())
-	}
-	if paymentInfo.Currency != "wei" || paymentInfo.Unit != "seconds" {
-		t.Fatalf("unexpected converted price info: %+v", paymentInfo)
-	}
-}
-
-func TestLiveRunnerRegistry_Converts720pUnitAsPerPixelPrice(t *testing.T) {
-	prevWatcher := core.PriceFeedWatcher
-	core.PriceFeedWatcher = stubPriceFeedWatcher{price: eth.PriceData{Price: big.NewRat(2000, 1)}}
-	defer func() { core.PriceFeedWatcher = prevWatcher }()
-
-	registry := newOnchainLiveRunnerTestRegistry()
-	req := liveRunnerTestHeartbeat("runner-720p")
-	req.PriceInfo = LiveRunnerPriceInfo{Price: json.Number("10"), Unit: "720p"}
-	liveRunnerTestRegister(t, registry, req)
-
-	paymentInfo, err := registry.PaymentInfo("runner-720p")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if paymentInfo == nil {
-		t.Fatal("expected payment price info")
-	}
-	expected, err := common.PriceToInt64(big.NewRat(5_000_000_000_000_000, 3600*1280*720*30))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := paymentInfo.Price.String(); got != expected.Num().String() {
-		t.Fatalf("unexpected converted price: got=%s want=%s", got, expected.Num().String())
-	}
-	if paymentInfo.Currency != "wei" || paymentInfo.Unit != "720p-pixel-seconds" {
-		t.Fatalf("unexpected converted 720p price info: %+v", paymentInfo)
-	}
-}
-
-func TestLiveRunnerRegistry_ScopeRunnerUsesLivePriceConversion(t *testing.T) {
-	prevWatcher := core.PriceFeedWatcher
-	core.PriceFeedWatcher = stubPriceFeedWatcher{price: eth.PriceData{Price: big.NewRat(2000, 1)}}
-	defer func() { core.PriceFeedWatcher = prevWatcher }()
-
-	registry := newOnchainLiveRunnerTestRegistry()
-	req := liveRunnerTestHeartbeat("scope-runner")
-	req.App = "live-video-to-video/scope"
-	req.PriceInfo = LiveRunnerPriceInfo{Price: json.Number("10")}
-	liveRunnerTestRegister(t, registry, req)
-
-	paymentInfo, err := registry.PaymentInfo("scope-runner")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if paymentInfo == nil {
-		t.Fatal("expected payment price info")
-	}
-	expected, err := common.PriceToInt64(big.NewRat(5_000_000_000_000_000, 3600))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := paymentInfo.Price.String(); got != expected.Num().String() {
-		t.Fatalf("unexpected converted scope live runner price: got=%s want=%s", got, expected.Num().String())
-	}
-	if paymentInfo.Currency != "wei" || paymentInfo.Unit != "seconds" {
-		t.Fatalf("unexpected converted scope live runner price info: %+v", paymentInfo)
+			paymentInfo, err := registry.PaymentInfo(req.RunnerID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expected, err := common.PriceToInt64(big.NewRat(5_000_000_000_000_000, test.unitDivisor))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if paymentInfo == nil || paymentInfo.Price.String() != expected.Num().String() ||
+				paymentInfo.Currency != "wei" || paymentInfo.Unit != test.outputUnit {
+				t.Fatalf("unexpected converted price info: %+v", paymentInfo)
+			}
+		})
 	}
 }
 
 func TestLiveRunnerRegistry_SharedURLAppKeepsPerRunnerPrices(t *testing.T) {
+	prevWatcher := core.PriceFeedWatcher
+	core.PriceFeedWatcher = stubPriceFeedWatcher{price: eth.PriceData{Price: big.NewRat(2000, 1)}}
+	defer func() { core.PriceFeedWatcher = prevWatcher }()
+
 	registry := newOnchainLiveRunnerTestRegistry()
 
 	req1 := liveRunnerTestHeartbeat("runner-1")
@@ -1519,16 +1382,19 @@ func TestLiveRunnerRegistry_SharedURLAppKeepsPerRunnerPrices(t *testing.T) {
 	resp1 := liveRunnerTestRegister(t, registry, req1)
 	liveRunnerTestRegister(t, registry, req2)
 
-	if err := registry.Unregister("runner-1", resp1.HeartbeatSecret); err != nil {
-		t.Fatal(err)
-	}
-	runner, unlock, err := registry.lockLiveRunner("runner-2")
+	before, err := registry.PaymentInfo("runner-2")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer unlock()
-	if got := runner.PriceInfo.Price.String(); got != "20" {
-		t.Fatalf("expected remaining runner price to stay isolated, got %s", got)
+	if err := registry.Unregister("runner-1", resp1.HeartbeatSecret); err != nil {
+		t.Fatal(err)
+	}
+	after, err := registry.PaymentInfo("runner-2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before == nil || after == nil || *before != *after {
+		t.Fatalf("expected remaining runner price to stay isolated: before=%+v after=%+v", before, after)
 	}
 }
 
@@ -1554,13 +1420,6 @@ func TestLiveRunnerRegistry_ReserveSessionCapacity(t *testing.T) {
 	}
 	if sessionID1 == sessionID2 {
 		t.Fatalf("expected unique session IDs, got %s", sessionID1)
-	}
-
-	registry.mu.Lock()
-	active := len(registry.runners["runner-1"].sessions)
-	registry.mu.Unlock()
-	if active != 2 {
-		t.Fatalf("expected 2 active sessions, got %d", active)
 	}
 
 	if _, _, err := registry.ReserveSession("runner-1"); !isRunnerErrorStatus(err, http.StatusServiceUnavailable) {
@@ -1743,7 +1602,7 @@ func TestLiveRunnerRegistry_CreateSessionProxyDefaultPath(t *testing.T) {
 }
 
 func TestLiveRunnerRegistry_CreateSessionProxyHostTemplate(t *testing.T) {
-	registry := NewLiveRunnerRegistry(LiveRunnerRegistryConfig{
+	registry := newLiveRunnerTestRegistryWithConfig(LiveRunnerRegistryConfig{
 		Host:             liveRunnerTestHost{},
 		ProxyURLTemplate: "https://{proxy}.daydream.example.com",
 	})
@@ -1919,37 +1778,6 @@ func TestProxyURLTemplateProxyIDAndAppPathBroadInputs(t *testing.T) {
 	}
 }
 
-func TestProxyURLTemplateProxyIDAndAppPathQuick(t *testing.T) {
-	serviceURI, _ := url.Parse("http://localhost:1234")
-	pathTmpl, err := parseProxyURLTemplate("", serviceURI)
-	if err != nil {
-		t.Fatal(err)
-	}
-	hostTmpl, err := parseProxyURLTemplate("https://edge-{proxy}.daydream.example.com/proxy", serviceURI)
-	if err != nil {
-		t.Fatal(err)
-	}
-	config := &quick.Config{MaxCount: 5000}
-
-	t.Run("path template", func(t *testing.T) {
-		err := quick.Check(func(req proxyPathTemplateRequest) bool {
-			return proxyExtractionMatchesExpected(pathTmpl, req.Host, req.Path)
-		}, config)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	t.Run("host template", func(t *testing.T) {
-		err := quick.Check(func(req proxyHostTemplateRequest) bool {
-			return proxyExtractionMatchesExpected(hostTmpl, req.Host, req.Path)
-		}, config)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-}
-
 func BenchmarkProxyURLTemplateExtraction(b *testing.B) {
 	serviceURI, _ := url.Parse("http://localhost:1234")
 	pathTmpl, err := parseProxyURLTemplate("", serviceURI)
@@ -1984,69 +1812,6 @@ func BenchmarkProxyURLTemplateExtraction(b *testing.B) {
 	})
 }
 
-type proxyPathTemplateRequest struct {
-	Host string
-	Path string
-}
-
-func (proxyPathTemplateRequest) Generate(r *rand.Rand, size int) reflect.Value {
-	req := proxyPathTemplateRequest{
-		Host: randomUserSuppliedString(r, size),
-		Path: randomUserSuppliedString(r, size),
-	}
-	switch r.Intn(6) {
-	case 0, 1:
-		req.Host = randomCase(r, "localhost:1234")
-		req.Path = "/run/" + randomNonEmptyPathSegment(r, size)
-		if r.Intn(2) == 0 {
-			req.Path += "/" + randomUserSuppliedString(r, size)
-		}
-	case 2:
-		req.Host = randomCase(r, "localhost:1234")
-		req.Path = "/run/"
-	case 3:
-		req.Host = randomUserSuppliedString(r, size)
-		req.Path = "/run/" + randomNonEmptyPathSegment(r, size)
-	case 4:
-		req.Host = randomCase(r, "localhost:1234")
-		req.Path = "/" + randomUserSuppliedString(r, size)
-	}
-	return reflect.ValueOf(req)
-}
-
-type proxyHostTemplateRequest struct {
-	Host string
-	Path string
-}
-
-func (proxyHostTemplateRequest) Generate(r *rand.Rand, size int) reflect.Value {
-	req := proxyHostTemplateRequest{
-		Host: randomUserSuppliedString(r, size),
-		Path: randomUserSuppliedString(r, size),
-	}
-	switch r.Intn(6) {
-	case 0, 1:
-		req.Host = randomCase(r, "edge-"+randomNonEmptyHostProxyID(r, size)+".daydream.example.com")
-		if r.Intn(3) == 0 {
-			req.Host += ":443"
-		}
-		req.Path = "/proxy"
-		if r.Intn(2) == 0 {
-			req.Path += "/" + randomUserSuppliedString(r, size)
-		}
-	case 2:
-		req.Host = randomCase(r, "edge-.daydream.example.com")
-		req.Path = "/proxy/" + randomUserSuppliedString(r, size)
-	case 3:
-		req.Host = randomCase(r, "edge-"+randomNonEmptyHostProxyID(r, size)+".daydream.example.com")
-		req.Path = "/proxyish/" + randomUserSuppliedString(r, size)
-	case 4:
-		req.Host = randomUserSuppliedString(r, size)
-		req.Path = "/proxy/" + randomUserSuppliedString(r, size)
-	}
-	return reflect.ValueOf(req)
-}
-
 type proxyBenchmarkRequest struct {
 	host string
 	path string
@@ -2057,129 +1822,6 @@ var (
 	benchmarkAppPath string
 	benchmarkMatched bool
 )
-
-func proxyExtractionMatchesExpected(tmpl proxyURLTemplate, host, path string) bool {
-	gotProxyID, gotAppPath, gotMatched := tmpl.proxyIDAndAppPath(host, path)
-	wantProxyID, wantAppPath, wantMatched := expectedProxyIDAndAppPath(tmpl, host, path)
-	return gotProxyID == wantProxyID && gotAppPath == wantAppPath && gotMatched == wantMatched
-}
-
-func expectedProxyIDAndAppPath(tmpl proxyURLTemplate, host, path string) (string, string, bool) {
-	if tmpl.placeholderInHost {
-		requestHost := expectedStripHostPort(host)
-		start := len(tmpl.hostPrefix)
-		end := len(requestHost) - len(tmpl.hostSuffix)
-		if start >= end {
-			return "", "", false
-		}
-		if !strings.EqualFold(requestHost[:start], tmpl.hostPrefix) || !strings.EqualFold(requestHost[end:], tmpl.hostSuffix) {
-			return "", "", false
-		}
-		appPath, ok := expectedStripProxyPathPrefix(path, tmpl.staticPath)
-		if !ok {
-			return "", "", false
-		}
-		return strings.ToLower(requestHost[start:end]), appPath, true
-	}
-	if !strings.EqualFold(tmpl.host, host) || !strings.HasPrefix(path, tmpl.pathPrefix) {
-		return "", "", false
-	}
-	rest := path[len(tmpl.pathPrefix):]
-	if rest == "" {
-		return "", "", false
-	}
-	slash := strings.IndexByte(rest, '/')
-	if slash < 0 {
-		return rest, "", true
-	}
-	if slash == 0 {
-		return "", "", false
-	}
-	return rest[:slash], rest[slash+1:], true
-}
-
-func expectedStripHostPort(host string) string {
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		return h
-	}
-	return host
-}
-
-func expectedStripProxyPathPrefix(path, prefix string) (string, bool) {
-	if prefix == "" {
-		return strings.TrimPrefix(path, "/"), true
-	}
-	if path == prefix {
-		return "", true
-	}
-	if strings.HasPrefix(path, prefix+"/") {
-		return strings.TrimPrefix(path[len(prefix):], "/"), true
-	}
-	return "", false
-}
-
-func randomUserSuppliedString(r *rand.Rand, size int) string {
-	maxLen := size + 8
-	if maxLen > 96 {
-		maxLen = 96
-	}
-	n := r.Intn(maxLen + 1)
-	var b strings.Builder
-	b.Grow(n)
-	for i := 0; i < n; i++ {
-		switch r.Intn(8) {
-		case 0:
-			b.WriteByte(byte(r.Intn(32)))
-		case 1:
-			b.WriteByte(byte(127 + r.Intn(129)))
-		case 2:
-			b.WriteRune([]rune{'/', '?', '#', '[', ']', '@', ':', '%', ' ', '\t', '\n'}[r.Intn(11)])
-		case 3:
-			b.WriteString("%2F")
-		case 4:
-			b.WriteRune([]rune{'é', 'ø', '中', '☃'}[r.Intn(4)])
-		default:
-			const ascii = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~!$&'()*+,;="
-			b.WriteByte(ascii[r.Intn(len(ascii))])
-		}
-	}
-	return b.String()
-}
-
-func randomNonEmptyPathSegment(r *rand.Rand, size int) string {
-	for i := 0; i < 10; i++ {
-		s := strings.ReplaceAll(randomUserSuppliedString(r, size), "/", "")
-		if s != "" {
-			return s
-		}
-	}
-	return "x"
-}
-
-func randomNonEmptyHostProxyID(r *rand.Rand, size int) string {
-	for i := 0; i < 10; i++ {
-		s := strings.Map(func(ch rune) rune {
-			if ch == ':' {
-				return -1
-			}
-			return ch
-		}, randomUserSuppliedString(r, size))
-		if s != "" {
-			return s
-		}
-	}
-	return "x"
-}
-
-func randomCase(r *rand.Rand, s string) string {
-	b := []byte(s)
-	for i, ch := range b {
-		if 'a' <= ch && ch <= 'z' && r.Intn(2) == 0 {
-			b[i] = ch - 'a' + 'A'
-		}
-	}
-	return string(b)
-}
 
 func benchmarkProxyExtraction(b *testing.B, requests []proxyBenchmarkRequest, extract func(string, string) (string, string, bool)) {
 	b.ReportAllocs()
@@ -2537,13 +2179,14 @@ func TestLiveRunnerRegistry_ExpireAndUnregisterClearSessions(t *testing.T) {
 
 	registry.heartbeatTTL = defaultLiveRunnerHeartbeatTTL
 	resp2 := liveRunnerTestRegister(t, registry, liveRunnerTestHeartbeat("runner-2"))
-	if _, _, err := registry.ReserveSession("runner-2"); err != nil {
+	sessionID2, _, err := registry.ReserveSession("runner-2")
+	if err != nil {
 		t.Fatal(err)
 	}
 	if err := registry.Unregister("runner-2", resp2.HeartbeatSecret); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := registry.RunnerEndpointForSession("runner-2", sessionID); !isRunnerErrorStatus(err, http.StatusNotFound) {
+	if _, err := registry.RunnerEndpointForSession("runner-2", sessionID2); !isRunnerErrorStatus(err, http.StatusNotFound) {
 		t.Fatalf("expected unregistered runner to be removed, got %v", err)
 	}
 }
@@ -2643,13 +2286,12 @@ func newLiveRunnerTestTrickleServer(t *testing.T) (*trickle.Server, string, func
 	return trickleSrv, channelBaseURL, channelStatus
 }
 
-func liveRunnerTestSetO2RKeepaliveInterval(t *testing.T, interval time.Duration) func() {
-	t.Helper()
-	previous := liveRunnerO2RKeepaliveInterval
-	liveRunnerO2RKeepaliveInterval = interval
-	return func() {
-		liveRunnerO2RKeepaliveInterval = previous
-	}
+func liveRunnerTestRandomO2RInterval() time.Duration {
+	return time.Duration(5+rand.Intn(21)) * time.Millisecond
+}
+
+func liveRunnerTestQuietO2RInterval() time.Duration {
+	return time.Hour + time.Duration(rand.Intn(60))*time.Minute
 }
 
 func liveRunnerTestReadTrickleMessage(t *testing.T, trickleSrv *trickle.Server, channelName string, match func(string) bool) string {

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -67,71 +67,45 @@ func (s stubPriceFeedWatcher) Current() (eth.PriceData, error) {
 
 func (s stubPriceFeedWatcher) Subscribe(context.Context, chan<- eth.PriceData) {}
 
-func TestAIWorkerResults_ErrorsWhenAuthHeaderMissing(t *testing.T) {
-	var l lphttp
+func TestAIWorkerResultsValidation(t *testing.T) {
+	tests := []struct {
+		name         string
+		orchestrator bool
+		mutate       func(http.Header)
+		status       int
+		message      string
+	}{
+		{name: "missing auth", status: http.StatusUnauthorized, message: "Unauthorized"},
+		{name: "invalid credentials", orchestrator: true, mutate: func(headers http.Header) {
+			headers.Set("Credentials", "BAD CREDENTIALS")
+		}, status: http.StatusUnauthorized, message: "invalid secret"},
+		{name: "missing content type", orchestrator: true, mutate: func(headers http.Header) {
+			headers.Del("Content-Type")
+		}, status: http.StatusUnsupportedMediaType, message: "mime: no media type"},
+		{name: "missing task ID", orchestrator: true, mutate: func(headers http.Header) {
+			headers.Del("TaskId")
+		}, status: http.StatusBadRequest, message: "Invalid Task ID"},
+	}
 
-	var w = httptest.NewRecorder()
-	r, err := http.NewRequest(http.MethodPost, "/aiResults", nil)
-	require.NoError(t, err)
-
-	code, body := aiResultsTest(l, w, r)
-
-	require.Equal(t, http.StatusUnauthorized, code)
-	require.Contains(t, body, "Unauthorized")
-}
-
-func TestAIWorkerResults_ErrorsWhenCredentialsInvalid(t *testing.T) {
-	var l lphttp
-	l.orchestrator = newStubOrchestrator()
-	l.orchestrator.TranscoderSecret()
-	var w = httptest.NewRecorder()
-
-	r, err := http.NewRequest(http.MethodPost, "/aiResults", nil)
-	require.NoError(t, err)
-
-	r.Header.Set("Authorization", protoVerAIWorker)
-	r.Header.Set("Credentials", "BAD CREDENTIALS")
-
-	code, body := aiResultsTest(l, w, r)
-	require.Equal(t, http.StatusUnauthorized, code)
-	require.Contains(t, body, "invalid secret")
-}
-
-func TestAIWorkerResults_ErrorsWhenContentTypeMissing(t *testing.T) {
-	var l lphttp
-	l.orchestrator = newStubOrchestrator()
-	l.orchestrator.TranscoderSecret()
-	var w = httptest.NewRecorder()
-
-	r, err := http.NewRequest(http.MethodPost, "/aiResults", nil)
-	require.NoError(t, err)
-
-	r.Header.Set("Authorization", protoVerAIWorker)
-	r.Header.Set("Credentials", "")
-
-	code, body := aiResultsTest(l, w, r)
-
-	require.Equal(t, http.StatusUnsupportedMediaType, code)
-	require.Contains(t, body, "mime: no media type")
-}
-
-func TestAIWorkerResults_ErrorsWhenTaskIDMissing(t *testing.T) {
-	var l lphttp
-	l.orchestrator = newStubOrchestrator()
-	l.orchestrator.TranscoderSecret()
-	var w = httptest.NewRecorder()
-
-	r, err := http.NewRequest(http.MethodPost, "/aiResults", nil)
-	require.NoError(t, err)
-
-	r.Header.Set("Authorization", protoVerAIWorker)
-	r.Header.Set("Credentials", "")
-	r.Header.Set("Content-Type", "application/json")
-
-	code, body := aiResultsTest(l, w, r)
-
-	require.Equal(t, http.StatusBadRequest, code)
-	require.Contains(t, body, "Invalid Task ID")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var l lphttp
+			req := httptest.NewRequest(http.MethodPost, "/aiResults", nil)
+			if test.orchestrator {
+				l.orchestrator = newStubOrchestrator()
+				req.Header.Set("Authorization", protoVerAIWorker)
+				req.Header.Set("Credentials", l.orchestrator.TranscoderSecret())
+				req.Header.Set("Content-Type", aiWorkerErrorMimeType)
+				req.Header.Set("TaskId", "1")
+			}
+			if test.mutate != nil {
+				test.mutate(req.Header)
+			}
+			code, body := aiResultsTest(l, httptest.NewRecorder(), req)
+			require.Equal(t, test.status, code)
+			require.Contains(t, body, test.message)
+		})
+	}
 }
 
 func TestAIWorkerResults_BadRequestType(t *testing.T) {
@@ -323,45 +297,6 @@ func TestLiveRunnerDiscoveryOnchainIncludesPriceInfo(t *testing.T) {
 	require.Equal(t, "wei", resp[0].Runners[0].PriceInfo.Currency)
 	require.Equal(t, "seconds", resp[0].Runners[0].PriceInfo.Unit)
 	require.Contains(t, w.Body.String(), "price_info")
-}
-
-func TestLiveRunnerDiscoveryOnchainConverts720pPriceToPixel(t *testing.T) {
-	lp := newLiveRunnerHTTP(t, true)
-	manager := runner.NewLiveRunnerRegistry(runner.LiveRunnerRegistryConfig{Host: testLiveRunnerHost{orchestrator: lp.orchestrator}, Onchain: true})
-	t.Cleanup(manager.Stop)
-	lp.node.LiveRunnerManager = manager
-	trickleBaseURL := lp.orchestrator.ServiceURI().JoinPath(TrickleHTTPPath).String()
-	manager.SetTrickleServer(lp.trickleSrv, trickleBaseURL, trickleBaseURL)
-	prevWatcher := core.PriceFeedWatcher
-	core.PriceFeedWatcher = stubPriceFeedWatcher{price: eth.PriceData{Price: big.NewRat(2000, 1)}}
-	defer func() { core.PriceFeedWatcher = prevWatcher }()
-	_, err := manager.Heartbeat(runner.LiveRunnerHeartbeatRequest{
-		RunnerID:  t.Name(),
-		RunnerURL: "https://runner.example.com",
-		Version:   "1.2.3",
-		Status:    "ready",
-		App:       "live-video-to-video/scope",
-		Capacity:  2,
-		PriceInfo: runner.LiveRunnerPriceInfo{
-			Price: json.Number("0.001990656"),
-			Unit:  "720p",
-		},
-	}, lp.orchestrator.RegistrationSecret())
-	require.NoError(t, err)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/discovery", nil)
-	lp.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusOK, w.Code)
-	var resp []liveRunnerDiscoveryEntry
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.Len(t, resp, 1)
-	require.Len(t, resp[0].Runners, 1)
-	require.NotNil(t, resp[0].Runners[0].PriceInfo)
-	require.Equal(t, "10", resp[0].Runners[0].PriceInfo.Price.String())
-	require.Equal(t, "wei", resp[0].Runners[0].PriceInfo.Currency)
-	require.Equal(t, "720p-pixel-seconds", resp[0].Runners[0].PriceInfo.Unit)
 }
 
 func TestLiveRunnerDiscoveryServerlessWorker(t *testing.T) {
@@ -738,43 +673,6 @@ func TestLiveRunnerReserveSessionOnchainReturnsPaymentChallenge(t *testing.T) {
 	require.Nil(t, oInfo.GetCapabilities())
 }
 
-func TestRunnerOrchInfoUsesWeiSecondsPrice(t *testing.T) {
-	lp := newLiveRunnerHTTPOnchain(t)
-	orch := lp.orchestrator.(*stubOrchestrator)
-
-	oInfo, err := lp.runnerOrchInfo(orch.Address(), &runner.LiveRunnerPriceInfo{
-		Price:    json.Number("10"),
-		Currency: "wei",
-		Unit:     "seconds",
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, oInfo.GetPriceInfo())
-	require.Equal(t, int64(10), oInfo.GetPriceInfo().GetPricePerUnit())
-	require.Equal(t, int64(1), oInfo.GetPriceInfo().GetPixelsPerUnit())
-}
-
-func TestLiveRunnerReserveSessionOnchainAcceptsPaidReservation(t *testing.T) {
-	lp := newLiveRunnerHTTPOnchain(t)
-	registerLiveRunnerForSession(t, lp, nil)
-
-	challenge, oInfo := requestLiveRunnerPaymentChallenge(t, lp, "runner-1")
-	orch := lp.orchestrator.(*stubOrchestrator)
-	headers := liveRunnerReservationPaymentHeaders(t, orch, oInfo.GetAuthToken(), challenge.ManifestID)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/apps/runner-1/session", nil)
-	setRequestHeaders(req, headers)
-	lp.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusOK, w.Code)
-	var resp liveRunnerSessionResponse
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.Equal(t, challenge.ManifestID, resp.SessionID)
-	require.Equal(t, "http://localhost:1234/apps/runner-1/session/"+resp.SessionID+"/app", resp.AppURL)
-	require.Equal(t, "http://localhost:1234/apps/runner-1/session/"+resp.SessionID, resp.ControlURL)
-}
-
 func TestLiveRunnerSessionPaymentAcceptsPayment(t *testing.T) {
 	oldStorage := drivers.NodeStorage
 	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
@@ -821,33 +719,6 @@ func TestLiveRunnerSessionPaymentRejectsMissingSession(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/apps/runner-1/session/missing/payment", nil)
-	setRequestHeaders(req, headers)
-	lp.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusNotFound, w.Code)
-	require.Contains(t, w.Body.String(), "runner session not found")
-}
-
-func TestLiveRunnerSessionPaymentRejectsReleasedSession(t *testing.T) {
-	lp := newLiveRunnerHTTPOnchain(t)
-	registerLiveRunnerForSession(t, lp, nil)
-
-	challenge, oInfo := requestLiveRunnerPaymentChallenge(t, lp, "runner-1")
-	headers := liveRunnerReservationPaymentHeaders(t, lp.orchestrator.(*stubOrchestrator), oInfo.GetAuthToken(), challenge.ManifestID)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/apps/runner-1/session", nil)
-	setRequestHeaders(req, headers)
-	lp.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code)
-
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/apps/runner-1/session/"+challenge.ManifestID+"/stop", nil)
-	lp.ServeHTTP(w, req)
-	require.Equal(t, http.StatusNoContent, w.Code)
-
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/apps/runner-1/session/"+challenge.ManifestID+"/payment", nil)
 	setRequestHeaders(req, headers)
 	lp.ServeHTTP(w, req)
 
@@ -943,36 +814,6 @@ func TestPreparePaymentProcessor(t *testing.T) {
 	require.ErrorContains(t, err, "unsupported live runner payment unit")
 }
 
-func TestLiveRunnerPaidSessionMonitorDebitsSecondsBalance(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		lp := newLiveRunnerHTTPOnchain(t)
-		lp.node.LivePaymentInterval = time.Second
-		registerLiveRunnerForSession(t, lp, &liveRunnerRegistrationOptions{PriceUnit: "hour"})
-		manager := lp.node.LiveRunnerManager.(*runner.LiveRunnerRegistry)
-		defer manager.Stop()
-
-		orch := lp.orchestrator.(*stubOrchestrator)
-		orch.balances = make(map[ethcommon.Address]map[core.ManifestID]*big.Rat)
-		orch.paymentCredit = big.NewRat(3, 1)
-
-		sessionID := reservePaidLiveRunnerSession(t, lp, "runner-1", liveTestPricePerSecond(1))
-		balance := orch.Balance(orch.Address(), core.ManifestID(sessionID))
-		require.NotNil(t, balance)
-		require.Equal(t, "3", balance.FloatString(0))
-
-		time.Sleep(time.Second)
-		synctest.Wait()
-
-		balance = orch.Balance(orch.Address(), core.ManifestID(sessionID))
-		require.NotNil(t, balance)
-		require.Equal(t, "2", balance.FloatString(0))
-
-		require.NoError(t, manager.ReleaseSession("runner-1", sessionID))
-		time.Sleep(time.Second)
-		synctest.Wait()
-	})
-}
-
 func TestLiveRunnerPaidSessionMonitorReleasesOnInsufficientBalance(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		lp := newLiveRunnerHTTPOnchain(t)
@@ -1022,26 +863,6 @@ func TestLiveRunnerPaidSessionMonitorExitsAfterManualStop(t *testing.T) {
 		balance := orch.Balance(orch.Address(), core.ManifestID(sessionID))
 		require.NotNil(t, balance)
 		require.Equal(t, "3", balance.FloatString(0))
-	})
-}
-
-func TestLiveRunnerOffchainSessionDoesNotStartPaymentMonitor(t *testing.T) {
-	synctest.Test(t, func(t *testing.T) {
-		lp := newLiveRunnerHTTP(t, true)
-		lp.node.LivePaymentInterval = time.Second
-		registerLiveRunnerForSession(t, lp, nil)
-		manager := lp.node.LiveRunnerManager.(*runner.LiveRunnerRegistry)
-		defer manager.Stop()
-
-		sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
-
-		time.Sleep(time.Second)
-		synctest.Wait()
-
-		if _, err := manager.RunnerEndpointForSession("runner-1", sessionID); err != nil {
-			t.Fatal(err)
-		}
-		require.NoError(t, manager.ReleaseSession("runner-1", sessionID))
 	})
 }
 
@@ -1130,15 +951,6 @@ func TestScopePaidRetryUsesChallengeManifestID(t *testing.T) {
 	balance := orch.Balance(orch.Address(), core.ManifestID(challenge.ManifestID))
 	require.NotNil(t, balance)
 	require.Equal(t, "100", balance.FloatString(0))
-
-	orch.balanceMu.Lock()
-	balanceBuckets := make(map[core.ManifestID]*big.Rat, len(orch.balances[orch.Address()]))
-	for manifestID, balance := range orch.balances[orch.Address()] {
-		balanceBuckets[manifestID] = balance
-	}
-	orch.balanceMu.Unlock()
-	require.Len(t, balanceBuckets, 1)
-	require.Contains(t, balanceBuckets, core.ManifestID(challenge.ManifestID))
 }
 
 func TestScopePaidRetryRecurringAccountingUsesChallengeManifestID(t *testing.T) {
@@ -1175,15 +987,6 @@ func TestScopePaidRetryRecurringAccountingUsesChallengeManifestID(t *testing.T) 
 		balance = orch.Balance(orch.Address(), core.ManifestID(challenge.ManifestID))
 		require.NotNil(t, balance)
 		require.Equal(t, "2", balance.FloatString(0))
-
-		orch.balanceMu.Lock()
-		balanceBuckets := make(map[core.ManifestID]*big.Rat, len(orch.balances[orch.Address()]))
-		for manifestID, balance := range orch.balances[orch.Address()] {
-			balanceBuckets[manifestID] = balance
-		}
-		orch.balanceMu.Unlock()
-		require.Len(t, balanceBuckets, 1)
-		require.Contains(t, balanceBuckets, core.ManifestID(challenge.ManifestID))
 
 		require.NoError(t, eventsCh.Close())
 		synctest.Wait()
@@ -1325,7 +1128,7 @@ func TestLiveRunnerInternalStopSessionReleasesCapacity(t *testing.T) {
 	sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
 
 	w := httptest.NewRecorder()
-	req := newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/stop", "")
+	req := newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/stop", "")
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusNoContent, w.Code)
 
@@ -1572,7 +1375,7 @@ func TestLiveRunnerCreateSessionProxyAndProxyDefaultPath(t *testing.T) {
 	sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
 
 	w := httptest.NewRecorder()
-	req := newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/proxy", `{"target_url":`+strconv.Quote(upstream.URL+"/target")+`}`)
+	req := newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/proxy", `{"target_url":`+strconv.Quote(upstream.URL+"/target")+`}`)
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 	var proxy runner.LiveRunnerProxy
@@ -1704,7 +1507,7 @@ func TestLiveRunnerCreateSessionProxyDefaultsToAppPath(t *testing.T) {
 			appPath, appQuery, appSessionID := gotPath, gotQuery, gotSessionID
 
 			w = httptest.NewRecorder()
-			req = newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/proxy", test.body)
+			req = newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/proxy", test.body)
 			lp.ServeHTTP(w, req)
 			require.Equal(t, http.StatusOK, w.Code)
 			var proxy runner.LiveRunnerProxy
@@ -1752,7 +1555,7 @@ func TestLiveRunnerSessionProxyHostTemplate(t *testing.T) {
 	registerLiveRunnerForSession(t, lp, &liveRunnerRegistrationOptions{RunnerURL: upstream.URL + "/base"})
 	sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
 	w := httptest.NewRecorder()
-	req := newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/proxy", `{"target_url":`+strconv.Quote(upstream.URL+"/target")+`}`)
+	req := newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/proxy", `{"target_url":`+strconv.Quote(upstream.URL+"/target")+`}`)
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 	var proxy runner.LiveRunnerProxy
@@ -1777,7 +1580,7 @@ func TestLiveRunnerCreateSessionProxyRejectsUnauthorizedAndBadTarget(t *testing.
 	require.Equal(t, http.StatusUnauthorized, w.Code)
 
 	w = httptest.NewRecorder()
-	req = newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/proxy", `{"target_url":"https://other.example.com/app"}`)
+	req = newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/proxy", `{"target_url":"https://other.example.com/app"}`)
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusBadRequest, w.Code)
 	require.Contains(t, w.Body.String(), "hostname")
@@ -1789,7 +1592,7 @@ func TestLiveRunnerCreateTrickleChannel(t *testing.T) {
 	sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
 
 	w := httptest.NewRecorder()
-	req := newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"foo/bar","mime_type":"video/MP2T"},{"name":"events","mime_type":"application/json"}]}`)
+	req := newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"foo/bar","mime_type":"video/MP2T"},{"name":"events","mime_type":"application/json"}]}`)
 	lp.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
@@ -1830,7 +1633,7 @@ func TestLiveRunnerCreateTrickleChannelUsesLiveRunnerAddr(t *testing.T) {
 	sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
 
 	w := httptest.NewRecorder()
-	req := newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"override"}]}`)
+	req := newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"override"}]}`)
 	lp.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
@@ -1847,14 +1650,14 @@ func TestLiveRunnerCreateTrickleChannelReturnsExisting(t *testing.T) {
 	sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
 
 	w := httptest.NewRecorder()
-	req := newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"existing","mime_type":"video/MP2T"}]}`)
+	req := newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"existing","mime_type":"video/MP2T"}]}`)
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 	var first liveRunnerTrickleChannelsResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &first))
 
 	w = httptest.NewRecorder()
-	req = newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"existing","mime_type":"application/json"}]}`)
+	req = newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"existing","mime_type":"application/json"}]}`)
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 	var second liveRunnerTrickleChannelsResponse
@@ -1870,13 +1673,13 @@ func TestLiveRunnerCreateTrickleChannelRejectsInvalidSessionAndName(t *testing.T
 	registerLiveRunnerForSession(t, lp, nil)
 
 	w := httptest.NewRecorder()
-	req := newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/missing/channels", `{"channels":[{"name":"valid"}]}`)
+	req := httptest.NewRequest(http.MethodPost, "/runner/runner-1/session/missing/channels", strings.NewReader(`{"channels":[{"name":"valid"}]}`))
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusNotFound, w.Code)
 
 	sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
 	w = httptest.NewRecorder()
-	req = newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"bad.name"}]}`)
+	req = newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"bad.name"}]}`)
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -1957,12 +1760,12 @@ func TestLiveRunnerDeleteTrickleChannel(t *testing.T) {
 	sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
 
 	w := httptest.NewRecorder()
-	req := newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"delete-me"},{"name":"delete-me-too"}]}`)
+	req := newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"delete-me"},{"name":"delete-me-too"}]}`)
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
 	w = httptest.NewRecorder()
-	req = newLiveRunnerChannelRequest(lp, http.MethodDelete, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":["delete-me","delete-me-too"]}`)
+	req = newLiveRunnerChannelRequest(t, lp, http.MethodDelete, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":["delete-me","delete-me-too"]}`)
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 	var resp deleteLiveRunnerTrickleChannelsResponse
@@ -1981,7 +1784,7 @@ func TestLiveRunnerStopSessionClosesTrickleChannels(t *testing.T) {
 	sessionID := reserveLiveRunnerSession(t, lp, "runner-1")
 
 	w := httptest.NewRecorder()
-	req := newLiveRunnerChannelRequest(lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"stop-cleanup"}]}`)
+	req := newLiveRunnerChannelRequest(t, lp, http.MethodPost, "/runner/runner-1/session/"+sessionID+"/channels", `{"channels":[{"name":"stop-cleanup"}]}`)
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
@@ -2091,19 +1894,6 @@ func newScopeOffchainHTTP(t *testing.T) *lphttp {
 	return lp
 }
 
-func newLiveRunnerHTTPWithNode(t *testing.T, node *core.LivepeerNode) *lphttp {
-	t.Helper()
-	orch := newStubOrchestrator()
-	orch.secret = "live-runner-secret"
-	lp := &lphttp{
-		orchestrator: orch,
-		node:         node,
-		transRPC:     http.NewServeMux(),
-	}
-	require.NoError(t, startAIServer(lp))
-	return lp
-}
-
 func requestLiveRunnerPaymentChallenge(t *testing.T, lp *lphttp, runnerID string) (liveRunnerPaymentChallengeResponse, *lpnet.OrchestratorInfo) {
 	t.Helper()
 	w := httptest.NewRecorder()
@@ -2196,20 +1986,12 @@ func liveRunnerTestPricePerSecond(pricePerSecond int64) *lpnet.PriceInfo {
 	}
 }
 
-func liveTestPricePerSecond(pricePerSecond int64) *lpnet.PriceInfo {
-	return &lpnet.PriceInfo{
-		PricePerUnit:  pricePerSecond,
-		PixelsPerUnit: 1,
-	}
-}
-
 type liveRunnerRegistrationOptions struct {
 	RunnerID  string
 	RunnerURL string
 	Capacity  int
 	Mode      string
 	Proxy     bool
-	PriceUnit string
 }
 
 func registerLiveRunnerForSession(t *testing.T, lp *lphttp, opts *liveRunnerRegistrationOptions) {
@@ -2244,10 +2026,6 @@ func registerLiveRunnerForSession(t *testing.T, lp *lphttp, opts *liveRunnerRegi
 	if opts.Mode != "" && opts.Mode != runner.LiveRunnerModePersistent && opts.Mode != runner.LiveRunnerModeSingleShot {
 		require.FailNow(t, "invalid live runner mode", "mode=%q", opts.Mode)
 	}
-	priceUnit := opts.PriceUnit
-	if priceUnit == "" {
-		priceUnit = "720p"
-	}
 	manager, ok := lp.liveRunnerManager()
 	require.True(t, ok)
 	_, err := manager.Heartbeat(runner.LiveRunnerHeartbeatRequest{
@@ -2260,7 +2038,7 @@ func registerLiveRunnerForSession(t *testing.T, lp *lphttp, opts *liveRunnerRegi
 		Capacity:  capacity,
 		PriceInfo: runner.LiveRunnerPriceInfo{
 			Price: json.Number("0.001990656"),
-			Unit:  priceUnit,
+			Unit:  "720p",
 		},
 	}, lp.orchestrator.RegistrationSecret())
 	require.NoError(t, err)
@@ -2294,27 +2072,22 @@ func reservePaidLiveRunnerSession(t *testing.T, lp *lphttp, runnerID string, pri
 	return resp.SessionID
 }
 
-func newLiveRunnerChannelRequest(lp *lphttp, method, target, body string) *http.Request {
+func newLiveRunnerChannelRequest(t *testing.T, lp *lphttp, method, target, body string) *http.Request {
+	t.Helper()
 	req := httptest.NewRequest(method, target, strings.NewReader(body))
 	path := strings.Split(strings.TrimPrefix(target, "/"), "?")[0]
 	parts := strings.Split(path, "/")
 	if len(parts) >= 5 && parts[0] == "runner" && parts[2] == "session" {
-		setLiveRunnerSessionToken(nil, lp, req, parts[1], parts[3])
+		setLiveRunnerSessionToken(t, lp, req, parts[1], parts[3])
 	}
 	return req
 }
 
-func setLiveRunnerSessionToken(t require.TestingT, lp *lphttp, req *http.Request, runnerID, sessionID string) {
+func setLiveRunnerSessionToken(t *testing.T, lp *lphttp, req *http.Request, runnerID, sessionID string) {
+	t.Helper()
 	manager, ok := lp.liveRunnerManager()
-	if !ok {
-		if t != nil {
-			require.FailNow(t, "live runner manager unavailable")
-		}
-		return
-	}
+	require.True(t, ok, "live runner manager unavailable")
 	token, err := manager.SessionTokenForSession(runnerID, sessionID)
-	if err != nil {
-		return
-	}
+	require.NoError(t, err)
 	req.Header.Set("Livepeer-Session-Token", token)
 }

--- a/test.sh
+++ b/test.sh
@@ -13,6 +13,9 @@ go test -run Nvidia_ -race
 go test -run Capabilities_ -race
 cd ..
 
+# Be more strict with live runner tests: run with race detector enabled
+go test ./ai/runner -race
+
 # Be more strict with discovery tests: run with race detector enabled
 cd discovery
 go test -race


### PR DESCRIPTION
## Summary
- Consolidate overlapping Live Runner registry and AI HTTP coverage while preserving unique concurrency, proxy, trickle, discovery, payment, and error-path behavior.
- Replace white-box setup and assertions with public behavior where practical; direct runner locks remain only in tests that exercise lock isolation.
- Remove the duplicate proxy-parser oracle and redundant pricing and payment cases. No production or fixed-price changes are included.

## Test plan
- go test ./ai/runner -count=1
- go test ./server -run Test(AIWorkerResults|LiveRunner|RunnerOrchInfo|PreparePaymentProcessor|Scope) -count=1
- Targeted race tests for Live Runner concurrency and AI HTTP lifecycle cases
- BenchmarkProxyURLTemplateExtraction smoke benchmark
- Separate fixed-price registry and HTTP tests in the original worktree

## Reduction
- ai/runner/live_runner_test.go: 2,705 to 2,348 lines
- server/ai_http_test.go: 2,320 to 2,092 lines
- 585 net lines removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable “O2R keepalive” interval for live-runner registries, with validation and sensible defaults.

* **Tests**
  * Consolidated AI worker error validation into a single table-driven test.
  * Updated live-runner discovery to assert required on-chain `PriceInfo` in `/discovery`.
  * Refreshed live-runner heartbeat/capacity tests to validate via public discovery/payment/session behavior.
  * Simplified and reworked paid-session/payment and reservation assertions; adjusted unregister/monitor expectations.
  * Expanded test coverage with an additional `ai/runner` race-detector run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->