### PR TITLE
fix(docker): clone ffmpeg from the github mirror and pin to n8.1.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN curl -o /nasm-3.01.tar.gz "https://www.nasm.us/pub/nasm/releasebuilds/3.01/n
 	&& make \
 	&& make install
 
-RUN FFMPEG_SHA=b76053d8bf322b197a9d07bd27bbdad14fd5bc15 git clone --depth 1 https://git.ffmpeg.org/ffmpeg.git /ffmpeg \
+RUN FFMPEG_SHA=b76053d8bf322b197a9d07bd27bbdad14fd5bc15 git clone --depth 1 https://github.com/FFmpeg/FFmpeg.git /ffmpeg \
 	&& cd /ffmpeg && git fetch --depth 1 origin ${FFMPEG_SHA} \
 	&& git checkout ${FFMPEG_SHA} \
 	&& ./configure --enable-gpl --enable-libx264 --enable-libfdk-aac --enable-nonfree --prefix=build && make -j"$(nproc)" && make install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,9 +42,9 @@ RUN curl -o /nasm-3.01.tar.gz "https://www.nasm.us/pub/nasm/releasebuilds/3.01/n
 	&& make \
 	&& make install
 
-RUN FFMPEG_SHA=b76053d8bf322b197a9d07bd27bbdad14fd5bc15 git clone --depth 1 https://github.com/FFmpeg/FFmpeg.git /ffmpeg \
-	&& cd /ffmpeg && git fetch --depth 1 origin ${FFMPEG_SHA} \
-	&& git checkout ${FFMPEG_SHA} \
+# ffmpeg n8.1.2 == commit 38b88335f99e
+RUN	git clone --depth 1 --branch n8.1.2 https://github.com/FFmpeg/FFmpeg.git /ffmpeg \
+	&& cd /ffmpeg \
 	&& ./configure --enable-gpl --enable-libx264 --enable-libfdk-aac --enable-nonfree --prefix=build && make -j"$(nproc)" && make install
 
 ENV	GOPATH=/go \


### PR DESCRIPTION
Combines #4024 and #4022 into one PR, as requested in review. Both were approved separately. Kept as two commits so each half stays reviewable and revertable.

## 1. Clone from the GitHub mirror (#4024)

`git.ffmpeg.org` intermittently returns HTTP 502, failing the clone with `exit code: 128`:

```
4.430  Cloning into '/ffmpeg'...
7.337  fatal: unable to access 'https://git.ffmpeg.org/ffmpeg.git/': The requested URL returned error: 502
```

It broke the v0.9.1 build three times from GitHub hosted runners and once from a self hosted runner, while cloning fine from a local workstation in between. Details in #4023.

The server side cause is unconfirmed and `github.com/FFmpeg/FFmpeg` is not an officially endorsed mirror; see #4023 and #4024 for the full caveats. Note the build already clones from `github.com` three times, including twice from `install_ffmpeg.sh` via lpms, so this does not add a dependency that is not already load bearing.

## 2. Pin ffmpeg to n8.1.2 (#4022)

The `FFMPEG_SHA` pin never took effect. `VAR=value command` is a POSIX prefix assignment, so the variable only entered `git clone`'s environment. Both later commands expanded it to an empty string: `git fetch` took the default branch, and bare `git checkout` **exited 0**. That silent success is why it went unnoticed since #3353 (Feb 2025), during which every builder image compiled upstream `master` as of build time.

`git clone` accepts tags but not commit SHAs, which is why the original needed the clone-then-fetch dance. Pinning a tag removes the variable, and therefore the whole bug class.

`n8.1.2` over `n9.0.1` for maturity: eight weeks in the field versus a tag cut hours before. All of `n9.0.1`, `n9.0` and `n8.1.2` were verified to configure and build in a replica of the builder environment (ubuntu 20.04, libx264 0.155, libfdk-aac 0.1.6, gcc 9, nasm 3.01) with the exact flags from this file. `n8.1.2` contains the HEVC-in-FLV commit the original pin was chosen for.

## Verification

The builder job skips its build step on PRs (gated on `github.ref_name` matching `main|master|vX.Y.Z`), so a green check here does not exercise this layer. On #4024 the guard was temporarily disabled to test it for real, then removed:

https://github.com/livepeer/go-livepeer/actions/runs/31608535985

| Job | Runner | Result |
|---|---|---|
| `go-livepeer builder docker image generation` | GitHub hosted `ubuntu-24.04` | success, 26m04s |
| `Docker image generation` | self hosted | success |

```
14:50:57  #15 [build 6/14] RUN ... git clone --depth 1 https://github.com/FFmpeg/FFmpeg.git /ffmpeg ...
14:50:57  #15 0.059  Cloning into '/ffmpeg'...
14:56:08  #15 DONE 310.8s
```

That run cold built the ffmpeg layer from the mirror on a hosted runner, which is where the 502s occurred. It did not include the `n8.1.2` pin, which was verified locally instead.

## Behaviour change

Because the pin never worked, images since Feb 2025 shipped whatever `master` was at build time. This is the first build to honour a pin, so the shipped `ffmpeg`/`ffprobe` and the libs under `/usr/local/lib` move to `n8.1.2`. The CGO link target is unaffected: that comes from `install_ffmpeg.sh` via lpms and is pinned separately.

Supersedes #4022 and #4024. Closes #4021. Closes #4023.