### PR TITLE
cli: return an error when the orchestrator record cannot be read

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,3 +23,5 @@
 #### Broadcaster
 
 #### CLI
+
+- [#4086](https://github.com/livepeer/go-livepeer/pull/4086) cli: Report the error and return to the menu when the orchestrator config prompt cannot read the orchestrator record, instead of crashing (@Strykar)

--- a/cmd/livepeer_cli/wizard_test.go
+++ b/cmd/livepeer_cli/wizard_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,4 +72,25 @@ func TestHttpGetUnreachable(t *testing.T) {
 	assert.Equal(t, "", body)
 	assert.False(t, ok)
 	assert.Equal(t, "", httpGet(url))
+}
+
+// A node that cannot read its own orchestrator record answers /orchestratorInfo with a
+// plain-text 500. That body does not unmarshal, so getOrchestratorInfo hands back a nil
+// transcoder, which the prompt used to carry past the questions and then dereference.
+// It has to report the error before asking anything, so this returns without reading
+// stdin or reaching myHostPort.
+func TestPromptOrchestratorConfigReportsAnUnreadableRecord(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "could not get transcoder", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	assert.NoError(t, err)
+
+	w := &wizard{host: u.Hostname(), httpPort: u.Port()}
+	_, _, _, _, _, _, err = w.promptOrchestratorConfig()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "could not read orchestrator record")
 }

--- a/cmd/livepeer_cli/wizard_transcoder.go
+++ b/cmd/livepeer_cli/wizard_transcoder.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"net/url"
@@ -48,14 +49,19 @@ func myHostPort() string {
 	return "https://" + ip + ":" + defaultRPCPort
 }
 
