### PR TITLE
ci: restrict release workflow to trusted pushes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,12 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      }}
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why

The release workflow currently runs after successful pull-request builds as well as trusted pushes. Because `workflow_run` jobs receive privileged tokens and secrets, pull-request artifacts can reach the signing and publishing workflow. This change restricts the job to successful pushes originating from this repository.

Without this gate, untrusted pull-request artifacts could be signed or published if their branch name matched the release-tag pattern.

## Follow-up: protected releases

This PR does not create the following repository resources.

### Dedicated `github-release` environment

Configure it with:

- A `release-managers` team as required reviewers.
- “Prevent self-review” enabled.
- Administrator bypass disabled.
- GPG signing key/passphrase moved from repository secrets to environment secrets.
- Only the final signing/publishing job referencing `environment: github-release` and receiving `contents: write`.

GitHub will hold that job—and its secrets—until an authorized reviewer approves it. GitHub requires only one reviewer from the configured list.

### Release-tag ruleset

The `release-managers` team does not exist yet. Create it first, then add an active tag ruleset targeting `v*` with **Restrict creations**, **Restrict updates**, and **Restrict deletions**, granting bypass only to `release-managers`. Do not create the ruleset before the team exists, because it would leave no authorized actor able to create release tags.
