### PR TITLE
ci: keep cross builds from running generators for the wrong platform

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -150,7 +150,7 @@ jobs:
           GHA_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
         run: |
           git config --global --add safe.directory '*'
-          ./ci_env.sh make
+          ./ci_env.sh make binaries
 
       - name: Archive binaries for windows
         if: matrix.target.GOOS == 'windows'
@@ -248,7 +248,7 @@ jobs:
         run: |
           git config --global --add safe.directory '*'
           export PKG_CONFIG_PATH=~/compiled/lib/pkgconfig
-          ./ci_env.sh make
+          ./ci_env.sh make binaries
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: match-tag

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ ABIGEN=GOOS= GOARCH= go run github.com/ethereum/go-ethereum/cmd/abigen
 
 all: net/lp_rpc.pb.go net/redeemer.pb.go net/redeemer_mock.pb.go core/test_segment.go eth/contracts/chainlink/AggregatorV3Interface.go livepeer livepeer_cli livepeer_router livepeer_bench
 
+# Release builds: skip the generated files, they are committed.
+.PHONY: binaries
+binaries: livepeer livepeer_cli livepeer_router livepeer_bench
+
 net/lp_rpc.pb.go: net/lp_rpc.proto
 	protoc -I=. --go_out=. --go-grpc_out=. $^
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 SHELL=/bin/bash
 GO_BUILD_DIR?="./"
 
-MOCKGEN=go run github.com/golang/mock/mockgen
-ABIGEN=go run github.com/ethereum/go-ethereum/cmd/abigen
+# Generators run on the host even when cross-compiling, so GOOS and GOARCH
+# from the environment must not leak into them.
+MOCKGEN=GOOS= GOARCH= go run github.com/golang/mock/mockgen
+ABIGEN=GOOS= GOARCH= go run github.com/ethereum/go-ethereum/cmd/abigen
 
 all: net/lp_rpc.pb.go net/redeemer.pb.go net/redeemer_mock.pb.go core/test_segment.go eth/contracts/chainlink/AggregatorV3Interface.go livepeer livepeer_cli livepeer_router livepeer_bench
 


### PR DESCRIPTION
The "Build binaries for windows" job exports `GOOS=windows` for the whole `make` run. Git checkout can leave a `.proto` one second newer than its generated `.pb.go`, so `make` regenerates it, which makes the mock look stale, and `go run mockgen` then builds a Windows executable that Linux cannot run:

```
fork/exec /tmp/go-build.../exe/mockgen.exe: exec format error
make: *** [Makefile:16: net/redeemer_mock.pb.go] Error 1
```

Example failure on #4061: https://github.com/livepeer/go-livepeer/actions/runs/34338692941/job/102424142497

Two commits:

1. **Generators build for the host.** `GOOS= GOARCH=` in front of the mockgen and abigen invocations. They run once on the build machine and emit Go source, so the cross-compile target must never apply to them. This also fixes `GOOS=windows make` on a developer machine.
2. **Release jobs build only the binaries.** A `binaries` target with the four shipped binaries, used by the two build jobs instead of bare `make`. CI then never touches the generated files, so the timestamp race cannot trigger there, and the protoc and solc steps drop out of release builds.

## Reproduce the first commit

```bash
touch net/redeemer.pb.go net/redeemer_grpc.pb.go
GOOS=windows GOARCH=amd64 make net/redeemer_mock.pb.go
```

On master this fails with `mockgen.exe: exec format error`. With the fix it regenerates the mocks and exits 0. `git status` then shows only a cosmetic `interface{}` to `any` change from the newer mockgen in go.mod, which is not committed here.