### PR TITLE
docs: require a routable orchestrator address in the local examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * CLI: Privileged HTTP endpoints on port 7935 now require `POST`.
 * CLI: Routes on port 7935 that submit Ethereum transactions, sign messages, or change gas controls are disabled by default unless the node is started with `-enableCliTxRoutes`
+* Gateway: Orchestrators must advertise a routable service address. When a gateway and an orchestrator run on the same machine, start the orchestrator with `-serviceAddr <host-ip>:8935` instead of `127.0.0.1`, `localhost` or `0.0.0.0`, and point the gateway's `-orchAddr` at that address.
 
 ## v0.9.1
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -19,6 +19,8 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
 
 ### Configuration Files
 
+The configurations below run a gateway and an orchestrator on the same machine. Replace `<host-ip>` with a routable address of your machine, such as its LAN IP. Since v0.9.2 the orchestrator's service address must be routable, so `127.0.0.1`, `localhost` and `0.0.0.0` no longer work there.
+
 <details>
 <summary>Launch.json (transcoding)</summary>
 
@@ -50,7 +52,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-orchestrator",
         "-transcoder",
-        "-serviceAddr=0.0.0.0:8935",
+        "-serviceAddr=<host-ip>:8935",
         "-v=6",
         "-nvidia=all"
       ]
@@ -65,7 +67,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-orchestrator",
         "-orchSecret=orchSecret",
-        "-serviceAddr=0.0.0.0:8935",
+        "-serviceAddr=<host-ip>:8935",
         "-v=6"
       ]
     },
@@ -79,7 +81,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-transcoder",
         "-orchSecret=orchSecret",
-        "-orchAddr=0.0.0.0:8935",
+        "-orchAddr=<host-ip>:8935",
         "-v=6",
         "-nvidia=all"
       ]
@@ -94,7 +96,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-gateway",
         "-transcodingOptions=${env:HOME}/.lpData/offchain/transcodingOptions.json",
-        "-orchAddr=0.0.0.0:8935",
+        "-orchAddr=<host-ip>:8935",
         "-httpAddr=0.0.0.0:9935",
         "-v",
         "6"
@@ -110,7 +112,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-orchestrator",
         "-transcoder",
-        "-serviceAddr=0.0.0.0:8935",
+        "-serviceAddr=<host-ip>:8935",
         "-v=6",
         "-nvidia=all",
         "-network=arbitrum-one-mainnet",
@@ -131,7 +133,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-orchestrator",
         "-orchSecret=orchSecret",
-        "-serviceAddr=0.0.0.0:8935",
+        "-serviceAddr=<host-ip>:8935",
         "-v=6",
         "-network=arbitrum-one-mainnet",
         "-ethUrl=https://arb1.arbitrum.io/rpc",
@@ -151,7 +153,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-transcoder",
         "-orchSecret=orchSecret",
-        "-orchAddr=0.0.0.0:8935",
+        "-orchAddr=<host-ip>:8935",
         "-v=6",
         "-nvidia=all"
       ]
@@ -166,7 +168,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-gateway",
         "-transcodingOptions=${env:HOME}/.lpData/offchain/transcodingOptions.json",
-        "-orchAddr=0.0.0.0:8935",
+        "-orchAddr=<host-ip>:8935",
         "-httpAddr=0.0.0.0:9935",
         "-v",
         "6",
@@ -226,7 +228,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-orchestrator",
         "-aiWorker",
-        "-serviceAddr=0.0.0.0:8935",
+        "-serviceAddr=<host-ip>:8935",
         "-v=6",
         "-nvidia=all",
         "-aiModels=${env:HOME}/.lpData/cfg/aiModels.json",
@@ -243,7 +245,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-orchestrator",
         "-orchSecret=orchSecret",
-        "-serviceAddr=0.0.0.0:8935",
+        "-serviceAddr=<host-ip>:8935",
         "-v=6"
       ]
     },
@@ -257,7 +259,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-aiWorker",
         "-orchSecret=orchSecret",
-        "-orchAddr=0.0.0.0:8935",
+        "-orchAddr=<host-ip>:8935",
         "-v=6",
         "-nvidia=all",
         "-aiModels=${env:HOME}/.lpData/cfg/aiModels.json",
@@ -274,7 +276,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-gateway",
         "-datadir=${env:HOME}/.lpData2",
-        "-orchAddr=0.0.0.0:8935",
+        "-orchAddr=<host-ip>:8935",
         "-httpAddr=0.0.0.0:9935",
         "-v",
         "6",
@@ -292,7 +294,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
         "-orchestrator",
         "-aiWorker",
         "-aiServiceRegistry",
-        "-serviceAddr=0.0.0.0:8935",
+        "-serviceAddr=<host-ip>:8935",
         "-v=6",
         "-nvidia=all",
         "-aiModels=${env:HOME}/.lpData/cfg/aiModels.json",
@@ -315,7 +317,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
         "-orchestrator",
         "-orchSecret=orchSecret",
         "-aiServiceRegistry",
-        "-serviceAddr=0.0.0.0:8935",
+        "-serviceAddr=<host-ip>:8935",
         "-v=6",
         "-network=arbitrum-one-mainnet",
         "-ethUrl=https://arb1.arbitrum.io/rpc",
@@ -335,7 +337,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
       "args": [
         "-aiWorker",
         "-orchSecret=orchSecret",
-        "-orchAddr=0.0.0.0:8935",
+        "-orchAddr=<host-ip>:8935",
         "-v=6",
         "-nvidia=all",
         "-aiModels=${env:HOME}/.lpData/cfg/aiModels.json",
@@ -353,7 +355,7 @@ To debug the code, it is recommended to use [Visual Studio Code](https://code.vi
         "-gateway",
         "-aiServiceRegistry",
         "-datadir=${env:HOME}/.lpData2",
-        "-orchAddr=0.0.0.0:8935",
+        "-orchAddr=<host-ip>:8935",
         "-httpAddr=0.0.0.0:9935",
         "-v",
         "6",

--- a/doc/remote-signer.md
+++ b/doc/remote-signer.md
@@ -158,7 +158,7 @@ Example:
   -httpAddr :9935 \
   -remoteSignerUrl http://127.0.0.1:7936 \
   -remoteSignerHeaders 'Authorization:Bearer gateway-token,X-Tenant:acme' \
-  -orchAddr localhost:8935 \
+  -orchAddr <host-ip>:8935 \
   -v 6
 ```
 


### PR DESCRIPTION
Since v0.9.2 an orchestrator's service address must be routable. The common developer setup of a gateway and an orchestrator on one machine with `-serviceAddr 0.0.0.0:8935` or `localhost:8935` no longer streams, and the only hint is a 503 with "No sessions available".

This documents the requirement and fixes the examples that stopped working:

- Changelog entry under v0.9.2: start the orchestrator with `-serviceAddr <host-ip>:8935` and point the gateway's `-orchAddr` at it.
- The VS Code launch configurations in the development doc used `0.0.0.0:8935`. They now use `<host-ip>:8935` with a short note.
- The remote signer example used `-orchAddr localhost:8935`.

The matching e2e harness change is #4044. Docs only.