### PR TITLE
Add a session-scoped payment URL to the runner challenge.

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -185,6 +185,7 @@ type liveRunnerPaymentChallengeResponse struct {
 	// Keep the URL in top-level JSON so clients do not need to parse the protobuf just to route payment.
 	Orchestrator string `json:"orchestrator"`
 	ManifestID   string `json:"manifest_id"`
+	PaymentURL   string `json:"payment_url"`
 }
 
 type liveRunnerTrickleChannelRequest struct {
@@ -402,7 +403,8 @@ func (h *lphttp) runnerChallenge(w http.ResponseWriter, r *http.Request, priceIn
 		respondWithError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	paymentURL := h.orchestrator.ServiceURI().JoinPath("apps", r.PathValue("runner_id"), "session", oInfo.GetAuthToken().GetSessionId(), "payment").String()
+	data, err := marshalLivePaymentChallengeResponse(oInfo, paymentURL)
 	if err != nil {
 		respondWithError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -427,7 +429,8 @@ func (h *lphttp) scopePaymentChallenge(w http.ResponseWriter, r *http.Request) (
 	if err != nil {
 		return false, err
 	}
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	paymentURL := h.orchestrator.ServiceURI().JoinPath("payment").String()
+	data, err := marshalLivePaymentChallengeResponse(oInfo, paymentURL)
 	if err != nil {
 		return false, err
 	}
@@ -437,7 +440,7 @@ func (h *lphttp) scopePaymentChallenge(w http.ResponseWriter, r *http.Request) (
 	return true, nil
 }
 
-func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo) ([]byte, error) {
+func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo, paymentURL string) ([]byte, error) {
 	buf, err := proto.Marshal(oInfo)
 	if err != nil {
 		return nil, err
@@ -446,6 +449,7 @@ func marshalLivePaymentChallengeResponse(oInfo *lpnet.OrchestratorInfo) ([]byte,
 		PaymentParams: base64.StdEncoding.EncodeToString(buf),
 		Orchestrator:  oInfo.GetTranscoder(),
 		ManifestID:    oInfo.GetAuthToken().GetSessionId(),
+		PaymentURL:    paymentURL,
 	})
 }
 

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -664,6 +664,7 @@ func TestLiveRunnerReserveSessionOnchainReturnsPaymentChallenge(t *testing.T) {
 	require.NotEmpty(t, challenge.PaymentParams)
 	require.Equal(t, lp.orchestrator.ServiceURI().String(), challenge.Orchestrator)
 	require.NotEmpty(t, challenge.ManifestID)
+	require.Equal(t, lp.orchestrator.ServiceURI().JoinPath("apps", "runner-1", "session", challenge.ManifestID, "payment").String(), challenge.PaymentURL)
 	require.Equal(t, challenge.ManifestID, oInfo.GetAuthToken().GetSessionId())
 	require.NotNil(t, oInfo.GetTicketParams())
 	require.NotNil(t, oInfo.GetPriceInfo())
@@ -1042,6 +1043,7 @@ func TestLiveRunnerReserveSessionOnchainUsesPublicServiceURIForPaymentChallenge(
 	require.Equal(t, http.StatusPaymentRequired, w.Code)
 	challenge, oInfo := decodeLiveRunnerPaymentChallenge(t, w.Body.Bytes())
 	require.Equal(t, "https://public.example.com", challenge.Orchestrator)
+	require.Equal(t, "https://public.example.com/apps/runner-1/session/"+challenge.ManifestID+"/payment", challenge.PaymentURL)
 	require.Equal(t, challenge.Orchestrator, oInfo.GetTranscoder())
 }
 
@@ -2054,7 +2056,9 @@ func requestScopePaymentChallenge(t *testing.T, lp *lphttp) (liveRunnerPaymentCh
 	setRequestHeaders(req, liveRunnerSenderHeaders(lp.orchestrator.(*stubOrchestrator)))
 	lp.ServeHTTP(w, req)
 	require.Equal(t, http.StatusPaymentRequired, w.Code)
-	return decodeLiveRunnerPaymentChallenge(t, w.Body.Bytes())
+	challenge, oInfo := decodeLiveRunnerPaymentChallenge(t, w.Body.Bytes())
+	require.Equal(t, lp.orchestrator.ServiceURI().JoinPath("payment").String(), challenge.PaymentURL)
+	return challenge, oInfo
 }
 
 func closeScopeEvents(t *testing.T, lp *lphttp, manifestID string) {

--- a/server/rpc.go
+++ b/server/rpc.go
@@ -496,7 +496,8 @@ func (h *lphttp) RefreshPayment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	data, err := marshalLivePaymentChallengeResponse(oInfo)
+	paymentURL := h.orchestrator.ServiceURI().JoinPath("payment").String()
+	data, err := marshalLivePaymentChallengeResponse(oInfo, paymentURL)
 	if err != nil {
 		respondJsonError(ctx, w, err, http.StatusInternalServerError)
 		return

--- a/server/rpc_test.go
+++ b/server/rpc_test.go
@@ -1358,6 +1358,7 @@ func TestRefreshPayment_ReturnsPinnedPaymentChallenge(t *testing.T) {
 	challenge, got := decodeLiveRunnerPaymentChallenge(t, rr.Body.Bytes())
 	require.Equal(t, "http://orch.example", challenge.Orchestrator)
 	require.Equal(t, string(manifestID), challenge.ManifestID)
+	require.Equal(t, "http://orch.example/payment", challenge.PaymentURL)
 	require.Equal(t, "http://orch.example", got.Transcoder)
 	require.True(t, proto.Equal(ticketParams, got.TicketParams))
 	require.Equal(t, int64(7), got.PriceInfo.PricePerUnit)


### PR DESCRIPTION
This way ongoing single-shot payments know where to go.

Sending to the orchestrator's generic `/payment` endpoint is still possible, but is not tied to a session, so the client wouldn't get get any feedback whether it was paying towards a valid session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment challenges now include a direct payment URL.
  * Live runner challenges link to the appropriate runner session payment page.
  * Scope and refresh-payment challenges link to the orchestrator payment page.

* **Bug Fixes**
  * Improved payment challenge responses so users receive the correct destination for completing payment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->