### PR TITLE
Update Discord links to the current invite URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://github.com/livepeer/go-livepeer/discussions
     about: Please ask and answer questions related to the go-livepeer software here.
   - name: Livepeer Question
-    url: https://discord.gg/livepeer
+    url: https://discord.gg/55SZFEEH5y
     about: "Have a general Livepeer question? Join us in the Livepeer Discord server. We're here to help!"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 [![Go Report Card](https://goreportcard.com/badge/github.com/livepeer/go-livepeer)](https://goreportcard.com/report/github.com/livepeer/go-livepeer)
-[![Discord](https://img.shields.io/discord/423160867534929930.svg?style=flat-square)](https://discord.gg/livepeer)
+[![Discord](https://img.shields.io/discord/423160867534929930.svg?style=flat-square)](https://discord.gg/55SZFEEH5y)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Contributions welcome](https://img.shields.io/badge/contributions-welcome-orange.svg?style=flat-square)](CONTRIBUTING.md)
 
@@ -63,5 +63,5 @@ other resources:
 - 📖 [The Livepeer Docs](https://livepeer.org/docs)
 - 🔭 [The 10-Minute Primer](https://livepeer.org/primer/)
 - ✍ [The Livepeer Blog](https://medium.com/livepeer-blog)
-- 💬 [The Livepeer Chat](https://discord.gg/livepeer)
+- 💬 [The Livepeer Chat](https://discord.gg/55SZFEEH5y)
 - ❓ [The Livepeer Forum](https://forum.livepeer.org/)


### PR DESCRIPTION
## What changed

The `discord.gg/livepeer` vanity URL no longer resolves to the Livepeer Discord server. Both usages now point at the current, non-expiring invite `https://discord.gg/55SZFEEH5y`:

- **`README.md`** — the Discord badge link and "The Livepeer Chat" resource link
- **`.github/ISSUE_TEMPLATE/config.yml`** — the "Livepeer Question" contact link

The `CONTRIBUTING.md` invite (`discordapp.com/invite/7wRSUGX`) still resolves and is left as is.

Docs only; no code paths touched.

## Notes for reviewers

- The invite code `55SZFEEH5y` matches the one adopted in livepeer/website#94 and livepeer/docs#995.
- The README badge still reads its member count from server ID `423160867534929930`, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)