### PR TITLE
core: validate download URLs and re-check them on redirect

### DIFF
--- a/core/os.go
+++ b/core/os.go
@@ -11,6 +11,8 @@ import (
 	gonet "net"
 	"net/http"
 	"net/netip"
+	"net/url"
+	"strings"
 	"syscall"
 	"time"
 
@@ -20,10 +22,16 @@ import (
 	"github.com/livepeer/go-tools/drivers"
 )
 
-// DownloadData downloads data while refusing connections to addresses that
-// reach the local host, including after DNS resolution or an HTTP redirect.
+// DownloadData downloads data while refusing connections to non-public
+// addresses (loopback, private, link-local, multicast, …) and rejecting
+// URLs with unsafe schemes, embedded credentials, or path-traversal
+// sequences. These checks run both on the original URL and after DNS
+// resolution or any HTTP redirect.
 func DownloadData(ctx context.Context, uri string) ([]byte, error) {
-	return downloadDataHTTP(ctx, uri, localhostBlockedHTTPClient)
+	if err := validateDownloadURL(uri); err != nil {
+		return nil, err
+	}
+	return downloadDataHTTP(ctx, uri, ssrfBlockedHTTPClient)
 }
 
 // DownloadDataAllowLocalhost downloads data without blocking local host
@@ -33,9 +41,45 @@ func DownloadDataAllowLocalhost(ctx context.Context, uri string) ([]byte, error)
 	return downloadDataHTTP(ctx, uri, httpc)
 }
 
-var errLocalhostDownload = errors.New("localhost downloads are blocked")
+var (
+	errLocalhostDownload = errors.New("localhost downloads are blocked")
+	errPrivateDownload   = errors.New("private/internal address downloads are blocked")
+	errUnsafeURL         = errors.New("unsafe download URL")
+)
 
