### PR TITLE
cli: read staking amounts in LPT instead of LPTU

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,3 +23,6 @@
 #### Broadcaster
 
 #### CLI
+
+- [#4083](https://github.com/livepeer/go-livepeer/pull/4083) cli: Read bond, unbond, activation and transfer amounts in LPT instead of LPTU (@Strykar)
+- [#4083](https://github.com/livepeer/go-livepeer/pull/4083) cli: Stop the unbond prompt from looping forever when nothing is bonded (@Strykar)

--- a/cmd/livepeer_cli/wizard_bond.go
+++ b/cmd/livepeer_cli/wizard_bond.go
@@ -167,9 +167,12 @@ func (w *wizard) bond() {
 		return
 	}
 
+	fmt.Printf("Current LPT balance: %v\n", eth.FormatUnits(balBigInt, "LPT"))
+
 	amount := big.NewInt(0)
 	for amount.Cmp(big.NewInt(0)) == 0 || balBigInt.Cmp(amount) < 0 {
-		amount = w.readBigInt("Enter bond amount")
+		fmt.Printf("Enter bond amount in LPT - ")
+		amount = w.readPositiveBaseAmount()
 		if amount.Cmp(big.NewInt(0)) == 0 {
 			break
 		}
@@ -253,7 +256,7 @@ func (w *wizard) unbond() {
 		return
 	}
 
-	if dInfo.BondedAmount.Cmp(big.NewInt(0)) < 0 {
+	if dInfo.BondedAmount.Cmp(big.NewInt(0)) <= 0 {
 		fmt.Printf("You are not bonded\n")
 		return
 	}
@@ -280,7 +283,8 @@ func (w *wizard) unbond() {
 	}
 
 	for amount.Cmp(big.NewInt(0)) == 0 || dInfo.BondedAmount.Cmp(amount) < 0 {
-		amount = w.readBigInt("Enter unbond amount")
+		fmt.Printf("Enter unbond amount in LPT - ")
+		amount = w.readPositiveBaseAmount()
 		if dInfo.BondedAmount.Cmp(amount) < 0 {
 			fmt.Printf("Must enter an amount less than or equal to the current bonded amount.")
 		}

--- a/cmd/livepeer_cli/wizard_stats.go
+++ b/cmd/livepeer_cli/wizard_stats.go
@@ -386,6 +386,17 @@ func (w *wizard) getTokenBalance() string {
 	return b
 }
 
+// getFormattedTokenBalance returns the node's LPT balance in LPT, or whatever
+// getTokenBalance returned if that is not a number.
+func (w *wizard) getFormattedTokenBalance() string {
+	b := w.getTokenBalance()
+	bal, err := lcommon.ParseBigInt(b)
+	if err != nil {
+		return b
+	}
+	return eth.FormatUnits(bal, "LPT")
+}
+
 func (w *wizard) getEthBalance() string {
 	e := httpGet(fmt.Sprintf("http://%v:%v/ethBalance", w.host, w.httpPort))
 	if e == "" {

--- a/cmd/livepeer_cli/wizard_test.go
+++ b/cmd/livepeer_cli/wizard_test.go
@@ -1,11 +1,20 @@
 package main
 
 import (
+	"bufio"
+	"encoding/json"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	lpTypes "github.com/livepeer/go-livepeer/eth/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // httpGet returns the response body whatever the status, so a handler that reports an
@@ -71,4 +80,206 @@ func TestHttpGetUnreachable(t *testing.T) {
 	assert.Equal(t, "", body)
 	assert.False(t, ok)
 	assert.Equal(t, "", httpGet(url))
+}
+
+func newTestWizard(input string) *wizard {
+	return &wizard{in: bufio.NewReader(strings.NewReader(input))}
+}
+
+// newTestNode starts a stub of the node's CLI HTTP API and returns a wizard
+// pointing at it along with the form values it received.
+func newTestNode(t *testing.T, input string, routes map[string]string) (*wizard, map[string]url.Values) {
+	posted := make(map[string]url.Values)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			// t.Errorf, not require: this runs on the server goroutine, where
+			// FailNow is not allowed
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("parsing form for %v: %v", r.URL.Path, err)
+				return
+			}
+			posted[r.URL.Path] = r.PostForm
+			return
+		}
+		body, ok := routes[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	host, port, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	require.NoError(t, err)
+
+	w := newTestWizard(input)
+	w.host = host
+	w.httpPort = port
+
+	return w, posted
+}
+
+func TestReadPositiveBaseAmount(t *testing.T) {
+	assert := assert.New(t)
+
+	// a whole number of tokens
+	assert.Equal("5000000000000000000", newTestWizard("5\n").readPositiveBaseAmount().String())
+
+	// a fractional amount
+	assert.Equal("1500000000000000000", newTestWizard("1.5\n").readPositiveBaseAmount().String())
+
+	// an explicit sign
+	assert.Equal("1500000000000000000", newTestWizard("+1.5\n").readPositiveBaseAmount().String())
+
+	// the smallest unit
+	assert.Equal("1", newTestWizard("0.000000000000000001\n").readPositiveBaseAmount().String())
+
+	// zero, which the bond flow uses to skip bonding
+	assert.Equal("0", newTestWizard("0\n").readPositiveBaseAmount().String())
+
+	// a negative amount is rejected and the wizard asks again
+	assert.Equal("2000000000000000000", newTestWizard("-1\n2\n").readPositiveBaseAmount().String())
+
+	// so is an amount with more than 18 decimals
+	assert.Equal("500000000000000000", newTestWizard("0.1111111111111111111\n0.5\n").readPositiveBaseAmount().String())
+
+	// and so is anything that is not a number
+	assert.Equal("3000000000000000000", newTestWizard("abc\n3\n").readPositiveBaseAmount().String())
+}
+
+func TestBondAmountIsReadAsLPT(t *testing.T) {
+	toAddr := "0x0000000000000000000000000000000000000001"
+	// no orchestrator list, so the wizard asks for an address, then 1.5 LPT out
+	// of a 10 LPT balance
+	w, posted := newTestNode(t, toAddr+"\n1.5\n", map[string]string{
+		"/tokenBalance": "10000000000000000000",
+	})
+
+	w.bond()
+
+	require.Contains(t, posted, "/bond")
+	assert.Equal(t, "1500000000000000000", posted["/bond"].Get("amount"))
+	assert.Equal(t, toAddr, posted["/bond"].Get("toAddr"))
+}
+
+func TestUnbondAmountIsReadAsLPT(t *testing.T) {
+	dInfo, err := json.Marshal(lpTypes.Delegator{
+		Address:         ethcommon.HexToAddress("0x0000000000000000000000000000000000000002"),
+		DelegateAddress: ethcommon.HexToAddress("0x0000000000000000000000000000000000000001"),
+		BondedAmount:    new(big.Int).Mul(big.NewInt(10), big.NewInt(1e18)),
+	})
+	require.NoError(t, err)
+
+	// not a full unbond, then 0.5 LPT out of the 10 LPT bonded
+	w, posted := newTestNode(t, "n\n0.5\n", map[string]string{
+		"/delegatorInfo": string(dInfo),
+	})
+
+	w.unbond()
+
+	require.Contains(t, posted, "/unbond")
+	assert.Equal(t, "500000000000000000", posted["/unbond"].Get("amount"))
+}
+
+func TestUnbondRefusesWhenNotBonded(t *testing.T) {
+	dInfo, err := json.Marshal(lpTypes.Delegator{
+		Address:      ethcommon.HexToAddress("0x0000000000000000000000000000000000000002"),
+		BondedAmount: big.NewInt(0),
+	})
+	require.NoError(t, err)
+
+	// stdin is empty: nothing bonded means unbond has to bail out before it asks
+	// anything, or it would loop on a condition it can never satisfy
+	w, posted := newTestNode(t, "", map[string]string{
+		"/delegatorInfo": string(dInfo),
+	})
+
+	w.unbond()
+
+	assert.NotContains(t, posted, "/unbond")
+}
+
+func TestTransferTokensAmountIsReadAsLPT(t *testing.T) {
+	toAddr := "0x0000000000000000000000000000000000000001"
+	w, posted := newTestNode(t, toAddr+"\n2.5\ny\n", map[string]string{
+		"/tokenBalance": "10000000000000000000",
+	})
+
+	w.transferTokens()
+
+	require.Contains(t, posted, "/transferTokens")
+	assert.Equal(t, "2500000000000000000", posted["/transferTokens"].Get("amount"))
+	assert.Equal(t, toAddr, posted["/transferTokens"].Get("to"))
+}
+
+// orchestratorInfo has to carry a service URI and non-nil cuts: promptOrchestratorConfig
+// dereferences the orchestrator either way, and falls back to an external IP lookup when
+// the service URI is empty.
+func orchestratorInfoJSON(t *testing.T) string {
+	body, err := json.Marshal(struct {
+		Transcoder *lpTypes.Transcoder
+		PriceInfo  *big.Rat
+	}{
+		Transcoder: &lpTypes.Transcoder{
+			Address:    ethcommon.HexToAddress("0x0000000000000000000000000000000000000002"),
+			ServiceURI: "https://127.0.0.1:8935",
+			RewardCut:  big.NewInt(0),
+			FeeShare:   big.NewInt(0),
+		},
+	})
+	require.NoError(t, err)
+
+	return string(body)
+}
+
+// the six empty lines take the default for every orchestrator config prompt: reward cut,
+// fee cut, pixels per unit, currency, price per unit, and the service URI
+const orchestratorConfigDefaults = "\n\n\n\n\n\n"
+
+func TestActivateOrchestratorBondAmountIsReadAsLPT(t *testing.T) {
+	dInfo, err := json.Marshal(lpTypes.Delegator{
+		Address:      ethcommon.HexToAddress("0x0000000000000000000000000000000000000002"),
+		BondedAmount: big.NewInt(0),
+	})
+	require.NoError(t, err)
+
+	// nothing bonded, so the wizard asks for a self-bond after the config prompts
+	w, posted := newTestNode(t, orchestratorConfigDefaults+"1.5\n", map[string]string{
+		"/delegatorInfo":    string(dInfo),
+		"/orchestratorInfo": orchestratorInfoJSON(t),
+		"/unbondingLocks":   "[]",
+		"/tokenBalance":     "10000000000000000000",
+	})
+
+	w.activateOrchestrator()
+
+	require.Contains(t, posted, "/activateOrchestrator")
+	assert.Equal(t, "1500000000000000000", posted["/activateOrchestrator"].Get("amount"))
+	assert.Equal(t, "https://127.0.0.1:8935", posted["/activateOrchestrator"].Get("serviceURI"))
+}
+
+func TestSetOrchestratorConfigReportsBalance(t *testing.T) {
+	w, posted := newTestNode(t, orchestratorConfigDefaults, map[string]string{
+		"/orchestratorInfo": orchestratorInfoJSON(t),
+		"/tokenBalance":     "10000000000000000000",
+	})
+
+	w.setOrchestratorConfig()
+
+	require.Contains(t, posted, "/setOrchestratorConfig")
+	assert.Equal(t, "https://127.0.0.1:8935", posted["/setOrchestratorConfig"].Get("serviceURI"))
+}
+
+func TestFormattedTokenBalanceKeepsWhatTheNodeSaid(t *testing.T) {
+	// the node reports errors as a plain body, so a balance that is not a number has to
+	// come through as it is rather than as a 0 LPT the operator would believe
+	w, _ := newTestNode(t, "", map[string]string{
+		"/tokenBalance": "Error getting token balance: execution reverted",
+	})
+	assert.Equal(t, "Error getting token balance: execution reverted", w.getFormattedTokenBalance())
+
+	w, _ = newTestNode(t, "", map[string]string{"/tokenBalance": "10000000000000000000"})
+	assert.Equal(t, "10 LPT", w.getFormattedTokenBalance())
 }

--- a/cmd/livepeer_cli/wizard_token.go
+++ b/cmd/livepeer_cli/wizard_token.go
@@ -4,15 +4,18 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/livepeer/go-livepeer/eth"
 )
 
 func (w *wizard) transferTokens() {
-	fmt.Printf("Current LPT balance: %v\n", w.getTokenBalance())
+	fmt.Printf("Current LPT balance: %v\n", w.getFormattedTokenBalance())
 
 	fmt.Printf("Enter recipient address (in hex i.e. 0xfoo) - ")
 	to := w.readString()
 
-	amount := w.readBigInt("Enter amount")
+	fmt.Printf("Enter amount in LPT - ")
+	amount := w.readPositiveBaseAmount()
 
 	val := url.Values{
 		"to":     {fmt.Sprintf("%v", to)},
@@ -22,7 +25,7 @@ func (w *wizard) transferTokens() {
 	var input string
 	userAccepted := false
 	for !userAccepted {
-		fmt.Printf("Are you sure you want to send %s LPTU to \"%s\"? (y/n) - ", val["amount"][0], val["to"][0])
+		fmt.Printf("Are you sure you want to send %s to \"%s\"? (y/n) - ", eth.FormatUnits(amount, "LPT"), val["to"][0])
 
 		input = w.readString()
 

--- a/cmd/livepeer_cli/wizard_transcoder.go
+++ b/cmd/livepeer_cli/wizard_transcoder.go
@@ -107,8 +107,8 @@ func (w *wizard) activateOrchestrator() {
 		return
 	}
 
-	fmt.Printf("Current token balance: %v\n", w.getTokenBalance())
-	fmt.Printf("Current bonded amount: %v\n", d.BondedAmount.String())
+	fmt.Printf("Current token balance: %v\n", w.getFormattedTokenBalance())
+	fmt.Printf("Current bonded amount: %v\n", eth.FormatUnits(d.BondedAmount, "LPT"))
 
 	val := w.getOrchestratorConfigFormValues()
 
@@ -157,7 +157,8 @@ func (w *wizard) activateOrchestrator() {
 
 			amount := big.NewInt(0)
 			for amount.Cmp(big.NewInt(0)) == 0 || balBigInt.Cmp(amount) < 0 {
-				amount = w.readBigInt("Enter bond amount")
+				fmt.Printf("Enter bond amount in LPT - ")
+				amount = w.readPositiveBaseAmount()
 				if balBigInt.Cmp(amount) < 0 {
 					fmt.Printf("Must enter an amount smaller than the current balance. ")
 				}
@@ -186,7 +187,7 @@ func (w *wizard) setOrchestratorConfig() {
 		return
 	}
 
-	fmt.Printf("Current token balance: %v\n", w.getTokenBalance())
+	fmt.Printf("Current token balance: %v\n", w.getFormattedTokenBalance())
 
 	val := w.getOrchestratorConfigFormValues()
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

`livepeer_cli` prints balances in LPT and reads amounts in LPTU. Type back the number it
just showed you and it is rejected:

```
Current Bonded Amount: 17471.404866149158765313 LPT
Would you like to fully unbond? (y/n) - > n
Enter unbond amount - > 1471.404866149158765313
ERROR[08-27|18:41:04] Invalid input, expected big integer      err="failed to parse big integer"
```

Four prompts read base units: bond, unbond, transfer and the bond step of orchestrator
activation. This switches them to `readPositiveBaseAmount`, the helper the ETH deposit
prompt already uses, and names the unit in each prompt. Four display lines that printed base
units now go through `eth.FormatUnits`.

One adjacent fix rides along. `unbond`'s not-bonded guard tested `BondedAmount < 0`, which
cannot happen, so a delegator with nothing bonded passed it and reached the amount loop,
which wants a value both above zero and at most zero. It is `<= 0` now, the same test
`activateOrchestrator` already used.

The node still receives base units, so the HTTP API is unchanged.

```
Current LPT balance: 10 LPT
Enter bond amount in LPT - > 1.5
```

**Specific updates (required)**

- `bond`, `unbond`, `transferTokens` and `activateOrchestrator` read LPT and say so
- `getFormattedTokenBalance` added next to `getTokenBalance`, so the three balance prints
  do not each repeat the parse
- transfer confirmation reads `send 2.5 LPT` instead of `send 2500000000000000000 LPTU`
- tests for the three flows that assert what lands in the POST body
- `unbond` bails out when nothing is bonded, instead of looping on an unsatisfiable
  condition, with a test

**How did you test each of these updates (required)**

`make` and `go build ./cmd/livepeer_cli/`, then `go test ./cmd/livepeer_cli/`, also under
`-race`, plus `go vet` and `gofmt`. The three new
end-to-end tests run the real `bond()`, `unbond()` and `transferTokens()` against an
`httptest` stub of the CLI API with stdin scripted, and assert the amount in the POST body:
`1.5` in gives `amount=1500000000000000000`. A fourth drives `activateOrchestrator` through
its whole config prompt sequence and asserts the same thing about its bond amount, a fifth
covers the guard fix (nothing bonded, empty stdin, no POST), and a sixth covers the balance
helper, including the path where the node answers with an error string instead of a number.
Each was checked by reverting its change alone and confirming the test goes red. One more test covers `readPositiveBaseAmount` over eight input
classes: integer, decimal, signed, one base unit, zero, negative, more than 18 decimals,
non-numeric. That helper is unchanged here, so it pins existing behaviour rather than
proving anything about this patch, which is why the revert experiment leaves it alone.

`./test.sh` runs green here except for two failures that also happen at the base commit
`38eb47d1` with this patch reverted, so they are this machine and not this change:
`core.TestCapability_TranscoderCapabilities`, which wants an H.264 hardware capability the
local ffmpeg build does not report, and `server.TestSubmitSegment_HttpPostError`, which
expects "connection refused" from `https://127.0.0.1` but gets a 403 from an nginx that is
listening there. Everything else passes.

**Notes for reviewers**

Four things worth knowing. The first three are pre-existing and separate from this patch;
the fourth is a side effect of it.

1. Test failures in this package are opaque. On bad input the wizard retries, hits EOF, and
   `readString` calls `log.Crit`, which is `os.Exit(1)`. go-ethereum's root logger discards
   by default, so nothing explains the exit and the rest of the package's tests go
   unreported. A regression here looks like a bare exit status, not an assertion.
2. `eth.ToBaseAmount`'s regex has an unescaped dot, so `1,5` and `1e18` get past validation
   and fail later in `big.Int.SetString` with a confusing padded-string error. Still
   rejected, just with the wrong message. Separate one-liner, happy to send it.
3. The "Must enter an amount smaller than the current balance" text in bond and activation
   sits on a condition that allows equality. `unbond`'s wording is right. Left alone.
4. Retry prompts changed slightly. `readBigInt` reprinted the whole prompt after bad input;
   the shared helper prints only `> `, so the unit hint is not repeated. This matches the
   ETH deposit prompt's existing behaviour.

**Does this pull request close any open issues?**

Fixes #1835

**Checklist:**

- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
