### PR TITLE
feat(server): enable payments for single-shot live runner sessions

### DIFF
--- a/doc/live-runner.md
+++ b/doc/live-runner.md
@@ -393,8 +393,15 @@ Required` with payment parameters. The client retries with
 usage on its configured payment interval and releases the session if payment
 fails.
 
-The current single-shot proxy path does not perform a payment challenge or
-accounting. Use persistent mode when on-chain payment enforcement is required.
+A priced single-shot runner uses the same payment challenge and accounting as a
+persistent session, but scoped to a single request. Without payment material the
+orchestrator returns `402 Payment Required` with payment parameters; the client
+retries with `Livepeer-Payment` and `Livepeer-Segment`. The orchestrator
+processes the initial payment, accounts usage on its configured payment interval
+for the lifetime of the proxied request, and releases the session when the
+request completes. Because a single-shot session lives for exactly one request,
+there is no per-session `/payment` refresh endpoint; use persistent mode when a
+client must refresh payment across multiple requests.
 
 Offchain runners do not issue payment challenges. For the underlying ticket
 protocol, see [Payments](payments.md).
@@ -541,7 +548,7 @@ session.
 | `POST /apps/{runner_id}/session/{session_id}/stop` | Client; session is identified by the URL | Releases a persistent session, its channels, and proxies. | `204`, `404` |
 | `POST /apps/{runner_id}/session/{session_id}/payment` | Paying client; `Livepeer-Payment` and `Livepeer-Segment` | Adds payment for an active session. The payment manifest must match `session_id`. | `200`, `400`, `403`, `404` |
 | `ANY /apps/{runner_id}/session/{session_id}/app/{app_path...}` | Client; access is by the reserved public URL | Proxies any HTTP method, SSE response, or WebSocket upgrade to a persistent runner. | Upstream status, `404`, `502` |
-| `ANY /apps/{runner_id}/app/{app_path...}` | Client; no application-level authentication | Reserves a single-shot session, proxies one request, then releases it. The current path does not enforce runner payment. | Upstream status, `400`, `404`, `503`, `502` |
+| `ANY /apps/{runner_id}/app/{app_path...}` | Client; no auth offchain. Onchain uses `Livepeer-Payer-Address` for the initial challenge and `Livepeer-Payment` plus `Livepeer-Segment` to reserve. | Reserves a single-shot session, proxies one request, then releases it. A priced runner first returns a payment challenge and accounts usage for the duration of the request. | Upstream status, `400`, `402`, `404`, `503`, `502` |
 
 The `runner_id` path value may be a static label when `routing` is `label`.
 

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -764,7 +764,7 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 		}
 	}()
 
-	ctx = clog.AddVal(r.Context(), "runner_id", runnerID)
+	ctx = clog.AddVal(ctx, "runner_id", runnerID)
 	ctx = clog.AddVal(ctx, "session_id", sessionID)
 	if paymentRequired {
 		var newPaymentProcessor func(context.Context, time.Duration, func(int64) error) *LivePaymentProcessor

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -43,6 +43,8 @@ var TrickleHTTPPath = "/ai/trickle/"
 
 const maxLiveRunnerTrickleChannelsPerRequest = 25
 const liveRunnerSenderHeader = "Livepeer-Payer-Address"
+const liveRunnerSessionIDHeader = "Livepeer-Session-Id"
+const liveRunnerSessionControlHeader = "Livepeer-Session-Control"
 const maxScopeRequestBodySize = 1 << 20 // 1 MB
 
 func startAIServer(lp *lphttp) error {
@@ -184,6 +186,8 @@ type liveRunnerPaymentChallengeResponse struct {
 	// Keep the URL in top-level JSON so clients do not need to parse the protobuf just to route payment.
 	Orchestrator string `json:"orchestrator"`
 	ManifestID   string `json:"manifest_id"`
+	// Interval at which the orchestrator debits the session balance.
+	PaymentIntervalMs int64 `json:"payment_interval_ms"`
 }
 
 type liveRunnerTrickleChannelRequest struct {
@@ -280,44 +284,8 @@ func (h *lphttp) ReserveLiveRunnerSession(w http.ResponseWriter, r *http.Request
 			respondWithError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		monitorCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-		paymentReceiver := livePaymentReceiver{orchestrator: h.orchestrator}
-		accountPaymentFunc := func(units int64) error {
-			err := paymentReceiver.AccountPayment(monitorCtx, &SegmentInfoReceiver{
-				sender:    getPaymentSender(payment),
-				units:     units,
-				priceInfo: payment.GetExpectedPrice(),
-				sessionID: string(segData.ManifestID),
-			})
-			if err != nil {
-				clog.Errorf(monitorCtx, "Error accounting live runner payment, releasing session err=%v", err)
-				if releaseErr := manager.ReleaseSession(runnerID, sessionID); releaseErr != nil {
-					clog.Errorf(monitorCtx, "Error releasing live runner session after payment failure err=%v", releaseErr)
-				}
-				// Stop both the ticker loop below and the LivePaymentProcessor goroutine.
-				cancel()
-			}
-			return err
-		}
-		paymentProcessor := newPaymentProcessor(monitorCtx, h.node.LivePaymentInterval, accountPaymentFunc)
-		go func() {
-			ticker := time.NewTicker(h.node.LivePaymentInterval)
-			defer ticker.Stop()
-			defer cancel()
-			for {
-				select {
-				case <-ticker.C:
-					// Stop monitoring once the live runner session has been released
-					// by an explicit stop, runner cleanup, expiry, or payment failure.
-					if _, err := manager.RunnerEndpointForSession(runnerID, sessionID); err != nil {
-						return
-					}
-					paymentProcessor.process(monitorCtx)
-				case <-monitorCtx.Done():
-					return
-				}
-			}
-		}()
+		// Detach from the request ctx so the loop outlives this reservation call.
+		h.startLiveRunnerSessionPaymentLoop(context.WithoutCancel(ctx), manager, newPaymentProcessor, runnerID, sessionID, payment, segData.ManifestID)
 	}
 	controlURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID).String()
 	data, err := json.Marshal(liveRunnerSessionResponse{SessionID: sessionID, AppURL: appURL, ControlURL: controlURL})
@@ -339,6 +307,49 @@ func preparePaymentProcessor(unit string) (func(context.Context, time.Duration, 
 	}
 }
 
+// startLiveRunnerSessionPaymentLoop starts the metering loop; the caller controls
+// its lifetime via the ctx it passes.
+func (h *lphttp) startLiveRunnerSessionPaymentLoop(ctx context.Context, manager liveRunnerManager, newPaymentProcessor func(context.Context, time.Duration, func(int64) error) *LivePaymentProcessor, runnerID, sessionID string, payment lpnet.Payment, manifestID core.ManifestID) {
+	loopCtx, cancel := context.WithCancel(ctx)
+	paymentReceiver := livePaymentReceiver{orchestrator: h.orchestrator}
+	accountPaymentFunc := func(units int64) error {
+		err := paymentReceiver.AccountPayment(loopCtx, &SegmentInfoReceiver{
+			sender:    getPaymentSender(payment),
+			units:     units,
+			priceInfo: payment.GetExpectedPrice(),
+			sessionID: string(manifestID),
+		})
+		if err != nil {
+			clog.Errorf(loopCtx, "Error accounting live runner payment, releasing session err=%v", err)
+			if releaseErr := manager.ReleaseSession(runnerID, sessionID); releaseErr != nil {
+				clog.Errorf(loopCtx, "Error releasing live runner session after payment failure err=%v", releaseErr)
+			}
+			// Stop both the ticker loop below and the LivePaymentProcessor goroutine.
+			cancel()
+		}
+		return err
+	}
+	paymentProcessor := newPaymentProcessor(loopCtx, h.node.LivePaymentInterval, accountPaymentFunc)
+	go func() {
+		ticker := time.NewTicker(h.node.LivePaymentInterval)
+		defer ticker.Stop()
+		defer cancel()
+		for {
+			select {
+			case <-ticker.C:
+				// Stop the loop once the live runner session has been released
+				// by an explicit stop, runner cleanup, expiry, or payment failure.
+				if _, err := manager.RunnerEndpointForSession(runnerID, sessionID); err != nil {
+					return
+				}
+				paymentProcessor.process(loopCtx)
+			case <-loopCtx.Done():
+				return
+			}
+		}
+	}()
+}
+
 func (h *lphttp) runnerChallenge(w http.ResponseWriter, r *http.Request, priceInfo *runner.LiveRunnerPriceInfo) {
 	sender, err := h.runnerSender(r)
 	if err != nil {
@@ -350,7 +361,7 @@ func (h *lphttp) runnerChallenge(w http.ResponseWriter, r *http.Request, priceIn
 		respondWithError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		respondWithError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -375,7 +386,7 @@ func (h *lphttp) scopePaymentChallenge(w http.ResponseWriter, r *http.Request) (
 	if err != nil {
 		return false, err
 	}
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		return false, err
 	}
@@ -385,15 +396,16 @@ func (h *lphttp) scopePaymentChallenge(w http.ResponseWriter, r *http.Request) (
 	return true, nil
 }
 
-func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo) ([]byte, error) {
+func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo, paymentInterval time.Duration) ([]byte, error) {
 	buf, err := proto.Marshal(oInfo)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(liveRunnerPaymentChallengeResponse{
-		PaymentParams: base64.StdEncoding.EncodeToString(buf),
-		Orchestrator:  oInfo.GetTranscoder(),
-		ManifestID:    oInfo.GetAuthToken().GetSessionId(),
+		PaymentParams:     base64.StdEncoding.EncodeToString(buf),
+		Orchestrator:      oInfo.GetTranscoder(),
+		ManifestID:        oInfo.GetAuthToken().GetSessionId(),
+		PaymentIntervalMs: paymentInterval.Milliseconds(),
 	})
 }
 
@@ -709,22 +721,73 @@ func (h *lphttp) ProxyLiveRunnerSingleShot(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	sessionID, endpoint, err := manager.ReserveSession(runnerID)
+	priceInfo, err := manager.PaymentInfo(runnerID)
 	if err != nil {
 		respondWithLiveRunnerError(w, err)
 		return
 	}
+	paymentRequired := priceInfo != nil
+	if paymentRequired && r.Header.Get(paymentHeader) == "" && r.Header.Get(segmentHeader) == "" {
+		h.runnerChallenge(w, r, priceInfo)
+		return
+	}
+
+	var (
+		payment   lpnet.Payment
+		segData   *core.SegTranscodingMetadata
+		ctx       = r.Context()
+		sessionID string
+	)
+	if paymentRequired {
+		var err error
+		payment, segData, ctx, err = h.processPaymentAndSegmentHeaders(w, r)
+		if err != nil {
+			return
+		}
+		if string(segData.ManifestID) != segData.AuthToken.SessionId {
+			respondWithError(w, "mismatched manifest and auth token", http.StatusForbidden)
+			return
+		}
+		// for easier correlation across orch, gw, signer
+		sessionID = string(segData.ManifestID)
+	}
+	sessionID, endpoint, err := manager.ReserveSession(runnerID, sessionID)
+	if err != nil {
+		respondWithLiveRunnerError(w, err)
+		return
+	}
+
+	// Release on return: a single-shot session lives for exactly one request.
 	defer func() {
 		if err := manager.ReleaseSession(runnerID, sessionID); err != nil {
 			slog.Error("error releasing single-shot session", "runner_id", runnerID, "session_id", sessionID, "err", err)
 		}
 	}()
 
+	ctx = clog.AddVal(r.Context(), "runner_id", runnerID)
+	ctx = clog.AddVal(ctx, "session_id", sessionID)
+	if paymentRequired {
+		var newPaymentProcessor func(context.Context, time.Duration, func(int64) error) *LivePaymentProcessor
+		newPaymentProcessor, err = preparePaymentProcessor(priceInfo.Unit)
+		if err != nil {
+			respondWithError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if err := h.orchestrator.ProcessPayment(ctx, payment, segData.ManifestID); err != nil {
+			// Session released by the defer above.
+			respondWithError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// Bound to the request ctx so the loop ends when this single-shot call returns.
+		h.startLiveRunnerSessionPaymentLoop(ctx, manager, newPaymentProcessor, runnerID, sessionID, payment, segData.ManifestID)
+	}
+
 	sessionToken, err := manager.SessionTokenForSession(runnerID, sessionID)
 	if err != nil {
 		respondWithLiveRunnerError(w, err)
 		return
 	}
+
 	h.proxyLiveRunner(w, r, runnerID, sessionID, sessionToken, endpoint, r.PathValue("app_path"))
 }
 
@@ -773,9 +836,9 @@ func (h *lphttp) proxyLiveRunner(w http.ResponseWriter, r *http.Request, runnerI
 			req.Out.URL.RawQuery = req.In.URL.RawQuery
 			req.Out.Host = target.Host
 			req.Out.Header.Set("Livepeer-Runner-Route", runnerID)
-			req.Out.Header.Set("Livepeer-Session-Id", sessionID)
+			req.Out.Header.Set(liveRunnerSessionIDHeader, sessionID)
 			req.Out.Header.Set("Livepeer-Session-Token", sessionToken)
-			req.Out.Header.Set("Livepeer-Session-Control", sessionControlURL)
+			req.Out.Header.Set(liveRunnerSessionControlHeader, sessionControlURL)
 		},
 		ErrorHandler: func(w http.ResponseWriter, req *http.Request, err error) {
 			respondWithError(w, err.Error(), http.StatusBadGateway)
@@ -1204,6 +1267,7 @@ func (h *lphttp) StartScope() http.Handler {
 				return err
 			}
 			paymentProcessor = NewLV2VPaymentProcessor(ctx, h.node.LivePaymentInterval, accountPaymentFunc)
+
 		} else {
 			clog.Warningf(ctx, "No price info found for model %v, Orchestrator will not charge for video processing", modelID)
 		}

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -1535,7 +1535,7 @@ func TestLiveRunnerSingleShotProxyAllowsPaymentWhileRequestOpen(t *testing.T) {
 	orch.balances = make(map[ethcommon.Address]map[core.ManifestID]*big.Rat)
 	orch.paymentCredit = big.NewRat(100, 1)
 
-	challenge, oInfo := requestLiveRunnerPaymentChallenge(t, lp, "runner-1")
+	challenge, oInfo := requestLiveRunnerSingleShotPaymentChallenge(t, lp, "runner-1")
 	headers := liveRunnerReservationPaymentHeaders(t, orch, oInfo.GetAuthToken(), challenge.ManifestID)
 
 	proxyDone := make(chan int, 1)
@@ -2179,6 +2179,16 @@ func requestLiveRunnerPaymentChallenge(t *testing.T, lp *lphttp, runnerID string
 	t.Helper()
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/apps/"+runnerID+"/session", nil)
+	setRequestHeaders(req, liveRunnerSenderHeaders(lp.orchestrator.(*stubOrchestrator)))
+	lp.ServeHTTP(w, req)
+	require.Equal(t, http.StatusPaymentRequired, w.Code)
+	return decodeLiveRunnerPaymentChallenge(t, w.Body.Bytes())
+}
+
+func requestLiveRunnerSingleShotPaymentChallenge(t *testing.T, lp *lphttp, runnerID string) (liveRunnerPaymentChallengeResponse, *lpnet.OrchestratorInfo) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/apps/"+runnerID+"/app/v1/foo", strings.NewReader(`{"prompt":"hi"}`))
 	setRequestHeaders(req, liveRunnerSenderHeaders(lp.orchestrator.(*stubOrchestrator)))
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusPaymentRequired, w.Code)

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -1497,6 +1497,77 @@ func TestLiveRunnerSingleShotProxyForwardsAndReleasesCapacity(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, w.Code)
 }
 
+func TestLiveRunnerSingleShotProxyOnchainReturnsPaymentChallenge(t *testing.T) {
+	lp := newLiveRunnerHTTPOnchain(t)
+	registerLiveRunnerForSession(t, lp, &liveRunnerRegistrationOptions{Mode: runner.LiveRunnerModeSingleShot})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/apps/runner-1/app/v1/foo", strings.NewReader(`{"prompt":"hi"}`))
+	setRequestHeaders(req, liveRunnerSenderHeaders(lp.orchestrator.(*stubOrchestrator)))
+	lp.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusPaymentRequired, w.Code)
+	challenge, oInfo := decodeLiveRunnerPaymentChallenge(t, w.Body.Bytes())
+	require.NotEmpty(t, challenge.ManifestID)
+	require.Equal(t, int64(5000), challenge.PaymentIntervalMs)
+	require.Equal(t, int64(10), oInfo.GetPriceInfo().GetPricePerUnit())
+	require.Equal(t, int64(1), oInfo.GetPriceInfo().GetPixelsPerUnit())
+}
+
+func TestLiveRunnerSingleShotProxyAllowsPaymentWhileRequestOpen(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-release
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("done"))
+	}))
+	defer upstream.Close()
+
+	oldStorage := drivers.NodeStorage
+	drivers.NodeStorage = drivers.NewMemoryDriver(nil)
+	t.Cleanup(func() { drivers.NodeStorage = oldStorage })
+
+	lp := newLiveRunnerHTTPOnchain(t)
+	registerLiveRunnerForSession(t, lp, &liveRunnerRegistrationOptions{RunnerURL: upstream.URL, Mode: runner.LiveRunnerModeSingleShot})
+	orch := lp.orchestrator.(*stubOrchestrator)
+	orch.balances = make(map[ethcommon.Address]map[core.ManifestID]*big.Rat)
+	orch.paymentCredit = big.NewRat(100, 1)
+
+	challenge, oInfo := requestLiveRunnerPaymentChallenge(t, lp, "runner-1")
+	headers := liveRunnerReservationPaymentHeaders(t, orch, oInfo.GetAuthToken(), challenge.ManifestID)
+
+	proxyDone := make(chan int, 1)
+	go func() {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/apps/runner-1/app/hold", nil)
+		setRequestHeaders(req, headers)
+		lp.ServeHTTP(w, req)
+		proxyDone <- w.Code
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for single-shot request to reach runner")
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/apps/runner-1/session/"+challenge.ManifestID+"/payment", nil)
+	setRequestHeaders(req, headers)
+	lp.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var paymentResult lpnet.PaymentResult
+	require.NoError(t, proto.Unmarshal(w.Body.Bytes(), &paymentResult))
+	require.NotNil(t, paymentResult.GetInfo())
+	require.Equal(t, challenge.ManifestID, paymentResult.GetInfo().GetAuthToken().GetSessionId())
+
+	close(release)
+	require.Equal(t, http.StatusOK, <-proxyDone)
+}
+
 func TestLiveRunnerSingleShotProxyNoCapacityWhileRequestInFlight(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -496,7 +496,7 @@ func (h *lphttp) RefreshPayment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		respondJsonError(ctx, w, err, http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Resubmitting PR #3975 closed with initial merge of live runner. Rick approved PR #3975 but I combined all the changes to one commit on this PR.

**What does this pull request do? Explain your changes. (required)**

Enables on-chain payments for single-shot live runner calls. Single-shot mode was functional but unpaid: `ProxyLiveRunnerSingleShot` reserved a session, proxied, and released with no payment gate. This makes single-shot (request/response and short-lived / batch) calls billable, mirroring the existing persistent (ReserveLiveRunnerSession) payment flow. Parity with the persistent path is intentional. The deliberate differences are the single-shot mode guard, release-on-return, the metering-loop lifetime, and the proxy (vs JSON) response.

**Specific updates (required)**

- Extract `startLiveRunnerSessionPaymentLoop` from `ReserveLiveRunnerSession` into a shared method that debits the prepaid balance every `LivePaymentInterval` via a `LivePaymentProcessor`. The caller controls the loop lifetime by passing its own context: the persistent path passes `context.WithoutCancel(ctx)` so the loop outlives the reservation call; the single-shot path passes the request `ctx` so the loop ends when the request returns. The loop also stops if the session is released or accounting fails.
- Add `preparePaymentProcessor` to select between `NewLivePaymentProcessor` (seconds unit) and `NewLV2VPaymentProcessor` (720p-pixel-seconds unit) based on `priceInfo.Unit`. Both the persistent and single-shot paths use this, so single-shot billing respects the same unit-based pricing as persistent sessions.
- Extend `marshalLivePaymentChallengeResponse` to accept `paymentInterval time.Duration` and include `payment_interval_ms` (the orchestrator's debit interval) in the `402` challenge body. Updated all callers: `runnerChallenge`, `scopePaymentChallenge`, and `RefreshPayment`.
- Gate `ProxyLiveRunnerSingleShot` on payment: when `priceInfo` is present and no `Livepeer-Payment` / `Livepeer-Segment` headers are supplied, return a `402` challenge via the shared `runnerChallenge` (carrying ticket params, manifest_id, and payment_interval_ms). When headers are present, parse them with `processPaymentAndSegmentHeaders`, verify the manifest matches the auth token session, reserve the session (manifest_id = session id), process the payment with `ProcessPayment`, start the request-scoped metering loop, proxy to the runner, and release the session on return via defer.
- Add `liveRunnerSessionIDHeader` / `liveRunnerSessionControlHeader` constants used by `proxyLiveRunner` for session routing.
- Held-open (SSE / WebSocket) sessions continue to be funded via the existing session-scoped `POST /apps/{runner}/session/{id}/payment` endpoint (`PaymentForLiveRunnerSession`); no changes were needed there.

**How did you test each of these updates (required)**

Ensured go-livepeer builds, tests pass and ran the new logic against this branch in the [app-examples](https://github.com/livepeer/app-examples/tree/test/single-shot-examples) repo confirming payments now work for single-shot runners.

**Does this pull request close any open issues?**

Fixes https://github.com/livepeer/go-livepeer/issues/3955

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] Read the [contribution guide](./CONTRIBUTING.md)
- [X] `make` runs successfully
- [X] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [ ] [Pending changelog](./CHANGELOG_PENDING.md) updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-chain payment challenge and usage accounting for priced single-shot live runner requests.
  * Payment challenges now include the live payment interval (`payment_interval_ms`).
  * Payments can be submitted during an in-flight single-shot request, with metering until the request completes.
* **Bug Fixes**
  * Improved single-shot payment handling to ensure correct session lifecycle and metering during proxied requests.
  * Updated proxy routing so live-runner session headers are forwarded correctly.
* **Documentation**
  * Refreshed the live-runner docs and HTTP API behavior for priced single-shot reservations/proxy flows.
* **Tests**
  * Added coverage for returning payment challenges and paying while a request is in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->