### PR TITLE
ci: keep releases working under a read-only default token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,6 @@ jobs:
   release:
     name: Prepare github release
     runs-on: ubuntu-24.04
-    # Needed to publish the release; declared explicitly so the repository
-    # default token can stay read-only.
     permissions:
       contents: write
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ jobs:
   release:
     name: Prepare github release
     runs-on: ubuntu-24.04
+    # Needed to publish the release; declared explicitly so the repository
+    # default token can stay read-only.
+    permissions:
+      contents: write
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: checkout


### PR DESCRIPTION
The release job publishes with softprops/action-gh-release, which needs contents: write. It has no permissions block today, so it depends on the repository default token being read and write — and that default also hands write access to every other workflow and to any third-party action they pull in.

This declares the permission on the job that actually needs it. Once merged, the repository default can move to read-only (Settings, Actions, General, Workflow permissions) and the "Allow GitHub Actions to create and approve pull requests" box can be unticked. The other eleven main repos were switched over on 9 September; go-livepeer is the last one, and this workflow is the only reason it was held back.