### PR TITLE
docs(box): note the firewall, ffmpeg, image pull and warm-up requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ orchestrator.log
 mediamtx.log
 
 box/supabase
+box/.cache/

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,27 @@ box-stream:
 box-playback:
 	./box/stream.sh playback
 
+.PHONY: box-live-runner
+box-live-runner:
+ifeq ($(strip ${DOCKER}),true)
+	docker build -t livepeer/go-livepeer -f docker/Dockerfile .
+else ifneq ($(strip ${REBUILD}),false)
+	@$(MAKE) livepeer
+endif
+	./box/live-runner.sh orchestrator
+
+.PHONY: box-live-runner-app
+box-live-runner-app:
+	./box/live-runner.sh app
+
+.PHONY: box-live-runner-call
+box-live-runner-call:
+	./box/live-runner.sh call
+
+.PHONY: box-live-runner-echo
+box-live-runner-echo:
+	./box/live-runner.sh echo
+
 .PHONY: box-supabase
 box-supabase:
 	./box/supabase.sh

--- a/box/box.md
+++ b/box/box.md
@@ -2,7 +2,26 @@
 
 ## Requirements
 - Docker is installed (executing `docker` should succeed)
-- [ffmpeg](https://ffmpeg.org/) is installed (executing `ffmpeg` and `ffplay` should succeed)
+- [ffmpeg](https://ffmpeg.org/) is installed (executing `ffmpeg` and `ffplay` should succeed). The gateway also runs the `ffmpeg` on its PATH to publish output to MediaMTX. A broken build there shows up as an empty playback.
+- The runner container can reach the host on port 8935 for trickle. With a default-deny firewall, allow it on the Docker bridge, for example `sudo ufw allow in on docker0 to any port 8935 proto tcp`. Blocked traffic shows up as `no orchestrators available` from the gateway.
+
+## Without an ai-runner checkout
+
+`make box` rebuilds the runner image from a sibling `ai-runner` checkout, which is archived. Pull the images and skip the rebuild instead:
+
+```bash
+docker pull livepeer/ai-runner:live-app-noop
+docker pull livepeerci/mediamtx
+export REBUILD=false
+```
+
+Without a local `mediamtx` binary, run it from the image:
+
+```bash
+docker run --rm --name mediamtx --network host -v $(pwd)/box/mediamtx.yml:/mediamtx.yml livepeerci/mediamtx
+```
+
+The noop runner takes about a minute to start. Wait until `curl http://127.0.0.1:8900/health` returns `{"status":"IDLE"}` before `make box-stream`.
 
 ## Usage (Linux AMD64)
 

--- a/box/box.md
+++ b/box/box.md
@@ -148,6 +148,37 @@ To rebuild and restart the runner, run the following command:
 make box-runner
 ```
 
+## Live runner
+
+The live runner is the other way to run realtime apps on an orchestrator: the app is a plain HTTP service that registers itself, and the orchestrator reverse-proxies clients to it. These targets test it with the published [runner-app-examples](https://github.com/livepeer/runner-app-examples) images. Stop the box orchestrator first, both use port 8935. Needs `curl` and `jq`. The echo test also needs [uv](https://docs.astral.sh/uv/), `ffmpeg` and `ffplay`.
+
+1. Start an orchestrator with live runners enabled
+
+   ```bash
+   make box-live-runner
+   ```
+
+2. Start the hello-world app. It registers itself with the orchestrator
+
+   ```bash
+   make box-live-runner-app
+   ```
+
+3. Call it through the orchestrator. Prints the discovery entry and `{"message": "Hello, box!"}`
+
+   ```bash
+   make box-live-runner-call
+   ```
+
+For realtime video over trickle, run the echo app instead and pipe a test pattern through it. A blurred test pattern in ffplay is the pass:
+
+```bash
+APP=echo make box-live-runner-app
+make box-live-runner-echo
+```
+
+`DOCKER=true` runs the orchestrator from the `livepeer/go-livepeer` image. `FFMPEG` and `FFPLAY` override the binaries used by the echo test.
+
 ## Frontend
 
 To start the frontend, run the following commands:

--- a/box/live-runner.sh
+++ b/box/live-runner.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Smoke test the live runner path with the published example apps from
+# https://github.com/livepeer/runner-app-examples.
+set -e
+
+DOCKER=${DOCKER:-false}
+APP=${APP:-hello-world}
+ORCH_SECRET=${ORCH_SECRET:-abcdef}
+ORCH_URL=${ORCH_URL:-https://127.0.0.1:8935}
+EXAMPLES_REF=${EXAMPLES_REF:-main}
+FFMPEG=${FFMPEG:-ffmpeg}
+FFPLAY=${FFPLAY:-ffplay}
+CACHE_DIR="$(dirname "${BASH_SOURCE[0]}")/.cache"
+
+ORCH_ARGS=(
+  -orchestrator
+  -useLiveRunners
+  -orchSecret "$ORCH_SECRET"
+  -serviceAddr 127.0.0.1:8935
+  -liveRunnerAddr "$ORCH_URL"
+  -cliAddr 127.0.0.1:7935
+  -network offchain
+  -monitor=false
+  -v 6
+)
+
+discover() {
+  curl -sk "$ORCH_URL/discovery"
+}
+
+wait_for_runner() {
+  for _ in $(seq 1 30); do
+    URL=$(discover | jq -r '.[0].runners[0].url // empty')
+    [ -n "$URL" ] && return 0
+    sleep 1
+  done
+  echo "No live runner registered at $ORCH_URL/discovery" >&2
+  exit 1
+}
+
+case "$1" in
+  orchestrator)
+    if [ "$DOCKER" = "false" ]; then
+      ./livepeer "${ORCH_ARGS[@]}"
+    else
+      docker run --rm --name live-runner-orchestrator --network host livepeer/go-livepeer "${ORCH_ARGS[@]}"
+    fi
+    ;;
+  app)
+    docker run --rm --name "live-runner-$APP" --network host \
+      "ghcr.io/livepeer/runner-example-$APP:latest" \
+      --host=0.0.0.0 --orchestrator="$ORCH_URL" --orchSecret="$ORCH_SECRET" \
+      --runner-url=http://127.0.0.1:8989
+    ;;
+  call)
+    wait_for_runner
+    discover | jq '.[].runners[] | {app, mode, url}'
+    curl -sk -X POST "$URL/hello" -H 'Content-Type: application/json' -d '{"name":"box"}'
+    echo
+    ;;
+  echo)
+    wait_for_runner
+    mkdir -p "$CACHE_DIR"
+    if [ ! -f "$CACHE_DIR/echo-client.py" ]; then
+      curl -sfo "$CACHE_DIR/echo-client.py" \
+        "https://raw.githubusercontent.com/livepeer/runner-app-examples/$EXAMPLES_REF/echo/client.py"
+    fi
+    "$FFMPEG" -re -f lavfi -i testsrc=size=1280x720:rate=30 \
+      -c:v libx264 -tune zerolatency -preset ultrafast -pix_fmt yuv420p -f mpegts - \
+      | uv run --with av --with aiohttp --with 'livepeer-gateway>=1.0.0' \
+          "$CACHE_DIR/echo-client.py" - --mode blur --discovery "$ORCH_URL/discovery" --output - \
+      | "$FFPLAY" -fflags nobuffer -flags low_delay -framedrop -i -
+    ;;
+  *)
+    echo "Usage: $0 {orchestrator|app|call|echo}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Four things that fail silently when running the box on a fresh machine:

- The runner container must reach the host on 8935 for trickle; a default-deny firewall on the Docker bridge blocks it. The gateway then only says `no orchestrators available`.
- The gateway publishes output with the `ffmpeg` on its PATH; a broken build there means empty playback with healthy-looking status.
- `make box` rebuilds the runner from a sibling ai-runner checkout, which is archived. Added the pull-and-skip-rebuild path, including MediaMTX from its image.
- The noop runner needs about a minute before it accepts a stream.

Docs only.