### PR TITLE
discovery: check a ticket recipient against the address registered for its URI

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,5 +19,6 @@
 #### General
 
 #### Broadcaster
+- [#4085](https://github.com/livepeer/go-livepeer/pull/4085) discovery: check an orchestrator's ticket recipient against the address registered for its ServiceURI (@Strykar)
 
 #### CLI

--- a/common/types.go
+++ b/common/types.go
@@ -64,6 +64,16 @@ type OrchestratorLocalInfo struct {
 	URL     *url.URL `json:"Url"`
 	Score   float32
 	Latency *time.Duration
+	// ExpectedRecipient is the ticket recipient this endpoint should name, when
+	// the gateway has grounds to expect one. For an orchestrator reached through
+	// its registered ServiceURI that is the address registered on chain; for an
+	// endpoint advertised by another orchestrator it is that orchestrator's
+	// recipient. Raw bytes because it is compared against
+	// TicketParams.Recipient, which is also raw bytes.
+	//
+	// Empty when there are no grounds, for example a webhook pool or a
+	// -orchAddr list, in which case nothing is checked.
+	ExpectedRecipient []byte `json:"-"`
 }
 
 // combines B's local metadata about O with info received from this O

--- a/discovery/db_discovery.go
+++ b/discovery/db_discovery.go
@@ -125,40 +125,43 @@ func (cfg DBOrchestratorPoolCacheConfig) New() (*DBOrchestratorPoolCache, error)
 	return dbo, nil
 }
 