-func rejectLocalhostDial(_ context.Context, _, address string, _ syscall.RawConn) error {
+// validateDownloadURL performs pre-dial, pre-request validation on the raw URL
+// string. It rejects non-HTTP(S) schemes, embedded credentials, path traversal,
+// and fragment-only or opaque URIs.
+func validateDownloadURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("%w: %v", errUnsafeURL, err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return fmt.Errorf("%w: scheme %q not allowed", errUnsafeURL, u.Scheme)
+	}
+	if u.User != nil {
+		return fmt.Errorf("%w: embedded credentials not allowed", errUnsafeURL)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%w: missing host", errUnsafeURL)
+	}
+	cleaned := strings.ReplaceAll(u.Path, "\\", "/")
+	for _, seg := range strings.Split(cleaned, "/") {
+		if seg == ".." {
+			return fmt.Errorf("%w: path traversal not allowed", errUnsafeURL)
+		}
+	}
+	return nil
+}
+
+// rejectNonPublicDial blocks connections to any resolved address that is not
+// a global-unicast, routable address. This covers loopback, private (RFC 1918),
+// link-local, multicast, and unspecified addresses — catching DNS-rebinding
+// and redirect-based SSRF bypasses at the socket level.
+func rejectNonPublicDial(_ context.Context, _, address string, _ syscall.RawConn) error {
 	host, _, err := gonet.SplitHostPort(address)
 	if err != nil {
 		return fmt.Errorf("invalid resolved download address %q: %w", address, err)
@@ -46,11 +90,22 @@ func rejectLocalhostDial(_ context.Context, _, address string, _ syscall.RawConn
 		return fmt.Errorf("invalid resolved download host %q: %w", host, err)
 	}
 	addr = addr.Unmap()
+
 	if addr.IsLoopback() || addr.IsUnspecified() {
 		return fmt.Errorf("%w: %s", errLocalhostDownload, address)
 	}
-
+	if addr.IsPrivate() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() || addr.IsMulticast() {
+		return fmt.Errorf("%w: %s", errPrivateDownload, address)
+	}
+	if !addr.IsGlobalUnicast() {
+		return fmt.Errorf("%w: %s is not a public address", errPrivateDownload, address)
+	}
 	return nil
+}
+
+// Kept for backward compatibility with callers that reference the old name.
+func rejectLocalhostDial(ctx context.Context, network, address string, conn syscall.RawConn) error {
+	return rejectNonPublicDial(ctx, network, address, conn)
 }
 
 var httpc = &http.Client{
@@ -58,18 +113,24 @@ var httpc = &http.Client{
 	Timeout:   common.HTTPTimeout / 2,
 }
 
-var localhostBlockedHTTPClient = &http.Client{
+var ssrfBlockedHTTPClient = &http.Client{
 	Transport: &http.Transport{
-		DialContext:     (&gonet.Dialer{ControlContext: rejectLocalhostDial}).DialContext,
+		DialContext:     (&gonet.Dialer{ControlContext: rejectNonPublicDial}).DialContext,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	},
+	CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+		return validateDownloadURL(req.URL.String())
 	},
 	Timeout: common.HTTPTimeout / 2,
 }
 
+// localhostBlockedHTTPClient is kept as an alias for backward compatibility.
+var localhostBlockedHTTPClient = ssrfBlockedHTTPClient
+
 // LocalhostBlockedHTTPClient returns the shared HTTP client that refuses
-// connections to local host addresses. Callers must not mutate the client.
+// connections to non-public addresses. Callers must not mutate the client.
 func LocalhostBlockedHTTPClient() *http.Client {
-	return localhostBlockedHTTPClient
+	return ssrfBlockedHTTPClient
 }
 
 func FromNetOsInfo(os *net.OSInfo) *drivers.OSInfo {

--- a/core/os.go
+++ b/core/os.go
@@ -22,16 +22,15 @@ import (
 	"github.com/livepeer/go-tools/drivers"
 )
 
-// DownloadData downloads data while refusing connections to non-public
-// addresses (loopback, private, link-local, multicast, …) and rejecting
-// URLs with unsafe schemes, embedded credentials, or path-traversal
-// sequences. These checks run both on the original URL and after DNS
-// resolution or any HTTP redirect.
+// DownloadData downloads data while refusing connections to addresses that
+// reach the local host, including after DNS resolution or an HTTP redirect.
+// It also rejects URLs with unsafe schemes, embedded credentials, or
+// path-traversal sequences, both on the original URL and on every redirect.
 func DownloadData(ctx context.Context, uri string) ([]byte, error) {
 	if err := validateDownloadURL(uri); err != nil {
 		return nil, err
 	}
-	return downloadDataHTTP(ctx, uri, ssrfBlockedHTTPClient)
+	return downloadDataHTTP(ctx, uri, localhostBlockedHTTPClient)
 }
 
 // DownloadDataAllowLocalhost downloads data without blocking local host
@@ -43,7 +42,6 @@ func DownloadDataAllowLocalhost(ctx context.Context, uri string) ([]byte, error)
 
 var (
 	errLocalhostDownload = errors.New("localhost downloads are blocked")
-	errPrivateDownload   = errors.New("private/internal address downloads are blocked")
 	errUnsafeURL         = errors.New("unsafe download URL")
 )
 
@@ -75,11 +73,7 @@ func validateDownloadURL(rawURL string) error {
 	return nil
 }
 
-// rejectNonPublicDial blocks connections to any resolved address that is not
-// a global-unicast, routable address. This covers loopback, private (RFC 1918),
-// link-local, multicast, and unspecified addresses — catching DNS-rebinding
-// and redirect-based SSRF bypasses at the socket level.
-func rejectNonPublicDial(_ context.Context, _, address string, _ syscall.RawConn) error {
+func rejectLocalhostDial(_ context.Context, _, address string, _ syscall.RawConn) error {
 	host, _, err := gonet.SplitHostPort(address)
 	if err != nil {
 		return fmt.Errorf("invalid resolved download address %q: %w", address, err)
@@ -90,22 +84,11 @@ func rejectNonPublicDial(_ context.Context, _, address string, _ syscall.RawConn
 		return fmt.Errorf("invalid resolved download host %q: %w", host, err)
 	}
 	addr = addr.Unmap()
-
 	if addr.IsLoopback() || addr.IsUnspecified() {
 		return fmt.Errorf("%w: %s", errLocalhostDownload, address)
 	}
-	if addr.IsPrivate() || addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() || addr.IsMulticast() {
-		return fmt.Errorf("%w: %s", errPrivateDownload, address)
-	}
-	if !addr.IsGlobalUnicast() {
-		return fmt.Errorf("%w: %s is not a public address", errPrivateDownload, address)
-	}
-	return nil
-}
 
-// Kept for backward compatibility with callers that reference the old name.
-func rejectLocalhostDial(ctx context.Context, network, address string, conn syscall.RawConn) error {
-	return rejectNonPublicDial(ctx, network, address, conn)
+	return nil
 }
 
 var httpc = &http.Client{
@@ -113,9 +96,9 @@ var httpc = &http.Client{
 	Timeout:   common.HTTPTimeout / 2,
 }
 
-var ssrfBlockedHTTPClient = &http.Client{
+var localhostBlockedHTTPClient = &http.Client{
 	Transport: &http.Transport{
-		DialContext:     (&gonet.Dialer{ControlContext: rejectNonPublicDial}).DialContext,
+		DialContext:     (&gonet.Dialer{ControlContext: rejectLocalhostDial}).DialContext,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	},
 	CheckRedirect: func(req *http.Request, _ []*http.Request) error {
@@ -124,13 +107,10 @@ var ssrfBlockedHTTPClient = &http.Client{
 	Timeout: common.HTTPTimeout / 2,
 }
 
-// localhostBlockedHTTPClient is kept as an alias for backward compatibility.
-var localhostBlockedHTTPClient = ssrfBlockedHTTPClient
-
 // LocalhostBlockedHTTPClient returns the shared HTTP client that refuses
-// connections to non-public addresses. Callers must not mutate the client.
+// connections to local host addresses. Callers must not mutate the client.
 func LocalhostBlockedHTTPClient() *http.Client {
-	return ssrfBlockedHTTPClient
+	return localhostBlockedHTTPClient
 }
 
 func FromNetOsInfo(os *net.OSInfo) *drivers.OSInfo {

--- a/core/os_test.go
+++ b/core/os_test.go
@@ -13,42 +13,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRejectNonPublicDial(t *testing.T) {
+func TestRejectLocalhostDial(t *testing.T) {
 	tests := []struct {
 		name    string
 		address string
-		wantErr error
+		blocked bool
 	}{
-		{name: "IPv4 loopback", address: "127.0.0.1:7935", wantErr: errLocalhostDownload},
-		{name: "IPv4 loopback range", address: "127.255.255.254:7935", wantErr: errLocalhostDownload},
-		{name: "IPv6 loopback", address: "[::1]:7935", wantErr: errLocalhostDownload},
-		{name: "IPv4-mapped IPv6 loopback", address: "[::ffff:127.0.0.1]:7935", wantErr: errLocalhostDownload},
-		{name: "unspecified IPv4", address: "0.0.0.0:7935", wantErr: errLocalhostDownload},
-		{name: "unspecified IPv6", address: "[::]:7935", wantErr: errLocalhostDownload},
-		{name: "private IPv4 10.x", address: "10.0.0.1:9000", wantErr: errPrivateDownload},
-		{name: "private IPv4 192.168.x", address: "192.168.1.1:9000", wantErr: errPrivateDownload},
-		{name: "private IPv4 172.16.x", address: "172.16.0.1:9000", wantErr: errPrivateDownload},
-		{name: "link-local IPv4", address: "169.254.1.1:9000", wantErr: errPrivateDownload},
-		{name: "private IPv6", address: "[fd00::1]:9000", wantErr: errPrivateDownload},
-		{name: "link-local IPv6", address: "[fe80::1]:9000", wantErr: errPrivateDownload},
-		{name: "multicast IPv4", address: "224.0.0.1:9000", wantErr: errPrivateDownload},
-		{name: "multicast IPv6", address: "[ff02::1]:9000", wantErr: errPrivateDownload},
+		{name: "IPv4 loopback", address: "127.0.0.1:7935", blocked: true},
+		{name: "IPv4 loopback range", address: "127.255.255.254:7935", blocked: true},
+		{name: "IPv6 loopback", address: "[::1]:7935", blocked: true},
+		{name: "IPv4-mapped IPv6 loopback", address: "[::ffff:127.0.0.1]:7935", blocked: true},
+		{name: "unspecified IPv4", address: "0.0.0.0:7935", blocked: true},
+		{name: "unspecified IPv6", address: "[::]:7935", blocked: true},
+		{name: "private IPv4", address: "10.0.0.1:9000"},
+		{name: "link-local IPv4", address: "169.254.1.1:9000"},
 		{name: "public IPv4", address: "8.8.8.8:443"},
-		{name: "public IPv6", address: "[2001:4860:4860::8888]:443"},
+		{name: "private IPv6", address: "[fd00::1]:9000"},
+		{name: "link-local IPv6", address: "[fe80::1%lo0]:9000"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := rejectNonPublicDial(context.Background(), "tcp", tt.address, nil)
-			if tt.wantErr != nil {
-				require.ErrorIs(t, err, tt.wantErr)
+			err := rejectLocalhostDial(context.Background(), "tcp", tt.address, nil)
+			if tt.blocked {
+				require.ErrorIs(t, err, errLocalhostDownload)
 			} else {
 				require.NoError(t, err)
 			}
 		})
 	}
 
-	require.Error(t, rejectNonPublicDial(context.Background(), "tcp", "127.0.0.1", nil))
+	require.Error(t, rejectLocalhostDial(context.Background(), "tcp", "127.0.0.1", nil))
 }
 
 func TestValidateDownloadURL(t *testing.T) {
@@ -114,20 +109,7 @@ func TestDownloadDataAllowLocalhostAllowsLoopback(t *testing.T) {
 	require.Equal(t, []byte("segment"), data)
 }
 
-func TestDownloadDataBlocksPrivateAddress(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/data", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("segment"))
-	})
-	baseURL := newNonLoopbackHTTPServer(t, mux)
-
-	// Non-loopback interface addresses on CI/dev boxes are typically private
-	// (10.x, 172.x, 192.168.x) and should now be blocked.
-	_, err := DownloadData(context.Background(), baseURL+"/data")
-	require.Error(t, err)
-}
-
-func TestDownloadDataBlocksRedirectToLoopback(t *testing.T) {
+func TestDownloadDataAllowsPrivateAddressAndBlocksRedirectToLoopback(t *testing.T) {
 	var protectedHits atomic.Int32
 	protected := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		protectedHits.Add(1)
@@ -135,12 +117,28 @@ func TestDownloadDataBlocksRedirectToLoopback(t *testing.T) {
 	}))
 	defer protected.Close()
 
-	// Use a public-reachable test URL that redirects to loopback.
-	// In unit tests we can't easily test a real public→loopback redirect,
-	// so test that the protected server itself (loopback) is blocked.
-	_, err := DownloadData(context.Background(), protected.URL)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/data", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("segment"))
+	})
+	mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, protected.URL, http.StatusFound)
+	})
+	mux.HandleFunc("/redirect-unsafe", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "file:///etc/passwd", http.StatusFound)
+	})
+	baseURL := newNonLoopbackHTTPServer(t, mux)
+
+	data, err := DownloadData(context.Background(), baseURL+"/data")
+	require.NoError(t, err)
+	require.Equal(t, []byte("segment"), data)
+
+	_, err = DownloadData(context.Background(), baseURL+"/redirect")
 	require.ErrorIs(t, err, errLocalhostDownload)
 	require.Zero(t, protectedHits.Load())
+
+	_, err = DownloadData(context.Background(), baseURL+"/redirect-unsafe")
+	require.ErrorIs(t, err, errUnsafeURL)
 }
 
 func newNonLoopbackHTTPServer(t *testing.T, handler http.Handler) string {

--- a/core/os_test.go
+++ b/core/os_test.go
@@ -13,37 +13,73 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRejectLocalhostDial(t *testing.T) {
+func TestRejectNonPublicDial(t *testing.T) {
 	tests := []struct {
 		name    string
 		address string
-		blocked bool
+		wantErr error
 	}{
-		{name: "IPv4 loopback", address: "127.0.0.1:7935", blocked: true},
-		{name: "IPv4 loopback range", address: "127.255.255.254:7935", blocked: true},
-		{name: "IPv6 loopback", address: "[::1]:7935", blocked: true},
-		{name: "IPv4-mapped IPv6 loopback", address: "[::ffff:127.0.0.1]:7935", blocked: true},
-		{name: "unspecified IPv4", address: "0.0.0.0:7935", blocked: true},
-		{name: "unspecified IPv6", address: "[::]:7935", blocked: true},
-		{name: "private IPv4", address: "10.0.0.1:9000"},
-		{name: "link-local IPv4", address: "169.254.1.1:9000"},
+		{name: "IPv4 loopback", address: "127.0.0.1:7935", wantErr: errLocalhostDownload},
+		{name: "IPv4 loopback range", address: "127.255.255.254:7935", wantErr: errLocalhostDownload},
+		{name: "IPv6 loopback", address: "[::1]:7935", wantErr: errLocalhostDownload},
+		{name: "IPv4-mapped IPv6 loopback", address: "[::ffff:127.0.0.1]:7935", wantErr: errLocalhostDownload},
+		{name: "unspecified IPv4", address: "0.0.0.0:7935", wantErr: errLocalhostDownload},
+		{name: "unspecified IPv6", address: "[::]:7935", wantErr: errLocalhostDownload},
+		{name: "private IPv4 10.x", address: "10.0.0.1:9000", wantErr: errPrivateDownload},
+		{name: "private IPv4 192.168.x", address: "192.168.1.1:9000", wantErr: errPrivateDownload},
+		{name: "private IPv4 172.16.x", address: "172.16.0.1:9000", wantErr: errPrivateDownload},
+		{name: "link-local IPv4", address: "169.254.1.1:9000", wantErr: errPrivateDownload},
+		{name: "private IPv6", address: "[fd00::1]:9000", wantErr: errPrivateDownload},
+		{name: "link-local IPv6", address: "[fe80::1]:9000", wantErr: errPrivateDownload},
+		{name: "multicast IPv4", address: "224.0.0.1:9000", wantErr: errPrivateDownload},
+		{name: "multicast IPv6", address: "[ff02::1]:9000", wantErr: errPrivateDownload},
 		{name: "public IPv4", address: "8.8.8.8:443"},
-		{name: "private IPv6", address: "[fd00::1]:9000"},
-		{name: "link-local IPv6", address: "[fe80::1%lo0]:9000"},
+		{name: "public IPv6", address: "[2001:4860:4860::8888]:443"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := rejectLocalhostDial(context.Background(), "tcp", tt.address, nil)
-			if tt.blocked {
-				require.ErrorIs(t, err, errLocalhostDownload)
+			err := rejectNonPublicDial(context.Background(), "tcp", tt.address, nil)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
 			}
 		})
 	}
 
-	require.Error(t, rejectLocalhostDial(context.Background(), "tcp", "127.0.0.1", nil))
+	require.Error(t, rejectNonPublicDial(context.Background(), "tcp", "127.0.0.1", nil))
+}
+
+func TestValidateDownloadURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "valid https", url: "https://storage.example.com/seg/0.ts"},
+		{name: "valid http", url: "http://cdn.example.com/seg/0.ts"},
+		{name: "ftp blocked", url: "ftp://evil.com/file", wantErr: true},
+		{name: "file scheme blocked", url: "file:///etc/passwd", wantErr: true},
+		{name: "gopher blocked", url: "gopher://evil.com", wantErr: true},
+		{name: "empty scheme blocked", url: "://foo", wantErr: true},
+		{name: "embedded credentials", url: "http://user:pass@host.com/x", wantErr: true},
+		{name: "path traversal", url: "http://host.com/../../etc/passwd", wantErr: true},
+		{name: "encoded path traversal", url: "http://host.com/a/%2e%2e/b", wantErr: true},
+		{name: "missing host", url: "http:///path", wantErr: true},
+		{name: "data URI", url: "data:text/html,<script>", wantErr: true},
+		{name: "javascript URI", url: "javascript:alert(1)", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDownloadURL(tt.url)
+			if tt.wantErr {
+				require.ErrorIs(t, err, errUnsafeURL)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestDownloadDataRejectsLoopback(t *testing.T) {
@@ -78,7 +114,20 @@ func TestDownloadDataAllowLocalhostAllowsLoopback(t *testing.T) {
 	require.Equal(t, []byte("segment"), data)
 }
 
-func TestDownloadDataAllowsPrivateAddressAndBlocksRedirectToLoopback(t *testing.T) {
+func TestDownloadDataBlocksPrivateAddress(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/data", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("segment"))
+	})
+	baseURL := newNonLoopbackHTTPServer(t, mux)
+
+	// Non-loopback interface addresses on CI/dev boxes are typically private
+	// (10.x, 172.x, 192.168.x) and should now be blocked.
+	_, err := DownloadData(context.Background(), baseURL+"/data")
+	require.Error(t, err)
+}
+
+func TestDownloadDataBlocksRedirectToLoopback(t *testing.T) {
 	var protectedHits atomic.Int32
 	protected := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		protectedHits.Add(1)
@@ -86,20 +135,10 @@ func TestDownloadDataAllowsPrivateAddressAndBlocksRedirectToLoopback(t *testing.
 	}))
 	defer protected.Close()
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/data", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("segment"))
-	})
-	mux.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, protected.URL, http.StatusFound)
-	})
-	baseURL := newNonLoopbackHTTPServer(t, mux)
-
-	data, err := DownloadData(context.Background(), baseURL+"/data")
-	require.NoError(t, err)
-	require.Equal(t, []byte("segment"), data)
-
-	_, err = DownloadData(context.Background(), baseURL+"/redirect")
+	// Use a public-reachable test URL that redirects to loopback.
+	// In unit tests we can't easily test a real public→loopback redirect,
+	// so test that the protected server itself (loopback) is blocked.
+	_, err := DownloadData(context.Background(), protected.URL)
 	require.ErrorIs(t, err, errLocalhostDownload)
 	require.Zero(t, protectedHits.Load())
 }


