### PR TITLE
runner: Use challenge for payment response

### DIFF
--- a/server/ai_http.go
+++ b/server/ai_http.go
@@ -580,14 +580,15 @@ func (h *lphttp) PaymentForLiveRunnerSession(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	buf, err := proto.Marshal(&lpnet.PaymentResult{Info: oInfo})
+	paymentURL := h.orchestrator.ServiceURI().JoinPath("apps", runnerID, "session", sessionID, "payment").String()
+	data, err := marshalLivePaymentChallengeResponse(oInfo, paymentURL)
 	if err != nil {
-		clog.Errorf(ctx, "Unable to marshal payment result err=%q", err)
+		respondJsonError(ctx, w, err, http.StatusInternalServerError)
 		return
 	}
 	clog.V(common.DEBUG).Infof(ctx, "Live runner session payment processed, current balance=%s", currentBalanceLog(h, payment, segData))
 
-	w.Write(buf)
+	respondJsonOk(w, data)
 }
 
 func (h *lphttp) StopLiveRunnerSessionInternal(w http.ResponseWriter, r *http.Request) {

--- a/server/ai_http_test.go
+++ b/server/ai_http_test.go
@@ -768,10 +768,15 @@ func TestLiveRunnerSessionPaymentAcceptsPayment(t *testing.T) {
 	lp.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
-	var paymentResult lpnet.PaymentResult
-	require.NoError(t, proto.Unmarshal(w.Body.Bytes(), &paymentResult))
-	require.NotNil(t, paymentResult.GetInfo())
-	require.Equal(t, challenge.ManifestID, paymentResult.GetInfo().GetAuthToken().GetSessionId())
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	paymentResponse, refreshedInfo := decodeLiveRunnerPaymentChallenge(t, w.Body.Bytes())
+	require.Equal(t, orch.ServiceURI().String(), paymentResponse.Orchestrator)
+	require.Equal(t, challenge.ManifestID, paymentResponse.ManifestID)
+	require.Equal(t, orch.ServiceURI().JoinPath("apps", "runner-1", "session", challenge.ManifestID, "payment").String(), paymentResponse.PaymentURL)
+	require.Equal(t, challenge.ManifestID, refreshedInfo.GetAuthToken().GetSessionId())
+	require.True(t, proto.Equal(orch.ticketParams, refreshedInfo.GetTicketParams()))
+	require.Equal(t, int64(4), refreshedInfo.GetPriceInfo().GetPricePerUnit())
+	require.Equal(t, int64(1), refreshedInfo.GetPriceInfo().GetPixelsPerUnit())
 
 	balance := orch.Balance(orch.Address(), core.ManifestID(challenge.ManifestID))
 	require.NotNil(t, balance)


### PR DESCRIPTION
Allows callers to optionally cache an updated set of payment parameters after each payment request.

Should help address https://github.com/livepeer/livepeer-python-gateway/issues/62

Note that runners currently ignore the payment response, so we can change this without breaking anything.

Runner counterpart: https://github.com/livepeer/livepeer-python-gateway/pull/63