### PR TITLE
build(docker): pin ffmpeg to n8.1.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,9 +42,8 @@ RUN curl -o /nasm-3.01.tar.gz "https://www.nasm.us/pub/nasm/releasebuilds/3.01/n
 	&& make \
 	&& make install
 
-RUN FFMPEG_SHA=b76053d8bf322b197a9d07bd27bbdad14fd5bc15 git clone --depth 1 https://git.ffmpeg.org/ffmpeg.git /ffmpeg \
-	&& cd /ffmpeg && git fetch --depth 1 origin ${FFMPEG_SHA} \
-	&& git checkout ${FFMPEG_SHA} \
+RUN	git clone --depth 1 --branch n8.1.2 https://git.ffmpeg.org/ffmpeg.git /ffmpeg \
+	&& cd /ffmpeg \
 	&& ./configure --enable-gpl --enable-libx264 --enable-libfdk-aac --enable-nonfree --prefix=build && make -j"$(nproc)" && make install
 
 ENV	GOPATH=/go \


### PR DESCRIPTION
## What

Pins the FFmpeg build in `docker/Dockerfile` to release tag `n8.1.2`.

## Why

The existing `FFMPEG_SHA=b76053d8...` pin has never taken effect. `VAR=value command` is a POSIX prefix assignment, so the variable only entered `git clone`'s environment and never became a shell variable. Both following commands expanded it to an empty string:

- `git fetch --depth 1 origin` took the default branch
- `git checkout` ran with no argument and **exited 0**

The zero exit is why it went unnoticed for 18 months: the `&&` chain continued and the build succeeded, just against the wrong source. Every builder image since #3353 has compiled upstream `master` as of build time, so the image was never reproducible.

Reproducible in one line:

```console
$ FFMPEG_SHA=b76053d8bf322b197a9d07bd27bbdad14fd5bc15 git clone --depth 1 https://git.ffmpeg.org/ffmpeg.git /tmp/f \
    && cd /tmp/f && git fetch --depth 1 origin ${FFMPEG_SHA} && git checkout ${FFMPEG_SHA}
$ git rev-parse HEAD
82d03c6d8e1a16182b3db873eada6b968996437c   # today's master, not the pin
$ git branch --show-current
master                                     # still attached; a real SHA checkout detaches HEAD
```

## Approach

`git clone` accepts tags but not commit SHAs, which is why the original needed the clone-then-fetch-then-checkout dance. Pinning a tag lets `--branch` do it in one step and removes the variable entirely, along with the whole bug class.

## Validation

Built each candidate in a replica of the builder environment (ubuntu 20.04, libx264 0.155, libfdk-aac 0.1.6, gcc 9, nasm 3.01) using the exact configure flags from this file:

| Tag | Tagged | `./configure` | `make` + `make install` |
|---|---|---|---|
| `n9.0.1` | 11 hours ago | ok | ok |
| `n9.0` | 9 days ago | ok | ok |
| **`n8.1.2`** | **8 weeks ago** | **ok** | **ok** |

Nothing is broken upstream, so this is a maturity choice rather than a compatibility one: eight weeks of field exposure against a tag cut hours ago. `n8.1.2` is 7000+ commits ahead of the old pin and contains the HEVC-in-FLV commit (`avformat/flvdec: add support for legacy HEVC files`) that `b76053d8` was originally chosen for.

## Open question

@j0sh do you want to use a release tag here, or make master-tracking explicit instead. Tracking master is what has effectively been happening, so this PR is a behaviour change either way. Tags additionally get maintenance backports and tell a reviewer what is shipping.

## Out of scope

This does not touch the `git.ffmpeg.org` dependency. Note that changing this line invalidates the layer cache, so CI will cold-build it. If `git.ffmpeg.org` is still unreachable from the runners it will fail with `exit code: 128`, which is the separate half of #4021.

Refs #4021
