### PR TITLE
pm: add diagnostics to insufficient sender reserve errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,8 @@
 
 #### Orchestrator
 
+- The "insufficient sender reserve" error now reports which check failed and the values involved (faceValue vs ticketEV vs sender max float, or faceValue vs redemption tx cost) so operators can tell whether the sender's reserve, `-ticketEV`, or `-maxFaceValue` needs adjusting
+
 #### Transcoder
 
 ### Bug Fixes 🐞

--- a/pm/recipient.go
+++ b/pm/recipient.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
+	"fmt"
 	"math/big"
 	"sync"
 
@@ -293,7 +294,7 @@ func (r *recipient) faceValue(sender ethcommon.Address) (*big.Int, error) {
 		monitor.MaxFloat(sender.Hex(), maxFloat)
 	}
 	if faceValue.Cmp(r.cfg.EV) < 0 {
-		return nil, errInsufficientSenderReserve
+		return nil, fmt.Errorf("%w: faceValue %v is less than ticketEV %v (sender max float: %v); the sender's reserve is too low for this orchestrator's -ticketEV", errInsufficientSenderReserve, faceValue, r.cfg.EV, maxFloat)
 	}
 
 	// faceValue must be >= txCostWithGasPrice(current gasPrice) OR >= txCostWithGasPrice(avg gasPrice)
@@ -309,7 +310,7 @@ func (r *recipient) faceValue(sender ethcommon.Address) (*big.Int, error) {
 	// and needs to be redeemed.
 	// For now, avgGasPrice is hardcoded. See the comment for avgGasPrice for TODO information.
 	if faceValue.Cmp(txCost) < 0 && faceValue.Cmp(r.txCostWithGasPrice(avgGasPrice)) < 0 {
-		return nil, errInsufficientSenderReserve
+		return nil, fmt.Errorf("%w: faceValue %v cannot cover the ticket redemption tx cost (at current gas price: %v, at avg gas price: %v); increase -maxFaceValue or the sender's reserve", errInsufficientSenderReserve, faceValue, txCost, r.txCostWithGasPrice(avgGasPrice))
 	}
 
 	return faceValue, nil

--- a/pm/recipient_test.go
+++ b/pm/recipient_test.go
@@ -528,7 +528,8 @@ func TestTicketParams(t *testing.T) {
 	// Test insufficient sender reserve error due to maxFloat < EV
 	sm.maxFloat = new(big.Int).Sub(cfg.EV, big.NewInt(1))
 	_, err = r.TicketParams(sender, big.NewRat(1, 1))
-	assert.EqualError(err, errInsufficientSenderReserve.Error())
+	assert.ErrorIs(err, errInsufficientSenderReserve)
+	assert.ErrorContains(err, "less than ticketEV")
 
 	// Test faceValue < txCostWithGasPrice(current gasPrice) and faceValue > txCostWithGasPrice(avg gasPrice)
 	// Set current gasPrice higher than avg gasPrice
@@ -553,7 +554,8 @@ func TestTicketParams(t *testing.T) {
 	require.True(sm.maxFloat.Cmp(txCost) < 0)
 	require.True(sm.maxFloat.Cmp(txCostAvgGasPrice) < 0)
 	_, err = r.TicketParams(sender, big.NewRat(1, 1))
-	assert.EqualError(err, errInsufficientSenderReserve.Error())
+	assert.ErrorIs(err, errInsufficientSenderReserve)
+	assert.ErrorContains(err, "cannot cover the ticket redemption tx cost")
 
 	// Test lazy evaluation when faceValue > txCostWithGasPrice(current gasPrice)
 	// Set current gasPrice lower than avg gasPrice
@@ -587,7 +589,7 @@ func TestTicketParams(t *testing.T) {
 	sm.maxFloat = big.NewInt(0) // Set maxFloat to some value less than EV
 
 	_, err = r.TicketParams(sender, big.NewRat(1, 1))
-	assert.EqualError(err, errInsufficientSenderReserve.Error())
+	assert.ErrorIs(err, errInsufficientSenderReserve)
 }
 
 func TestTxCostMultiplier_UsingFaceValue_ReturnsDefaultMultiplier(t *testing.T) {
@@ -638,7 +640,7 @@ func TestTxCostMultiplier_InsufficientReserve_ReturnsError(t *testing.T) {
 
 	mul, err := r.TxCostMultiplier(sender)
 	assert.Nil(t, mul)
-	assert.EqualError(t, err, errInsufficientSenderReserve.Error())
+	assert.ErrorIs(t, err, errInsufficientSenderReserve)
 }
 
 func TestTxCostMultiplier_ZeroTxCost_Returns_Zero(t *testing.T) {


### PR DESCRIPTION
## What

`faceValue()` in `pm/recipient.go` returns the same bare `insufficient sender reserve` error from two unrelated checks:

1. `faceValue < ticketEV` after clamping to the sender's max float: the sender's reserve really is too low for the orchestrator's `-ticketEV`.
2. `faceValue < txCost(current gas)` and `faceValue < txCost(avg gas)`: the ticket could never pay for its own redemption. This is typically caused by a too low `-maxFaceValue` (on Arbitrum the floor is `redeemGas 1.2M x 3 gwei hardcoded avg = 3.6e15 wei`) and fires no matter how large the sender's reserve is.

Debugging case 2 with the current message points operators at the sender's reserve, which is a dead end. I lost a debugging session to exactly this: an orchestrator with `-maxFaceValue=1e13` can never pass check 2, but the error suggested funding the gateway's reserve.

## Changes

- Wrap `errInsufficientSenderReserve` with `%w` at both sites, including the values involved (faceValue, ticketEV, sender max float, redemption cost at current and avg gas price) and naming the knob responsible per site.
- Tests updated from `assert.EqualError` to `assert.ErrorIs` (plus `ErrorContains` to pin the branch where the test targets a specific check). `errors.Is` compatibility is preserved, so no behavior change for callers.
- CHANGELOG_PENDING entry.

## Example messages

Before (both cases): `insufficient sender reserve`

After:
- `insufficient sender reserve: faceValue 999999999 is less than ticketEV 1000000000 (sender max float: 999999999); the sender's reserve is too low for this orchestrator's -ticketEV`
- `insufficient sender reserve: faceValue 10000000000000 cannot cover the ticket redemption tx cost (at current gas price: 12000000000000, at avg gas price: 3600000000000000); increase -maxFaceValue or the sender's reserve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “insufficient sender reserve” error messages with specific validation details and relevant numeric values.
  * Errors now distinguish whether the issue involves ticket value, sender maximum float, or redemption transaction costs.
  * Preserved compatibility for applications that identify the underlying insufficient-reserve error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->