### PR TITLE
ci: hold release publishing for reviewer approval

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,9 @@ jobs:
   release:
     name: Prepare github release
     runs-on: ubuntu-24.04
+    environment:
+      name: github-release
+      url: https://github.com/livepeer/go-livepeer/releases
     permissions:
       contents: write
     if: >-


### PR DESCRIPTION
Implements the `github-release` environment follow-up from [#4066](https://github.com/livepeer/go-livepeer/pull/4066#issue-5408418585).

The publishing job now runs in the `github-release` environment, just created, which is configured with the `release-managers` team as required reviewers, self-review prevented, and administrator bypass disabled. GitHub holds the job, and its secrets, until a release manager approves.

The other follow-up from that PR, the `v*` tag ruleset restricting creations, updates and deletions to `release-managers`, is already active.