### PR TITLE
log: quiet per-segment trickle traces and FFmpeg scale_npp warnings

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,7 @@
 ### Bug Fixes 🐞
 
 #### General
+- Demote per-segment trickle POST/GET traces to debug, and initialize FFmpeg logging at error so NVIDIA `scale_npp` downscale fallbacks do not flood production logs
 
 #### Broadcaster
 

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -509,6 +509,13 @@ func (cfg LivepeerConfig) PrintConfig(w io.Writer) {
 }
 
 func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
+	// The livepeer binary never called lpms_init, so FFmpeg stayed at its default
+	// INFO level. NVIDIA scale_npp then logs a warning on every downscale
+	// ("super-sampling not supported for output dimensions, using lanczos")
+	// because LPMS requests interp_algo=super, which only applies to upscales.
+	// ERROR keeps real encoder/decoder failures and drops that expected noise.
+	ffmpeg.InitFFmpegWithLogLevel(ffmpeg.FFLogError)
+
 	if *cfg.MaxSessions == "auto" && *cfg.Orchestrator {
 		if *cfg.Transcoder {
 			glog.Exit("-maxSessions 'auto' cannot be used when both -orchestrator and -transcoder are specified")

--- a/trickle/trickle_server.go
+++ b/trickle/trickle_server.go
@@ -477,7 +477,7 @@ func (s *Stream) handlePost(w http.ResponseWriter, r *http.Request, idx int) {
 		if err != nil {
 			if err == FirstByteTimeout {
 				// Keepalive via provisional headers
-				slog.Info("Sending provisional headers for", "stream", s.name, "idx", idx)
+				slog.Debug("Sending provisional headers for", "stream", s.name, "idx", idx)
 				w.WriteHeader(http.StatusContinue)
 				continue
 			} else if err == io.EOF {
@@ -512,7 +512,7 @@ func (s *Stream) handlePost(w http.ResponseWriter, r *http.Request, idx int) {
 	// Mark segment as closed
 	w.Header().Set("Lp-Trickle-Seq", strconv.Itoa(segment.idx))
 	segment.close()
-	slog.Info("POST completed", "stream", s.name, "idx", idx, "bytes", totalRead, "took", time.Since(startedAt))
+	slog.Debug("POST completed", "stream", s.name, "idx", idx, "bytes", totalRead, "took", time.Since(startedAt))
 }
 
 func (s *Stream) getForWrite(idx int) (*Segment, bool) {
@@ -521,7 +521,7 @@ func (s *Stream) getForWrite(idx int) (*Segment, bool) {
 	if idx == -1 {
 		idx = s.nextWrite
 	}
-	slog.Info("POST segment", "stream", s.name, "idx", idx, "next", s.nextWrite)
+	slog.Debug("POST segment", "stream", s.name, "idx", idx, "next", s.nextWrite)
 	segmentPos := idx % maxSegmentsPerStream
 	if segment := s.segments[segmentPos]; segment != nil {
 		if idx == segment.idx {
@@ -559,9 +559,9 @@ func (s *Stream) getForRead(idx int) (*Segment, int, bool, bool) {
 		// read request is just a little bit ahead of write head
 		segment = newSegment(idx)
 		s.segments[segmentPos] = segment
-		slog.Info("GET precreating", "stream", s.name, "idx", idx, "next", s.nextWrite)
+		slog.Debug("GET precreating", "stream", s.name, "idx", idx, "next", s.nextWrite)
 	}
-	slog.Info("GET segment", "stream", s.name, "idx", idx, "next", s.nextWrite, "exists?", exists(segment, idx))
+	slog.Debug("GET segment", "stream", s.name, "idx", idx, "next", s.nextWrite, "exists?", exists(segment, idx))
 	return segment, s.nextWrite, exists(segment, idx), s.closed
 }
 


### PR DESCRIPTION
## Summary
- Demote per-segment trickle protocol traces (`POST segment`, `GET segment`, `GET precreating`, `POST completed`, provisional headers) from Info to Debug. Live-runner o2r keepalives currently log twice every 10s per runner at Info, and `-v` does not hide `slog.Info`.
- Initialize FFmpeg logging in the livepeer binary at error. The process never called `lpms_init`, so av_log stayed at INFO and NVIDIA `scale_npp` warned on every downscale (`super-sampling not supported for output dimensions, using lanczos`) because LPMS always requests `interp_algo=super`.
- Stream lifecycle and error logs stay at Info. Segment traces remain available with `-v=6`.

## Test plan
- [x] `go test ./trickle/ -count=1`
- [x] `go test -tags=mainnet,experimental ./cmd/livepeer/starter/ -count=1`
- [ ] On an NVIDIA node with `-useLiveRunners`, confirm o2r `POST segment` lines and `scale_npp` lanczos warnings are gone at default `-v=3`
- [ ] Confirm encoder/decoder failures still print
- [ ] Confirm `-v=6` restores trickle segment traces