### PR TITLE
ci(dependabot): group weekly updates with a cooldown so PRs get merged

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,17 +1,54 @@
 version: 2
 
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
-
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    # Never resolve a release younger than a week: gives the ecosystem time
+    # to detect and yank compromised versions before we pull them in.
+    cooldown:
+      default-days: 7
+    groups:
+      # go-ethereum uses 1.x versioning where minors are breaking. Keep it
+      # in its own PR so it cannot block the routine group.
+      go-ethereum:
+        patterns:
+          - github.com/ethereum/go-ethereum
+      # One combined PR per week instead of one per package.
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    # One combined PR; action majors are routine tag moves and CI
+    # validates the grouped PR anyway.
+    groups:
+      actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: docker
     directory: /docker
     schedule:
-      interval: daily
+      interval: weekly
+    cooldown:
+      default-days: 7
+    # Base image choices are deliberate platform decisions, not routine
+    # updates: CUDA is pinned on purpose and Ubuntu majors need manual work.
+    ignore:
+      - dependency-name: nvidia/cuda
+      - dependency-name: ubuntu
+        update-types: ["version-update:semver-major"]
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,10 +9,12 @@ updates:
     # to detect and yank compromised versions before we pull them in.
     cooldown:
       default-days: 7
+    # Version and security updates are grouped separately. go-ethereum
+    # minors are breaking and usually need code changes, so it gets its
+    # own PR in both streams and cannot block the rest.
     groups:
-      # go-ethereum uses 1.x versioning where minors are breaking. Keep it
-      # in its own PR so it cannot block the routine group.
       go-ethereum:
+        applies-to: version-updates
         patterns:
           - github.com/ethereum/go-ethereum
       # One combined PR per week instead of one per package.
@@ -21,6 +23,16 @@ updates:
         update-types:
           - minor
           - patch
+      go-ethereum-security:
+        applies-to: security-updates
+        patterns:
+          - github.com/ethereum/go-ethereum
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - github.com/ethereum/go-ethereum
     open-pull-requests-limit: 5
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
The current Dependabot config opens daily, ungrouped PRs for every bump. That produced 27 open Dependabot PRs and 30 open security alerts, and no Dependabot PR has merged since February 2024 because each one is superseded before review.

This mirrors the setup we use in explorer: weekly runs, a 7 day cooldown so compromised releases can be yanked before we resolve them, and one grouped PR per ecosystem. go-ethereum is split into its own group since its minor releases are breaking, and the CUDA and Ubuntu base image pins are ignored because those are deliberate platform choices.

Follow-ups outside this PR: close the stale open Dependabot PRs once this lands, and fix the dead Debian bullseye package in the test Docker image that currently fails CI for the grouped security PR.
