### PR TITLE
signer: Add price ceilings

### DIFF
--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -166,12 +166,27 @@ Example:
 
 When running a gateway in offchain mode (ie, with `-remoteSignerUrl` and no Ethereum flags), the gateway does not check orchestrator pricing. Instead, price checks happen in the remote signer during payment generation.
 
+The price can be limited three ways: by the signer's configuration, by the
+client in the payment request, and by the signer auth webhook. All are compared
+if present, effectively the taking the minimum.
+
+Any max price must be positive and explicitly denominated in `wei`. Its unit
+must match the payment type: `seconds` for `live`, `720p-pixel-seconds` for `lv2v`,
+or `fixed` for `fixed`. Invalid request ceilings return HTTP 400.
+
+The first payment becomes a ceiling for subsequent requests in the session. If
+refreshed payment parameters exceed the initial price, the signer rejects with
+a HTTP 481.
+
 - **Remote signer configuration**: configure the signer with the same pricing and PM knobs you would normally configure on a gateway, e.g.:
   - `-maxPricePerUnit`, `-pixelsPerUnit`
   - `-maxPricePerCapability` (optional, capability/model pricing config)
   - `-maxTicketEV`, `-maxTotalEV`, etc.
+- **Request maximum** A client requesting a payment can also specify a `maxPrice` taken from the discovery pricing, or put in their own max (in wei). This ensures that the discovery price and actual price do not drift too much. It is recommended that clients add a ~1.2% buffer to the discovery price which should cover roughly 95% of hourly ETH-USD price moves. The format follows that of the discovery pricing scheme.
+- **Auth webhook** The auth webhook can also return a `maxPrice` in the same format as the discovery price.
 - **Selection behavior**: if an orchestrator’s price is above the signer’s configured limits, the signer rejects the payment request (HTTP 481) and the gateway will retry with a different orchestrator session.
 - **LV2V session price is fixed**: Live Video-to-Video (LV2V) jobs treat price as fixed for the lifetime of the session, captured at session initialization time.
+
 
 ### Tuning ticket EV to avoid “too many tickets” errors
 
@@ -229,7 +244,7 @@ Example body:
     "PMSessionID": "session-1",
     "LastUpdate": "2026-04-07T20:00:00Z",
     "OrchestratorAddress": "0x1234...",
-    "App": "live-video-to-video/scope",
+    "App": "livepeer-echo-stream",
     "AuthExpiry": 0,
     "SenderNonce": 7,
     "Balance": "500/1",
@@ -251,11 +266,12 @@ The webhook itself must return **HTTP 200** and include a JSON body with:
 | `reason` | `string`| No       | Error message returned to the gateway caller when `status` is not `200` |
 | `expiry` | `int64` | No       | Unix timestamp in seconds until which the authorization can be reused |
 | `auth_id` | `string` | No     | Opaque authorization identifier (optional) |
+| `maxPrice` | `object` | No    | Positive `wei` price ceiling whose unit must match the payment type |
 
 Example success response:
 
 ```json
-{"status": 200, "expiry": 1775574245, "auth_id": "auth-456"}
+{"status": 200, "expiry": 1775574245, "auth_id": "auth-456", "maxPrice": {"price": 1300, "currency": "wei", "unit": "seconds"}}
 ```
 
 Example rejection response:
@@ -268,6 +284,7 @@ Example rejection response:
 - **HTTP 200 with `status != 200`**: the signer aborts and returns that `status` to the gateway caller, wrapped in the standard API error JSON envelope. If `reason` is present it is used as the error message. This can be used by implementers to steer downstream caller behavior.
 - **Any non-200 webhook HTTP response**: the signer treats this as an internal webhook failure (eg, webhook service error or signer misconfiguration) and returns HTTP 500.
 - **Missing, zero, malformed, or otherwise invalid `status`**: the signer returns HTTP 500.
