### PR TITLE
server: Report payment interval in payment challenges

### DIFF
--- a/doc/live-runner.md
+++ b/doc/live-runner.md
@@ -391,7 +391,9 @@ parameters. The client retries the same request with `Livepeer-Payment` and
 `Livepeer-Segment`, then periodically refreshes payment at
 `POST /apps/{runner_id}/session/{session_id}/payment`. The orchestrator accounts
 usage on its configured payment interval and releases the session if payment
-fails. If the payment unit is `fixed` then payment is only processed once.
+fails. The challenge response reports that interval as `payment_interval_ms` so
+clients can size and time payments to keep the session balance funded. If the
+payment unit is `fixed` then payment is only processed once.
 
 Offchain runners do not issue payment challenges. For the underlying ticket
 protocol, see [Payments](payments.md).

--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -185,6 +185,8 @@ type liveRunnerPaymentChallengeResponse struct {
 	// Keep the URL in top-level JSON so clients do not need to parse the protobuf just to route payment.
 	Orchestrator string `json:"orchestrator"`
 	ManifestID   string `json:"manifest_id"`
+	// Interval at which the orchestrator debits the session balance.
+	PaymentIntervalMs int64 `json:"payment_interval_ms"`
 }
 
 type liveRunnerTrickleChannelRequest struct {
@@ -402,7 +404,7 @@ func (h *lphttp) runnerChallenge(w http.ResponseWriter, r *http.Request, priceIn
 		respondWithError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		respondWithError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -427,7 +429,7 @@ func (h *lphttp) scopePaymentChallenge(w http.ResponseWriter, r *http.Request) (
 	if err != nil {
 		return false, err
 	}
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		return false, err
 	}
@@ -437,15 +439,16 @@ func (h *lphttp) scopePaymentChallenge(w http.ResponseWriter, r *http.Request) (
 	return true, nil
 }
 
-func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo) ([]byte, error) {
+func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo, paymentInterval time.Duration) ([]byte, error) {
 	buf, err := proto.Marshal(oInfo)
 	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(liveRunnerPaymentChallengeResponse{
-		PaymentParams: base64.StdEncoding.EncodeToString(buf),
-		Orchestrator:  oInfo.GetTranscoder(),
-		ManifestID:    oInfo.GetAuthToken().GetSessionId(),
+		PaymentParams:     base64.StdEncoding.EncodeToString(buf),
+		Orchestrator:      oInfo.GetTranscoder(),
+		ManifestID:        oInfo.GetAuthToken().GetSessionId(),
+		PaymentIntervalMs: paymentInterval.Milliseconds(),
 	})
 }
 

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -664,6 +664,7 @@ func TestLiveRunnerReserveSessionOnchainReturnsPaymentChallenge(t *testing.T) {
 	require.NotEmpty(t, challenge.PaymentParams)
 	require.Equal(t, lp.orchestrator.ServiceURI().String(), challenge.Orchestrator)
 	require.NotEmpty(t, challenge.ManifestID)
+	require.Equal(t, int64(5000), challenge.PaymentIntervalMs)
 	require.Equal(t, challenge.ManifestID, oInfo.GetAuthToken().GetSessionId())
 	require.NotNil(t, oInfo.GetTicketParams())
 	require.NotNil(t, oInfo.GetPriceInfo())

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -496,7 +496,7 @@ func (h *lphttp) RefreshPayment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	data, err := marshalLivePaymentChallengeResponse(oInfo, h.node.LivePaymentInterval)
 	if err != nil {
 		respondJsonError(ctx, w, err, http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Stacked on #4000 (which is stacked on #3999).

**What does this pull request do?**

Adds `payment_interval_ms` to the payment challenge JSON so paying clients know the orchestrator's debit cadence and can size and time payments to keep the session balance funded. Without it, clients have no way to learn the interval and risk being released for underpayment between top-ups.

Ports the challenge-interval change from #3998 by @ad-astra-video (originally approved as #3975), rebased onto the #3999/#4000 payment refactor. Credited as co-author.

**Specific updates**

- Add `payment_interval_ms` to `liveRunnerPaymentChallengeResponse`, populated from `node.LivePaymentInterval` in all three challenge producers: session reservation / single-shot challenge (`runnerChallenge`), scope challenge (`scopePaymentChallenge`), and the remote signer refresh path (`RefreshPayment` in rpc.go).
- Assert the field in `TestLiveRunnerReserveSessionOnchainReturnsPaymentChallenge`.
- Document the field in `doc/live-runner.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)