### PR TITLE
test(pricefeedwatcher): assert only one watch loop is started

### DIFF
--- a/eth/watchers/pricefeedwatcher_test.go
+++ b/eth/watchers/pricefeedwatcher_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/big"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/livepeer/go-livepeer/eth"
@@ -63,7 +64,8 @@ func TestPriceFeedWatcher_Subscribe(t *testing.T) {
 
 	w := &priceFeedWatcher{priceFeed: priceFeedMock}
 
-	// Start a bunch of subscriptions and make sure only 1 watch loop gets started
+	// Start a bunch of subscriptions and make sure the watch loop gets started.
+	// TestPriceFeedWatcher_SingleWatchLoop covers that only 1 loop is started.
 	cancelSub := []context.CancelFunc{}
 	for i := 0; i < 5; i++ {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -91,6 +93,34 @@ func TestPriceFeedWatcher_Subscribe(t *testing.T) {
 	defer cancel()
 	w.Subscribe(ctx, make(chan eth.PriceData, 1))
 	require.NotNil(w.cancelWatch)
+}
+
+// TestPriceFeedWatcher_SingleWatchLoop makes sure that multiple subscriptions
+// share a single watch loop. Each loop polls the price feed once per period, so
+// an extra loop shows up as an extra FetchPriceData call.
+func TestPriceFeedWatcher_SingleWatchLoop(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		priceFeedMock := new(mockPriceFeedEthClient)
+		priceFeedMock.On("FetchPriceData").Return(eth.PriceData{
+			RoundID:   10,
+			Price:     big.NewRat(3, 2),
+			UpdatedAt: time.Now(),
+		}, nil)
+
+		w := &priceFeedWatcher{priceFeed: priceFeedMock}
+
+		for i := 0; i < 5; i++ {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			w.Subscribe(ctx, make(chan eth.PriceData, 1))
+		}
+
+		// Let exactly one tick of the watch loop fire.
+		synctest.Sleep(priceUpdatePeriod + time.Second)
+		synctest.Wait()
+
+		priceFeedMock.AssertNumberOfCalls(t, "FetchPriceData", 1)
+	})
 }
 
 func TestPriceFeedWatcher_Watch(t *testing.T) {


### PR DESCRIPTION
Follow-up to #4031, targeting `ja/golang-1.27` so it lands with the Go 1.27 bump.

#4031 removes the `reflect`-based cancel func comparison from `TestPriceFeedWatcher_Subscribe`. That removal is correct, but it leaves the "only 1 watch loop gets started" comment describing something nothing checks. This adds a test that actually checks it.

### Why the old assertion could not work

It compared `reflect.ValueOf(w.cancelWatch).Pointer()` across subscriptions. For a func value that returns the address of the compiled function body, not the identity of the closure. Every `cancelWatch` comes from `context.WithCancel`, so all of them share one code address:

```
c1=0x4933a0 c2=0x4933a0  equal=true
```

Two unrelated cancel funcs, guaranteed equal. The assertion passed whether `ensureWatchLocked` assigned once or five times, so it could not detect the bug it was written for. `reflect`'s docs say as much: for a `Func` the result "is not necessarily enough to identify a single function uniquely".

### What this asserts instead

A duplicate watch loop is observable: each loop gets its own ticker and polls `w.priceFeed` once per `priceUpdatePeriod`. So N loops means N `FetchPriceData` calls per tick.

`priceUpdatePeriod` is 1 hour, which is why this was not testable before. `testing/synctest` (already used elsewhere in #4031) makes the hour instant, puts `newTruncatedTicker` on a deterministic boundary, and `synctest.Wait()` blocks until every bubble goroutine is idle. No sleeps, no flake.

### Verified both directions

- Against the real code: passes.
- With the `if w.cancelWatch != nil { return }` guard in `ensureWatchLocked` removed: fails with `Expected number of calls (1) does not match the actual number of calls (5)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)