+- ***maxPrice**: Malformed `maxPrice` is treated as webhook misconfiguration and returns HTTP 500. If the orchestrator's price is higher than the webhook maxPrice, the response returns HTTP 481.
 - If `auth_id` is omitted, the signer falls back to the incoming request's `Signer-Auth-Id` header. If both are present, the webhook `auth_id` takes precedence.
 - Once an auth ID is persisted in signed payment state, a different webhook `auth_id` or fallback `Signer-Auth-Id` on a later request is treated as an internal error and returns HTTP 500.
 

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -250,6 +250,7 @@ Example body:
     "Balance": "500/1",
     "InitialPricePerUnit": 1200,
     "InitialPixelsPerUnit": 1,
+    "Type": "live",
     "SequenceNumber": 3,
     "AuthID": "auth-456"
   }
@@ -309,3 +310,8 @@ When `-remoteSignerWebhookUrl` is configured, the remote signer calls the auth w
 For the moment, remote signers are intended to sit behind infrastructure controls rather than being exposed directly to end-users. For example, run the remote signer on a private network or behind an authenticated proxy. Do not expose the remote signer to unauthenticated end-users. Run the remote signer close to gateways on a private network; protect it like you would an internal wallet service. If a proxy sits in front of the signer, configure it to scrub all incoming `Signer-` headers from untrusted clients before applying trusted internal headers.
 
 Remote signers are stateless, so signer nodes can operate in a redundant configuration (eg, round-robin DNS, anycasting) with no special gateway-side configuration.
