### PR TITLE
fix: report successful test token requests

### DIFF
--- a/cmd/livepeer_cli/wizard.go
+++ b/cmd/livepeer_cli/wizard.go
@@ -314,18 +314,23 @@ func httpPostWithParamsHeaders(url string, val url.Values, headers map[string]st
 	return string(result), resp.StatusCode >= 200 && resp.StatusCode < 300
 }
 
-func httpPost(url string) string {
+func httpPostWithStatus(url string) (string, bool) {
 	resp, err := http.Post(url, "application/x-www-form-urlencoded", nil)
 	if err != nil {
 		log.Error("Error sending HTTP POST: ", "url", url, "err", err)
-		return ""
+		return "", false
 	}
 
 	defer resp.Body.Close()
 	result, err := ioutil.ReadAll(resp.Body)
-	if err != nil || string(result) == "" {
-		return ""
+	if err != nil {
+		return "", false
 	}
 
-	return string(result)
+	return string(result), resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+func httpPost(url string) string {
+	result, _ := httpPostWithStatus(url)
+	return result
 }

--- a/cmd/livepeer_cli/wizard_ticketbroker_test.go
+++ b/cmd/livepeer_cli/wizard_ticketbroker_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/livepeer/go-livepeer/pm"
@@ -51,4 +53,31 @@ func TestSenderStatus(t *testing.T) {
 	s = createSender(big.NewInt(7), big.NewInt(0), big.NewInt(0))
 	ss = senderStatus(s, big.NewInt(3))
 	assert.Equal(Locked, ss)
+}
+
+func TestHTTPPostWithStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantOK     bool
+	}{
+		{name: "success with empty body", statusCode: http.StatusNoContent, wantOK: true},
+		{name: "success with body", statusCode: http.StatusOK, body: "accepted", wantOK: true},
+		{name: "server error", statusCode: http.StatusInternalServerError, body: "failed", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			body, ok := httpPostWithStatus(server.URL)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.body, body)
+		})
+	}
 }

--- a/cmd/livepeer_cli/wizard_token.go
+++ b/cmd/livepeer_cli/wizard_token.go
@@ -41,5 +41,8 @@ func (w *wizard) transferTokens() {
 }
 
 func (w *wizard) requestTokens() {
-	httpPost(fmt.Sprintf("http://%v:%v/requestTokens", w.host, w.httpPort))
+	_, ok := httpPostWithStatus(fmt.Sprintf("http://%v:%v/requestTokens", w.host, w.httpPort))
+	if ok {
+		fmt.Println("Successfully requested test LPT tokens.")
+	}
 }


### PR DESCRIPTION
Closes #500

## Summary
- Add a status-aware POST helper while preserving the existing response-only helper.
- Print a success message after the test-token request returns a 2xx response.
- Avoid reporting success for transport errors, non-2xx responses, or unreadable bodies.
- Add an httptest table covering empty-body success, body success, and server error responses.

## Verification
- `gofmt` passes on all changed Go files.
- The focused Go test command reaches the checked-out dependency graph but is blocked by existing `ffmpeg` profile symbols missing from `common/util.go`; the failure is outside the changed files.