### PR TITLE
ci: update GitHub Actions for Node.js 24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,7 @@ jobs:
           apt install -yqq build-essential make git zip unzip zlib1g-dev zlib1g libzlcore-dev yasm
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -68,7 +68,7 @@ jobs:
 
       - name: Set up go
         id: go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: './go.mod'
           cache: true
@@ -169,7 +169,7 @@ jobs:
           tar -czvf "../releases/$LP_BUILD_DIR.tar.gz" ./
 
       - name: Upload artifacts for cutting release
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: release-artifacts-${{ matrix.target.GOOS }}-${{ matrix.target.type }}-${{ matrix.target.GOARCH }}
           path: releases/
@@ -191,7 +191,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -200,7 +200,7 @@ jobs:
 
       - name: Set up go
         id: go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: './go.mod'
           cache: true
@@ -217,7 +217,7 @@ jobs:
 
       - name: Cache ffmpeg
         id: cache-ffmpeg
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/compiled
           key: ${{ runner.os }}-${{ matrix.target.GOOS }}-${{ matrix.target.GOARCH }}-ffmpeg-${{ hashFiles('**/install_ffmpeg.sh') }}
@@ -250,11 +250,15 @@ jobs:
           export PKG_CONFIG_PATH=~/compiled/lib/pkgconfig
           ./ci_env.sh make
 
-      - uses: actions-ecosystem/action-regex-match@v2
+      - name: Match release ref
         id: match-tag
-        with:
-          text: ${{ github.ref_name }}
-          regex: '^(master|main|v[0-9]+\.\d+\.\d+)$'
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$REF_NAME" =~ ^(master|main|v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "match=${BASH_REMATCH[0]}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Codesign and notarize binaries
         if: steps.match-tag.outputs.match != '' && matrix.target.GOOS == 'darwin'
@@ -277,7 +281,7 @@ jobs:
           tar -czvf "../releases/${LP_BUILD_DIR}.tar.gz" .
 
       - name: Upload artifacts for cutting release
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: release-artifacts-${{ matrix.target.GOOS }}-${{ matrix.target.GOARCH }}
           path: releases/
@@ -294,7 +298,7 @@ jobs:
       - linux-build
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -303,7 +307,7 @@ jobs:
 
       - name: Set up python
         id: python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: 3.12
           cache: pip
@@ -311,7 +315,7 @@ jobs:
           update-environment: true
 
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: release-artifacts-*
           path: releases/
@@ -335,14 +339,14 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.CI_GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.CI_GOOGLE_SERVICE_ACCOUNT }}
 
       - name: Upload release archives to Google Cloud
         id: upload-archives
-        uses: google-github-actions/upload-cloud-storage@v2
+        uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: "releases"
           destination: "build.livepeer.live/${{ github.event.repository.name }}/${{ (github.ref_type == 'tag' && github.ref_name) || (github.event.pull_request.head.sha || github.sha) }}"
@@ -351,7 +355,7 @@ jobs:
 
       - name: Upload branch manifest file
         id: upload-manifest
-        uses: google-github-actions/upload-cloud-storage@v2
+        uses: google-github-actions/upload-cloud-storage@v3
         with:
           path: ${{ steps.branch-manifest.outputs.manifest-file }}
           destination: "build.livepeer.live/${{ github.event.repository.name }}/"