+
+## Request Fields
+
+For the latest documentation on each `/generate-live-payment` request field,
+see [`RemotePaymentRequest`](../server/remote_signer.go).

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 echo 'WARNING: downloading and executing lpms/install_ffmpeg.sh, use it directly in case of issues'
-curl https://raw.githubusercontent.com/livepeer/lpms/bc67cafe732afb08053328483f73cf000a28d330/install_ffmpeg.sh | bash -s $1
+curl https://raw.githubusercontent.com/livepeer/lpms/467824663359a0a48f04e8563e99e1bec1561455/install_ffmpeg.sh | bash -s $1

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -682,7 +682,7 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 		if callbackResp.MaxPrice != nil {
 			authMaxPrice, err := parseRemotePaymentMaxPrice(callbackResp.MaxPrice, req.Type)
 			if err != nil {
-				respondJsonError(ctx, w, fmt.Errorf("signer auth invalid maxPrice: %w", err), http.StatusInternalServerError)
+				respondJsonError(ctx, w, fmt.Errorf("signer auth invalid maxPrice: %w", err), http.StatusBadGateway)
 				return
 			}
 			if err := checkRemotePaymentPrice(orchPrice, remotePaymentPriceCeiling{source: "auth webhook maxPrice", price: authMaxPrice}); err != nil {

--- a/server/remote_signer.go
+++ b/server/remote_signer.go
@@ -187,6 +187,9 @@ type RemotePaymentRequest struct {
 	// Job type to automatically calculate payments. Valid values: `live`, `lv2v`, `fixed`. Optional.
 	Type string `json:"type"`
 
+	// Maximum acceptable price for this request. Optional.
+	MaxPrice *runner.LiveRunnerPriceInfo `json:"maxPrice,omitempty"`
+
 	// Capabilities to include in the ticket. Optional; may be set for the lv2v job type.
 	Capabilities []byte `json:"capabilities"`
 }
@@ -213,6 +216,60 @@ type authResponse struct {
 	Expiry int64 `json:"expiry,omitempty"`
 	// Optional opaque identifier.
 	AuthID string `json:"auth_id,omitempty"`
+	// Optional maximum acceptable challenge price.
+	MaxPrice *runner.LiveRunnerPriceInfo `json:"maxPrice,omitempty"`
+}
+
+type remotePaymentPriceCeiling struct {
+	source string
+	price  *big.Rat
+}
+
+func parseRemotePaymentMaxPrice(maxPrice *runner.LiveRunnerPriceInfo, paymentType string) (*big.Rat, error) {
+	if maxPrice == nil {
+		return nil, nil
+	}
+
+	price, ok := new(big.Rat).SetString(strings.TrimSpace(maxPrice.Price.String()))
+	if !ok || price.Sign() <= 0 {
+		return nil, errors.New("maxPrice.price must be a positive decimal")
+	}
+	if strings.ToLower(strings.TrimSpace(maxPrice.Currency)) != "wei" {
+		return nil, errors.New("maxPrice.currency must be wei")
+	}
+
+	var expectedUnit string
+	switch paymentType {
+	case RemoteType_Live:
+		expectedUnit = "seconds"
+	case RemoteType_LiveVideoToVideo:
+		expectedUnit = "720p-pixel-seconds"
+	case RemoteType_Fixed:
+		expectedUnit = "fixed"
+	default:
+		return nil, errors.New("maxPrice requires payment type live, lv2v, or fixed")
+	}
+	if unit := strings.ToLower(strings.TrimSpace(maxPrice.Unit)); unit != expectedUnit {
+		return nil, fmt.Errorf("maxPrice.unit must be %s for payment type %s", expectedUnit, paymentType)
+	}
+
+	return price, nil
+}
+
+func checkRemotePaymentPrice(orchPrice *big.Rat, ceilings ...remotePaymentPriceCeiling) error {
+	var effective remotePaymentPriceCeiling
+	for _, ceiling := range ceilings {
+		if ceiling.price == nil {
+			continue
+		}
+		if effective.price == nil || ceiling.price.Cmp(effective.price) < 0 {
+			effective = ceiling
+		}
+	}
+	if effective.price != nil && orchPrice.Cmp(effective.price) > 0 {
+		return fmt.Errorf("orchestrator price %v exceeds %s ceiling %v", orchPrice.FloatString(3), effective.source, effective.price.FloatString(3))
+	}
+	return nil
 }
 
 // Signs the serialized state with the remote signer's Ethereum key.
@@ -511,11 +568,26 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Validate orchestrator price against configured max price
+	// Validate orchestrator price against all ceilings available before the auth callback.
 	orchPrice := new(big.Rat).SetFrac64(priceInfo.PricePerUnit, priceInfo.PixelsPerUnit)
-	maxPrice := BroadcastCfg.GetCapabilitiesMaxPrice(streamParams.Capabilities)
-	if maxPrice != nil && orchPrice.Cmp(maxPrice) > 0 {
-		err := fmt.Errorf("orchestrator price %v exceeds maximum price %v", orchPrice.FloatString(3), maxPrice.FloatString(3))
+	requestMaxPrice, err := parseRemotePaymentMaxPrice(req.MaxPrice, req.Type)
+	if err != nil {
+		respondJsonError(ctx, w, err, http.StatusBadRequest)
+		return
+	}
+	var initialMaxPrice *big.Rat
+	if hasState {
+		if state.InitialPricePerUnit <= 0 || state.InitialPixelsPerUnit <= 0 {
+			respondJsonError(ctx, w, errors.New("invalid initial price in state"), http.StatusBadRequest)
+			return
+		}
+		initialMaxPrice = new(big.Rat).SetFrac64(state.InitialPricePerUnit, state.InitialPixelsPerUnit)
+	}
+	if err := checkRemotePaymentPrice(orchPrice,
+		remotePaymentPriceCeiling{source: "configured maximum price", price: BroadcastCfg.GetCapabilitiesMaxPrice(streamParams.Capabilities)},
+		remotePaymentPriceCeiling{source: "request maxPrice", price: requestMaxPrice},
+		remotePaymentPriceCeiling{source: "initial session price", price: initialMaxPrice},
+	); err != nil {
 		clog.Warningf(ctx, "Rejecting payment request: %v", err)
 		respondJsonError(ctx, w, err, HTTPStatusPriceExceeded)
 		return
@@ -607,6 +679,18 @@ func (ls *LivepeerServer) GenerateLivePayment(w http.ResponseWriter, r *http.Req
 	}
 	if callbackResp != nil {
 		state.AuthExpiry = callbackResp.Expiry
+		if callbackResp.MaxPrice != nil {
+			authMaxPrice, err := parseRemotePaymentMaxPrice(callbackResp.MaxPrice, req.Type)
+			if err != nil {
+				respondJsonError(ctx, w, fmt.Errorf("signer auth invalid maxPrice: %w", err), http.StatusInternalServerError)
+				return
+			}
+			if err := checkRemotePaymentPrice(orchPrice, remotePaymentPriceCeiling{source: "auth webhook maxPrice", price: authMaxPrice}); err != nil {
+				clog.Warningf(ctx, "Rejecting payment request: %v", err)
+				respondJsonError(ctx, w, err, HTTPStatusPriceExceeded)
+				return
+			}
+		}
 	}
 	authID := r.Header.Get(remoteSignerAuthIDHeader)
 	if callbackResp != nil && callbackResp.AuthID != "" {

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -277,6 +277,67 @@ func TestGenerateLivePayment_RequestValidationErrors(t *testing.T) {
 			wantMsg:    "orchestrator price",
 		},
 		{
+			name: "orchestrator price exceeds request max price",
+			req: func() RemotePaymentRequest {
+				oInfo := proto.Clone(baseOrchInfo).(*net.OrchestratorInfo)
+				oInfo.PriceInfo = &net.PriceInfo{PricePerUnit: 10, PixelsPerUnit: 1}
+				return RemotePaymentRequest{
+					Orchestrator: makeOrchBlob(oInfo),
+					Type:         RemoteType_Fixed,
+					MaxPrice: &runner.LiveRunnerPriceInfo{
+						Price:    json.Number("9"),
+						Currency: "wei",
+						Unit:     "fixed",
+					},
+				}
+			}(),
+			wantStatus: HTTPStatusPriceExceeded,
+			wantMsg:    "request maxPrice",
+		},
+		{
+			name: "request max price requires typed payment",
+			req: func() RemotePaymentRequest {
+				r := baseReq()
+				r.MaxPrice = &runner.LiveRunnerPriceInfo{Price: json.Number("1"), Currency: "wei", Unit: "fixed"}
+				return r
+			}(),
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    "maxPrice requires payment type",
+		},
+		{
+			name: "request max price requires wei",
+			req: func() RemotePaymentRequest {
+				r := baseReq()
+				r.Type = RemoteType_Fixed
+				r.MaxPrice = &runner.LiveRunnerPriceInfo{Price: json.Number("1"), Currency: "usd", Unit: "fixed"}
+				return r
+			}(),
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    "maxPrice.currency must be wei",
+		},
+		{
+			name: "request max price unit must match type",
+			req: func() RemotePaymentRequest {
+				r := baseReq()
+				r.Type = RemoteType_Live
+				r.MaxPrice = &runner.LiveRunnerPriceInfo{Price: json.Number("1"), Currency: "wei", Unit: "fixed"}
+				return r
+			}(),
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    "maxPrice.unit must be seconds",
+		},
+		{
+			name: "request max price must be positive",
+			req: func() RemotePaymentRequest {
+				r := baseReq()
+				r.Type = RemoteType_Fixed
+				r.MaxPrice = &runner.LiveRunnerPriceInfo{Price: json.Number("0"), Currency: "wei", Unit: "fixed"}
+				return r
+			}(),
+			wantStatus: http.StatusBadRequest,
+			wantMsg:    "maxPrice.price must be a positive decimal",
+		},
+		{
 			name: "fixed orchestrator price uses existing max price check",
 			req: func() RemotePaymentRequest {
 				oInfo := proto.Clone(baseOrchInfo).(*net.OrchestratorInfo)
@@ -342,6 +403,65 @@ func TestGenerateLivePayment_RequestValidationErrors(t *testing.T) {
 			if tt.wantHeader != "" {
 				require.Equal(tt.wantHeader, rr.Header().Get(RefreshSessionOrchestratorURLHeader))
 			}
+		})
+	}
+}
+
+func TestParseRemotePaymentMaxPrice(t *testing.T) {
+	tests := []struct {
+		name        string
+		maxPrice    *runner.LiveRunnerPriceInfo
+		paymentType string
+		want        *big.Rat
+		wantError   string
+	}{
+		{
+			name:        "live decimal",
+			maxPrice:    &runner.LiveRunnerPriceInfo{Price: json.Number("101.2"), Currency: "wei", Unit: "seconds"},
+			paymentType: RemoteType_Live,
+			want:        big.NewRat(506, 5),
+		},
+		{
+			name:        "lv2v",
+			maxPrice:    &runner.LiveRunnerPriceInfo{Price: json.Number("7"), Currency: "wei", Unit: "720p-pixel-seconds"},
+			paymentType: RemoteType_LiveVideoToVideo,
+			want:        big.NewRat(7, 1),
+		},
+		{
+			name:        "fixed",
+			maxPrice:    &runner.LiveRunnerPriceInfo{Price: json.Number("3"), Currency: "wei", Unit: "fixed"},
+			paymentType: RemoteType_Fixed,
+			want:        big.NewRat(3, 1),
+		},
+		{
+			name:        "malformed price",
+			maxPrice:    &runner.LiveRunnerPriceInfo{Price: json.Number("wat"), Currency: "wei", Unit: "fixed"},
+			paymentType: RemoteType_Fixed,
+			wantError:   "positive decimal",
+		},
+		{
+			name:        "negative price",
+			maxPrice:    &runner.LiveRunnerPriceInfo{Price: json.Number("-1"), Currency: "wei", Unit: "fixed"},
+			paymentType: RemoteType_Fixed,
+			wantError:   "positive decimal",
+		},
+		{
+			name:        "missing currency",
+			maxPrice:    &runner.LiveRunnerPriceInfo{Price: json.Number("1"), Unit: "fixed"},
+			paymentType: RemoteType_Fixed,
+			wantError:   "currency must be wei",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRemotePaymentMaxPrice(tt.maxPrice, tt.paymentType)
+			if tt.wantError != "" {
+				require.ErrorContains(t, err, tt.wantError)
+				return
+			}
+			require.NoError(t, err)
+			require.Zero(t, got.Cmp(tt.want))
 		})
 	}
 }
@@ -479,15 +599,15 @@ func TestGenerateLivePayment_StateValidationErrors(t *testing.T) {
 			wantMsg:    "orchestratorAddress mismatch",
 		},
 		{
-			name:       "orchestrator price increased more than 2x",
+			name:       "orchestrator price exceeds initial session price",
 			stateBytes: priceIncreaseStateBytes,
 			orchInfo: func() *net.OrchestratorInfo {
 				oInfo := proto.Clone(orchInfo).(*net.OrchestratorInfo)
-				oInfo.PriceInfo = &net.PriceInfo{PricePerUnit: 250, PixelsPerUnit: 1}
+				oInfo.PriceInfo = &net.PriceInfo{PricePerUnit: 150, PixelsPerUnit: 1}
 				return oInfo
 			}(),
 			wantStatus: HTTPStatusPriceExceeded,
-			wantMsg:    "Orchestrator price has more than doubled",
+			wantMsg:    "initial session price ceiling",
 		},
 		{
 			name: "zero tickets returns 482",
@@ -655,7 +775,7 @@ func TestGenerateLivePayment_LV2V_Succeeds(t *testing.T) {
 	_, err = base64.StdEncoding.DecodeString(resp.SegCreds)
 	require.NoError(err)
 
-	// Check that the initial price is still used even after a 1.5x increase
+	// Check that the initial price is still used even after a challenge price decrease.
 	var state1 RemotePaymentState
 	require.NoError(json.Unmarshal(resp.State.State, &state1))
 	oldBal := new(big.Rat)
@@ -671,7 +791,7 @@ func TestGenerateLivePayment_LV2V_Succeeds(t *testing.T) {
 
 	updatedInfo := proto.Clone(oInfo).(*net.OrchestratorInfo)
 	updatedInfo.PriceInfo = &net.PriceInfo{
-		PricePerUnit:  oInfo.PriceInfo.PricePerUnit * 3 / 2, // 1.5x increase
+		PricePerUnit:  oInfo.PriceInfo.PricePerUnit * 3 / 4,
 		PixelsPerUnit: oInfo.PriceInfo.PixelsPerUnit,
 	}
 	orchBlob, err = proto.Marshal(updatedInfo)
@@ -684,6 +804,8 @@ func TestGenerateLivePayment_LV2V_Succeeds(t *testing.T) {
 		InPixels:     inPixelsUpdated,
 		State:        resp.State,
 	})
+	require.Equal(updatedInfo.PriceInfo.PricePerUnit, payment2.ExpectedPrice.PricePerUnit)
+	require.Equal(updatedInfo.PriceInfo.PixelsPerUnit, payment2.ExpectedPrice.PixelsPerUnit)
 
 	var stateFee2 RemotePaymentState
 	require.NoError(json.Unmarshal(resp2.State.State, &stateFee2))
@@ -859,7 +981,12 @@ func TestGenerateLivePayment_FixedBillsOneUnitAndAllowsState(t *testing.T) {
 			ManifestID:   manifestID,
 			InPixels:     1_000_000,
 			Type:         RemoteType_Fixed,
-			State:        state,
+			MaxPrice: &runner.LiveRunnerPriceInfo{
+				Price:    json.Number("4"),
+				Currency: "wei",
+				Unit:     "fixed",
+			},
+			State: state,
 		})
 		require.NoError(err)
 		rr := httptest.NewRecorder()
@@ -878,6 +1005,8 @@ func TestGenerateLivePayment_FixedBillsOneUnitAndAllowsState(t *testing.T) {
 	// Like other payment types, an initial request may omit the manifest ID.
 	first, firstPayment := doPayment("", RemotePaymentStateSig{})
 	require.Len(firstPayment.TicketSenderParams, 1)
+	require.EqualValues(3, firstPayment.ExpectedPrice.PricePerUnit)
+	require.EqualValues(1, firstPayment.ExpectedPrice.PixelsPerUnit)
 	var firstState RemotePaymentState
 	require.NoError(json.Unmarshal(first.State.State, &firstState))
 	require.Equal(RemoteType_Fixed, firstState.Type)
@@ -915,9 +1044,12 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 	require.NoError(err)
 
 	type paymentRequestOptions struct {
-		authID string
-		app    string
-		state  RemotePaymentStateSig
+		authID    string
+		app       string
+		typeID    string
+		priceInfo *net.PriceInfo
+		maxPrice  *runner.LiveRunnerPriceInfo
+		state     RemotePaymentStateSig
 	}
 	doPayment := func(requestHeader string, options ...paymentRequestOptions) *httptest.ResponseRecorder {
 		require.LessOrEqual(len(options), 1)
@@ -925,11 +1057,20 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		if len(options) == 1 {
 			opts = options[0]
 		}
+		requestOrchBlob := orchBlob
+		if opts.priceInfo != nil {
+			requestOInfo := proto.Clone(oInfo).(*net.OrchestratorInfo)
+			requestOInfo.PriceInfo = opts.priceInfo
+			requestOrchBlob, err = proto.Marshal(requestOInfo)
+			require.NoError(err)
+		}
 		reqBody, err := json.Marshal(RemotePaymentRequest{
-			Orchestrator: orchBlob,
+			Orchestrator: requestOrchBlob,
 			ManifestID:   "manifest",
 			App:          opts.app,
 			InPixels:     1,
+			Type:         opts.typeID,
+			MaxPrice:     opts.maxPrice,
 			State:        opts.state,
 		})
 		require.NoError(err)
@@ -957,6 +1098,128 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 
 		rr := doPayment("no-callback")
 		require.Equal(http.StatusOK, rr.Code)
+	})
+
+	t.Run("callback max price rejects challenged price", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":200,"maxPrice":{"price":0.5,"currency":"wei","unit":"fixed"}}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPayment("max-price-rejected", paymentRequestOptions{typeID: RemoteType_Fixed})
+		require.Equal(HTTPStatusPriceExceeded, rr.Code)
+		var apiErr apiErrorResponse
+		require.NoError(json.NewDecoder(rr.Body).Decode(&apiErr))
+		require.Contains(apiErr.Error.Message, "auth webhook maxPrice")
+	})
+
+	t.Run("invalid callback max price returns 500", func(t *testing.T) {
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":200,"maxPrice":{"price":2,"currency":"usd","unit":"fixed"}}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		rr := doPayment("invalid-max-price", paymentRequestOptions{typeID: RemoteType_Fixed})
+		require.Equal(http.StatusInternalServerError, rr.Code)
+	})
+
+	t.Run("most restrictive price ceiling wins", func(t *testing.T) {
+		callbackCalls := 0
+		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callbackCalls++
+			w.WriteHeader(http.StatusOK)
+			if callbackCalls == 1 {
+				_, _ = w.Write([]byte(`{"status":200}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"status":200,"maxPrice":{"price":0.5,"currency":"wei","unit":"fixed"}}`))
+		}))
+		defer webhook.Close()
+
+		webhookURL, err := url.Parse(webhook.URL)
+		require.NoError(err)
+		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
+		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
+
+		BroadcastCfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(3, 1)))
+		defer BroadcastCfg.SetMaxPrice(nil)
+
+		// Equality is accepted: the challenge and request ceiling are both 2 wei.
+		first := doPayment("price-ceiling-equality", paymentRequestOptions{
+			typeID:    RemoteType_Fixed,
+			priceInfo: &net.PriceInfo{PricePerUnit: 2, PixelsPerUnit: 1},
+			maxPrice:  &runner.LiveRunnerPriceInfo{Price: json.Number("2"), Currency: "wei", Unit: "fixed"},
+		})
+		require.Equal(http.StatusOK, first.Code, first.Body.String())
+		var firstResp RemotePaymentResponse
+		require.NoError(json.NewDecoder(first.Body).Decode(&firstResp))
+		require.Equal(1, callbackCalls)
+
+		// Request maxPrice is lower than the configured and initial ceilings.
+		requestLimited := doPayment("request-ceiling-precedence", paymentRequestOptions{
+			typeID:    RemoteType_Fixed,
+			priceInfo: &net.PriceInfo{PricePerUnit: 7, PixelsPerUnit: 4},
+			maxPrice:  &runner.LiveRunnerPriceInfo{Price: json.Number("1.5"), Currency: "wei", Unit: "fixed"},
+			state:     firstResp.State,
+		})
+		require.Equal(HTTPStatusPriceExceeded, requestLimited.Code)
+		var requestErr apiErrorResponse
+		require.NoError(json.NewDecoder(requestLimited.Body).Decode(&requestErr))
+		require.Contains(requestErr.Error.Message, "request maxPrice")
+		require.Equal(1, callbackCalls)
+
+		// The initial price is lower than the configured and request ceilings.
+		initialLimited := doPayment("initial-ceiling-precedence", paymentRequestOptions{
+			typeID:    RemoteType_Fixed,
+			priceInfo: &net.PriceInfo{PricePerUnit: 9, PixelsPerUnit: 4},
+			maxPrice:  &runner.LiveRunnerPriceInfo{Price: json.Number("2.5"), Currency: "wei", Unit: "fixed"},
+			state:     firstResp.State,
+		})
+		require.Equal(HTTPStatusPriceExceeded, initialLimited.Code)
+		var initialErr apiErrorResponse
+		require.NoError(json.NewDecoder(initialLimited.Body).Decode(&initialErr))
+		require.Contains(initialErr.Error.Message, "initial session price")
+		require.Equal(1, callbackCalls)
+
+		// A lowered signer configuration is more restrictive than request and initial ceilings.
+		BroadcastCfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(3, 2)))
+		configuredLimited := doPayment("configured-ceiling-precedence", paymentRequestOptions{
+			typeID:    RemoteType_Fixed,
+			priceInfo: &net.PriceInfo{PricePerUnit: 7, PixelsPerUnit: 4},
+			maxPrice:  &runner.LiveRunnerPriceInfo{Price: json.Number("2.5"), Currency: "wei", Unit: "fixed"},
+			state:     firstResp.State,
+		})
+		require.Equal(HTTPStatusPriceExceeded, configuredLimited.Code)
+		var configuredErr apiErrorResponse
+		require.NoError(json.NewDecoder(configuredLimited.Body).Decode(&configuredErr))
+		require.Contains(configuredErr.Error.Message, "configured maximum price")
+		require.Equal(1, callbackCalls)
+
+		// The request passes all pre-callback ceilings, then the webhook ceiling rejects it.
+		BroadcastCfg.SetMaxPrice(core.NewFixedPrice(big.NewRat(3, 1)))
+		webhookLimited := doPayment("webhook-ceiling-precedence", paymentRequestOptions{
+			typeID:    RemoteType_Fixed,
+			priceInfo: &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 1},
+			maxPrice:  &runner.LiveRunnerPriceInfo{Price: json.Number("1.5"), Currency: "wei", Unit: "fixed"},
+			state:     firstResp.State,
+		})
+		require.Equal(HTTPStatusPriceExceeded, webhookLimited.Code)
+		var webhookErr apiErrorResponse
+		require.NoError(json.NewDecoder(webhookLimited.Body).Decode(&webhookErr))
+		require.Contains(webhookErr.Error.Message, "auth webhook maxPrice")
+		require.Equal(2, callbackCalls)
 	})
 
 	t.Run("callback receives request headers and outbound auth headers", func(t *testing.T) {
@@ -1097,7 +1360,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		webhook := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callbackCalls++
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(fmt.Sprintf(`{"status":200,"expiry":%d,"auth_id":"cached-auth-id"}`, expiry)))
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"status":200,"expiry":%d,"auth_id":"cached-auth-id","maxPrice":{"price":2,"currency":"wei","unit":"fixed"}}`, expiry)))
 		}))
 		defer webhook.Close()
 
@@ -1106,7 +1369,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		ls.LivepeerNode.RemoteSignerWebhookURL = webhookURL
 		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
 
-		first := doPayment("req-skip-first")
+		first := doPayment("req-skip-first", paymentRequestOptions{typeID: RemoteType_Fixed})
 		require.Equal(http.StatusOK, first.Code)
 
 		var firstResp RemotePaymentResponse
@@ -1115,7 +1378,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		require.NoError(json.Unmarshal(firstResp.State.State, &firstState))
 		require.Equal("cached-auth-id", firstState.AuthID)
 
-		second := doPayment("req-skip-second", paymentRequestOptions{state: firstResp.State})
+		second := doPayment("req-skip-second", paymentRequestOptions{typeID: RemoteType_Fixed, state: firstResp.State})
 		require.Equal(http.StatusOK, second.Code)
 		var secondResp RemotePaymentResponse
 		require.NoError(json.NewDecoder(second.Body).Decode(&secondResp))
@@ -1126,6 +1389,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 
 		third := doPayment("req-skip-third", paymentRequestOptions{
 			authID: "new-header-auth-id",
+			typeID: RemoteType_Fixed,
 			state:  secondResp.State,
 		})
 		require.Equal(http.StatusInternalServerError, third.Code)

--- a/server/remote_signer_test.go
+++ b/server/remote_signer_test.go
@@ -1132,7 +1132,7 @@ func TestGenerateLivePayment_WebhookCallback(t *testing.T) {
 		ls.LivepeerNode.RemoteSignerWebhookHeaders = nil
 
 		rr := doPayment("invalid-max-price", paymentRequestOptions{typeID: RemoteType_Fixed})
-		require.Equal(http.StatusInternalServerError, rr.Code)
+		require.Equal(http.StatusBadGateway, rr.Code)
 	})
 
 	t.Run("most restrictive price ceiling wins", func(t *testing.T) {


### PR DESCRIPTION
Add optional maxPrice fields to payment requests and auth webhook responses. This works in conjunction with the signer-configured max; if all three are present, the minimum is effectively used.

Also cap the session price at the initial price, since orchestrators should also fix the price at session start, so there is no need to accommodate ~2x drift within ValidatePrice. In practice this should not lead to a behavior change.