### PR TITLE
box: add make targets to smoke test the live runner path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ orchestrator.log
 mediamtx.log
 
 box/supabase
+box/.cache/

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,27 @@ box-stream:
 box-playback:
 	./box/stream.sh playback
 
+.PHONY: box-live-runner
+box-live-runner:
+ifeq ($(strip ${DOCKER}),true)
+	docker build -t livepeer/go-livepeer -f docker/Dockerfile .
+else ifneq ($(strip ${REBUILD}),false)
+	@$(MAKE) livepeer
+endif
+	./box/live-runner.sh orchestrator
+
+.PHONY: box-live-runner-app
+box-live-runner-app:
+	./box/live-runner.sh app
+
+.PHONY: box-live-runner-call
+box-live-runner-call:
+	./box/live-runner.sh call
+
+.PHONY: box-live-runner-echo
+box-live-runner-echo:
+	./box/live-runner.sh echo
+
 .PHONY: box-supabase
 box-supabase:
 	./box/supabase.sh

--- a/box/box.md
+++ b/box/box.md
@@ -148,6 +148,37 @@ To rebuild and restart the runner, run the following command:
 make box-runner
 ```
 
+## Live runner
+
+The live runner is the other way to run realtime apps on an orchestrator: the app is a plain HTTP service that registers itself, and the orchestrator reverse-proxies clients to it. These targets test it with the published [runner-app-examples](https://github.com/livepeer/runner-app-examples) images. Stop the box orchestrator first, both use port 8935. Needs `curl` and `jq`. The echo test also needs [uv](https://docs.astral.sh/uv/), `ffmpeg` and `ffplay`.
+
+1. Start an orchestrator with live runners enabled
+
+   ```bash
+   make box-live-runner
+   ```
+
+2. Start the hello-world app. It registers itself with the orchestrator
+
+   ```bash
+   make box-live-runner-app
+   ```
+
+3. Call it through the orchestrator. Prints the discovery entry and `{"message": "Hello, box!"}`
+
+   ```bash
+   make box-live-runner-call
+   ```
+
+For realtime video over trickle, run the echo app instead and pipe a test pattern through it. A blurred test pattern in ffplay is the pass:
+
+```bash
+APP=echo make box-live-runner-app
+make box-live-runner-echo
+```
+
+`DOCKER=true` runs the orchestrator from the `livepeer/go-livepeer` image. `FFMPEG` and `FFPLAY` override the binaries used by the echo test.
+
 ## Frontend
 
 To start the frontend, run the following commands:

--- a/box/live-runner.sh
+++ b/box/live-runner.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Smoke test the live runner path with the published example apps from
+# https://github.com/livepeer/runner-app-examples.
+set -e
+
+DOCKER=${DOCKER:-false}
+APP=${APP:-hello-world}
+ORCH_SECRET=${ORCH_SECRET:-abcdef}
+ORCH_URL=${ORCH_URL:-https://127.0.0.1:8935}
+EXAMPLES_REF=${EXAMPLES_REF:-main}
+FFMPEG=${FFMPEG:-ffmpeg}
+FFPLAY=${FFPLAY:-ffplay}
+CACHE_DIR="$(dirname "${BASH_SOURCE[0]}")/.cache"
+
+ORCH_ARGS=(
+  -orchestrator
+  -useLiveRunners
+  -orchSecret "$ORCH_SECRET"
+  -serviceAddr 127.0.0.1:8935
+  -liveRunnerAddr "$ORCH_URL"
+  -cliAddr 127.0.0.1:7935
+  -network offchain
+  -monitor=false
+  -v 6
+)
+
+discover() {
+  curl -sk "$ORCH_URL/discovery"
+}
+
+wait_for_runner() {
+  for _ in $(seq 1 30); do
+    URL=$(discover | jq -r '.[0].runners[0].url // empty')
+    [ -n "$URL" ] && return 0
+    sleep 1
+  done
+  echo "No live runner registered at $ORCH_URL/discovery" >&2
+  exit 1
+}
+
+case "$1" in
+  orchestrator)
+    if [ "$DOCKER" = "false" ]; then
+      ./livepeer "${ORCH_ARGS[@]}"
+    else
+      docker run --rm --name live-runner-orchestrator --network host livepeer/go-livepeer "${ORCH_ARGS[@]}"
+    fi
+    ;;
+  app)
+    docker run --rm --name "live-runner-$APP" --network host \
+      "ghcr.io/livepeer/runner-example-$APP:latest" \
+      --host=0.0.0.0 --orchestrator="$ORCH_URL" --orchSecret="$ORCH_SECRET" \
+      --runner-url=http://127.0.0.1:8989
+    ;;
+  call)
+    wait_for_runner
+    discover | jq '.[].runners[] | {app, mode, url}'
+    curl -sk -X POST "$URL/hello" -H 'Content-Type: application/json' -d '{"name":"box"}'
+    echo
+    ;;
+  echo)
+    wait_for_runner
+    mkdir -p "$CACHE_DIR"
+    if [ ! -f "$CACHE_DIR/echo-client.py" ]; then
+      curl -sfo "$CACHE_DIR/echo-client.py" \
+        "https://raw.githubusercontent.com/livepeer/runner-app-examples/$EXAMPLES_REF/echo/client.py"
+    fi
+    "$FFMPEG" -re -f lavfi -i testsrc=size=1280x720:rate=30 \
+      -c:v libx264 -tune zerolatency -preset ultrafast -pix_fmt yuv420p -f mpegts - \
+      | uv run --with av --with aiohttp --with 'livepeer-gateway>=1.0.0' \
+          "$CACHE_DIR/echo-client.py" - --mode blur --discovery "$ORCH_URL/discovery" --output - \
+      | "$FFPLAY" -fflags nobuffer -flags low_delay -framedrop -i -
+    ;;
+  *)
+    echo "Usage: $0 {orchestrator|app|call|echo}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Box only covered the AI worker path. This adds the same one-command smoke test for the live runner, using the published `runner-app-examples` images so nothing has to be cloned or built.

- `make box-live-runner`: orchestrator with live runners enabled, from the local build or the Docker image with `DOCKER=true`.
- `make box-live-runner-app`: runs `ghcr.io/livepeer/runner-example-hello-world`, or another example with `APP=echo`.
- `make box-live-runner-call`: waits for discovery, then calls hello-world through the orchestrator. Verified locally: returns `{"message": "Hello, box!"}`.
- `make box-live-runner-echo`: pipes an ffmpeg test pattern through the echo app over trickle into ffplay, fetching the example's client on first use.

Stacked on #4060 since both edit box.md. Shell, Makefile and docs only.
