### PR TITLE
fix(starter): default -cliAddr for every node type

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,7 +18,7 @@
 
 #### General
 
-- [#XXXX](https://github.com/livepeer/go-livepeer/pull/XXXX) Default `-cliAddr` to a loopback address for every node type, so redeemer and reward caller nodes no longer fail to start by binding the CLI server to `:80` (@rickstaa)
+- [#4078](https://github.com/livepeer/go-livepeer/pull/4078) Default `-cliAddr` to a loopback address for every node type, so redeemer and reward caller nodes no longer fail to start by binding the CLI server to `:80` (@rickstaa)
 
 #### Broadcaster
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,8 @@
 
 #### General
 
+- [#XXXX](https://github.com/livepeer/go-livepeer/pull/XXXX) Default `-cliAddr` to a loopback address for every node type, so redeemer and reward caller nodes no longer fail to start by binding the CLI server to `:80` (@rickstaa)
+
 #### Broadcaster
 
 #### CLI

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -1643,7 +1643,6 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 	}
 
 	httpIngest := true
-
 	*cfg.CliAddr = cliAddr(*cfg.CliAddr, n.NodeType)
 
 	if n.NodeType == core.BroadcasterNode {
@@ -2342,8 +2341,6 @@ func setupOrchestrator(n *core.LivepeerNode, ethOrchAddr ethcommon.Address) erro
 	return nil
 }
 
-// cliAddr returns the address the CLI server binds. Every node type gets a default, so
-// none is left with the empty address that net/http serves on :80.
 func cliAddr(addr string, nodeType core.NodeType) string {
 	const host = "127.0.0.1"
 	switch nodeType {

--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -77,6 +77,8 @@ const (
 	TranscoderCliPort   = "6935"
 	AIWorkerCliPort     = "4935"
 	RemoteSignerCliPort = "3935"
+	RedeemerCliPort     = "11935"
+	DefaultCliPort      = "10935"
 
 	RefreshPerfScoreInterval = 10 * time.Minute
 )
@@ -1642,12 +1644,13 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 
 	httpIngest := true
 
+	*cfg.CliAddr = cliAddr(*cfg.CliAddr, n.NodeType)
+
 	if n.NodeType == core.BroadcasterNode {
 		// default lpms listener for broadcaster; same as default rpc port
 		// TODO provide an option to disable this?
 		*cfg.RtmpAddr = defaultAddr(*cfg.RtmpAddr, "127.0.0.1", BroadcasterRtmpPort)
 		*cfg.HttpAddr = defaultAddr(*cfg.HttpAddr, "127.0.0.1", BroadcasterRpcPort)
-		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", BroadcasterCliPort)
 
 		if *cfg.GatewayHost != "" {
 			n.GatewayHost = *cfg.GatewayHost
@@ -1793,8 +1796,6 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 		server.MaxAttempts = *cfg.MaxAttempts
 
 	} else if n.NodeType == core.OrchestratorNode {
-		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", OrchestratorCliPort)
-
 		suri, err := getServiceURI(n, *cfg.ServiceAddr)
 		if err != nil {
 			glog.Exit("Error getting service URI: ", err)
@@ -1821,12 +1822,6 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				}
 			}
 		}
-	} else if n.NodeType == core.TranscoderNode {
-		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", TranscoderCliPort)
-	} else if n.NodeType == core.AIWorkerNode {
-		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", AIWorkerCliPort)
-	} else if n.NodeType == core.RemoteSignerNode {
-		*cfg.CliAddr = defaultAddr(*cfg.CliAddr, "127.0.0.1", RemoteSignerCliPort)
 	}
 	if isWildcardIPAddr(*cfg.CliAddr) {
 		glog.Warningf("Binding -cliAddr to a wildcard address (%s) exposes the CLI server on all network interfaces; use a loopback address or restrict access with a firewall", *cfg.CliAddr)
@@ -2345,6 +2340,28 @@ func setupOrchestrator(n *core.LivepeerNode, ethOrchAddr ethcommon.Address) erro
 	}
 
 	return nil
+}
+
+// cliAddr returns the address the CLI server binds. Every node type gets a default, so
+// none is left with the empty address that net/http serves on :80.
+func cliAddr(addr string, nodeType core.NodeType) string {
+	const host = "127.0.0.1"
+	switch nodeType {
+	case core.BroadcasterNode:
+		return defaultAddr(addr, host, BroadcasterCliPort)
+	case core.OrchestratorNode:
+		return defaultAddr(addr, host, OrchestratorCliPort)
+	case core.TranscoderNode:
+		return defaultAddr(addr, host, TranscoderCliPort)
+	case core.AIWorkerNode:
+		return defaultAddr(addr, host, AIWorkerCliPort)
+	case core.RemoteSignerNode:
+		return defaultAddr(addr, host, RemoteSignerCliPort)
+	case core.RedeemerNode:
+		return defaultAddr(addr, host, RedeemerCliPort)
+	default:
+		return defaultAddr(addr, host, DefaultCliPort)
+	}
 }
 
 func defaultAddr(addr, defaultHost, defaultPort string) string {

--- a/cmd/livepeer/starter/starter_test.go
+++ b/cmd/livepeer/starter/starter_test.go
@@ -9,9 +9,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"strings"
+
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/livepeer/go-livepeer/ai/runner"
 	"github.com/livepeer/go-livepeer/common"
+
 	"github.com/livepeer/go-livepeer/core"
 	"github.com/livepeer/go-livepeer/eth"
 	lpTypes "github.com/livepeer/go-livepeer/eth/types"
@@ -553,4 +556,34 @@ type testWriter struct {
 func (w *testWriter) Write(p []byte) (n int, err error) {
 	*w.buf = append(*w.buf, p...)
 	return len(p), nil
+}
+
+func TestCliAddr(t *testing.T) {
+	// Every node type must get a default. A type reaching the default case is fine; a type
+	// left with the empty address is not, since net/http then serves it on :80.
+	nodeTypes := []core.NodeType{
+		core.DefaultNode, core.BroadcasterNode, core.OrchestratorNode,
+		core.TranscoderNode, core.AIWorkerNode, core.RedeemerNode, core.RemoteSignerNode,
+	}
+	for _, nt := range nodeTypes {
+		t.Run(nt.String(), func(t *testing.T) {
+			addr := cliAddr("", nt)
+			assert.NotEmpty(t, addr)
+			assert.True(t, strings.HasPrefix(addr, "127.0.0.1:"), "must bind loopback, got %v", addr)
+		})
+	}
+
+	// Ports are distinct so co-located nodes do not fight for the socket.
+	seen := map[string]core.NodeType{}
+	for _, nt := range nodeTypes {
+		addr := cliAddr("", nt)
+		if other, dup := seen[addr]; dup {
+			t.Errorf("%v and %v share %v", other, nt, addr)
+		}
+		seen[addr] = nt
+	}
+
+	// An explicit -cliAddr always wins.
+	assert.Equal(t, "0.0.0.0:1234", cliAddr("0.0.0.0:1234", core.RedeemerNode))
+	assert.Equal(t, "127.0.0.1:1234", cliAddr(":1234", core.DefaultNode))
 }


### PR DESCRIPTION
The `-cliAddr` default is filled in by a chain of node-type branches that ends without an `else`. Redeemer nodes and LIP-118 reward callers match no branch, so they keep the empty address, which Go serves on `:80`. That fails with `bind: permission denied` as a non-root user and shuts the node down. When it does bind, as root or with `CAP_NET_BIND_SERVICE`, it publishes the transaction-signing CLI server on every interface.

#3962 fixed the same shape for remote signer by adding one more branch. This moves the defaulting into a single function with a default case instead, so a node type added later cannot inherit `:80` again. Redeemer gets 11935 and anything unmatched gets 10935, both loopback, so a redeemer and a reward caller on one host do not collide.

Nodes that pass `-cliAddr` explicitly are unaffected, and every existing node type keeps the port it had. A test asserts that no node type is left with an empty address and that the ports are distinct.