### PR DESCRIPTION
## Summary

Follow-up hardening for `core.DownloadData`, layered on top of the localhost-blocking fix in 5b7581c. Two gaps remained after that change:

- The dial-time check only inspects the **resolved IP**, so a URL with a non-HTTP scheme, embedded credentials, or path-traversal segments was passed straight to the transport.
- The dial check ran on redirects, but nothing re-validated the redirect **URL** itself.

This PR adds `validateDownloadURL`, applied both to the caller-supplied URL and, via `CheckRedirect`, to every redirect hop. It rejects:

- schemes other than `http`/`https` (`file:`, `gopher:`, `data:`, `javascript:`, …)
- embedded credentials (`http://user:pass@host/`)
- `..` path segments, including percent-encoded (`%2e%2e`) and backslash-separated forms
- empty hosts and unparseable URLs

## Deliberately unchanged

Reachability is **not** narrowed. The dial control stays loopback-and-unspecified only, and private/RFC1918, link-local, and CGNAT addresses remain reachable — orchestrators, broadcasters, and object stores routinely run on LAN, Docker, and Kubernetes addresses, so blocking those would break real deployments. `TestDownloadDataAllowsPrivateAddressAndBlocksRedirectToLoopback` is kept as the guard on that behavior.

`DownloadDataAllowLocalhost` is also untouched and keeps its existing opt-out semantics.

The diff against `master` is purely additive apart from one line: `+79 / -1`.

## Test plan

- [x] `TestValidateDownloadURL` — new table test covering each rejected class plus valid `http`/`https` URLs
- [x] `TestDownloadDataAllowsPrivateAddressAndBlocksRedirectToLoopback` — extended with a `/redirect-unsafe` hop that 302s to `file:///etc/passwd`, asserting `CheckRedirect` rejects it; still asserts a private-address fetch succeeds and a redirect to loopback is refused with zero hits on the protected server
- [x] `TestRejectLocalhostDial` — unchanged, still passes
- [x] Full package green: `go test -tags=mainnet,experimental ./core/ -count=1`
- [x] `go build -tags=mainnet,experimental ./core/... ./server/...` and `gofmt` clean

> Note for the merger: please **squash**. The first commit on this branch also blocked private addresses; the second walks that back for the reasons above.