### PR TITLE
ci: restore CodeQL uploads under the read-only default token

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -137,6 +137,9 @@ jobs:
   codeql:
     name: Perform CodeQL analysis
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Check out code


### PR DESCRIPTION
Since #4063 restricted the default `GITHUB_TOKEN`, the `codeql` job in `test.yaml` runs with `contents: read`, `metadata: read`, `packages: read` and nothing else. It never declared its own permissions, so it was missed when the other workflows were updated.

Uploading an analysis for `refs/heads/master` needs `security-events: write`, so every push to master fails at the upload step with `Resource not accessible by integration`. Pull request analyses are accepted without it, which is why only pushes go red and the last successful master analysis was minutes before #4063 landed.

The same missing permission also stops the action reaching the CodeQL Action API, so it reports no feature flags and falls back to the bundled CLI. That accounts for eight of the warnings on every run, including the ones on pull requests that pass.

Granting the job `security-events: write` fixes both. Fork pull requests keep the API warning, since GitHub always issues them a read-only token.