--- a/.github/workflows/docker-mediamtx.yaml
+++ b/.github/workflows/docker-mediamtx.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -34,14 +34,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for image
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             livepeerci/mediamtx
@@ -58,20 +58,20 @@ jobs:
             type=raw,value=${{ github.event.pull_request.head.ref }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: docker/
           file: "docker/Dockerfile.mediamtx"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: [self-hosted, linux, amd64]
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -38,10 +38,10 @@ jobs:
           ./ci_env.sh
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -65,20 +65,20 @@ jobs:
             type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') && github.event.base_ref == 'refs/heads/master' }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build and push livepeer docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             BUILD_TAGS=${{ steps.build-tag.outputs.build-tags }}
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -119,11 +119,15 @@ jobs:
           sudo apt autoremove -y
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android
 
-      - uses: actions-ecosystem/action-regex-match@v2
+      - name: Match release ref
         id: match-tag
-        with:
-          text: ${{ github.ref_name }}
-          regex: '^(main|master|v[0-9]+\.\d+\.\d+)$'
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$REF_NAME" =~ ^(main|master|v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "match=${BASH_REMATCH[0]}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Get build tags
         id: build-tag
@@ -131,10 +135,10 @@ jobs:
           ./ci_env.sh
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for builder image
         id: meta-builder
@@ -155,13 +159,13 @@ jobs:
             type=raw,value=${{ github.event.pull_request.head.ref }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -169,7 +173,7 @@ jobs:
 
       - name: Build and push livepeer builder
         if: ${{ steps.match-tag.outputs.match != '' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             BUILD_TAGS=${{ steps.build-tag.outputs.build-tags }}

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -12,8 +12,8 @@ jobs:
       issues: write
     steps:
       - name: Label issues
-        uses: andymckay/labeler@master
-        with:
-          add-labels: "status: triage"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          ignore-if-assigned: false
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          gh issue edit "$ISSUE_URL" --add-label "status: triage"

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,5 +12,5 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/labeler@v5
+      - uses: actions/checkout@v7
+      - uses: actions/labeler@v7

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,5 +12,4 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
       - uses: actions/labeler@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,12 +15,6 @@ jobs:
       contents: write
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: checkout
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_branch }}
-
       - name: Download artifacts from build stage
         uses: dawidd6/action-download-artifact@v24
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,13 +16,13 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Download artifacts from build stage
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v24
         with:
           workflow: build.yaml
           run_id: ${{ github.event.workflow_run.id }}
@@ -37,11 +37,15 @@ jobs:
           find . -type f -exec mv '{}' ./ \;
           find . -type d -empty -delete
 
-      - uses: actions-ecosystem/action-regex-match@v2
+      - name: Match release tag
         id: match-tag
-        with:
-          text: ${{ github.event.workflow_run.head_branch }}
-          regex: '^v([0-9]+\.\d+\.\d+)$'
+        shell: bash
+        env:
+          REF_NAME: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [[ "$REF_NAME" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "match=${BASH_REMATCH[0]}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Generate sha256 checksum and gpg signatures for release artifacts
         if: ${{ steps.match-tag.outputs.match != '' }}
@@ -53,7 +57,7 @@ jobs:
           gpg-key-passphrase: ${{ secrets.CI_GPG_SIGNING_PASSPHRASE }}
 
       - name: Release to github
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: ${{ steps.match-tag.outputs.match != '' }}
         with:
           generate_release_notes: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Block fixup commit merge
         uses: 13rac1/block-fixup-merge-action@v2.0.0
@@ -42,7 +42,7 @@ jobs:
           sudo apt update && sudo apt install -yqq git zip unzip zlib1g-dev zlib1g
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -55,7 +55,7 @@ jobs:
 
       - name: Set up go
         id: go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: './go.mod'
           cache: true
@@ -63,7 +63,7 @@ jobs:
 
       - name: Cache ffmpeg
         id: cache-ffmpeg
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /home/runner/compiled
           key: ${{ runner.os }}-ffmpeg-${{ hashFiles('install_ffmpeg.sh') }}
@@ -127,7 +127,7 @@ jobs:
           ./test_e2e.sh
 
       - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CI_CODECOV_TOKEN }}
           files: ./cover.out
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           # Check https://github.com/livepeer/go-livepeer/pull/1891
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v7
         with:
           # Check https://github.com/livepeer/go-livepeer/pull/1891
           # for ref value discussion


### PR DESCRIPTION
## Summary

This PR supersedes #4058. It carries forward its maintained-action upgrades, except for two `actions/checkout` invocations that are removed because the jobs do not use repository contents:

- `actions/checkout@v7`
- `actions/setup-go@v7`
- `actions/upload-artifact@v7`
- `actions/cache@v6`
- `actions/setup-python@v7`
- `actions/download-artifact@v8`
- `google-github-actions/auth@v3`
- `google-github-actions/upload-cloud-storage@v3`
- `docker/setup-qemu-action@v4`
- `docker/setup-buildx-action@v4`
- `docker/metadata-action@v6`
- `docker/login-action@v4`
- `docker/build-push-action@v7`
- `actions/labeler@v7`
- `dawidd6/action-download-artifact@v24`
- `softprops/action-gh-release@v3`
- `codecov/codecov-action@v7`

It also addresses the remaining deprecated JavaScript actions found during the workflow audit.

## Additional changes

### Replace action-regex-match with Bash

`actions-ecosystem/action-regex-match@v2` has no newer maintained release. The steps in `build.yaml`, `docker.yaml`, and `release.yaml` only need a simple regex check, so Bash safely reproduces the action's `match` output without introducing another JavaScript action.

### Replace the archived issue labeler

`andymckay/labeler@master` is archived, references a mutable branch, and relies on a deprecated JavaScript runtime. `gh issue edit` is available on the GitHub-hosted runner and uses the job's existing `issues: write` token permission to add the same `status: triage` label without a third-party action.

### Remove unnecessary checkout steps

`pr-labeler.yml` does not need a checkout because `actions/labeler@v7` fetches its default configuration through the GitHub API when it is not present on the runner. `release.yaml` operates only on downloaded build artifacts and GitHub APIs. Removing both steps avoids unnecessary work and JavaScript action invocations without changing behavior.

## Dependency

This PR depends on livepeer/branch-manifest-action#79. That PR updates the shared `livepeer/branch-manifest-action@latest` implementation from Node.js 16 to Node.js 24 so all Livepeer repositories using it benefit from the runtime update. It should be merged and the `latest` tag advanced before this PR is considered complete.

## Validation

- verified the local workflow patch against the exact #4058 head; the intentional differences are the three Bash regex replacements, the issue-labeler replacement, and removal of the two unused checkout steps
- parsed all seven modified workflow files successfully as YAML
- `git diff --check` passes
- tested the Bash regex expressions against matching and non-matching release refs

Review requested from @rickstaa.
