### PR TITLE
cmd/livepeer_bench: fix segment path handling on Windows

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,3 +21,5 @@
 #### Broadcaster
 
 #### CLI
+
+- \#1844 Fix livepeer_bench segment path handling on Windows (@lukiod)

--- a/cmd/livepeer_bench/livepeer_bench.go
+++ b/cmd/livepeer_bench/livepeer_bench.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -87,7 +87,6 @@ func main() {
 	ffmpeg.InitFFmpegWithLogLevel(ffmpeg.LogLevel(*log * 8))
 
 	var wg sync.WaitGroup
-	dir := path.Dir(*in)
 
 	table := tablewriter.NewWriter(os.Stderr)
 	data := [][]string{
@@ -139,7 +138,7 @@ func main() {
 					if v == nil {
 						continue
 					}
-					u := path.Join(dir, v.URI)
+					u := segmentPath(*in, v.URI)
 					in := &ffmpeg.TranscodeOptionsIn{
 						Fname: u,
 						Accel: accel,
@@ -221,6 +220,14 @@ func main() {
 		statsTable.AppendBulk(stats)
 		statsTable.Render()
 	}
+}
+
+// segmentPath returns the path to a playlist segment by joining the input
+// manifest's directory with the segment's URI (which is relative to the
+// manifest). filepath is used instead of path so that Windows-style backslash
+// separators in the manifest path are handled correctly.
+func segmentPath(manifest, segmentURI string) string {
+	return filepath.Join(filepath.Dir(manifest), segmentURI)
 }
 
 func parseVideoProfiles(inp string) []ffmpeg.VideoProfile {

--- a/cmd/livepeer_bench/livepeer_bench_test.go
+++ b/cmd/livepeer_bench/livepeer_bench_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSegmentPath(t *testing.T) {
+	// Windows-style manifest path with backslash separators, as reported in
+	// issue #1844. On Windows the path package treats backslashes as ordinary
+	// characters, so path.Dir/path.Join produce a broken segment path;
+	// filepath handles them as separators.
+	if runtime.GOOS == "windows" {
+		const manifest = `C:\bench\media\input.m3u8`
+		want := filepath.Join(`C:\bench\media`, "seg0.ts")
+		if got := segmentPath(manifest, "seg0.ts"); got != want {
+			t.Fatalf("segmentPath(%q) = %q, want %q", manifest, got, want)
+		}
+		return
+	}
+
+	// POSIX-style manifest path: forward slashes. filepath and path agree on
+	// this input, but this guards the normal case against regression.
+	const manifest = "/tmp/bench/media/input.m3u8"
+	want := filepath.Join("/tmp/bench/media", "seg0.ts")
+	if got := segmentPath(manifest, "seg0.ts"); got != want {
+		t.Fatalf("segmentPath(%q) = %q, want %q", manifest, got, want)
+	}
+}


### PR DESCRIPTION
Fixes #1844

## Problem

`livepeer_bench` builds the path to each playlist segment from the input manifest's directory using Go's `path` package (`path.Dir` / `path.Join`). The `path` package assumes forward-slash separators, so a Windows-style manifest path (e.g. `C:\bench\media\input.m3u8`) makes `path.Dir` return `.` and produces a broken segment path, failing the benchmark on Windows.

## Approach

Switch to `path/filepath`, which is OS-aware and treats `\` as a path separator on Windows. The directory/URI join is extracted into a small `segmentPath` helper so it can be unit-tested.

## Tests

Added `TestSegmentPath` in `cmd/livepeer_bench/livepeer_bench_test.go`:

- On Windows it exercises the exact backslash case from the issue and asserts the correct segment path.
- On other platforms it asserts the forward-slash case still produces the correct path.

The backslash assertion is necessarily Windows-gated: on Linux/macOS `filepath` and `path` are identical for backslashes, so the bug is only observable (and testable) on a Windows host.

## Notes

I could not run `go build ./...` / `go test` locally: the pinned `github.com/livepeer/lpms/ffmpeg` cgo bindings fail to compile against this machine's FFmpeg 9.0.1 (undeclared `avfilter_compare_sign_bypath`, `avformat_transfer_internal_stream_timing_info`, `AVFMT_TBCF_DEMUXER`, `av_opt_set_int_list`). This is a pre-existing dependency/environment mismatch unrelated to this change. I verified the change with `gofmt` (clean), a standalone stdlib-only compile/run of the helper (POSIX case correct), and a `GOOS=windows` cross-compile (succeeds).