-func (w *wizard) promptOrchestratorConfig() (blockRewardCut, feeCut float64, pricePerUnit, currency, pixelsPerUnit, serviceURI string) {
+func (w *wizard) promptOrchestratorConfig() (blockRewardCut, feeCut float64, pricePerUnit, currency, pixelsPerUnit, serviceURI string, err error) {
 	orch, _, err := w.getOrchestratorInfo()
-	if err != nil || orch == nil {
-		fmt.Println("unable to get current reward cut and fee cut")
-	} else {
-		blockRewardCut = eth.ToPerc(orch.RewardCut)
-		feeCut = eth.ToPerc(flipPerc(orch.FeeShare))
+	if err != nil {
+		err = fmt.Errorf("could not read orchestrator record: %w", err)
+		return
 	}
+	if orch == nil {
+		err = errors.New("no orchestrator record in the response")
+		return
+	}
+
+	blockRewardCut = eth.ToPerc(orch.RewardCut)
+	feeCut = eth.ToPerc(flipPerc(orch.FeeShare))
 
 	fmt.Printf("Enter block reward cut percentage (current=%v default=%v) - ", blockRewardCut, defaultRewardCut)
 	blockRewardCut = w.readDefaultFloat(defaultRewardCut)
@@ -97,7 +103,7 @@ func (w *wizard) promptOrchestratorConfig() (blockRewardCut, feeCut float64, pri
 		return in, nil
 	})
 
-	return blockRewardCut, 100 - feeCut, pricePerUnit, currency, pixelsPerUnit, serviceURI
+	return blockRewardCut, 100 - feeCut, pricePerUnit, currency, pixelsPerUnit, serviceURI, nil
 }
 
 func (w *wizard) activateOrchestrator() {
@@ -110,7 +116,11 @@ func (w *wizard) activateOrchestrator() {
 	fmt.Printf("Current token balance: %v\n", w.getTokenBalance())
 	fmt.Printf("Current bonded amount: %v\n", d.BondedAmount.String())
 
-	val := w.getOrchestratorConfigFormValues()
+	val, err := w.getOrchestratorConfigFormValues()
+	if err != nil {
+		fmt.Printf("Error getting orchestrator config: %v\n", err)
+		return
+	}
 
 	if d.BondedAmount.Cmp(big.NewInt(0)) <= 0 || d.DelegateAddress != d.Address {
 		fmt.Printf("You must bond to yourself in order to become an orchestrator\n")
@@ -188,7 +198,11 @@ func (w *wizard) setOrchestratorConfig() {
 
 	fmt.Printf("Current token balance: %v\n", w.getTokenBalance())
 
-	val := w.getOrchestratorConfigFormValues()
+	val, err := w.getOrchestratorConfigFormValues()
+	if err != nil {
+		fmt.Printf("Error getting orchestrator config: %v\n", err)
+		return
+	}
 
 	result, ok := httpPostWithParams(fmt.Sprintf("http://%v:%v/setOrchestratorConfig", w.host, w.httpPort), val)
 
@@ -200,8 +214,11 @@ func (w *wizard) setOrchestratorConfig() {
 	fmt.Println("\nTransaction sent. Once confirmed, please restart your node if the ServiceURI has been reset")
 }
 
-func (w *wizard) getOrchestratorConfigFormValues() url.Values {
-	blockRewardCut, feeShare, pricePerUnit, currency, pixelsPerUnit, serviceURI := w.promptOrchestratorConfig()
+func (w *wizard) getOrchestratorConfigFormValues() (url.Values, error) {
+	blockRewardCut, feeShare, pricePerUnit, currency, pixelsPerUnit, serviceURI, err := w.promptOrchestratorConfig()
+	if err != nil {
+		return nil, err
+	}
 
 	return url.Values{
 		"blockRewardCut": {fmt.Sprintf("%v", blockRewardCut)},
@@ -210,7 +227,7 @@ func (w *wizard) getOrchestratorConfigFormValues() url.Values {
 		"currency":       {fmt.Sprintf("%v", currency)},
 		"pixelsPerUnit":  {fmt.Sprintf("%v", pixelsPerUnit)},
 		"serviceURI":     {fmt.Sprintf("%v", serviceURI)},
-	}
+	}, nil
 }
 
 func (w *wizard) callReward() {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

`promptOrchestratorConfig` reads the orchestrator's record and tolerates not getting one:

```go
orch, _, err := w.getOrchestratorInfo()      // wizard_transcoder.go:52
if err != nil || orch == nil {
	fmt.Println("unable to get current reward cut and fee cut")
} else {
	...
}
```

Twenty-eight lines later it dereferences that pointer unguarded, at line 80, to pick the default service URI (line numbers are at the base commit). So the wizard prints its message and then segfaults.

`/orchestratorInfo` answers with a plain 500 body, "could not get transcoder", whenever `GetTranscoder` fails. `getOrchestratorInfo` does not check the status code, so that text goes to `json.Unmarshal`, fails, and comes back as `(nil, nil, err)`. Any node whose transcoder lookup is failing while the rest of it works crashes the CLI here.

There is no reason to tolerate it. Without a record the prompt cannot show the current reward cut or fee cut, so the operator would be answering questions about values the CLI never read. Return the error instead and let both callers report it and go back to the menu, which is what `callReward` already does with the same helper.

The operator now sees:

```
Error getting orchestrator config: could not read orchestrator record: invalid character 'c' looking for beginning of value
```

**Specific updates (required)**

- `promptOrchestratorConfig` returns an error and exits before asking anything when the record cannot be read
- `getOrchestratorConfigFormValues` propagates it; `activateOrchestrator` and `setOrchestratorConfig` report and return
- regression test driving the real 500 body through an `httptest` server
- changelog entry under Bug Fixes / CLI

**How did you test each of these updates (required)**

`TestPromptOrchestratorConfigReportsAnUnreadableRecord` stands up an `httptest` server answering `/orchestratorInfo` with the plain-text 500 the real handler sends, and asserts the prompt returns an error. The early return happens before any prompt and before `myHostPort()`, so it needs no stdin and makes no network call. Weakening the fix to swallow the error makes the test fail, so it is pinning the behaviour rather than passing incidentally.

Both menu actions were also driven against a stub node answering the same 500:

| Route | Before | After |
|---|---|---|
| "Set orchestrator config", onchain | SIGSEGV at `wizard_transcoder.go:80` | prints the error and returns to the menu |
| "become an orchestrator", onchain | SIGSEGV at `wizard_transcoder.go:80` | prints the error and returns to the menu |
| either one, offchain | returns cleanly | returns cleanly |

An offchain node does not reach the crash even though it has no eth client: `activateOrchestrator` reads `/delegatorInfo` first, which is `mustHaveClient`-wrapped and fails, so it returns at line 106, and `setOrchestratorConfig` refuses offchain mode at line 184.

`make`, `gofmt`, `go vet`, `go test ./cmd/livepeer_cli/` and `go test -race ./cmd/livepeer_cli/` are clean. `./test.sh` has 19 packages green and fails only on `core.TestCapability_TranscoderCapabilities` and `server.TestSubmitSegment_HttpPostError`, which fail the same way on this machine at the base commit with nothing applied: no H.264 hardware capability, and a local listener on 127.0.0.1:443 where the test wants a refused connection.

**Notes for reviewers**

1. The error is wrapped rather than replaced, so the underlying `invalid character 'c'` still shows. That noise is the layer below: `getOrchestratorInfo` ignores the status code, so a plain-text 500 reaches `json.Unmarshal`. A status check returning the body as the error would fix the message for all four callers and is worth its own change; it would not have removed the crash.
2. The `orch == nil` branch is unreachable today, since `eth/client.go`'s `GetTranscoder` returns `nil` only alongside an error and a struct literal on success, so `respondJson` never emits a null `Transcoder`. It costs nothing as a guard and stops this becoming a crash again if that ever changes.
3. The two other callers that check only `err`, `orchestratorStats` and `callReward`, are not exposed for the same reason. Happy to add the same guard for consistency if you want it.
4. This appends to the same `#### CLI` changelog section as #4083, so whichever lands second needs a one-line rebase. The code hunks do not overlap: #4083 touches lines 107, 157 and 186 of this file, this one touches 52 and 80.

**Does this pull request close any open issues?**

No.

**Checklist:**

- [x] Read the [contribution guide](./doc/contributing.md)
- [x] `make` runs successfully
- [x] All tests in `./test.sh` pass
- [ ] README and other documentation updated
- [x] [Pending changelog](./CHANGELOG_PENDING.md) updated