-func (dbo *DBOrchestratorPoolCache) getURLs() ([]*url.URL, error) {
+func (dbo *DBOrchestratorPoolCache) GetInfos() []common.OrchestratorLocalInfo {
+	infos, _ := dbo.getLocalInfos()
+	return infos
+}
+
+// getLocalInfos is getURLs plus the address registered for each ServiceURI, so
+// the poller and the dial path can check the recipient a response names.
+func (dbo *DBOrchestratorPoolCache) getLocalInfos() ([]common.OrchestratorLocalInfo, error) {
 	orchs, err := dbo.store.SelectOrchs(
 		&common.DBOrchFilter{
 			CurrentRound:   dbo.rm.LastInitializedRound(),
 			UpdatedLastDay: true,
 		},
 	)
-	if err != nil || len(orchs) <= 0 {
+	if err != nil {
 		return nil, err
 	}
-
-	var uris []*url.URL
+	infos := make([]common.OrchestratorLocalInfo, 0, len(orchs))
 	for _, orch := range orchs {
-		if uri, err := url.Parse(orch.ServiceURI); err == nil {
-			uris = append(uris, uri)
+		uri, err := url.Parse(orch.ServiceURI)
+		if err != nil {
+			continue
 		}
+		infos = append(infos, common.OrchestratorLocalInfo{
+			URL:               uri,
+			Score:             common.Score_Untrusted,
+			ExpectedRecipient: expectedRecipient(orch.EthereumAddr),
+		})
 	}
-	return uris, nil
-}
-
-func (dbo *DBOrchestratorPoolCache) GetInfos() []common.OrchestratorLocalInfo {
-	uris, _ := dbo.getURLs()
-	infos := make([]common.OrchestratorLocalInfo, 0, len(uris))
-	for _, uri := range uris {
-		infos = append(infos, common.OrchestratorLocalInfo{URL: uri, Score: common.Score_Untrusted})
-	}
-	return infos
+	return infos, nil
 }
 
 func (dbo *DBOrchestratorPoolCache) GetOrchestrators(ctx context.Context, numOrchestrators int, suspender common.Suspender, caps common.CapabilityComparator,
 	scorePred common.ScorePred) (common.OrchestratorDescriptors, error) {
 
-	uris, err := dbo.getURLs()
-	if err != nil || len(uris) <= 0 {
+	infos, err := dbo.getLocalInfos()
+	if err != nil || len(infos) <= 0 {
 		return nil, err
 	}
 
@@ -195,7 +198,7 @@ func (dbo *DBOrchestratorPoolCache) GetOrchestrators(ctx context.Context, numOrc
 
 	orchPool, err := NewOrchestratorPoolWithConfig(OrchestratorPoolConfig{
 		Broadcaster:         dbo.bcast,
-		URIs:                uris,
+		Infos:               infos,
 		Pred:                pred,
 		Score:               common.Score_Untrusted,
 		OrchBlacklist:       dbo.orchBlacklist,
@@ -349,7 +352,10 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchInfos() error {
 			if err != nil {
 				continue
 			}
-			orchs = append(orchs, common.OrchestratorLocalInfo{URL: url})
+			orchs = append(orchs, common.OrchestratorLocalInfo{
+				URL:               url,
+				ExpectedRecipient: expectedRecipient(o.EthereumAddr),
+			})
 		}
 
 		glog.Infof("Using DB orchestrator pool with %d orchestrators", len(orchs))
@@ -420,6 +426,14 @@ func (dbo *DBOrchestratorPoolCache) cacheOrchInfos() error {
 
 		var dbOrch *common.DBOrch
 		if info.GetTicketParams() != nil {
+			// The row is keyed on the recipient the response supplies, so an
+			// endpoint naming another orchestrator's address would orphan a row
+			// or overwrite that orchestrator's price entry.
+			if recipientMismatch(ctx, &orch, info) {
+				errc <- fmt.Errorf("unexpected ticket recipient orch=%v", info.GetTranscoder())
+				return
+			}
+
 			dbOrch = &common.DBOrch{
 				EthereumAddr: ethcommon.BytesToAddress(info.TicketParams.Recipient).Hex(),
 			}
@@ -674,4 +688,14 @@ func callOrchestratorDiscovery(ctx context.Context, orchURI *url.URL) (json.RawM
 	}
 
 	return json.RawMessage(body), nil
+}
+
+// expectedRecipient converts a registered address into an expectation. An empty
+// address is no expectation rather than the zero address, which would reject
+// every response for that row.
+func expectedRecipient(ethereumAddr string) []byte {
+	if ethereumAddr == "" {
+		return nil
+	}
+	return ethcommon.HexToAddress(ethereumAddr).Bytes()
 }

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"bytes"
 	"container/heap"
 	"context"
 	"encoding/hex"
@@ -31,8 +32,11 @@ var serverGetOrchInfo = server.GetOrchestratorInfo
 
 // OrchestratorPoolConfig groups options used to construct an orchestratorPool.
 type OrchestratorPoolConfig struct {
-	Broadcaster         common.Broadcaster
-	URIs                []*url.URL
+	Broadcaster common.Broadcaster
+	URIs        []*url.URL
+	// Infos supersedes URIs when set, so callers that know more about an
+	// endpoint than its URL can pass it through.
+	Infos               []common.OrchestratorLocalInfo
 	Pred                func(*net.OrchestratorInfo) bool
 	Score               float32
 	OrchBlacklist       []string
@@ -92,13 +96,16 @@ func NewOrchestratorPoolWithPred(bcast common.Broadcaster, addresses []*url.URL,
 }
 
 func NewOrchestratorPoolWithConfig(cfg OrchestratorPoolConfig) (*orchestratorPool, error) {
-	if len(cfg.URIs) == 0 {
+	if len(cfg.URIs) == 0 && len(cfg.Infos) == 0 {
 		return nil, errors.New("orchestrator pool config must contain at least one URI")
 	}
 
-	infos := make([]common.OrchestratorLocalInfo, 0, len(cfg.URIs))
-	for _, uri := range cfg.URIs {
-		infos = append(infos, common.OrchestratorLocalInfo{URL: uri, Score: cfg.Score})
+	infos := cfg.Infos
+	if len(infos) == 0 {
+		infos = make([]common.OrchestratorLocalInfo, 0, len(cfg.URIs))
+		for _, uri := range cfg.URIs {
+			infos = append(infos, common.OrchestratorLocalInfo{URL: uri, Score: cfg.Score})
+		}
 	}
 
 	return &orchestratorPool{
@@ -226,7 +233,7 @@ func (o *orchestratorPool) GetOrchestrators(ctx context.Context, numOrchestrator
 			}
 		}
 
-		if err == nil && !isBlacklisted(info) && isCompatible(info) && doingWork {
+		if err == nil && !isBlacklisted(info) && !recipientMismatch(ctx, od.LocalInfo, info) && isCompatible(info) && doingWork {
 			infoCh <- orchDescr
 			return
 		}
@@ -355,4 +362,33 @@ func (o *orchestratorPool) Broadcaster() common.Broadcaster {
 
 func (o *orchestratorPool) pollOrchestratorInfo(ctx context.Context) {
 
+}
+
+// recipientMismatch reports whether an endpoint named a ticket recipient other
+// than the one the gateway had grounds to expect.
+//
+// The recipient is what tickets are made payable to and what selection groups
+// sessions by, so an endpoint free to name any address is paid as, and counted
+// as, whoever it likes. An empty expectation means the gateway has no grounds,
+// and nothing is checked.
+//
+// Refs #4082.
+func recipientMismatch(ctx context.Context, li *common.OrchestratorLocalInfo, info *net.OrchestratorInfo) bool {
+	expected := li.ExpectedRecipient
+	if len(expected) == 0 {
+		return false
+	}
+	claimed := info.GetTicketParams().GetRecipient()
+	if len(claimed) == 0 {
+		// No claim to contradict. The dial path already rejects nil ticket
+		// params in its pred, and the poller tolerates them for capability
+		// caching, so this is not the place to decide that.
+		return false
+	}
+	if bytes.Equal(expected, claimed) {
+		return false
+	}
+	clog.V(common.DEBUG).Infof(ctx, "Discarding orchestrator naming an unexpected payee uri=%v expected=0x%x claimed=0x%x",
+		li.URL, expected, claimed)
+	return true
 }

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -2458,3 +2458,149 @@ func wgWait(wg *sync.WaitGroup) bool {
 		return false
 	}
 }
+
+func TestRecipientMismatch(t *testing.T) {
+	assert := assert.New(t)
+	expected := ethcommon.HexToAddress("0x1111111111111111111111111111111111111111").Bytes()
+	other := ethcommon.HexToAddress("0x2222222222222222222222222222222222222222").Bytes()
+	u, _ := url.Parse("https://orch.example.com:8935")
+	ctx := context.Background()
+
+	li := func(exp []byte) *common.OrchestratorLocalInfo {
+		return &common.OrchestratorLocalInfo{URL: u, ExpectedRecipient: exp}
+	}
+	info := func(r []byte) *net.OrchestratorInfo {
+		return &net.OrchestratorInfo{Transcoder: u.String(), TicketParams: &net.TicketParams{Recipient: r}}
+	}
+
+	// no expectation: a webhook pool or -orchAddr list, nothing to check against
+	assert.False(recipientMismatch(ctx, li(nil), info(other)))
+	// response agrees with the chain
+	assert.False(recipientMismatch(ctx, li(expected), info(expected)))
+	// response names someone else
+	assert.True(recipientMismatch(ctx, li(expected), info(other)))
+	// no claim to contradict. The dial path's pred already rejects nil ticket
+	// params, and the poller tolerates them for capability caching, so this
+	// predicate does not decide it.
+	assert.False(recipientMismatch(ctx, li(expected), &net.OrchestratorInfo{Transcoder: u.String()}))
+	// an empty registered address is no expectation, not the zero address
+	assert.False(recipientMismatch(ctx, li(expectedRecipient("")), info(other)))
+}
+
+// The dial path builds its pool from the DB, so the address registered for a
+// ServiceURI is available and must be enforced there, not only in the poller.
+func sync_TestDBOrchestratorPoolCache_GetOrchestrators_RejectsUnexpectedRecipient(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	honestURL := "https://honest.example.com:8935"
+	liarURL := "https://liar.example.com:8935"
+	honest := ethcommon.HexToAddress("0x1111111111111111111111111111111111111111")
+	liar := ethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+	someoneElse := ethcommon.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	getOrchInfo := func(ctx context.Context, bcast common.Broadcaster, u *url.URL, _ server.GetOrchestratorInfoParams) (*net.OrchestratorInfo, error) {
+		r := honest
+		if u.String() == liarURL {
+			r = someoneElse // not the address registered for liarURL
+		}
+		return &net.OrchestratorInfo{
+			Address:      pm.RandBytes(20),
+			Transcoder:   u.String(),
+			PriceInfo:    &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 1},
+			TicketParams: &net.TicketParams{Recipient: r.Bytes()},
+		}, nil
+	}
+
+	uH, _ := url.Parse(honestURL)
+	uL, _ := url.Parse(liarURL)
+	pool, err := NewOrchestratorPoolWithConfig(OrchestratorPoolConfig{
+		Infos: []common.OrchestratorLocalInfo{
+			{URL: uH, Score: common.Score_Untrusted, ExpectedRecipient: honest.Bytes()},
+			{URL: uL, Score: common.Score_Untrusted, ExpectedRecipient: liar.Bytes()},
+		},
+		DiscoveryTimeout: 50 * time.Millisecond,
+	})
+	require.NoError(err)
+	pool.getOrchInfo = getOrchInfo
+
+	ods, err := pool.GetOrchestrators(context.TODO(), 2, newStubSuspender(), newStubCapabilities(), common.ScoreAtLeast(0))
+	require.NoError(err)
+
+	var got []string
+	for _, od := range ods {
+		got = append(got, od.LocalInfo.URL.String())
+	}
+	assert.ElementsMatch([]string{honestURL}, got,
+		"the endpoint naming an address other than the one registered for it must not be dialled")
+}
+
+func TestDBOrchestratorPoolCache_GetOrchestrators_RejectsUnexpectedRecipient(t *testing.T) {
+	synctest.Test(t, sync_TestDBOrchestratorPoolCache_GetOrchestrators_RejectsUnexpectedRecipient)
+}
+
+// In steady state node.OrchestratorPool is the DBOrchestratorPoolCache itself,
+// so cacheOrchInfos takes the GetInfos() branch rather than the DB fallback.
+// This exercises that branch: rows go in the DB, the cache is its own pool, and
+// a response naming an address other than the registered one must not be cached.
+func TestDBOrchestratorPoolCache_cacheOrchInfos_GetInfosBranch_ChecksRecipient(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	honestURL := "https://honest.example.com:8935"
+	liarURL := "https://liar.example.com:8935"
+	honest := ethcommon.HexToAddress("0x1111111111111111111111111111111111111111")
+	liar := ethcommon.HexToAddress("0x2222222222222222222222222222222222222222")
+	someoneElse := ethcommon.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	// cacheOrchInfos only overrides the RPC when the pool is an *orchestratorPool,
+	// and here it is the cache itself, so stub the package-level hook.
+	oldOrchInfo := serverGetOrchInfo
+	defer func() { serverGetOrchInfo = oldOrchInfo }()
+	serverGetOrchInfo = func(ctx context.Context, bcast common.Broadcaster, u *url.URL, params server.GetOrchestratorInfoParams) (*net.OrchestratorInfo, error) {
+		r := honest
+		if u.String() == liarURL {
+			r = someoneElse // not the address registered for liarURL
+		}
+		return &net.OrchestratorInfo{
+			Address:      pm.RandBytes(20),
+			Transcoder:   u.String(),
+			PriceInfo:    &net.PriceInfo{PricePerUnit: 1, PixelsPerUnit: 1},
+			TicketParams: &net.TicketParams{Recipient: r.Bytes()},
+		}, nil
+	}
+
+	dbh, dbraw, err := common.TempDB(t)
+	defer dbh.Close()
+	defer dbraw.Close()
+	require.NoError(err)
+
+	// registered rows, so getLocalInfos has an address for each ServiceURI
+	for _, o := range []*common.DBOrch{
+		{ServiceURI: honestURL, EthereumAddr: honest.Hex(), PricePerPixel: 1, ActivationRound: 0, DeactivationRound: 1000},
+		{ServiceURI: liarURL, EthereumAddr: liar.Hex(), PricePerPixel: 1, ActivationRound: 0, DeactivationRound: 1000},
+	} {
+		require.NoError(dbh.UpdateOrch(o))
+	}
+
+	node := &core.LivepeerNode{Database: dbh}
+	dbo := &DBOrchestratorPoolCache{
+		store:               dbh,
+		rm:                  &stubRoundsManager{round: big.NewInt(1)},
+		bcast:               core.NewBroadcaster(node),
+		node:                node,
+		ignoreCapacityCheck: true,
+	}
+	// this is the steady-state arrangement: the cache is its own pool, so
+	// cacheOrchInfos reads GetInfos() rather than falling back to the DB
+	node.OrchestratorPool = dbo
+
+	require.NoError(dbo.cacheOrchInfos())
+
+	cached := map[string]bool{}
+	for _, o := range node.GetNetworkCapabilities() {
+		cached[o.OrchURI] = true
+	}
+	assert.True(cached[honestURL], "recipient matches the registered address")
+	assert.False(cached[liarURL], "recipient names an address other than the registered one")
+}


### PR DESCRIPTION
A gateway learns which address to pay from `OrchestratorInfo.TicketParams.Recipient` and never compares it against an address it had reason to expect. For an orchestrator reached through its registered ServiceURI that expectation exists and was being discarded: `SelectOrchs` returns rows carrying both `ServiceURI` and `EthereumAddr`, and only the URL survived.

That value matters in three places:

- tickets are made payable to it
- `selectUnknownSession` groups sessions by it
- `cacheOrchInfos` keys the DB row on it, so an endpoint naming another orchestrator's address orphans a row or overwrites that orchestrator's price entry

### The change

Carry the expectation on `OrchestratorLocalInfo` and check it where responses are consumed, through one predicate called from the discovery gate and from `cacheOrchInfos`. `GetInfos` carries the expectation too, since in steady state `node.OrchestratorPool` is the cache itself and that is what the poller reads.

`OrchestratorPoolConfig` gains `Infos` so a caller that knows more than a URL can pass it through; `URIs` behaves exactly as before. A row with an empty `EthereumAddr` yields no expectation rather than the zero address. A response naming no recipient at all is not contradicted here, since the dial path's `pred` already rejects nil ticket params and the poller tolerates them for capability caching.

### Behaviour change

On a DB-backed pool, an endpoint naming an address other than its registered one stops being dialled, where previously it was dialled and paid. The check is on `Recipient` rather than `OrchestratorInfo.Address` because with `-ethOrchAddr` the node's own account is a separate hot key while the recipient stays the registered orchestrator. I know of no supported configuration where a registered orchestrator's recipient legitimately differs from its registered address; if one exists, this should log and count rather than discard, and I will change it.

### Advertised nodes are not checked

`OrchestratorInfo.nodes` is untouched. The recursion builds a level-1 descriptor with an empty expectation, so an advertised node may still name any recipient. That path is opt-in and off by default, `-extraNodes` is 0. Whether a node must return its parent's recipient is question 2 on #4084.

### Testing

`go build ./...` clean; `discovery`, `common`, `byoc` and `cmd/livepeer/starter` pass. No existing test or fixture changed. `server`'s `TestSubmitSegment_HttpPostError` fails identically on unmodified master here, as does the one `go vet` warning. Removing the gate makes the dial-path test fail; reverting `GetInfos` to drop the expectation makes the poller test fail.

Refs #4082. That issue asks whether the responder can be shown to hold the registered key, which this does not answer. It enforces the narrower property that payment goes where the chain says it should.
