### PR TITLE
fix(docker): clone ffmpeg from the github mirror

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN curl -o /nasm-3.01.tar.gz "https://www.nasm.us/pub/nasm/releasebuilds/3.01/n
 	&& make \
 	&& make install
 
-RUN FFMPEG_SHA=b76053d8bf322b197a9d07bd27bbdad14fd5bc15 git clone --depth 1 https://git.ffmpeg.org/ffmpeg.git /ffmpeg \
+RUN FFMPEG_SHA=b76053d8bf322b197a9d07bd27bbdad14fd5bc15 git clone --depth 1 https://github.com/FFmpeg/FFmpeg.git /ffmpeg \
 	&& cd /ffmpeg && git fetch --depth 1 origin ${FFMPEG_SHA} \
 	&& git checkout ${FFMPEG_SHA} \
 	&& ./configure --enable-gpl --enable-libx264 --enable-libfdk-aac --enable-nonfree --prefix=build && make -j"$(nproc)" && make install


### PR DESCRIPTION
Clones FFmpeg from `https://github.com/FFmpeg/FFmpeg.git` instead of `https://git.ffmpeg.org/ffmpeg.git`. One URL, nothing else.

## Why

`git.ffmpeg.org` intermittently returns HTTP 502, which fails the clone with `exit code: 128`:

```
#19 4.430 Cloning into '/ffmpeg'...
#19 7.337 fatal: unable to access 'https://git.ffmpeg.org/ffmpeg.git/': The requested URL returned error: 502
```

It failed the v0.9.1 build three times today from GitHub hosted runners, once from a self hosted runner, and cloned fine from a local workstation in between. Details and timings in #4023.

**We do not know for certain that this is the root cause.** We have no visibility into the server. All ffmpeg.org hostnames resolve to a single address with no CDN or failover, which is consistent with a proxy returning 502 when the backend saturates under clone load, but that is a plausible explanation rather than a confirmed diagnosis. What we can say is that the 502s recur, that they are what breaks the build, and that they come from this host.

## Caveat

`github.com/FFmpeg/FFmpeg` is **not an official, FFmpeg endorsed mirror.** [ffmpeg.org/git-howto.html](https://ffmpeg.org/git-howto.html) does not mention GitHub or any mirror and directs git server problems to `root@ffmpeg.org`. The repository self describes as `Mirror of https://git.ffmpeg.org/ffmpeg.git`, is not a fork, and is current, but we are relying on its own claim.

Two things reduce that risk:

- A git commit SHA is a hash of the tree, so content cannot silently differ between hosts for the same SHA or tag.
- This build already depends on `github.com` for `grpc_health_probe` (line 30) and `tasmodel.pb` (line 57), so no new trust or availability dependency is introduced. If GitHub is down this build already fails earlier.

If we would rather not depend on the mirror, the alternatives are a retry loop around the clone or vendoring the FFmpeg source. Happy to switch to either.

## Scope

Deliberately only the URL, so it can be merged or reverted on its own. It does not change what gets built: the pin on this line does not work (see #4021), so the image tracks upstream master either way. That is fixed separately in #4022.

Refs #4023

🤖 Generated with [Claude Code](https://claude.com/claude-code)
